### PR TITLE
Add Id to StripeCustomerCreateOptions.

### DIFF
--- a/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
@@ -7,6 +7,9 @@ namespace Stripe
 {
     public class StripeCustomerCreateOptions
     {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
         [JsonProperty("account_balance")]
         public int? AccountBalance { get; set; }
 


### PR DESCRIPTION
Stripe allows us to specify a customer ID when creating customers. This option was missing from `StripeCustomerCreateOptions` prior to this PR.