### PR TITLE
Always use Bearer auth

### DIFF
--- a/src/Stripe.net/Services/OAuth/StripeOAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/StripeOAuthTokenService.cs
@@ -14,7 +14,7 @@ namespace Stripe
         public virtual StripeOAuthToken Create(StripeOAuthTokenCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeOAuthToken>.MapFromJson(
-                Requestor.PostStringBearer(this.ApplyAllParameters(createOptions, Urls.OAuthToken, false),
+                Requestor.PostString(this.ApplyAllParameters(createOptions, Urls.OAuthToken, false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -35,7 +35,7 @@ namespace Stripe
         public virtual async Task<StripeOAuthToken> CreateAsync(StripeOAuthTokenCreateOptions createOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeOAuthToken>.MapFromJson(
-                await Requestor.PostStringBearerAsync(this.ApplyAllParameters(createOptions, Urls.OAuthToken, false),
+                await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.OAuthToken, false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );


### PR DESCRIPTION
r? @brandur-stripe @fred-stripe 
cc @stripe/api-libraries @remi-stripe 

In the wake of https://github.com/stripe/stripe-node/pull/379 and https://github.com/stripe/stripe-go/pull/447, I figured I'd also add Bearer auth support to the .NET library.

It turns out the library already supports Bearer auth, it just doesn't use it by default. I have checked our internal logs and over the past week, 100% of requests sent by the library used Basic auth, so I think it's safe to say that ~no one is using this feature at the moment.

~This PR simply switches the default value of the `useBearer` flag to `true` to enable Bearer auth by default.~

This PR removes support for Basic auth entirely and leaves Bearer auth as the only auth method.
