### PR TITLE
Bring back support for source_transaction on the Transfer object

### DIFF
--- a/src/Stripe.Tests.XUnit/transfers/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/transfers/_fixture.cs
@@ -10,6 +10,7 @@ namespace Stripe.Tests.Xunit
         public StripeTransferUpdateOptions TransferUpdateOptions { get; }
         public StripeTransferListOptions TransferListOptions { get; }
 
+        public StripeCharge Charge { get; }
         public StripeTransfer Transfer { get; }
         public StripeTransfer TransferUpdated { get; }
         public StripeTransfer TransferRetrieved { get; }
@@ -17,13 +18,22 @@ namespace Stripe.Tests.Xunit
 
         public transfers_fixture()
         {
+            var transferGroup = $"test_group_{ Guid.NewGuid() }";
+
             // make sure the account has sufficient funds first
-            new StripeChargeService(Cache.ApiKey).Create(new StripeChargeCreateOptions
+            var chargeService = new StripeChargeService(Cache.ApiKey);
+            Charge = chargeService.Create(new StripeChargeCreateOptions
             {
                 Amount = 10000,
                 Currency = "usd",
-                SourceTokenOrExistingSourceId = "tok_bypassPending",
-                TransferGroup = $"test_group_{ Guid.NewGuid() }"
+                SourceCard = new SourceCard
+                {
+                    Number = "4000000000000077",
+                    ExpirationMonth = 10,
+                    ExpirationYear = 2021,
+                    Cvc = "123"
+                },
+                TransferGroup = transferGroup
             });
 
             TransferCreateOptions = new StripeTransferCreateOptions
@@ -31,7 +41,8 @@ namespace Stripe.Tests.Xunit
                 Amount = 1000,
                 Currency = "usd",
                 Destination = Cache.GetAccount().Id,
-                TransferGroup = $"test_group_{ Guid.NewGuid() }"
+                TransferGroup = transferGroup,
+                SourceTransaction = Charge.Id
             };
 
             TransferUpdateOptions = new StripeTransferUpdateOptions

--- a/src/Stripe.Tests.XUnit/transfers/creating_and_updating_transfers.cs
+++ b/src/Stripe.Tests.XUnit/transfers/creating_and_updating_transfers.cs
@@ -25,6 +25,12 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void created_has_right_source_transaction()
+        {
+            fixture.Transfer.SourceTransactionId.Should().Be(fixture.Charge.Id);
+        }
+
+        [Fact]
         public void created_has_the_right_amount()
         {
             fixture.Transfer.Amount.Should().Be(fixture.TransferCreateOptions.Amount);

--- a/src/Stripe.net/Entities/StripeTransfer.cs
+++ b/src/Stripe.net/Entities/StripeTransfer.cs
@@ -57,8 +57,8 @@ namespace Stripe
         [JsonProperty("reversed")]
         public bool Reversed { get; set; }
 
-        //[JsonProperty("source_transaction")]
-        //public string SourceTransactionId { get; set; }
+        [JsonProperty("source_transaction")]
+        public string SourceTransactionId { get; set; }
 
         [JsonProperty("source_type")]
         public string SourceType { get; set; }


### PR DESCRIPTION
The `source_transaction` property on a `Transfer` was removed for a few weeks but brought back official months ago. The library was never updated to support this though.

r? @anelder-stripe 