### PR TITLE
Broke out StripeRecipient ActiveAccount properties to a separate StripeRecipientActiveAccount object

### DIFF
--- a/src/Stripe/Entities/StripeRecipient.cs
+++ b/src/Stripe/Entities/StripeRecipient.cs
@@ -23,32 +23,8 @@ namespace Stripe
 		[JsonProperty("type")]
 		public string Type { get; set; }
 
-		[JsonProperty("active_account[id]")]
-		public string ActiveAccountId { get; set; }
-
-		[JsonProperty("active_account[object]")]
-		public string ActiveAccountObject { get; set; }
-
-		[JsonProperty("active_account[bank_name]")]
-		public string ActiveAccountBankName { get; set; }
-
-		[JsonProperty("active_account[country]")]
-		public string ActiveAccountCountry { get; set; }
-
-		[JsonProperty("active_account[currency]")]
-		public string ActiveAccountCurrency { get; set; }
-
-		[JsonProperty("active_account[last4]")]
-		public string ActiveAccountLast4 { get; set; }
-
-		[JsonProperty("active_account[fingerprint]")]
-		public string ActiveAccountFingerprint { get; set; }
-
-		[JsonProperty("active_account[validated]")]
-		public bool? ActiveAccountValidated { get; set; }
-
-		[JsonProperty("active_account[verified]")]
-		public bool? ActiveAccountVerified { get; set; }
+        [JsonProperty("active_account")]
+        public StripeRecipientActiveAccount ActiveAccount { get; set; }
 
 		[JsonProperty("description")]
 		public string Description { get; set; }

--- a/src/Stripe/Entities/StripeRecipientActiveAccount.cs
+++ b/src/Stripe/Entities/StripeRecipientActiveAccount.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeRecipientActiveAccount
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        [JsonProperty("validated")]
+        public bool? Validated { get; set; }
+
+        [JsonProperty("verified")]
+        public bool? Verified { get; set; }
+    }
+}

--- a/src/Stripe/Stripe.csproj
+++ b/src/Stripe/Stripe.csproj
@@ -35,8 +35,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -67,6 +67,7 @@
     <Compile Include="Entities\StripeOAuthToken.cs" />
     <Compile Include="Entities\StripePeriod.cs" />
     <Compile Include="Entities\StripeRecipient.cs" />
+    <Compile Include="Entities\StripeRecipientActiveAccount.cs" />
     <Compile Include="Entities\StripeToken.cs" />
     <Compile Include="Entities\StripeCharge.cs" />
     <Compile Include="Entities\StripeCard.cs" />
@@ -126,7 +127,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/src/Stripe/packages.config
+++ b/src/Stripe/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The existing ActiveAccount fields within StripeRecipient were not deserializing correctly, always having null values. Was unable to find correct JsonProperty annotation syntax to fix it either.
