### PR TITLE
Allow access to the StripeResponse on the StripeException resource

### DIFF
--- a/src/Stripe.net.Tests/charges/when_creating_a_charge_with_an_invalid_card.cs
+++ b/src/Stripe.net.Tests/charges/when_creating_a_charge_with_an_invalid_card.cs
@@ -21,6 +21,7 @@ namespace Stripe.Tests
             var exception = (StripeException) Catch.Exception(() => _stripeChargeService.Create(StripeChargeCreateOptions));
             exception.Message.ShouldNotBeNull();
             exception.StripeError.ChargeId.ShouldNotBeNull();
+            exception.StripeResponse.RequestId.ShouldNotBeNull();
         };
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeException.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeException.cs
@@ -7,6 +7,7 @@ namespace Stripe
     {
         public HttpStatusCode HttpStatusCode { get; set; }
         public StripeError StripeError { get; set; }
+        public StripeResponse StripeResponse { get; set; }
 
         public StripeException() 
         { 

--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -223,7 +223,10 @@ namespace Stripe.Infrastructure
                 ? Mapper<StripeError>.MapFromJson(responseContent, null, response) 
                 : Mapper<StripeError>.MapFromJson(responseContent, "error", response);
 
-            return new StripeException(statusCode, stripeError, stripeError.Message);
+            return new StripeException(statusCode, stripeError, stripeError.Message)
+            {
+                StripeResponse = response
+            };
         }
 
         private static StripeResponse BuildResponseData(HttpResponseMessage response, string responseText)


### PR DESCRIPTION
Adding this allows developers to see details about the request when getting and exception such as the Request Id (req_XXXXX).

This fixes https://github.com/stripe/stripe-dotnet/issues/1003

r? @brandur-stripe @fred-stripe 