### PR TITLE
The `customer` parameter is only available on subscription creation

### DIFF
--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
@@ -26,6 +26,9 @@ namespace Stripe
             }
         }
 
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
         // this will actually send items. this is to flag it for the middleware
         // to process it as a plugin
         [JsonProperty("subscription_items_array")]

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -20,9 +20,6 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        [JsonProperty("customer")]
-        public string CustomerId { get; set; }
-
         [JsonProperty("plan")]
         public string PlanId { get; set; }
 


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/947

r? @anelder-stripe 