### PR TITLE
StripeEventSearchOptions

### DIFF
--- a/src/Stripe/Services/Events/StripeEventSearchOptions.cs
+++ b/src/Stripe/Services/Events/StripeEventSearchOptions.cs
@@ -8,31 +8,36 @@ namespace Stripe
 		[JsonProperty("type")]
 		public string Type { get; set; }
 
-		[JsonProperty("created[gt]")]
+		public DateTime? Created { get; set; }
+		public DateTime? LessThan { get; set; }
+		public DateTime? LessThanOrEqualTo { get; set; }
 		public DateTime? GreaterThan { get; set; }
-
-		[JsonProperty("created[gte]")]
 		public DateTime? GreaterThanOrEqualTo { get; set; }
 
+		[JsonProperty("created")]
+		internal int? CreatedInternal { get { return ConvertToEpoch(Created); } }
+
 		[JsonProperty("created[lt]")]
-		public DateTime? LessThan { get; set; }
+		internal int? LessThanInternal { get { return ConvertToEpoch(LessThan); } }
 
 		[JsonProperty("created[lte]")]
-		public DateTime? LessThanOrEqualTo { get; set; }
+		internal int? LessThanOrEqualToInternal { get { return ConvertToEpoch(LessThanOrEqualTo); } }
 
-		public DateTime? Created { get; set; }
+		[JsonProperty("created[gt]")]
+		internal int? GreaterThanInternal { get { return ConvertToEpoch(GreaterThan); } }
 
-		[JsonProperty("created")]
-		internal int? Createdinternal
+		[JsonProperty("created[gte]")]
+		internal int? GreaterThanOrEqualToInternal { get { return ConvertToEpoch(GreaterThanOrEqualTo); } }
+
+
+
+		private int? ConvertToEpoch(DateTime? datetime)
 		{
-			get
-			{
-				if (!Created.HasValue) return null;
+			if (!datetime.HasValue) return null;
 
-				var diff = Created.Value - new DateTime(1970, 1, 1);
+			var diff = datetime.Value - new DateTime(1970, 1, 1);
 
-				return (int)Math.Floor(diff.TotalSeconds);
-			}
+			return (int)Math.Floor(diff.TotalSeconds);
 		}
 	}
 }


### PR DESCRIPTION
OK, it _almost_ worked.  The implementation was correct, but we needed to do the datetime-to-epoch conversions on all the dates, not just `Created`, so here is a pull-request with that class updated.  With the updated class in my code, these are the "tests" I ran, and everything came back peachy:

```
    public void TestStripe()
    {
        var k = new StripeEventService();

        var test0 = k.Get("evt_qmKj4NlutHhyvt"); // should return this specific event with correct properties, did
        var test1 = k.List(100, 0, null); // should return 100, did
        var test2 = k.List(100, 0, new StripeEventSearchOptions { Type = "charge.failed" }); // should return 2, did
        var test3 = k.List(100, 0, new StripeEventSearchOptions { Type = "invoice.*" }); // should return 43, did
        var test4 = k.List(100, 0, new StripeEventSearchOptions { Created = new DateTime(2012, 2, 21, 21, 57, 13) }); // should return 3, did
        var test5 = k.List(100, 0, new StripeEventSearchOptions { GreaterThan = new DateTime(2012, 2, 21, 21, 57, 13) }); // should return 2, did
        var test6 = k.List(100, 0, new StripeEventSearchOptions { GreaterThanOrEqualTo = new DateTime(2012, 2, 21, 21, 57, 13) }); // should return 5, did
        var test7 = k.List(100, 0, new StripeEventSearchOptions { LessThan = new DateTime(2012, 2, 21, 21, 57, 13) }); // should return 100, did
        var test8 = k.List(100, 0, new StripeEventSearchOptions { LessThanOrEqualTo = new DateTime(2012, 2, 21, 21, 57, 13) }); // should return 100, did

        var boom = "stop"; // breakpoint

    }
```
