### PR TITLE
Update Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Stripe.net [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf?svg=true)](https://ci.appveyor.com/project/stripe-appveyor-ci/stripe-dotnet)
+# Stripe.net [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf?svg=true)](https://ci.appveyor.com/project/stripe-appveyor-ci/stripe-dotnet) [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
 
-Stripe.net is an officially supported library for .NET 4.5+ that provides convenient access to the Stripe API.
+The official Stripe library, supporting .NET Standard 1.2+, .NET Core 1.0+, and .NET Framework 4.5+
 
 ## Installation
 
@@ -8,9 +8,11 @@ Stripe.net is an officially supported library for .NET 4.5+ that provides conven
 
 From the command line:
 
-```
-nuget install Stripe.net
-```
+	nuget install Stripe.net
+
+From Package Manager:
+
+	PM> Install-Package EntryPoint
 
 From within Visual Studio:
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ From the command line:
 
 From Package Manager:
 
-	PM> Install-Package EntryPoint
+	PM> Install-Package Stripe.net
 
 From within Visual Studio:
 


### PR DESCRIPTION
* Include shield for access to the Nuget package page
* Update headline for brevity/professionalism, and to include the broader support for modern .NET platforms, which is not otherwise advertised (the main reason for this PR)
* Add Package Manager install guideline, which is the normal standard on almost every nuget package on github, though there's certainly nothing wrong with providing several examples!