### PR TITLE
Changed single-use to single_use

### DIFF
--- a/src/Stripe.net/Constants/StripeSourceUsage.cs
+++ b/src/Stripe.net/Constants/StripeSourceUsage.cs
@@ -1,8 +1,8 @@
-﻿namespace Stripe
+namespace Stripe
 {
     public static class StripeSourceUsage
     {
         public const string Reusable = "reusable";
-        public const string SingleUse = "single-use";
+        public const string SingleUse = "single_use";
     }
 }


### PR DESCRIPTION
Looks like there's a typo in the Constants for Usage.