### PR TITLE
Add property StatementDescription to StripeChargeCreateOptions class

### DIFF
--- a/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe/Services/Charges/StripeChargeCreateOptions.cs
@@ -5,10 +5,6 @@ namespace Stripe
 {
 	public class StripeChargeCreateOptions : CreditCardOptions
 	{
-		private string _statementDescription;
-		
-		private const int StatementDescriptionMaxLength = 15;
-		
 		[JsonProperty("amount")]
 		public int? Amount { get; set; }
 
@@ -34,24 +30,6 @@ namespace Stripe
 		public Dictionary<string, string> Metadata { get; set; }
 
 		[JsonProperty("statement_description")]
-		public string StatementDescription {
-			get { return _statementDescription; }
-			set
-			{
-				if (value == null)
-				{
-					_statementDescription = value;
-				}
-				else if (value.Length > StatementDescriptionMaxLength)
-				{
-					_statementDescription = value.Substring(0, (StatementDescriptionMaxLength - 3));
-					_statementDescription = result + "...";
-				}
-				else
-				{
-					_statementDescription = value;
-				}
-			}
-		}
+		public string StatementDescription { get; set; }
 	}
 }


### PR DESCRIPTION
Add property for new argument that can be used during creation new charge for adding a per-charge description — a “dynamic descriptor”. Here is post about it https://stripe.com/blog/dynamic-descriptors
