### PR TITLE
Add Request property to StripeEvent class

### DIFF
--- a/src/Stripe/Entities/StripeEvent.cs
+++ b/src/Stripe/Entities/StripeEvent.cs
@@ -30,5 +30,8 @@ namespace Stripe
 
 		[JsonProperty("pending_webhooks")]
 		public int PendingWebhooks { get; set; }
+
+        [JsonProperty("request")]
+        public string Request { get; set; }
 	}
 }


### PR DESCRIPTION
It appears that Stripe has added a new property 'Request' to the StripeEvent object. I have added this property to the StripeEvent class. Note: I could not find any tests that were related to this class, so there are no tests that were altered or added.

From their documentation:

ID of the API request that caused the event. If null, the event was automatic (e.g. Stripe’s automatic subscription handling). Request logs are available in the dashboard but currently not in the API. Note: this property is populated for events on or after April 23, 2013.

This would make it possible to more easily identify events that occurred as a result of an API call or activity, as opposed to an automatic event such as those relating to subscription activities like charge.failed or charge.succeeded.
