### PR TITLE
Support shipping on Customer creation and update

### DIFF
--- a/src/Stripe.Tests.XUnit/charges/_cache.cs
+++ b/src/Stripe.Tests.XUnit/charges/_cache.cs
@@ -25,13 +25,15 @@ namespace Stripe.Tests.Xunit
                 Amount = 1000,
                 Currency = "usd",
                 SourceTokenOrExistingSourceId = "tok_visa",
-                Shipping = new StripeShippingOptions
+                Shipping = new StripeChargeShippingOptions
                 {
                     Name = "Namey Namerson",
                     Line1 = "123 Main St",
                     Line2 = "Apt B",
                     Country = "USA",
-                    State = "NC"
+                    State = "NC",
+                    TrackingNumber = "12345",
+                    Carrier = "Carrier",
                 }
             };
         }

--- a/src/Stripe.Tests.XUnit/charges/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/charges/_fixture.cs
@@ -37,6 +37,7 @@ namespace Stripe.Tests.Xunit
             };
 
             ChargeUpdateOptions.Shipping.Phone = "8675309";
+            ChargeUpdateOptions.Shipping.TrackingNumber = "56789";
 
             UpdatedCharge = service.Update(Charge.Id, ChargeUpdateOptions);
 

--- a/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
+++ b/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
@@ -57,6 +57,18 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void shipping_has_the_right_carrier()
+        {
+            fixture.Charge.Shipping.Carrier.Should().Be(Cache.GetStripeChargeCreateOptions().Shipping.Carrier);
+        }
+
+        [Fact]
+        public void shipping_has_the_right_tracking_number()
+        {
+            fixture.Charge.Shipping.TrackingNumber.Should().Be(Cache.GetStripeChargeCreateOptions().Shipping.TrackingNumber);
+        }
+
+        [Fact]
         public void updated_has_the_right_description()
         {
             fixture.UpdatedCharge.Description.Should().Be(fixture.ChargeUpdateOptions.Description);
@@ -66,6 +78,11 @@ namespace Stripe.Tests.Xunit
         public void updated_shipping_has_the_right_phone()
         {
             fixture.UpdatedCharge.Shipping.Phone.Should().Be(fixture.ChargeUpdateOptions.Shipping.Phone);
+        }
+
+        public void updated_shipping_has_the_right_tracking_number()
+        {
+            fixture.UpdatedCharge.Shipping.TrackingNumber.Should().Be(fixture.ChargeUpdateOptions.Shipping.TrackingNumber);
         }
 
         [Fact]
@@ -81,5 +98,6 @@ namespace Stripe.Tests.Xunit
             fixture.CapturedCharge.StatementDescriptor.Should().Be(fixture.ChargeCaptureOptions.StatementDescriptor);
             Assert.Equal(fixture.CapturedCharge.Amount - fixture.CapturedCharge.AmountRefunded, fixture.ChargeCaptureOptions.Amount);
         }
+
     }
 }

--- a/src/Stripe.Tests.XUnit/customers/_fixtures.cs
+++ b/src/Stripe.Tests.XUnit/customers/_fixtures.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Stripe.Tests.Xunit
+{
+    public class customers_fixture : IDisposable
+    {
+        public StripeCustomerCreateOptions CustomerCreateOptionsWithShipping { get; set; }
+        public StripeCustomerUpdateOptions CustomerUpdateOptionsWithShipping { get; set; }
+
+        public StripeCustomer CustomerWithShipping { get; set; }
+        public StripeCustomer UpdatedCustomerWithShipping { get; set; }
+
+        public customers_fixture()
+        {
+            CustomerCreateOptionsWithShipping = new StripeCustomerCreateOptions
+            {
+                Email = "createemail@example.com",
+                SourceToken = "tok_visa",
+                Shipping = new StripeShippingOptions
+                {
+                    Name = "Namey Namerson",
+                    Line1 = "123 Main St",
+                    Line2 = "Apt B",
+                    Country = "USA",
+                    State = "NC",
+                }
+            };
+
+            var service = new StripeCustomerService(Cache.ApiKey);
+            CustomerWithShipping = service.Create(CustomerCreateOptionsWithShipping);
+
+            CustomerUpdateOptionsWithShipping = new StripeCustomerUpdateOptions
+            {
+                Email = "updatedemail@example.com",
+                Shipping = CustomerCreateOptionsWithShipping.Shipping
+            };
+            CustomerUpdateOptionsWithShipping.Shipping.Phone = "8675309";
+
+            UpdatedCustomerWithShipping = service.Update(CustomerWithShipping.Id, CustomerUpdateOptionsWithShipping);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Stripe.Tests.XUnit/customers/creating_and_updating_customers.cs
+++ b/src/Stripe.Tests.XUnit/customers/creating_and_updating_customers.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_and_updating_customers : IClassFixture<customers_fixture>
+    {
+        private readonly customers_fixture fixture;
+
+        public creating_and_updating_customers(customers_fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void created_has_the_right_email()
+        {
+            fixture.CustomerWithShipping.Email.Should().Be(fixture.CustomerCreateOptionsWithShipping.Email);
+        }
+
+        [Fact]
+        public void shipping_is_not_null()
+        {
+            fixture.CustomerWithShipping.Shipping.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void shipping_has_the_right_name()
+        {
+            fixture.CustomerWithShipping.Shipping.Name.Should().Be(fixture.CustomerCreateOptionsWithShipping.Shipping.Name);
+        }
+
+        [Fact]
+        public void shipping_address_is_not_null()
+        {
+            fixture.CustomerWithShipping.Shipping.Address.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void shipping_has_the_right_line1()
+        {
+            fixture.CustomerWithShipping.Shipping.Address.Line1.Should().Be(fixture.CustomerCreateOptionsWithShipping.Shipping.Line1);
+        }
+
+        [Fact]
+        public void shipping_has_the_right_line2()
+        {
+            fixture.CustomerWithShipping.Shipping.Address.Line2.Should().Be(fixture.CustomerCreateOptionsWithShipping.Shipping.Line2);
+        }
+
+        [Fact]
+        public void shipping_has_the_right_country()
+        {
+            fixture.CustomerWithShipping.Shipping.Address.Country.Should().Be(fixture.CustomerCreateOptionsWithShipping.Shipping.Country);
+        }
+
+        [Fact]
+        public void shipping_has_the_right_state()
+        {
+            fixture.CustomerWithShipping.Shipping.Address.State.Should().Be(fixture.CustomerCreateOptionsWithShipping.Shipping.State);
+        }
+
+        [Fact]
+        public void updated_has_the_right_email()
+        {
+            fixture.UpdatedCustomerWithShipping.Email.Should().Be(fixture.CustomerUpdateOptionsWithShipping.Email);
+        }
+
+        [Fact]
+        public void updated_shipping_has_the_right_phone()
+        {
+            fixture.UpdatedCustomerWithShipping.Shipping.Phone.Should().Be(fixture.CustomerUpdateOptionsWithShipping.Shipping.Phone);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
@@ -76,7 +76,7 @@ namespace Stripe
         /// Shipping information for the charge. Helps prevent fraud on charges for physical goods. For more information, see the Charge object documentation.
         /// </summary>
         [JsonProperty("shipping")]
-        public StripeShippingOptions Shipping { get; set; }
+        public StripeChargeShippingOptions Shipping { get; set; }
 
         /// <summary>
         /// The ID of an existing customer that will be charged in this request.

--- a/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
@@ -21,6 +21,6 @@ namespace Stripe
         /// Shipping information for the charge. Helps prevent fraud on charges for physical goods. For more information, see the Charge object documentation.
         /// </summary>
         [JsonProperty("shipping")]
-        public StripeShippingOptions Shipping { get; set; }
+        public StripeChargeShippingOptions Shipping { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
@@ -31,6 +31,9 @@ namespace Stripe
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        [JsonProperty("shipping")]
+        public StripeShippingOptions Shipping { get; set; }
+
         [JsonProperty("source")]
         public string SourceToken { get; set; }
 

--- a/src/Stripe.net/Services/Customers/StripeCustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerUpdateOptions.cs
@@ -32,5 +32,8 @@ namespace Stripe
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("shipping")]
+        public StripeShippingOptions Shipping { get; set; }
     }
 }

--- a/src/Stripe.net/Services/StripeChargeShippingOptions.cs
+++ b/src/Stripe.net/Services/StripeChargeShippingOptions.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeChargeShippingOptions : StripeShippingOptions
+    {
+        [JsonProperty("shipping[carrier]")]
+        public string Carrier { get; set; }
+
+        [JsonProperty("shipping[tracking_number]")]
+        public string TrackingNumber { get; set; }
+    }
+}


### PR DESCRIPTION
The shipping hash is similar on Customer and Order and has more fields on the Charge resource. For this reason, we now have a common class called StripeShippingOptions and the Charge specific fields are added in a separate class called StripeChargeShippingOptions.

This also adds improved tests to ensure we test the extra fields for the `shipping` on Charge and that we test those fields properly on customer creation and update.

Fixes https://github.com/stripe/stripe-dotnet/issues/985