### PR TITLE
Add missing infrastructure tests

### DIFF
--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -80,6 +80,11 @@
     <Compile Include="coupons\when_creating_a_coupon_with_amount_off.cs" />
     <Compile Include="coupons\when_creating_a_coupon_with_an_api_key.cs" />
     <Compile Include="customers\when_creating_a_customer_with_an_api_key.cs" />
+    <Compile Include="infrastructure\test_data\sample_object.cs" />
+    <Compile Include="infrastructure\when_building_parameters.cs" />
+    <Compile Include="infrastructure\when_passed_empty_object.cs" />
+    <Compile Include="infrastructure\when_serializing_an_equals_datefilter.cs" />
+    <Compile Include="infrastructure\when_serializing_a_datefilter_query.cs" />
     <Compile Include="invoiceitems\when_creating_an_invoiceitem_with_an_api_key.cs" />
     <Compile Include="invoices\when_closing_an_invoice.cs" />
     <Compile Include="invoices\when_creating_an_invoice_with_an_api_key.cs" />

--- a/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
+++ b/src/Stripe.Tests/infrastructure/test_data/sample_object.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Stripe.Tests.infrastructure.test_data
+{
+	public class sample_object
+	{
+		public sample_object()
+		{
+			StringContainingText = "Foo";
+			StringWithDifferentName = "Foo";
+			Number = 42;
+			Metadata = new Dictionary<string, string> {
+				{ "A", "Value-A" },
+				{ "B", "Value-B" }
+			};
+			EqualDateFilter = new StripeDateFilter { EqualTo = DateTime.Parse("2000-01-01") };
+			LessThanDateFilter = new StripeDateFilter { LessThan = DateTime.Parse("2000-01-01") };
+			ComplexDateFilter = new StripeDateFilter
+			{
+				LessThan = DateTime.Parse("2100-01-01"),
+				GreaterThan = DateTime.Parse("2000-01-01")
+			};
+		}
+
+		public string StringWithoutAttribute { get; set; }
+
+		[JsonProperty("differentname")]
+		public string StringWithDifferentName { get; set; }
+
+		[JsonProperty("stringcontainingtext")]
+		public string StringContainingText { get; set; }
+
+		[JsonProperty("stringcontainingnull")]
+		public string StringContainingNull { get; set; }
+
+		[JsonProperty("number")]
+		public int Number { get; set; }
+
+		[JsonProperty("nullnumber")]
+		public int? NullNumber { get; set; }
+
+		[JsonProperty("metadata")]
+		public Dictionary<string, string> Metadata { get; set; }
+
+		[JsonProperty("dateequals")]
+		public StripeDateFilter EqualDateFilter { get; set; }
+
+		[JsonProperty("datelessthan")]
+		public StripeDateFilter LessThanDateFilter { get; set; }
+
+		[JsonProperty("datecomplex")]
+		public StripeDateFilter ComplexDateFilter { get; set; }
+	}
+}

--- a/src/Stripe.Tests/infrastructure/when_building_parameters.cs
+++ b/src/Stripe.Tests/infrastructure/when_building_parameters.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Machine.Specifications;
+using Stripe.Tests.infrastructure.test_data;
+
+namespace Stripe.Tests.infrastructure
+{
+	public class when_building_parameters
+	{
+		private const string origurl = "http://test/foo";
+		private static sample_object _testObject;
+		private static string _result;
+
+		Establish context = () =>
+		{
+			_testObject = new sample_object();
+		};
+
+		Because of = () =>
+		{
+			_result = ParameterBuilder.ApplyAllParameters(_testObject, origurl);
+		};
+
+		It should_start_with_original_url = () =>
+			_result.ShouldStartWith(origurl);
+
+		It should_contain_querystring_separator = () =>
+			_result.ShouldStartWith(origurl + "?");
+
+		It should_not_contain_property_without_attribute = () =>
+			_result.ShouldNotContain("StringWithoutAttribute=");
+
+		It should_use_name_from_property_attribute = () =>
+			_result.ShouldContain("differentname=");
+
+		It should_not_contain_null_string_property = () =>
+			_result.ShouldNotContain("stringcontainingnull=");
+
+		It should_contain_string_with_value = () =>
+			_result.ShouldContain("stringcontainingtext=Foo");
+
+		It should_contain_int_property = () =>
+			_result.ShouldContain("number=42");
+
+		It should_not_contain_null_int_property = () =>
+			_result.ShouldNotContain("nullnumber=");
+
+		It should_contain_metadata_as_inline_items = () =>
+			_result.ShouldContain("metadata[A]=Value-A");
+
+	}
+}

--- a/src/Stripe.Tests/infrastructure/when_passed_empty_object.cs
+++ b/src/Stripe.Tests/infrastructure/when_passed_empty_object.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Machine.Specifications;
+
+namespace Stripe.Tests.infrastructure
+{
+	public class when_passed_empty_object
+	{
+		private const string original = "foo";
+		private static string _result;
+
+		Because of = () =>
+			_result = ParameterBuilder.ApplyAllParameters(null, original);
+
+		It should_return_original = () =>
+			_result.ShouldEqual(original);
+	}
+}

--- a/src/Stripe.Tests/infrastructure/when_serializing_a_datefilter_query.cs
+++ b/src/Stripe.Tests/infrastructure/when_serializing_a_datefilter_query.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Machine.Specifications;
+using Stripe.Tests.infrastructure.test_data;
+
+namespace Stripe.Tests.infrastructure
+{
+	public class when_serializing_a_datefilter_query
+	{
+		private const string origurl = "http://test/foo";
+		private static sample_object _testObject;
+		private static string _result;
+
+		Establish context = () =>
+		{
+			_testObject = new sample_object();
+		};
+
+		Because of = () =>
+		{
+			_result = ParameterBuilder.ApplyAllParameters(_testObject, origurl);
+		};
+
+		It should_not_contain_plain_equals = () =>
+			_result.ShouldNotContain("datelessthan=");
+
+		It should_contain_less_than = () =>
+			_result.ShouldContain("datelessthan[lt]=946684800");
+
+		It should_contain_first_part_of_complex_query = () =>
+			_result.ShouldContain("datecomplex[gt]=946684800");
+
+		It should_contain_second_part_of_complex_query = () =>
+			_result.ShouldContain("datecomplex[lt]=4102444800");
+	}
+}

--- a/src/Stripe.Tests/infrastructure/when_serializing_an_equals_datefilter.cs
+++ b/src/Stripe.Tests/infrastructure/when_serializing_an_equals_datefilter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Machine.Specifications;
+using Stripe.Tests.infrastructure.test_data;
+
+namespace Stripe.Tests.infrastructure
+{
+	class when_serializing_an_equals_datefilter
+	{
+		private const string origurl = "http://test/foo";
+		private static sample_object _testObject;
+		private static string _result;
+
+		Establish context = () =>
+		{
+			_testObject = new sample_object();
+		};
+
+		Because of = () =>
+		{
+			_result = ParameterBuilder.ApplyAllParameters(_testObject, origurl);
+		};
+
+		It should_contain_plain_equals = () =>
+			_result.ShouldContain("dateequals=946684800");
+
+		It should_not_contain_complex_filter = () =>
+			_result.ShouldNotContain("dateequals[");
+	}
+}


### PR DESCRIPTION
This restores the tests which were not included when you merged in #130.  No changes are made to the library.
