### PR TITLE
Added support for the Stripe-Version header

### DIFF
--- a/src/Stripe/Infrastructure/Requestor.cs
+++ b/src/Stripe/Infrastructure/Requestor.cs
@@ -38,6 +38,7 @@ namespace Stripe
 		private static WebRequest GetWebRequest(string url, string method, string apiKey = null, bool useBearer = false)
 		{
 			apiKey = apiKey ?? StripeConfiguration.GetApiKey();
+			string apiVersion = StripeConfiguration.GetApiVersion();
 
 			var request = (HttpWebRequest)WebRequest.Create(url);
 			request.Method = method;
@@ -46,6 +47,9 @@ namespace Stripe
 				request.Headers.Add("Authorization", GetAuthorizationHeaderValue(apiKey));
 			else
 				request.Headers.Add("Authorization", GetAuthorizationHeaderValueBearer(apiKey));
+
+			if (!string.IsNullOrWhiteSpace(apiVersion))
+				request.Headers.Add("Stripe-Version", apiVersion);
 
 			request.ContentType = "application/x-www-form-urlencoded";
 			request.UserAgent = "Stripe.net (https://github.com/jaymedavis/stripe.net)";

--- a/src/Stripe/Infrastructure/StripeConfiguration.cs
+++ b/src/Stripe/Infrastructure/StripeConfiguration.cs
@@ -6,6 +6,7 @@ namespace Stripe
 	public static class StripeConfiguration
 	{
 		private static string _apiKey;
+		private static string _apiVersion;
 
 		internal static string GetApiKey()
 		{
@@ -18,6 +19,14 @@ namespace Stripe
 		public static void SetApiKey(string newApiKey)
 		{
 			_apiKey = newApiKey;
+		}
+
+		internal static string GetApiVersion()
+		{
+			if (string.IsNullOrEmpty(_apiVersion))
+				_apiVersion = ConfigurationManager.AppSettings["StripeApiVersion"];
+
+			return _apiVersion;
 		}
 	}
 }


### PR DESCRIPTION
This is an attempt to resolve issue #135.

I added support for the Stripe-Version header so that code can be tested against a new version of the API before upgrading the API in the Stripe dashboard (which upgrades both the live and test environments).  The API version is read from the StripeApiVersion app setting in Web.config.

I didn't write any tests and I haven't used your testing framework, but I'm happy to try if you have any ideas.  I was thinking maybe a test where we set the API to an old version version and assert that some feature is not available.

This is my first ever work with Git/GitHub and I'm a little unsure of the process.  Please let me know if I'm making any mistakes submitting these code changes.
