### PR TITLE
Add balance service (balance get only, does not include transaction history)

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -57,6 +57,8 @@
     </Compile>
     <Compile Include="account\account_behaviors.cs" />
     <Compile Include="account\when_retrieving_an_account.cs" />
+    <Compile Include="balance\balance_behaviors.cs" />
+    <Compile Include="balance\when_retrieving_a_balance.cs" />
     <Compile Include="charges\charge_behaviors.cs" />
     <Compile Include="charges\when_capturing_a_charge_with_a_card.cs" />
     <Compile Include="charges\when_setting_a_charge_to_capture.cs" />

--- a/src/Stripe.Tests/balance/balance_behaviors.cs
+++ b/src/Stripe.Tests/balance/balance_behaviors.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    [Behaviors]
+    public class balance_behaviors
+    {
+        protected static StripeBalance StripeBalance;
+
+        It should_have_pending_amounts = () =>
+            StripeBalance.Pending.Length.ShouldBeGreaterThan(0);
+
+        It should_have_available_amounts = () =>
+            StripeBalance.Available.Length.ShouldBeGreaterThan(0);
+
+        private It should_specify_currency_on_available_amount = () =>
+            StripeBalance.Available.First().Currency.ShouldNotBeNull();
+    }
+}

--- a/src/Stripe.Tests/balance/when_retrieving_a_balance.cs
+++ b/src/Stripe.Tests/balance/when_retrieving_a_balance.cs
@@ -1,0 +1,22 @@
+﻿using Machine.Specifications;
+
+namespace Stripe.Tests
+{
+    public class when_retrieving_a_balance
+    {
+        protected static StripeBalance StripeBalance;
+        private static StripeBalanceService _stripeBalanceService;
+
+        Establish context = () =>
+        {
+            _stripeBalanceService = new StripeBalanceService();
+        };
+
+        Because of = () =>
+        {
+            StripeBalance = _stripeBalanceService.Get();
+        };
+
+        Behaves_like<balance_behaviors> behaviors;
+    }
+}

--- a/src/Stripe/Entities/StripeAmount.cs
+++ b/src/Stripe/Entities/StripeAmount.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+ {
+     public class StripeAmount 
+     {
+         [JsonProperty("amount")]
+         public int Amount { get; set; }
+
+         [JsonProperty("currency")]
+         public string Currency { get; set; }
+     }
+ }

--- a/src/Stripe/Entities/StripeBalance.cs
+++ b/src/Stripe/Entities/StripeBalance.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeBalance
+    {
+        [JsonProperty("livemode")]
+        public bool? LiveMode { get; set; }
+
+        [JsonProperty("pending")]
+        public StripeAmount[] Pending { get; set; }
+
+        [JsonProperty("available")]
+        public StripeAmount[] Available { get; set; }
+    }
+}

--- a/src/Stripe/Infrastructure/Urls.cs
+++ b/src/Stripe/Infrastructure/Urls.cs
@@ -32,6 +32,11 @@
 			get { return BaseUrl + "/plans"; }
 		}
 
+        public static string Balance 
+        {
+            get { return BaseUrl + "/balance"; }
+        }
+        
 		public static string Customers
 		{
 			get { return BaseUrl + "/customers"; }

--- a/src/Stripe/Services/Balance/StripeBalanceService.cs
+++ b/src/Stripe/Services/Balance/StripeBalanceService.cs
@@ -1,0 +1,19 @@
+﻿namespace Stripe
+{
+    public class StripeBalanceService
+    {
+        private string ApiKey { get; set; }
+
+		public StripeBalanceService(string apiKey = null)
+		{
+			ApiKey = apiKey;
+		}
+
+		public virtual StripeBalance Get()
+		{
+			var response = Requestor.GetString(Urls.Balance, ApiKey);
+			return Mapper<StripeBalance>.MapFromJson(response);
+		}
+
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -51,6 +51,8 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Entities\StripeAmount.cs" />
+    <Compile Include="Entities\StripeBalance.cs" />
     <Compile Include="Entities\StripeCardList.cs" />
     <Compile Include="Entities\StripeDispute.cs" />
     <Compile Include="Entities\StripeAccount.cs" />
@@ -77,6 +79,7 @@
     <Compile Include="Infrastructure\Mapper.cs" />
     <Compile Include="Entities\StripeCustomer.cs" />
     <Compile Include="Services\Account\StripeAccountService.cs" />
+    <Compile Include="Services\Balance\StripeBalanceService.cs" />
     <Compile Include="Services\BankAccountOptions.cs" />
     <Compile Include="Services\Cards\StripeCardCreateOptions.cs" />
     <Compile Include="Services\Cards\StripeCardService.cs">
@@ -121,6 +124,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>copy /y "$(TargetDir)Stripe.dll" "$(SolutionDir)Stripe.Tests\_web_event_hooks\bin\Stripe.dll"


### PR DESCRIPTION
While the stripe balance service is 'experimental', getting the pending and available balance seems fairly important.  

Note that while Stripe supports balance transaction listing and transaction retrieval, these features are not implemented in this commit.
