### PR TITLE
Added InvoiceId property to StripeCharge

### DIFF
--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -42,5 +42,8 @@ namespace Stripe
 
 		[JsonProperty("card")]
         public StripeCard StripeCard { get; set; }
+
+        [JsonProperty("invoice")]
+        public string InvoiceId { get; set; }
     }
 }


### PR DESCRIPTION
When a StripeCharge is created as a result of an invoice, it contains an "invoice" property that is the invoice Id (similar to customerId).  This allows the caller to look up the associated invoice through a second call to StripeInvoiceService.
