### PR TITLE
Add Id to StripeCard and create convenience method for getting default card

### DIFF
--- a/src/Stripe/Entities/StripeCard.cs
+++ b/src/Stripe/Entities/StripeCard.cs
@@ -4,6 +4,9 @@ namespace Stripe
 {
 	public class StripeCard
 	{
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
 		[JsonProperty("address_country")]
 		public string AddressCountry { get; set; }
 

--- a/src/Stripe/Entities/StripeCustomer.cs
+++ b/src/Stripe/Entities/StripeCustomer.cs
@@ -42,5 +42,31 @@ namespace Stripe
 
 		[JsonProperty("cards")]
 		public StripeCardList StripeCardList { get; set; }
+
+        public StripeCard DefaultCard
+        {
+            get
+            {
+                if (StripeCardList == null)
+                    return null;
+
+                if (StripeCardList.StripeCards == null)
+                    return null;
+
+                if (StripeCardList.StripeCards.Count == 0)
+                    return null;
+
+                if (String.IsNullOrEmpty(StripeDefaultCardId))
+                    return null;
+
+                foreach (var card in StripeCardList.StripeCards)
+                {
+                    if (card.Id == StripeDefaultCardId)
+                        return card;
+                }
+
+                return null;
+            }
+        }
 	}
 }


### PR DESCRIPTION
StripeDefaultCardId had been added to StripeCustomer, but Id was missing from StripeCard. I added that property. I also created a property on StripeCustomer called DefaultCard which will return the StripCard from the StripeCardList that matches the StripeDefaultCardId. 

If you don't want to include the DefaultCard method, please at least merge in the change to StripeCard so we can actually compare cards against the StripeDefaultCardId.
