### PR TITLE
Reconcile events with the current API

### DIFF
--- a/src/Stripe.net/Constants/StripeEvents.cs
+++ b/src/Stripe.net/Constants/StripeEvents.cs
@@ -123,6 +123,11 @@ namespace Stripe
         /// Occurs when the dispute is updated (usually with evidence).
         /// </summary>
         public const string ChargeDisputeUpdated = "charge.dispute.updated";
+        
+        /// <summary>
+        /// Occurs whenever a refund is updated on selected payment methods.
+        /// </summary
+        public const string ChargeRefundUpdated = "charge.refund.updated";
 
         /// <summary>
         /// Occurs whenever a coupon is created.
@@ -218,11 +223,11 @@ namespace Stripe
         /// Occurs whenever an invoice attempts to be paid, and the payment succeeds.
         /// </summary>
         public const string InvoicePaymentSucceeded = "invoice.payment_succeeded";
-
+       
         /// <summary>
-        /// Occurs whenever an invoice email is sent out.
+        /// Occurs X number of days before a subscription is scheduled to create an invoice that is charged automatically, where X is determined by your subscriptions settings.
         /// </summary>
-        public const string InvoiceSent = "invoice.sent";
+        public const string InvoiceUpcoming = "invoice.upcoming";
 
         /// <summary>
         /// Occurs whenever an invoice changes (for example, the amount could change).


### PR DESCRIPTION
StripeEvents is missing charge.refund.updated and invoice.upcoming.  The API currently has no definition for the invoice.sent event.  Added the missing events with the API descriptions and removed the invoice.sent definition.