### PR TITLE
Update StripeInvoiceItem.cs to add additional properties.

### DIFF
--- a/src/Stripe/Entities/StripeInvoiceItem.cs
+++ b/src/Stripe/Entities/StripeInvoiceItem.cs
@@ -14,7 +14,13 @@ namespace Stripe
 
 		[JsonProperty("date")]
 		[JsonConverter(typeof(StripeDateTimeConverter))]
-		public DateTime Date { get; set; }
+		public DateTime? Date { get; set; }
+		
+		[JsonProperty("proration")]
+		public  bool? Prorated { get; set; }
+		
+		[JsonProperty("type")]
+		public string Type { get; set; }
 
 		[JsonProperty("currency")]
 		public string Currency { get; set; }


### PR DESCRIPTION
StripeInvoiceItem.cs now accepts the proration field from a Stripe API call as well as the type field. This is useful when handling API requests since some users may need to know if the invoice item is prorated and the type (either "invoiceitem" or "subscription").
