### PR TITLE
New native type parsing for web hook notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 *.cache
 _ReSharper.*
 *resharper*
+*.DotCover
 *.nupkg
 
 working

--- a/src/Stripe/Entities/StripeEventData.cs
+++ b/src/Stripe/Entities/StripeEventData.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
-using Stripe.Infrastructure;
+﻿using Newtonsoft.Json;
 
 namespace Stripe
 {
@@ -14,5 +9,42 @@ namespace Stripe
 
 		[JsonProperty("object")]
 		public dynamic Object { get; set; }
+
+        public object StripeType { get; private set; }
+
+        public void ParseStripeType()
+        {
+            if (Object == null) return;
+
+            Newtonsoft.Json.Linq.JObject data = (Newtonsoft.Json.Linq.JObject) Object;
+            Newtonsoft.Json.Linq.JToken value;  
+            if (data.TryGetValue("object", out value))
+            {
+                switch (value.ToString())
+                {
+                    case "charge":
+                        StripeType = Mapper<StripeCharge>.MapFromJson(Object.ToString());
+                        break;
+                    case "coupon":
+                        StripeType = Mapper<StripeCoupon>.MapFromJson(Object.ToString());
+                        break;
+                    case "customer":
+                        StripeType = Mapper<StripeCustomer>.MapFromJson(Object.ToString());
+                        break;
+                    case "event":
+                        StripeType = Mapper<StripeEvent>.MapFromJson(Object.ToString());
+                        break;
+                    case "invoice":
+                        StripeType = Mapper<StripeInvoice>.MapFromJson(Object.ToString());
+                        break;
+                    case "subscription":
+                        StripeType = Mapper<StripeSubscription>.MapFromJson(Object.ToString());
+                        break;
+                    case "transfer":
+                        StripeType = Mapper<StripeTransfer>.MapFromJson(Object.ToString());
+                        break;
+                }
+            }
+        }
 	}
 }

--- a/src/Stripe/Entities/StripeTransfer.cs
+++ b/src/Stripe/Entities/StripeTransfer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeTransfer
+    {
+        [JsonProperty("date")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Date { get; set; }
+
+        [JsonProperty("amount")]
+        public int? AmountInCents { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("other_transfers")]
+        public List<string> OtherTransfers { get; set; }
+
+        [JsonProperty("summary")]
+        public StripeTransferSummary Summary { get; set; }
+
+
+    }
+}

--- a/src/Stripe/Entities/StripeTransferSummary.cs
+++ b/src/Stripe/Entities/StripeTransferSummary.cs
@@ -1,0 +1,67 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeTransferSummary
+    {
+        /// <summary>
+        /// Count of adjustments
+        /// </summary>
+        [JsonProperty("adjustment_count")]
+        public int? AdjustmentCount { get; set; }
+
+        /// <summary>
+        /// Total of adjustments applied to account, in cents.
+        /// </summary>
+        [JsonProperty("adjustment_gross")]
+        public int? AdjustmentAmountInCents { get; set; }
+
+        /// <summary>
+        /// Count of successful charges
+        /// </summary>
+        [JsonProperty("charge_count")]
+        public int? ChargeCount { get; set; }
+
+        /// <summary>
+        /// Total fees, in cents
+        /// </summary>
+        [JsonProperty("charge_fees")]
+        public int? ChargeFeesInCents { get; set; }
+
+        /// <summary>
+        /// Total amount successfully charged to customers, in cents.
+        /// </summary>
+        [JsonProperty("charge_gross")]
+        public int? ChargeAmountInCents { get; set; }
+
+        /// <summary>
+        /// Net transfer, in cents
+        /// </summary>
+        [JsonProperty("net")]
+        public int? NetAmountInCents { get; set; }
+
+        /// <summary>
+        /// Count of refunds issued
+        /// </summary>
+        [JsonProperty("refund_count")]
+        public int? RefundCount { get; set; }
+
+        /// <summary>
+        /// Total fee amount for refunds, in cents
+        /// </summary>
+        [JsonProperty("refund_fees")]
+        public int? RefundFeesInCents { get; set; }
+
+        /// <summary>
+        /// Total amount of refunds issued, in cents
+        /// </summary>
+        [JsonProperty("refund_gross")]
+        public int? RefundAmountInCents { get; set; }
+
+        [JsonProperty("validation_count")]
+        public int? ValidationCount { get; set; }
+
+        [JsonProperty("validation_fees")]
+        public int? ValidationFeeAmountInCents { get; set; }
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Entities\StripeCoupon.cs" />
     <Compile Include="Entities\StripeDiscount.cs" />
     <Compile Include="Entities\StripeNextRecurringCharge.cs" />
+    <Compile Include="Entities\StripeTransfer.cs" />
+    <Compile Include="Entities\StripeTransferSummary.cs" />
     <Compile Include="Infrastructure\StripeDateTimeConverter.cs" />
     <Compile Include="Infrastructure\Mapper.cs" />
     <Compile Include="Entities\StripeCustomer.cs" />


### PR DESCRIPTION
Implemented parsing for Stripe web hooks so that referenced data will appear as a native Stripe type (StripeCharge, StripeCustomer, etc.).

Implemented new entitities StripeTransfer and StripeTransferSummary, which can appear as referenced entities in a Stripe web hook notification.

There are many ways to parse the json data into a native Stripe type and represent it.  In the end I created a new property called StripeType that is an object and also created a void method called ParseStripeType. Another approach that I considered was to change StripeEventData.Object from an auto-property to a regular field and implement the parsing on each set operation.  In the end I felt this was the most straightforward.

You're supposed to use the API something like this:

StripeEvent stripeEvent = StripeEventUtility.ParseEvent(json);
var data = stripeEvent.Data;
data.ParseStripeType();

if (data.StripeType is StripeCharge){
      var charge = data.StripeType as StripeCharge;
      //do something with the charge
}
else if (data.StripeType is StripeCustomer){
      var customer = data.StripeType as StripeCustomer;
      //do something with the customer
}
