### PR TITLE
Add support for account rejection

### DIFF
--- a/src/Stripe.Tests.XUnit/accounts/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/accounts/_fixture.cs
@@ -12,6 +12,7 @@ namespace Stripe.Tests.Xunit
         public StripeAccount Account { get; }
         public StripeAccount AccountUpdated { get; }
         public StripeAccount AccountRetrieved { get; }
+        public StripeAccount AccountRejected { get; }
         public IEnumerable<StripeAccount> AccountList { get; }
 
         public account_fixture()
@@ -74,11 +75,17 @@ namespace Stripe.Tests.Xunit
                 BusinessUrl = "https://subtracts.io"
             };
 
+            var _rejectOptions = new StripeAccountRejectOptions
+            {
+                Reason = "terms_of_service"
+            };
+
             var service = new StripeAccountService(Cache.ApiKey);
             Account = service.Create(AccountCreateOptions);
             AccountUpdated = service.Update(Account.Id, AccountUpdateOptions);
             AccountRetrieved = service.Get(Account.Id);
             AccountList = service.List();
+            AccountRejected = service.Reject(Account.Id, _rejectOptions);
         }
 
         public void Dispose()

--- a/src/Stripe.Tests.XUnit/accounts/creating_and_updating_accounts.cs
+++ b/src/Stripe.Tests.XUnit/accounts/creating_and_updating_accounts.cs
@@ -52,6 +52,14 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void rejected_is_disabled()
+        {
+            fixture.AccountRejected.ChargesEnabled.Should().BeFalse();
+            fixture.AccountRejected.PayoutsEnabled.Should().BeFalse();
+            fixture.AccountRejected.AccountVerification.DisabledReason.Should().Be("rejected.terms_of_service");
+        }
+
+        [Fact]
         public void list_is_not_null()
         {
             fixture.AccountList.Should().NotBeNull();

--- a/src/Stripe.net/Services/Account/StripeAccountRejectOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountRejectOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeAccountRejectOptions
+    {
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -52,6 +52,14 @@ namespace Stripe
             );
         }
 
+        public virtual StripeAccount Reject(string accountId, StripeAccountRejectOptions rejectOptions, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeAccount>.MapFromJson(
+                Requestor.PostString(this.ApplyAllParameters(rejectOptions, $"{Urls.BaseUrl}/accounts/{accountId}/reject", false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
         public virtual StripeDeleted Delete(string accountId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
@@ -103,6 +111,15 @@ namespace Stripe
         {
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/accounts/{accountId}", false),
+                SetupRequestOptions(requestOptions),
+                cancellationToken)
+            );
+        }
+
+        public virtual async Task<StripeAccount> RejectAsync(string accountId, StripeAccountRejectOptions rejectOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeAccount>.MapFromJson(
+                await Requestor.PostStringAsync(this.ApplyAllParameters(rejectOptions, $"{Urls.BaseUrl}/accounts/{accountId}/reject", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );


### PR DESCRIPTION
This add support for the rejection of Custom accounts. This fixes https://github.com/stripe/stripe-dotnet/issues/964

r? @anelder-stripe 