### PR TITLE
Added a small fix that should address the iteration issue

### DIFF
--- a/src/Stripe.net/Entities/StripeList.cs
+++ b/src/Stripe.net/Entities/StripeList.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeList<T> : StripeEntity
+    [JsonObject]
+    public class StripeList<T> : StripeEntity, IEnumerable<T>
     {
         [JsonProperty("object")]
         public string Object { get; set; }
@@ -22,5 +25,15 @@ namespace Stripe
 
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return Data.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return Data.GetEnumerator();
+        }
     }
 }

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -24,7 +24,7 @@ namespace Stripe
             var path = $"{Urls.BaseUrl}/accounts";
 
             return Mapper<StripeList<StripeAccount>>.MapFromJson(
-                Requestor.GetString(this.ApplyAllParameters(listOptions, path, false),
+                Requestor.GetString(this.ApplyAllParameters(listOptions, path, true),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -77,7 +77,7 @@ namespace Stripe
             var path = $"{Urls.BaseUrl}/accounts";
 
             return Mapper<StripeList<StripeAccount>>.MapFromJson(
-                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, path, false),
+                await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, path, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -19,11 +19,11 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeAccount> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeAccount> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             var path = $"{Urls.BaseUrl}/accounts";
 
-            return Mapper<StripeAccount>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeAccount>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, path, false),
                 SetupRequestOptions(requestOptions))
             );
@@ -72,11 +72,11 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeAccount>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeAccount>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var path = $"{Urls.BaseUrl}/accounts";
 
-            return Mapper<StripeAccount>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeAccount>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, path, false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundService.cs
@@ -25,7 +25,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions, updateOptions);
         }
 
-        public virtual IEnumerable<StripeApplicationFeeRefund> List(string applicationFeeId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeApplicationFeeRefund> List(string applicationFeeId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, listOptions);
         }
@@ -47,7 +47,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions, cancellationToken, updateOptions);
         }
 
-        public virtual Task<IEnumerable<StripeApplicationFeeRefund>> ListAsync(string applicationFeeId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeApplicationFeeRefund>> ListAsync(string applicationFeeId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
@@ -37,9 +37,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeApplicationFee> List(StripeApplicationFeeListOptions listOptions, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeApplicationFee> List(StripeApplicationFeeListOptions listOptions, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeApplicationFee>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeApplicationFee>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.ApplicationFees, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -69,9 +69,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeApplicationFee>> ListAsync(StripeApplicationFeeListOptions listOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeApplicationFee>> ListAsync(StripeApplicationFeeListOptions listOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeApplicationFee>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeApplicationFee>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.ApplicationFees, true),
                 SetupRequestOptions(requestOptions), 
                 cancellationToken)

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -54,9 +54,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<CustomerBankAccount> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<CustomerBankAccount> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<CustomerBankAccount>.MapCollectionFromJson(
+            return Mapper<StripeList<CustomerBankAccount>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/customers/{customerId}/bank_accounts", true),
                     SetupRequestOptions(requestOptions)
@@ -121,9 +121,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<CustomerBankAccount>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<CustomerBankAccount>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<CustomerBankAccount>.MapCollectionFromJson(
+            return Mapper<StripeList<CustomerBankAccount>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/customers/{customerId}/bank_accounts", true),
                     SetupRequestOptions(requestOptions),

--- a/src/Stripe.net/Services/Cards/StripeCardService.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardService.cs
@@ -65,11 +65,11 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeCard> List(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeCard> List(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null)
         {
             var url = SetupUrl(customerOrRecipientId, isRecipient);
 
-            return Mapper<StripeCard>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCard>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -133,11 +133,11 @@ namespace Stripe
                 );
         }
 
-        public virtual async Task<IEnumerable<StripeCard>> ListAsync(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeCard>> ListAsync(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var url = SetupUrl(customerOrRecipientId, isRecipient);
 
-            return Mapper<StripeCard>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCard>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -22,9 +22,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<CountrySpec> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<CountrySpec> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<CountrySpec>.MapCollectionFromJson(
+            return Mapper<StripeList<CountrySpec>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(listOptions, $"{Urls.CountrySpecs}", true),
                     SetupRequestOptions(requestOptions)
@@ -46,9 +46,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<CountrySpec>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<CountrySpec>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<CountrySpec>.MapCollectionFromJson(
+            return Mapper<StripeList<CountrySpec>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.CountrySpecs}", true),
                     SetupRequestOptions(requestOptions),

--- a/src/Stripe.net/Services/Coupons/StripeCouponService.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponService.cs
@@ -44,9 +44,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeCoupon> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeCoupon> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeCoupon>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCoupon>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Coupons, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -91,9 +91,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeCoupon>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeCoupon>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeCoupon>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCoupon>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Coupons, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerService.cs
@@ -93,9 +93,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeCustomer>> ListAsync(StripeCustomerListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeCustomer>> ListAsync(StripeCustomerListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeCustomer>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCustomer>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Customers, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerService.cs
@@ -47,14 +47,13 @@ namespace Stripe
              );
         }
 
-        public virtual IEnumerable<StripeCustomer> List(StripeCustomerListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeCustomer> List(StripeCustomerListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeCustomer>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeCustomer>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Customers, true),
                 SetupRequestOptions(requestOptions))
             );
         }
-
 
 
         //Async

--- a/src/Stripe.net/Services/Disputes/StripeDisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/StripeDisputeService.cs
@@ -28,7 +28,7 @@ namespace Stripe
             return Post($"{Urls.Disputes}/{disputeId}/close", requestOptions);
         }
 
-        public virtual IEnumerable<StripeDispute> List(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeDispute> List(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList(Urls.Disputes, requestOptions, listOptions);
         }
@@ -51,7 +51,7 @@ namespace Stripe
             return await PostAsync($"{Urls.Disputes}/{disputeId}/close", requestOptions, cancellationToken);
         }
 
-        public virtual async Task<IEnumerable<StripeDispute>> ListAsync(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeDispute>> ListAsync(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await GetEntityListAsync(Urls.Disputes, requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/Events/StripeEventService.cs
+++ b/src/Stripe.net/Services/Events/StripeEventService.cs
@@ -20,9 +20,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeEvent> List(StripeEventListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeEvent> List(StripeEventListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeEvent>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeEvent>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Events, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -40,9 +40,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeEvent>> ListAsync(StripeEventListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeEvent>> ListAsync(StripeEventListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeEvent>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeEvent>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Events, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/FileUploads/StripeFileUploadService.cs
+++ b/src/Stripe.net/Services/FileUploads/StripeFileUploadService.cs
@@ -30,9 +30,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeFileUpload> List(StripeFileUploadListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeFileUpload> List(StripeFileUploadListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeFileUpload>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeFileUpload>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(listOptions, Urls.FileUploads, true),
                     SetupRequestOptions(requestOptions)
@@ -61,9 +61,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeFileUpload>> ListAsync(StripeFileUploadListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeFileUpload>> ListAsync(StripeFileUploadListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeFileUpload>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeFileUpload>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, Urls.FileUploads, true),
                     SetupRequestOptions(requestOptions),

--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
@@ -47,9 +47,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeInvoiceLineItem> List(StripeInvoiceItemListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeInvoiceLineItem> List(StripeInvoiceItemListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.InvoiceItems, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -94,9 +94,9 @@ namespace Stripe
                 );
         }
 
-        public virtual async Task<IEnumerable<StripeInvoiceLineItem>> ListAsync(StripeInvoiceItemListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeInvoiceLineItem>> ListAsync(StripeInvoiceItemListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.InvoiceItems, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
@@ -49,27 +49,27 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeInvoice> List(StripeInvoiceListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeInvoice> List(StripeInvoiceListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeInvoice>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoice>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Invoices, true),
                 SetupRequestOptions(requestOptions))
             );
         }
 
-        public virtual IEnumerable<StripeInvoiceLineItem> ListLineItems(string invoiceId, StripeInvoiceListLineItemsOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeInvoiceLineItem> ListLineItems(string invoiceId, StripeInvoiceListLineItemsOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/{invoiceId}/lines", true),
                 SetupRequestOptions(requestOptions))
             );
         }
 
-        public virtual IEnumerable<StripeInvoiceLineItem> ListUpcomingLineItems(string customerId, StripeUpcomingInvoiceOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeInvoiceLineItem> ListUpcomingLineItems(string customerId, StripeUpcomingInvoiceOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
 
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -126,18 +126,18 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeInvoice>> ListAsync(StripeInvoiceListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeInvoice>> ListAsync(StripeInvoiceListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeInvoice>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoice>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Invoices, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
         }
 
-        public virtual async Task<IEnumerable<StripeInvoiceLineItem>> ListLineItemsAsync(string invoiceId, StripeInvoiceListLineItemsOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeInvoiceLineItem>> ListLineItemsAsync(string invoiceId, StripeInvoiceListLineItemsOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/{invoiceId}/lines", true),
                     SetupRequestOptions(requestOptions), 
@@ -145,11 +145,11 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeInvoiceLineItem>> ListUpcomingLineItemsAsync(string customerId, StripeUpcomingInvoiceOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeInvoiceLineItem>> ListUpcomingLineItemsAsync(string customerId, StripeUpcomingInvoiceOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
 
-            return Mapper<StripeInvoiceLineItem>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/Orders/StripeOrderService.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderService.cs
@@ -32,7 +32,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/orders/{orderId}/pay", requestOptions, options);
         }
 
-        public virtual IEnumerable<StripeOrder> List(StripeOrderListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeOrder> List(StripeOrderListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/orders", requestOptions, listOptions);
         }
@@ -60,7 +60,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/orders/{orderId}/pay", requestOptions, cancellationToken, options);
         }
 
-        public virtual Task<IEnumerable<StripeOrder>> ListAsync(StripeOrderListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeOrder>> ListAsync(StripeOrderListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/orders", requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/Payouts/StripePayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/StripePayoutService.cs
@@ -31,7 +31,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions, options);
         }
 
-        public virtual IEnumerable<StripePayout> List(StripePayoutListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripePayout> List(StripePayoutListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/payouts", requestOptions, listOptions);
         }
@@ -59,7 +59,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions, cancellationToken, options);
         }
 
-        public virtual Task<IEnumerable<StripePayout>> ListAsync(StripePayoutListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripePayout>> ListAsync(StripePayoutListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/payouts", requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/Plans/StripePlanService.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanService.cs
@@ -44,9 +44,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripePlan> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripePlan> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripePlan>.MapCollectionFromJson(
+            return Mapper<StripeList<StripePlan>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Plans, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -91,9 +91,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripePlan>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripePlan>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripePlan>.MapCollectionFromJson(
+            return Mapper<StripeList<StripePlan>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Plans, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/Products/StripeProductService.cs
+++ b/src/Stripe.net/Services/Products/StripeProductService.cs
@@ -27,7 +27,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/products/{productId}", requestOptions, options);
         }
 
-        public virtual IEnumerable<StripeProduct> List(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeProduct> List(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/products", requestOptions, listOptions);
         }
@@ -55,7 +55,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/products/{productId}", requestOptions, cancellationToken, options);
         }
 
-        public virtual Task<IEnumerable<StripeProduct>> ListAsync(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeProduct>> ListAsync(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/products", requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/Refunds/StripeRefundService.cs
+++ b/src/Stripe.net/Services/Refunds/StripeRefundService.cs
@@ -43,9 +43,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeRefund> List(StripeRefundListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeRefund> List(StripeRefundListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeRefund>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeRefund>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/refunds", true),
                     SetupRequestOptions(requestOptions)
@@ -87,9 +87,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeRefund>> ListAsync(StripeRefundListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeRefund>> ListAsync(StripeRefundListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeRefund>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeRefund>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/refunds", true),
                     SetupRequestOptions(requestOptions),

--- a/src/Stripe.net/Services/StripeBasicService.cs
+++ b/src/Stripe.net/Services/StripeBasicService.cs
@@ -24,9 +24,9 @@ namespace Stripe
             );
         }
 
-        public IEnumerable<EntityReturned> GetEntityList(string url, StripeRequestOptions requestOptions, object options = null)
+        public StripeList<EntityReturned> GetEntityList(string url, StripeRequestOptions requestOptions, object options = null)
         {
-            return Mapper<EntityReturned>.MapCollectionFromJson(
+            return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(options, url, true),
                     SetupRequestOptions(requestOptions)
@@ -68,9 +68,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<EntityReturned>> GetEntityListAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
+        public virtual async Task<StripeList<EntityReturned>> GetEntityListAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
         {
-            return Mapper<EntityReturned>.MapCollectionFromJson(
+            return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(options, url, true),
                     SetupRequestOptions(requestOptions),

--- a/src/Stripe.net/Services/StripeBasicService.cs
+++ b/src/Stripe.net/Services/StripeBasicService.cs
@@ -28,7 +28,7 @@ namespace Stripe
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 Requestor.GetString(
-                    this.ApplyAllParameters(options, url, true),
+                    this.ApplyAllParameters(options, url),
                     SetupRequestOptions(requestOptions)
                 )
             );
@@ -72,7 +72,7 @@ namespace Stripe
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(options, url, true),
+                    this.ApplyAllParameters(options, url),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
                 )

--- a/src/Stripe.net/Services/StripeBasicService.cs
+++ b/src/Stripe.net/Services/StripeBasicService.cs
@@ -28,7 +28,7 @@ namespace Stripe
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 Requestor.GetString(
-                    this.ApplyAllParameters(options, url),
+                    this.ApplyAllParameters(options, url, true),
                     SetupRequestOptions(requestOptions)
                 )
             );
@@ -72,7 +72,7 @@ namespace Stripe
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(options, url),
+                    this.ApplyAllParameters(options, url, true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
                 )

--- a/src/Stripe.net/Services/SubscriptionItems/StripeSubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/StripeSubscriptionItemService.cs
@@ -32,7 +32,7 @@ namespace Stripe
             return DeleteEntity($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions);
         }
 
-        public virtual IEnumerable<StripeSubscriptionItem> List(StripeSubscriptionItemListOptions options = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeSubscriptionItem> List(StripeSubscriptionItemListOptions options = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/subscription_items", requestOptions, options);
         }
@@ -60,7 +60,7 @@ namespace Stripe
             return DeleteEntityAsync($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions, cancellationToken);
         }
 
-        public virtual Task<IEnumerable<StripeSubscriptionItem>> ListAsync(StripeSubscriptionItemListOptions options = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeSubscriptionItem>> ListAsync(StripeSubscriptionItemListOptions options = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/subscription_items", requestOptions, cancellationToken, options);
         }

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
@@ -27,7 +27,7 @@ namespace Stripe
         }
 
         [Obsolete("List with customerId is deprecated, use List without the customerId.")]
-        public virtual IEnumerable<StripeSubscription> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeSubscription> List(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             var options = new StripeSubscriptionListOptions
             {
@@ -66,7 +66,7 @@ namespace Stripe
         }
 
         [Obsolete("ListAsync with customerId is deprecated, use ListAsync without the customerId.")]
-        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var options = new StripeSubscriptionListOptions
             {

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
@@ -69,9 +69,9 @@ namespace Stripe
             );
         }
 
-        public virtual IEnumerable<StripeSubscription> List(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeSubscription> List(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeSubscription>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeSubscription>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
                 SetupRequestOptions(requestOptions))
             );
@@ -140,9 +140,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<IEnumerable<StripeSubscription>> ListAsync(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeSubscription>> ListAsync(StripeSubscriptionListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeSubscription>.MapCollectionFromJson(
+            return Mapper<StripeList<StripeSubscription>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)

--- a/src/Stripe.net/Services/TransferReversals/StripeTransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/StripeTransferReversalService.cs
@@ -30,7 +30,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions, options);
         }
 
-        public virtual IEnumerable<StripeTransferReversal> List(string transferId, StripeListOptions options = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeTransferReversal> List(string transferId, StripeListOptions options = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, options);
         }
@@ -53,7 +53,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions, cancellationToken, options);      
         }
 
-        public virtual Task<IEnumerable<StripeTransferReversal>> ListAsync(string transferId, StripeListOptions options = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeTransferReversal>> ListAsync(string transferId, StripeListOptions options = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, cancellationToken, options);
         }

--- a/src/Stripe.net/Services/Transfers/StripeTransferService.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferService.cs
@@ -29,7 +29,7 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/transfers/{transferId}", requestOptions, options);
         }
 
-        public virtual IEnumerable<StripeTransfer> List(StripeTransferListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeTransfer> List(StripeTransferListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
             return GetEntityList($"{Urls.BaseUrl}/transfers", requestOptions, listOptions);
         }
@@ -52,7 +52,7 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/transfers/{transferId}", requestOptions, cancellationToken, options);
         }
 
-        public virtual Task<IEnumerable<StripeTransfer>> ListAsync(StripeTransferListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeTransfer>> ListAsync(StripeTransferListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return GetEntityListAsync($"{Urls.BaseUrl}/transfers", requestOptions, cancellationToken, listOptions);
         }


### PR DESCRIPTION
Extended the `StripeList` object to implement the `IEnumerable<T>` class.  It then routes the `GetEnumerator()`-method to that of the `Data`-attribute.  This should allow us to then modify the implementation to have it be "correct" without actually breaking any integrations.

cc: @fred-stripe + @remi-stripe - What do you think of this fix?  If you like it, we can just extend it to all of the `List()` methods.

Fixes #968 

