### PR TITLE
Amount is optional on source creation for reusable sources

### DIFF
--- a/src/Stripe.Tests.XUnit/sources/creating_reusable_card_source.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_reusable_card_source.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_reusable_card_source
+    {
+        private StripeSource Source { get; set; }
+
+        public creating_reusable_card_source()
+        {
+            var options = new StripeSourceCreateOptions
+            {
+                Type = StripeSourceType.Card,
+                Usage = StripeSourceUsage.Reusable,
+                Token = Cache.GetToken().Id,
+            };
+
+            Source = new StripeSourceService(Cache.ApiKey).Create(options);
+        }
+
+        [Fact]
+        public void source_should_not_be_null()
+        {
+            Source.Should().NotBeNull();
+            Source.Card.Should().NotBeNull();
+        }
+    }
+}

--- a/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
@@ -18,7 +18,7 @@ namespace Stripe
         /// Amount associated with the source. This is the amount for which the source will be chargeable once ready. Required for single-use sources.
         /// </summary>
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         /// <summary>
         /// The currency associated with the source. This is the currency for which the source will be chargeable once ready.


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/953 by making the `amount` parameter on Source creation optional. It is required only for one-time Sources and not for re-usable ones.

r? @anelder-stripe 