### PR TITLE
Add CustomerId to StripeTokenCreateOptions for generating tokens for shared customers

### DIFF
--- a/src/Stripe/Services/Tokens/StripeTokenCreateOptions.cs
+++ b/src/Stripe/Services/Tokens/StripeTokenCreateOptions.cs
@@ -4,5 +4,7 @@ namespace Stripe
 {
 	public class StripeTokenCreateOptions : CreditCardOptions
 	{
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
 	}
 }


### PR DESCRIPTION
The CustomerId was missing from the StripeTokenCreateOptions so that tokens can be created for share customers using the Stripe create token api.

https://stripe.com/docs/api#create_token

This is to address Issue #58 which I submitted.
