### PR TITLE
Added StatementDescription member to StripeCharge

### DIFF
--- a/src/Stripe.Tests/charges/charge_behaviors.cs
+++ b/src/Stripe.Tests/charges/charge_behaviors.cs
@@ -25,6 +25,9 @@ namespace Stripe.Tests
 		It should_have_the_correct_description = () =>
 			StripeCharge.Description.ShouldEqual(StripeChargeCreateOptions.Description);
 
+		It should_have_the_correct_statement_description = () =>
+			StripeCharge.StatementDescription.ShouldEqual(StripeChargeCreateOptions.StatementDescription);
+
 		It should_have_the_correct_live_mode = () =>
 			StripeCharge.LiveMode.ShouldEqual(false);
 

--- a/src/Stripe.Tests/charges/test_data/stripe_charge_create_options.cs
+++ b/src/Stripe.Tests/charges/test_data/stripe_charge_create_options.cs
@@ -19,6 +19,7 @@ namespace Stripe.Tests.test_data
 				CardName = "Joe Meatballs",
 				CardNumber = "4242424242424242",
 				Description = "Joe Meatball Charge",
+				StatementDescription = "Valid Card",
 				Amount = 5153,
 				Currency = "usd",
 				Metadata = new Dictionary<string, string>
@@ -44,6 +45,7 @@ namespace Stripe.Tests.test_data
 				CardName = "Joe Meatballs",
 				CardNumber = "425221",
 				Description = "Joe Meatball Charge",
+				StatementDescription = "Invalid Card",
 				Amount = 5153,
 				Currency = "usd"
 			};

--- a/src/Stripe/Entities/StripeCharge.cs
+++ b/src/Stripe/Entities/StripeCharge.cs
@@ -48,6 +48,9 @@ namespace Stripe
 		[JsonProperty("description")]
 		public string Description { get; set; }
 
+		[JsonProperty("statement_description")]
+		public string StatementDescription { get; set; }
+
 		[JsonProperty("paid")]
 		public bool? Paid { get; set; }
 


### PR DESCRIPTION
While integrating Stripe.Net I've noticed that the StatementDescription was missing in the StripeCharge so I've added it. The tests have been changed accordingly.
