### PR TITLE
Change of the Guard PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ test_script:
   - ps: Write-Host $("`n               RUNNING THE XUNIT TESTS               `n") -BackgroundColor DarkCyan
   - dotnet test src\Stripe.Tests.XUnit\Stripe.Tests.XUnit.csproj
   - ps: Write-Host $("`n               RUNNING THE MSPEC TESTS               `n") -BackgroundColor DarkCyan
-  - dotnet test src\Stripe.net.Tests\Stripe.net.Tests.csproj
+  - dotnet test src\Stripe.net.Tests\Stripe.net.Tests.csproj /p:TargetFramework=net46
 
 artifacts:
   - path: '**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,13 @@ version: 10.1.0.{build}
 image: Visual Studio 2017
 
 environment:
-  STRIPE_TEST_KEY:
-    secure: +p/EWA8+0B64k7a88nb6ZiSTcv6TIukyhQQU2Ljf7jNVtwVZXhJtNf5LdemV7EuY
   STRIPE_TEST_SK:
-    secure: FNxc9q82h6VFpNVkdYByjQ33o7XgzcBVKui2lK9qxTqJSa6gkAggzcSvew7w4xxK
+    secure: CcMNB0hu30XVzrZiu9MLdpEzejPmX1xqp/kizfUz5s0BaCzAKnfBYRjqO+Q8wTfN
 
 deploy:
 - provider: NuGet
   api_key:
-    secure: D6ys+uEckSSs1hTQ0/io7wKytQnGH32FMzsPCRBVT1L6wmGe2pj3bmVNgw/xKBqM
+    secure: cmo/iFw1omV9CJBtyj3k2smUjb9KUSaYdL++rPTntmzyJ32gq76WeyYnojL5opzw
   on:
     branch: master
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ![Stripe](https://stripe.com/img/navigation/logo.png?2)  
-[![Build status](https://ci.appveyor.com/api/projects/status/5kje1md0hltqfpyh/branch/master?svg=true)](https://ci.appveyor.com/project/JaymeDavis/stripe-net/branch/master)  
+[![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf?svg=true)](https://ci.appveyor.com/project/stripe-appveyor-ci/stripe-dotnet)
 [![waiting for release](https://badge.waffle.io/jaymedavis/stripe.net.svg?label=waiting%20for%20release&title=waiting%20for%20release)](http://waffle.io/jaymedavis/stripe.net)  
 
 **Stripe Services**

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf?svg=true)](https://ci.appveyor.com/project/stripe-appveyor-ci/stripe-dotnet)
 [![waiting for release](https://badge.waffle.io/jaymedavis/stripe.net.svg?label=waiting%20for%20release&title=waiting%20for%20release)](http://waffle.io/jaymedavis/stripe.net)  
 
+
 **Stripe Services**
 
 [3D Secure](#) (needs documentation)  

--- a/src/Stripe.net.Tests/Stripe.net.Tests.csproj
+++ b/src/Stripe.net.Tests/Stripe.net.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>net46;netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Stripe.net.Tests</AssemblyName>
     <PackageId>Stripe.net.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/Stripe.net.Tests/Stripe.net.Tests.csproj
+++ b/src/Stripe.net.Tests/Stripe.net.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net46;netcoreapp1.1</TargetFramework>
     <AssemblyName>Stripe.net.Tests</AssemblyName>
     <PackageId>Stripe.net.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
- Created a new Test Account (documented internally)
- Modified encrypted API Key for AppVeyor
- Modified encrypted API Key for NuGet
- Removed `STRIPE_TEST_KEY` environment variable
- Added netcoreapp1.1 as a target framework for basic tests