### PR TITLE
StripeInvoice was missing properties

### DIFF
--- a/src/Stripe/Entities/StripeInvoice.cs
+++ b/src/Stripe/Entities/StripeInvoice.cs
@@ -31,9 +31,6 @@ namespace Stripe
 		[JsonConverter(typeof(StripeDateTimeConverter))]
 		public DateTime? Date { get; set; }
 
-        [JsonProperty("discount")]
-        public int? DiscountInCents { get; set; }
-
         [JsonProperty("ending_balance")]
         public int? EndingBalanceInCents { get; set; }
 


### PR DESCRIPTION
I added the additional properties to StripeInvoice as documented here: https://stripe.com/docs/api#invoiceitem_object

These properties include:
AmountDueInCents
DiscountInCents
StartingBalanceInCents

and the one I most cared about:
NextPaymentAttempt

NextPaymentAttempt will be usually be null, with the exception of event notifications where the payment failed (think monthly subscriptions).
