### PR TITLE
Added support for ephemeral key creation

### DIFF
--- a/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Stripe.Tests.Xunit
+{
+    public class ephemeral_keys_fixture : IDisposable
+    {
+        public StripeEphemeralKeyCreateOptions EphemeralKeyCreateOptions { get; set; }
+
+        public StripeEphemeralKey EphemeralKey { get; set; }
+        public StripeEphemeralKey EphemeralKeyDeleted { get; set; }
+        public StripeCustomer Customer { get; set; }
+
+        public ephemeral_keys_fixture()
+        {
+            Customer = Cache.GetCustomer();
+
+            var service = new StripeEphemeralKeyService(Cache.ApiKey);
+
+            EphemeralKeyCreateOptions = new StripeEphemeralKeyCreateOptions
+            {
+                CustomerId = Customer.Id,
+            };
+
+            var requestOptions = new StripeRequestOptions();
+            requestOptions.EphemeralKeyStripeVersion = "2017-05-25";
+
+            EphemeralKey = service.Create(EphemeralKeyCreateOptions, requestOptions);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
@@ -7,18 +7,16 @@ namespace Stripe.Tests.Xunit
         public StripeEphemeralKeyCreateOptions EphemeralKeyCreateOptions { get; set; }
 
         public StripeEphemeralKey EphemeralKey { get; set; }
-        public StripeEphemeralKey EphemeralKeyDeleted { get; set; }
-        public StripeCustomer Customer { get; set; }
 
         public ephemeral_keys_fixture()
         {
-            Customer = Cache.GetCustomer();
+            var customer = Cache.GetCustomer();
 
             var service = new StripeEphemeralKeyService(Cache.ApiKey);
 
             EphemeralKeyCreateOptions = new StripeEphemeralKeyCreateOptions
             {
-                CustomerId = Customer.Id,
+                CustomerId = customer.Id,
             };
 
             var requestOptions = new StripeRequestOptions();

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
@@ -20,7 +20,7 @@ namespace Stripe.Tests.Xunit
             };
 
             var requestOptions = new StripeRequestOptions();
-            requestOptions.EphemeralKeyStripeVersion = "2017-05-25";
+            requestOptions.StripeVersion = "2017-05-25";
 
             EphemeralKey = service.Create(EphemeralKeyCreateOptions, requestOptions);
         }

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/_fixture.cs
@@ -17,12 +17,10 @@ namespace Stripe.Tests.Xunit
             EphemeralKeyCreateOptions = new StripeEphemeralKeyCreateOptions
             {
                 CustomerId = customer.Id,
+                StripeVersion = "2017-05-25",
             };
 
-            var requestOptions = new StripeRequestOptions();
-            requestOptions.StripeVersion = "2017-05-25";
-
-            EphemeralKey = service.Create(EphemeralKeyCreateOptions, requestOptions);
+            EphemeralKey = service.Create(EphemeralKeyCreateOptions);
         }
 
         public void Dispose() { }

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
@@ -35,7 +35,7 @@ namespace Stripe.Tests.Xunit
         [Fact]
         public void created_has_the_response_json()
         {
-            fixture.EphemeralKey.StripeResponse.ResponseJson.Should().NotBeNull();
+            fixture.EphemeralKey.RawJson.Should().NotBeNull();
         }
     }
 }

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
@@ -15,9 +15,21 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
-        public void created_has_the_right_customer_id()
+        public void created_has_the_number_of_associated_objects()
         {
             fixture.EphemeralKey.AssociatedObjects.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void created_has_the_right_customer_id()
+        {
+            fixture.EphemeralKey.AssociatedObjects.First().Id.Should().Be(fixture.EphemeralKeyCreateOptions.CustomerId);
+        }
+
+        [Fact]
+        public void created_has_the_right_livemode()
+        {
+            fixture.EphemeralKey.LiveMode.Should().Be(false);
         }
     }
 }

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_and_deleting_ephemeral_keys : IClassFixture<ephemeral_keys_fixture>
+    {
+        private readonly ephemeral_keys_fixture fixture;
+
+        public creating_and_deleting_ephemeral_keys(ephemeral_keys_fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void created_has_the_right_customer_id()
+        {
+            fixture.EphemeralKey.AssociatedObjects.Count().Should().Be(1);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
@@ -31,5 +31,11 @@ namespace Stripe.Tests.Xunit
         {
             fixture.EphemeralKey.LiveMode.Should().Be(false);
         }
+
+        [Fact]
+        public void created_has_the_response_json()
+        {
+            fixture.EphemeralKey.StripeResponse.ResponseJson.Should().NotBeNull();
+        }
     }
 }

--- a/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
+++ b/src/Stripe.Tests.XUnit/ephemeral_keys/creating_and_deleting_ephemeral_keys.cs
@@ -37,5 +37,15 @@ namespace Stripe.Tests.Xunit
         {
             fixture.EphemeralKey.RawJson.Should().NotBeNull();
         }
+
+        [Fact]
+        public void throws_if_stripe_version_not_set()
+        {
+            var exception = Assert.Throws<System.ArgumentException>(() =>
+                new StripeEphemeralKeyService(Cache.ApiKey).Create(new StripeEphemeralKeyCreateOptions())
+            );
+
+            exception.Message.Should().Contain("The StripeVersion parameter has to be set when creating");
+        }
     }
 }

--- a/src/Stripe.net/Entities/StripeEphemeralKey.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralKey.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeEphemeralKey : StripeEntityWithId
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("expires")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Expires { get; set; }
+
+        [JsonProperty("associated_objects")]
+        public List<StripeEphemeralkeyAssociatedObject> AssociatedObjects { get; set; }
+
+        // figure out how to get the raw JSON.
+    }
+}

--- a/src/Stripe.net/Entities/StripeEphemeralKey.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralKey.cs
@@ -22,7 +22,7 @@ namespace Stripe
         public DateTime Expires { get; set; }
 
         [JsonProperty("associated_objects")]
-        public List<StripeEphemeralkeyAssociatedObject> AssociatedObjects { get; set; }
+        public List<StripeEphemeralKeyAssociatedObject> AssociatedObjects { get; set; }
 
         // figure out how to get the raw JSON.
     }

--- a/src/Stripe.net/Entities/StripeEphemeralKey.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralKey.cs
@@ -24,6 +24,12 @@ namespace Stripe
         [JsonProperty("associated_objects")]
         public List<StripeEphemeralKeyAssociatedObject> AssociatedObjects { get; set; }
 
-        // figure out how to get the raw JSON.
+        // RawJson is the raw JSON data of the response that was used to initialize this
+        // ephemeral key. When working with mobile clients that might only understand
+        // one version of the API you should prefer to send this value back to them so
+        // that they'll be able to decode an object that's current according to their version.
+        public string RawJson {
+            get { return this.StripeResponse?.ResponseJson; }
+        }
     }
 }

--- a/src/Stripe.net/Entities/StripeEphemeralkeyAssociatedObject.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralkeyAssociatedObject.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeEphemeralkeyAssociatedObject : StripeEntityWithId
+    public class StripeEphemeralKeyAssociatedObject : StripeEntityWithId
     {
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/StripeEphemeralkeyAssociatedObject.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralkeyAssociatedObject.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeEphemeralkeyAssociatedObject : StripeEntityWithId
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -152,8 +152,8 @@ namespace Stripe.Infrastructure
             if (requestOptions.IdempotencyKey != null)
                 request.Headers.Add("Idempotency-Key", requestOptions.IdempotencyKey);
 
-            if (requestOptions.EphemeralKeyStripeVersion != null)
-                request.Headers.Add("Stripe-Version", requestOptions.EphemeralKeyStripeVersion);
+            if (requestOptions.StripeVersion != null)
+                request.Headers.Add("Stripe-Version", requestOptions.StripeVersion);
             else
                 request.Headers.Add("Stripe-Version", StripeConfiguration.StripeApiVersion);
 

--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -152,7 +152,10 @@ namespace Stripe.Infrastructure
             if (requestOptions.IdempotencyKey != null)
                 request.Headers.Add("Idempotency-Key", requestOptions.IdempotencyKey);
 
-            request.Headers.Add("Stripe-Version", StripeConfiguration.StripeApiVersion);
+            if (requestOptions.EphemeralKeyStripeVersion != null)
+                request.Headers.Add("Stripe-Version", requestOptions.EphemeralKeyStripeVersion);
+            else
+                request.Headers.Add("Stripe-Version", StripeConfiguration.StripeApiVersion);
 
             var client = new Client(request);
             client.ApplyUserAgent();

--- a/src/Stripe.net/Infrastructure/Urls.cs
+++ b/src/Stripe.net/Infrastructure/Urls.cs
@@ -38,6 +38,8 @@
 
         public static string ApplicationFees => BaseUrl + "/application_fees";
 
+        public static string EphemeralKeys => BaseUrl + "/ephemeral_keys";
+
         public static string OAuthToken => BaseConnectUrl + "/oauth/token";
 
         public static string OAuthDeauthorize => BaseConnectUrl + "/oauth/deauthorize";

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeEphemeralKeyCreateOptions
+    {
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
@@ -10,6 +10,7 @@ namespace Stripe
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        [JsonIgnore]
         public string StripeVersion { get; set; }
     }
 }

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
@@ -9,5 +9,7 @@ namespace Stripe
     {
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
+
+        public string StripeVersion { get; set; }
     }
 }

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeEphemeralKeyService : StripeService
+    {
+        public StripeEphemeralKeyService(string apiKey = null) : base(apiKey) { }
+
+
+
+        //Sync
+        public virtual StripeEphemeralKey Create(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeEphemeralKey>.MapFromJson(
+                Requestor.PostString(this.ApplyAllParameters(createOptions, Urls.EphemeralKeys, false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
+        public virtual StripeDeleted Delete(string EphemeralKeyId, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeDeleted>.MapFromJson(
+                Requestor.Delete(this.ApplyAllParameters(null, $"{Urls.EphemeralKeys}/{EphemeralKeyId}", false),
+                SetupRequestOptions(requestOptions))
+            );
+        }
+
+
+
+        //Async
+        public virtual async Task<StripeEphemeralKey> CreateAsync(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeEphemeralKey>.MapFromJson(
+                await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.EphemeralKeys, false),
+                SetupRequestOptions(requestOptions),
+                cancellationToken)
+            );
+        }
+
+        public virtual async Task<StripeDeleted> DeleteAsync(string EphemeralKeyId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeDeleted>.MapFromJson(
+                await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.EphemeralKeys}/{EphemeralKeyId}", false),
+                SetupRequestOptions(requestOptions),
+                cancellationToken)
+            );
+        }
+    }
+}

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
@@ -5,48 +5,32 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeEphemeralKeyService : StripeService
+    public class StripeEphemeralKeyService : StripeBasicService<StripeEphemeralKey>
     {
         public StripeEphemeralKeyService(string apiKey = null) : base(apiKey) { }
 
-
-
-        //Sync
+        // Sync
         public virtual StripeEphemeralKey Create(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeEphemeralKey>.MapFromJson(
-                Requestor.PostString(this.ApplyAllParameters(createOptions, Urls.EphemeralKeys, false),
-                SetupRequestOptions(requestOptions))
-            );
+            return Post(Urls.EphemeralKeys, requestOptions, createOptions);
         }
 
-        public virtual StripeDeleted Delete(string EphemeralKeyId, StripeRequestOptions requestOptions = null)
+        public virtual StripeDeleted Delete(string keyId, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeDeleted>.MapFromJson(
-                Requestor.Delete(this.ApplyAllParameters(null, $"{Urls.EphemeralKeys}/{EphemeralKeyId}", false),
-                SetupRequestOptions(requestOptions))
-            );
+            return DeleteEntity($"{Urls.EphemeralKeys}/{keyId}", requestOptions);
         }
 
 
 
-        //Async
-        public virtual async Task<StripeEphemeralKey> CreateAsync(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        // Async
+        public virtual Task<StripeEphemeralKey> CreateAsync(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeEphemeralKey>.MapFromJson(
-                await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.EphemeralKeys, false),
-                SetupRequestOptions(requestOptions),
-                cancellationToken)
-            );
+            return PostAsync(Urls.EphemeralKeys, requestOptions, cancellationToken, createOptions);
         }
 
-        public virtual async Task<StripeDeleted> DeleteAsync(string EphemeralKeyId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeDeleted> DeleteAsync(string keyId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeDeleted>.MapFromJson(
-                await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.EphemeralKeys}/{EphemeralKeyId}", false),
-                SetupRequestOptions(requestOptions),
-                cancellationToken)
-            );
+            return DeleteEntityAsync($"{Urls.EphemeralKeys}/{keyId}", requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
@@ -12,6 +12,11 @@ namespace Stripe
         // Sync
         public virtual StripeEphemeralKey Create(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {
+            if (createOptions.StripeVersion == null)
+            {
+                throw new System.ArgumentException("The StripeVersion parameter has to be set when creating an Ephemeral Key", "StripeVersion");
+            }
+
             // Creating an ephemeral key requires a specific API version to be set. This is handled as a parameter
             // but has to be set on the StripeRequestOptions instead.
             requestOptions = requestOptions ?? new StripeRequestOptions();

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
@@ -14,9 +14,7 @@ namespace Stripe
         {
             // Creating an ephemeral key requires a specific API version to be set. This is handled as a parameter
             // but has to be set on the StripeRequestOptions instead.
-            if (requestOptions == null)
-                requestOptions = new StripeRequestOptions();
-
+            requestOptions = requestOptions ?? new StripeRequestOptions();
             requestOptions.StripeVersion = createOptions.StripeVersion;
 
             return Post(Urls.EphemeralKeys, requestOptions, createOptions);
@@ -34,9 +32,7 @@ namespace Stripe
         {
             // Creating an ephemeral key requires a specific API version to be set. This is handled as a parameter
             // but has to be set on the StripeRequestOptions instead.
-            if (requestOptions == null)
-                requestOptions = new StripeRequestOptions();
-
+            requestOptions = requestOptions ?? new StripeRequestOptions();
             requestOptions.StripeVersion = createOptions.StripeVersion;
 
             return PostAsync(Urls.EphemeralKeys, requestOptions, cancellationToken, createOptions);

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyService.cs
@@ -12,6 +12,13 @@ namespace Stripe
         // Sync
         public virtual StripeEphemeralKey Create(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {
+            // Creating an ephemeral key requires a specific API version to be set. This is handled as a parameter
+            // but has to be set on the StripeRequestOptions instead.
+            if (requestOptions == null)
+                requestOptions = new StripeRequestOptions();
+
+            requestOptions.StripeVersion = createOptions.StripeVersion;
+
             return Post(Urls.EphemeralKeys, requestOptions, createOptions);
         }
 
@@ -25,6 +32,13 @@ namespace Stripe
         // Async
         public virtual Task<StripeEphemeralKey> CreateAsync(StripeEphemeralKeyCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            // Creating an ephemeral key requires a specific API version to be set. This is handled as a parameter
+            // but has to be set on the StripeRequestOptions instead.
+            if (requestOptions == null)
+                requestOptions = new StripeRequestOptions();
+
+            requestOptions.StripeVersion = createOptions.StripeVersion;
+
             return PostAsync(Urls.EphemeralKeys, requestOptions, cancellationToken, createOptions);
         }
 

--- a/src/Stripe.net/Services/StripeRequestOptions.cs
+++ b/src/Stripe.net/Services/StripeRequestOptions.cs
@@ -5,5 +5,8 @@
         public string ApiKey { get; set; }
         public string StripeConnectAccountId { get; set; }
         public string IdempotencyKey { get; set; }
+        // This is used specifically for Ephemeral Keys as they have to be created
+        // with a specific API version. Don't use it for anything else.
+        public string EphemeralKeyStripeVersion { get; set; }
     }
 }

--- a/src/Stripe.net/Services/StripeRequestOptions.cs
+++ b/src/Stripe.net/Services/StripeRequestOptions.cs
@@ -7,6 +7,6 @@
         public string IdempotencyKey { get; set; }
         // This is used specifically for Ephemeral Keys as they have to be created
         // with a specific API version. Don't use it for anything else.
-        public string EphemeralKeyStripeVersion { get; set; }
+        internal string StripeVersion { get; set; }
     }
 }

--- a/src/Stripe.net/Services/StripeRequestOptions.cs
+++ b/src/Stripe.net/Services/StripeRequestOptions.cs
@@ -5,8 +5,10 @@
         public string ApiKey { get; set; }
         public string StripeConnectAccountId { get; set; }
         public string IdempotencyKey { get; set; }
+
         // This is used specifically for Ephemeral Keys as they have to be created
-        // with a specific API version. Don't use it for anything else.
+        // with a specific API version. It should not be used for anything else which
+        // is why it is set as internal.
         internal string StripeVersion { get; set; }
     }
 }


### PR DESCRIPTION
Ephemeral keys are used in the iOS SDK to edit details on a customer safely in the app without leaking the real Secret API key.

This PR adds support for those. Ephemeral Keys have to be created with a specific API version. The reason is that the raw JSON is sent to the mobile application where our mobile SDK will parse the JSON to be able to use the ephemeral key. Since our SDK will change/evolve over time, the SDK has to explicitly pass an API version so that they get the JSON in the format expected.

Our library only handles one API version though similarly to stripe-go. This needs to be handled so that an API version can be forced for ephemeral keys and nothing else.

For now, I did the quick/dirty version of passing `requestOptions.EphemeralKeyStripeVersion` to see what it would look like.

cc @grey-stripe as you built this for the other SDKs.
