### PR TITLE
Added StripeDiscount member to StripeSubscription like StripeCustomer

### DIFF
--- a/src/Stripe/Entities/StripeSubscription.cs
+++ b/src/Stripe/Entities/StripeSubscription.cs
@@ -42,6 +42,9 @@ namespace Stripe
 		[JsonConverter(typeof(StripeDateTimeConverter))]
 		public DateTime? CanceledAt { get; set; }
 
+		[JsonProperty("discount")]
+		public StripeDiscount StripeDiscount { get; set; }
+
 		[JsonProperty("ended_at")]
 		[JsonConverter(typeof(StripeDateTimeConverter))]
 		public DateTime? EndedAt { get; set; }


### PR DESCRIPTION
Using `StripeSubscriptionCreateOptions.CouponId` Stripe creates the discount on the subscription rather than globally for the customer. I've added a `StripeDiscount` member to `StripeSubscription` so you can access the details of the discount when you fetch the `StripeSubscription`.
