### PR TITLE
Added support for updating a Card Source expiration date

### DIFF
--- a/src/Stripe.Tests.XUnit/sources/creating_and_updating_card_source.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_and_updating_card_source.cs
@@ -5,27 +5,52 @@ namespace Stripe.Tests.Xunit
 {
     public class creating_and_updating_card_source
     {
-        private StripeSource Source { get; set; }
+        public StripeSourceCreateOptions SourceCardCreateOptions { get; }
+        public StripeSourceUpdateOptions SourceCardUpdateOptions { get; }
+
+        public StripeSource SourceCard { get; }
+        public StripeSource SourceCardUpdated { get; }
 
         public creating_and_updating_card_source()
         {
-            var options = new StripeSourceCreateOptions
+            SourceCardCreateOptions = new StripeSourceCreateOptions
             {
                 Type = StripeSourceType.Card,
-                Amount = 100,
-                Currency = "usd",
-                Token = "tok_visa",
-                RedirectReturnUrl = "http://no.where/webhooks"
+                Token = "tok_visa"
             };
 
-            Source = new StripeSourceService(Cache.ApiKey).Create(options);
+            SourceCardUpdateOptions = new StripeSourceUpdateOptions
+            {
+                Card = new StripeSourceCardUpdateOptions
+                {
+                    ExpirationMonth = 12,
+                    ExpirationYear = 2028
+                }
+            };
+
+            var service = new StripeSourceService(Cache.ApiKey);
+            SourceCard = service.Create(SourceCardCreateOptions);
+            SourceCardUpdated = service.Update(SourceCard.Id, SourceCardUpdateOptions);
         }
 
         [Fact]
         public void source_should_not_be_null()
         {
-            Source.Should().NotBeNull();
-            Source.Card.Should().NotBeNull();
+            SourceCard.Should().NotBeNull();
+            SourceCard.Card.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void source_should_be_the_right_type()
+        {
+            SourceCard.Type.Should().Be(SourceCardCreateOptions.Type);
+        }
+
+        [Fact]
+        public void source_updated_should_have_the_correct_expiration_date()
+        {
+            SourceCard.Card.ExpirationMonth.Should().Be(SourceCardUpdateOptions.Card.ExpirationMonth);
+            SourceCard.Card.ExpirationYear.Should().Be(SourceCardUpdateOptions.Card.ExpirationYear);
         }
     }
 }

--- a/src/Stripe.net/Services/Sources/StripeSourceCardUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceCardUpdateOptions.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSourceCardUpdateOptions : INestedOptions
+    {
+        [JsonProperty("card[exp_month]")]
+        public int? ExpirationMonth { get; set; }
+
+        [JsonProperty("card[exp_year]")]
+        public int? ExpirationYear { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
@@ -17,5 +17,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("owner")]
         public StripeSourceOwner Owner { get; set; }
+
+        /// <summary>
+        /// Properties that can be updated on a Card Source.
+        /// </summary>
+        [JsonProperty("card")]
+        public StripeSourceCardUpdateOptions Card { get; set; }
     }
 }


### PR DESCRIPTION
You can now update a Card Source's expiration date via a new type. Also improved the Card Source tests.

r? @brandur-stripe @fred-stripe 