### PR TITLE
Updated Date Converter to output correct JSON date format

### DIFF
--- a/src/Stripe/Infrastructure/StripeDateTimeConverter.cs
+++ b/src/Stripe/Infrastructure/StripeDateTimeConverter.cs
@@ -13,9 +13,7 @@ namespace Stripe.Infrastructure
 	{
 		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
 		{
-			writer.WriteStartConstructor("Date");
-            writer.WriteValue(ConvertDateTimeToEpoch((DateTime)value));
-			writer.WriteEndConstructor();
+			writer.WriteRawValue(@"""\/Date(" + ConvertDateTimeToEpoch((DateTime)value).ToString() + @")\/""");
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
Just a quick but critical change to the Date Converter. When I copied the first one 2 weeks ago, I didn't really pay attention to what it was outputting. The way it was, it would print a date like `new Date(1326834836)` instead of `"\/Date(1326834836)\/"`.  According to this http://james.newtonking.com/archive/2009/02/20/good-date-times-with-json-net.aspx, doing it with the `new` constructor is actually illegal JSON (as well as inconsistent with the default JSON.net date serialization). I only noticed it when I was actually pulling from an ajax request and it was crapping out the success handler.  The way it is in this pull request works perfect now.
