### PR TITLE
Support the ability to pass custom parameters when capturing a charge

### DIFF
--- a/src/Stripe.Tests.XUnit/charges/_cache.cs
+++ b/src/Stripe.Tests.XUnit/charges/_cache.cs
@@ -10,6 +10,14 @@ namespace Stripe.Tests.Xunit
             return new StripeChargeService(apiKey).Create(GetStripeChargeCreateOptions());
         }
 
+        public static StripeCharge GetStripeChargeUncaptured(string apiKey)
+        {
+            var options = GetStripeChargeCreateOptions();
+            options.Capture = false;
+
+            return new StripeChargeService(apiKey).Create(options);
+        }
+
         public static StripeChargeCreateOptions GetStripeChargeCreateOptions()
         {
             return new StripeChargeCreateOptions

--- a/src/Stripe.Tests.XUnit/charges/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/charges/_fixture.cs
@@ -6,10 +6,13 @@ namespace Stripe.Tests.Xunit
     {
         public StripeChargeListOptions ChargeListOptions { get; set; }
         public StripeChargeUpdateOptions ChargeUpdateOptions { get; set; }
+        public StripeChargeCaptureOptions ChargeCaptureOptions { get; set; }
 
         public StripeCharge Charge { get; set; }
         public StripeList<StripeCharge> Charges { get; set; }
         public StripeCharge UpdatedCharge { get; set; }
+        public StripeCharge UncapturedCharge { get; set; }
+        public StripeCharge CapturedCharge { get; set; }
 
         public charges_fixture()
         {
@@ -36,6 +39,15 @@ namespace Stripe.Tests.Xunit
             ChargeUpdateOptions.Shipping.Phone = "8675309";
 
             UpdatedCharge = service.Update(Charge.Id, ChargeUpdateOptions);
+
+            UncapturedCharge = Cache.GetStripeChargeUncaptured(Cache.ApiKey);
+
+            ChargeCaptureOptions = new StripeChargeCaptureOptions
+            {
+                Amount = 123,
+                StatementDescriptor = "CapturedCharge"
+            };
+            CapturedCharge = service.Capture(UncapturedCharge.Id, ChargeCaptureOptions);
         }
 
         public void Dispose() { }

--- a/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
+++ b/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace Stripe.Tests.Xunit
 {
-    public class creating_and_updating_charges : IClassFixture<charges_fixture>
+    public class creating_updating_and_capturing_charges : IClassFixture<charges_fixture>
     {
         private readonly charges_fixture fixture;
 
-        public creating_and_updating_charges(charges_fixture fixture)
+        public creating_updating_and_capturing_charges(charges_fixture fixture)
         {
             this.fixture = fixture;
         }
@@ -66,6 +66,20 @@ namespace Stripe.Tests.Xunit
         public void updated_shipping_has_the_right_phone()
         {
             fixture.UpdatedCharge.Shipping.Phone.Should().Be(fixture.ChargeUpdateOptions.Shipping.Phone);
+        }
+
+        [Fact]
+        public void uncaptured_is_not_captured()
+        {
+            fixture.UncapturedCharge.Captured.Should().Be(false);
+        }
+
+        [Fact]
+        public void captured_is_captured_with_right_settings()
+        {
+            fixture.CapturedCharge.Captured.Should().Be(true);
+            fixture.CapturedCharge.StatementDescriptor.Should().Be(fixture.ChargeCaptureOptions.StatementDescriptor);
+            Assert.Equal(fixture.CapturedCharge.Amount - fixture.CapturedCharge.AmountRefunded, fixture.ChargeCaptureOptions.Amount);
         }
     }
 }

--- a/src/Stripe.net.Tests/charges/when_capturing_a_charge_with_a_card.cs
+++ b/src/Stripe.net.Tests/charges/when_capturing_a_charge_with_a_card.cs
@@ -19,7 +19,7 @@ namespace Stripe.Tests
         Because of = () =>
         {
             var charge = _stripeChargeService.Create(StripeChargeCreateOptions);
-            _stripeChargeService.Capture(charge.Id);
+            _stripeChargeService.Capture(charge.Id, null);
 
             StripeCharge = _stripeChargeService.Get(charge.Id);
         };

--- a/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeChargeCaptureOptions
+    {
+        /// <summary>
+        /// Amount to capture on the authorization
+        /// </summary>
+        [JsonProperty("amount")]
+        public int? Amount { get; set; }
+
+        /// <summary>
+        /// A fee in cents that will be applied to the charge and transferred to the application owner's Stripe account. To use an application fee, the request must be made on behalf of another account (using StripeRequestOptions available on all service methods), using the Stripe-Account header, an OAuth key, or the destination parameter. For more information, see the application fees documentation.
+        /// </summary>
+        [JsonProperty("application_fee")]
+        public int? ApplicationFee { get; set; }
+
+        /// <summary>
+        /// ID of an existing, connected stripe account.
+        /// </summary>
+        [JsonProperty("destination[account]")]
+        public string Destination { get; set; }
+
+        /// <summary>
+        /// The amount to transfer to the destination account without creating an Application Fee. Cannot be combined with the <see cref="ApplicationFee" /> parameter. Must be equal to or lesser than the charge amount.
+        /// </summary>
+        [JsonProperty("destination[amount]")]
+        public int? DestinationAmount { get; set; }
+
+        /// <summary>
+        /// Email address that will receive an email receipt confirming the transaction.
+        /// </summary>
+        [JsonProperty("receipt_email")]
+        public string ReceiptEmail { get; set; }
+
+        /// <summary>
+        /// An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. As an example, if your website is RunClub and the item you're charging for is a race ticket, you may want to specify a statement_descriptor of RunClub 5K race ticket. The statement description may not include <>"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Charges/StripeChargeService.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeService.cs
@@ -54,17 +54,10 @@ namespace Stripe
             );
         }
 
-        public virtual StripeCharge Capture(string chargeId, int? captureAmount = null, int? applicationFee = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeCharge Capture(string chargeId, StripeChargeCaptureOptions captureOptions, StripeRequestOptions requestOptions = null)
         {
-            var url = this.ApplyAllParameters(null, $"{Urls.Charges}/{chargeId}/capture", false);
-
-            if (captureAmount.HasValue)
-                url = ParameterBuilder.ApplyParameterToUrl(url, "amount", captureAmount.Value.ToString());
-            if (applicationFee.HasValue)
-                url = ParameterBuilder.ApplyParameterToUrl(url, "application_fee", applicationFee.Value.ToString());
-
             return Mapper<StripeCharge>.MapFromJson(
-                Requestor.PostString(url,
+                Requestor.PostString(this.ApplyAllParameters(captureOptions, $"{Urls.Charges}/{chargeId}/capture", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -108,17 +101,10 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<StripeCharge> CaptureAsync(string chargeId, int? captureAmount = null, int? applicationFee = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeCharge> CaptureAsync(string chargeId, StripeChargeCaptureOptions captureOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var url = this.ApplyAllParameters(null, $"{Urls.Charges}/{chargeId}/capture", false);
-
-            if (captureAmount.HasValue)
-                url = ParameterBuilder.ApplyParameterToUrl(url, "amount", captureAmount.Value.ToString());
-            if (applicationFee.HasValue)
-                url = ParameterBuilder.ApplyParameterToUrl(url, "application_fee", applicationFee.Value.ToString());
-
             return Mapper<StripeCharge>.MapFromJson(
-                await Requestor.PostStringAsync(url,
+                await Requestor.PostStringAsync(this.ApplyAllParameters(captureOptions, $"{Urls.Charges}/{chargeId}/capture", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );


### PR DESCRIPTION
This introduces a new resource, StripeChargeCaptureOptions. This also changes the signature of the Capture method. It moves away from a list of parameters and groups everything under a common resource as we do for other APIs such as the Pay Order one.

r? @brandur-stripe 

Fixes https://github.com/stripe/stripe-dotnet/issues/1017