### PR TITLE
Added support for migrating a recipient to a Custom account

### DIFF
--- a/src/Stripe.net/Entities/StripeRecipient.cs
+++ b/src/Stripe.net/Entities/StripeRecipient.cs
@@ -32,6 +32,9 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        [JsonProperty("migrated_to")]
+        public string MigratedTo { get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
 

--- a/src/Stripe.net/Services/Account/StripeAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountCreateOptions.cs
@@ -12,5 +12,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("from_recipient")]
+        public string FromRecipient { get; set; }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/952

I did not add any tests since it would involve creating new recipients which is something we're actively discouraging/deprecating. I tested locally that my recipient was migrated though.

r? @anelder-stripe 
