### PR TITLE
Added missing failure code to charge entity

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="customers\when_creating_a_customer_with_an_api_key.cs" />
     <Compile Include="invoiceitems\when_creating_an_invoiceitem_with_an_api_key.cs" />
     <Compile Include="invoices\when_creating_an_invoice_with_an_api_key.cs" />
+    <Compile Include="invoices\when_creating_an_invoice_with_failed_charge.cs" />
     <Compile Include="plans\test_data\stripe_plan_update_options.cs" />
     <Compile Include="plans\when_updating_a_plan.cs" />
     <Compile Include="plans\when_creating_a_plan_with_an_interval_count.cs" />

--- a/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
+++ b/src/Stripe.Tests/customers/test_data/stripe_customer_create_options.cs
@@ -35,6 +35,36 @@ namespace Stripe.Tests.test_data
 			return stripeCustomerCreateOptions;
 		}
 
+        public static StripeCustomerCreateOptions ValidCardButChargeFails(string _planId = null, string _couponId = null, DateTime? _trialEnd = null)
+        {
+            var stripeCustomerCreateOptions = new StripeCustomerCreateOptions()
+            {
+                CardAddressCountry = "US",
+                CardAddressLine1 = "234 Bacon St",
+                CardAddressLine2 = "Apt 1",
+                CardAddressState = "NC",
+                CardAddressZip = "27617",
+                Email = "pork@email.com",
+                CardCvc = "1661",
+                CardExpirationMonth = "10",
+                CardExpirationYear = "2021",
+                CardName = "Johnny Tenderloin",
+                CardNumber = "4000000000000341",
+                Description = "Johnny Tenderloin (pork@email.com)"
+            };
+
+            if (_planId != null)
+                stripeCustomerCreateOptions.PlanId = _planId;
+
+            if (_couponId != null)
+                stripeCustomerCreateOptions.CouponId = _couponId;
+
+            if (_trialEnd != null)
+                stripeCustomerCreateOptions.TrialEnd = _trialEnd;
+
+            return stripeCustomerCreateOptions;
+        }
+
 		public static StripeCustomerCreateOptions ValidToken(string tokenId, string _planId = null, string _couponId = null, DateTime? _trialEnd = null)
 		{
 			var stripeCustomerCreateOptions = new StripeCustomerCreateOptions()

--- a/src/Stripe.Tests/invoices/when_creating_an_invoice_with_failed_charge.cs
+++ b/src/Stripe.Tests/invoices/when_creating_an_invoice_with_failed_charge.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+	public class when_creating_an_invoice_with_failed_charge
+	{
+        private static StripeInvoice _stripeCreatedInvoice;
+        private static StripeInvoice _stripeFailedInvoice;
+		private static StripeInvoiceService _stripeInvoiceService;
+        private static StripeCharge _stripeCharge;
+        private static StripeException _stripeInvoiceException;
+
+		Establish context = () =>
+		{
+			var stripeCustomerService = new StripeCustomerService();
+			var stripeCustomerCreateOptions = test_data.stripe_customer_create_options.ValidCardButChargeFails();
+			var stripeCustomer = stripeCustomerService.Create(stripeCustomerCreateOptions);
+
+            var stripeInvoiceItemService = new StripeInvoiceItemService();
+            var StripeInvoiceItemCreateOptions = test_data.stripe_invoiceitem_create_options.Valid(stripeCustomer.Id);
+            stripeInvoiceItemService.Create(StripeInvoiceItemCreateOptions);
+
+			_stripeInvoiceService = new StripeInvoiceService();
+            _stripeCreatedInvoice = _stripeInvoiceService.Create(stripeCustomer.Id);
+		};
+
+	    private Because of = () =>
+	    {
+            try
+            {
+                _stripeInvoiceService.Pay(_stripeCreatedInvoice.Id);
+            }
+            catch (StripeException ex)
+            {
+                _stripeInvoiceException = ex;
+            }
+
+            _stripeFailedInvoice = _stripeInvoiceService.Get(_stripeCreatedInvoice.Id);
+
+	        var stripeChargeService = new StripeChargeService();
+            _stripeCharge = stripeChargeService.Get(_stripeFailedInvoice.ChargeId);
+	    };
+
+		It should_have_the_correct_id = () =>
+            _stripeFailedInvoice.Id.ShouldEqual(_stripeCreatedInvoice.Id);
+
+		It should_have_a_declined_failure_message = () =>
+            _stripeCharge.FailureMessage.ShouldBeEqualIgnoringCase("Your card was declined");
+
+        It should_have_a_declined_failure_code = () =>
+            _stripeCharge.FailureCode.ShouldBeEqualIgnoringCase("card_declined");
+
+        It should_have_a_declined_exception_code = () =>
+            _stripeInvoiceException.StripeError.Code.ShouldBeEqualIgnoringCase("card_declined");
+	}
+}

--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -52,5 +52,8 @@ namespace Stripe
 
 		[JsonProperty("failure_message")]
 		public string FailureMessage { get; private set; }
+
+        [JsonProperty("failure_code")]
+	    public string FailureCode { get; private set; }
 	}
 }


### PR DESCRIPTION
While using stripe.net I noticed it was missing the FailureCode property on the Charge object. I needed the failure code to know when a charge failed for an invoice so I can let the user know the issue with the payment for their invoice. I'm not sure why it wasn't there or if Stripe recently added it. I also added a test to make sure it was working properly.

Here is the documentation for the charge object: https://stripe.com/docs/api#charge_object
