### PR TITLE
Add support for SKU APIs

### DIFF
--- a/src/Stripe.Tests.XUnit/orders/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/orders/_fixture.cs
@@ -18,6 +18,22 @@ namespace Stripe.Tests.Xunit
 
         public orders_fixture()
         {
+            var productService = new StripeProductService(Cache.ApiKey);
+            var product = productService.Create(new StripeProductCreateOptions {
+                Name = "T-shirt",
+            });
+
+            var skuService = new StripeSkuService(Cache.ApiKey);
+            var sku = skuService.Create(new StripeSkuCreateOptions
+            {
+                Currency = "usd",
+                Inventory = new StripeInventoryOptions {
+                    Type = "infinite",
+                },
+                Price = 1234,
+                Product = product.Id
+            });
+
             OrderCreateOptions = new StripeOrderCreateOptions()
             {
                 Currency = "usd",
@@ -27,7 +43,7 @@ namespace Stripe.Tests.Xunit
                     {
                         Amount = 1,
                         Description = "Blue Shirts",
-                        Parent = "sku_stripe_net_test",  // TODO: Remove hardcoding
+                        Parent = sku.Id,
                         Quantity = 1
                     },
                 },

--- a/src/Stripe.Tests.XUnit/products/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/products/_fixture.cs
@@ -21,7 +21,13 @@ namespace Stripe.Tests.Xunit
         {
             ProductCreateOptions = new StripeProductCreateOptions
             {
-                Name = $"test-product-{ Guid.NewGuid() }"
+                Name = $"test-product-{ Guid.NewGuid() }",
+                PackageDimensions = new StripePackageDimensionOptions {
+                    Height = 100,
+                    Length = 100,
+                    Weight = 100,
+                    Width = 100,
+                }
             };
 
             ProductTwoCreateOptions = new StripeProductCreateOptions

--- a/src/Stripe.Tests.XUnit/products/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/products/_fixture.cs
@@ -53,6 +53,9 @@ namespace Stripe.Tests.Xunit
             };
 
             ProductList = service.List(ProductListOptions);
+
+            service.Delete(Product.Id);
+            service.Delete(ProductTwo.Id);
         }
     }
 }

--- a/src/Stripe.Tests.XUnit/products/creating_and_updating_products.cs
+++ b/src/Stripe.Tests.XUnit/products/creating_and_updating_products.cs
@@ -25,6 +25,15 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void created_has_right_package_dimensions()
+        {
+            fixture.Product.PackageDimensions.Height.Should().Be(fixture.ProductCreateOptions.PackageDimensions.Height);
+            fixture.Product.PackageDimensions.Length.Should().Be(fixture.ProductCreateOptions.PackageDimensions.Length);
+            fixture.Product.PackageDimensions.Weight.Should().Be(fixture.ProductCreateOptions.PackageDimensions.Weight);
+            fixture.Product.PackageDimensions.Width.Should().Be(fixture.ProductCreateOptions.PackageDimensions.Width);
+        }
+
+        [Fact]
         public void get_is_not_null()
         {
             fixture.ProductRetrieved.Should().NotBeNull();

--- a/src/Stripe.Tests.XUnit/skus/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/skus/_fixture.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stripe.Tests.Xunit
+{
+    public class skus_fixture
+    {
+        public StripeSkuCreateOptions SkuCreateOptions { get; }
+        public StripeSkuCreateOptions SkuTwoCreateOptions { get; }
+        public StripeSkuUpdateOptions SkuUpdateOptions { get; }
+
+        public StripeProduct Product { get; }
+        public StripeSku Sku { get; }
+        public StripeSku SkuTwo { get; }
+        public StripeSku SkuUpdated { get; }
+        public StripeSku SkuRetrieved { get; }
+        public StripeList<StripeSku> SkuList { get; }
+
+        public skus_fixture()
+        {
+            var productService = new StripeProductService(Cache.ApiKey);
+            Product = productService.Create(new StripeProductCreateOptions {
+                Name = "T-shirt",
+                Description = "stripe-dotnet product description",
+                Attributes = new string[] {"size", "color"},
+            });
+
+            SkuCreateOptions = new StripeSkuCreateOptions
+            {
+                Id = $"test-sku-{ Guid.NewGuid() }",
+                Attributes = new Dictionary<string, string>
+                {
+                    { "size", "medium" },
+                    { "color", "red" },
+                },
+                Currency = "usd",
+                Inventory = new StripeInventoryOptions {
+                    Quantity = 100,
+                    Type = "finite",
+                },
+                PackageDimensions = new StripePackageDimensionOptions {
+                    Height = 100,
+                    Length = 100,
+                    Weight = 100,
+                    Width = 100,
+                },
+                Price = 1234,
+                Product = Product.Id
+            };
+
+            SkuTwoCreateOptions = new StripeSkuCreateOptions
+            {
+                Id = $"test-sku-{ Guid.NewGuid() }",
+                Attributes = new Dictionary<string, string>
+                {
+                    { "size", "large" },
+                    { "color", "blue" },
+                },
+                Currency = "usd",
+                Inventory = new StripeInventoryOptions {
+                    Type = "infinite",
+                },
+                Price = 1345,
+                Product = Product.Id
+            };
+
+            SkuUpdateOptions = new StripeSkuUpdateOptions
+            {
+                Price = 9999,
+            };
+
+            var service = new StripeSkuService(Cache.ApiKey);
+            Sku = service.Create(SkuCreateOptions);
+            SkuTwo = service.Create(SkuTwoCreateOptions);
+            SkuUpdated = service.Update(Sku.Id, SkuUpdateOptions);
+            SkuRetrieved = service.Get(Sku.Id);
+
+            var SkuListOptions = new StripeSkuListOptions
+            {
+                Attributes = new Dictionary<string, string>
+                {
+                    { "size", "large" },
+                },
+                Product = Product.Id
+            };
+
+            SkuList = service.List(SkuListOptions);
+
+            service.Delete(Sku.Id);
+            service.Delete(SkuTwo.Id);
+            productService.Delete(Product.Id);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/skus/creating_and_updating_skus.cs
+++ b/src/Stripe.Tests.XUnit/skus/creating_and_updating_skus.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_and_updating_skus : IClassFixture<skus_fixture>
+    {
+        private readonly skus_fixture fixture;
+
+        public creating_and_updating_skus(skus_fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void created_is_not_null()
+        {
+            fixture.Sku.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void created_has_right_id()
+        {
+            fixture.Sku.Id.Should().Be(fixture.SkuCreateOptions.Id);
+        }
+
+        [Fact]
+        public void created_has_right_attributes()
+        {
+            fixture.Sku.Attributes.Should().Equal(fixture.SkuCreateOptions.Attributes);
+        }
+
+        [Fact]
+        public void created_has_right_inventory()
+        {
+            fixture.Sku.Inventory.Quantity.Should().Be(fixture.SkuCreateOptions.Inventory.Quantity);
+            fixture.Sku.Inventory.Type.Should().Be(fixture.SkuCreateOptions.Inventory.Type);
+        }
+
+        [Fact]
+        public void created_has_right_package_dimensions()
+        {
+            fixture.Sku.PackageDimensions.Height.Should().Be(fixture.SkuCreateOptions.PackageDimensions.Height);
+            fixture.Sku.PackageDimensions.Length.Should().Be(fixture.SkuCreateOptions.PackageDimensions.Length);
+            fixture.Sku.PackageDimensions.Weight.Should().Be(fixture.SkuCreateOptions.PackageDimensions.Weight);
+            fixture.Sku.PackageDimensions.Width.Should().Be(fixture.SkuCreateOptions.PackageDimensions.Width);
+        }
+
+        [Fact]
+        public void retrieved_has_the_correct_id()
+        {
+            fixture.SkuRetrieved.Id.Should().Be(fixture.Sku.Id);
+        }
+
+        [Fact]
+        public void updated_has_the_right_price()
+        {
+            fixture.SkuUpdated.Price.Should().Be(fixture.SkuUpdateOptions.Price);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/skus/when_listing_skus.cs
+++ b/src/Stripe.Tests.XUnit/skus/when_listing_skus.cs
@@ -1,0 +1,74 @@
+﻿using FluentAssertions;
+using Stripe.Tests.Xunit;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class when_listing_skus : IClassFixture<skus_fixture>
+    {
+        private readonly skus_fixture fixture;
+        StripeList<StripeSku> result;
+
+        public when_listing_skus(skus_fixture fixture)
+        {
+            this.fixture = fixture;
+            result = fixture.SkuList;
+        }
+
+
+        [Fact]
+        public void list_is_iterable()
+        {
+            var count = 0;
+            IEnumerable<StripeSku> enumerable = result as IEnumerable<StripeSku>;
+            foreach (var obj in enumerable)
+            {
+                count += 1;
+            }
+            Assert.Equal(result.ToList().Count > 0, true);
+            Assert.Equal(result.ToList().Count, count);
+
+        }
+
+        [Fact]
+        public void list_contents_equal()
+        {
+
+            var datahash = new HashSet<String>();
+            foreach (var obj in result.Data)
+            {
+                datahash.Add(obj.Id);
+            }
+
+            var enumhash = new HashSet<String>();
+            IEnumerable<StripeSku> enumerable = result as IEnumerable<StripeSku>;
+            foreach (var obj in enumerable)
+            {
+                enumhash.Add(obj.Id);
+            }
+
+            Assert.Equal(datahash, enumhash);
+
+        }
+
+        [Fact]
+        public void list_contains_extra_attributes()
+        {
+            Assert.NotNull(result.Object);
+            Assert.Equal(result.Object, "list");
+            Assert.NotNull(result.Data);
+            Assert.NotNull(result.Url);
+        }
+
+        [Fact]
+        public void list_has_the_expected_sku()
+        {
+            fixture.SkuList.Data.Count.Should().Be(1);
+            fixture.SkuList.Data.First().Id.Should().Be(fixture.SkuTwo.Id);
+            fixture.SkuList.Data.First().Product.Should().Be(fixture.Product.Id);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/DictionaryPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/DictionaryPlugin.cs
@@ -9,7 +9,7 @@ namespace Stripe.Infrastructure.Middleware
     {
         public bool Parse(ref string requestString, JsonPropertyAttribute attribute, PropertyInfo property, object propertyValue, object propertyParent)
         {
-            if (!attribute.PropertyName.Contains("metadata") && !attribute.PropertyName.Contains("fraud_details")) return false;
+            if (!attribute.PropertyName.Contains("metadata") && !attribute.PropertyName.Contains("fraud_details") && !attribute.PropertyName.Contains("attributes")) return false;
 
             var dictionary = (Dictionary<string, string>) propertyValue;
             if (dictionary == null) return true;

--- a/src/Stripe.net/Services/Products/StripePackageDimensionOptions.cs
+++ b/src/Stripe.net/Services/Products/StripePackageDimensionOptions.cs
@@ -3,18 +3,18 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripePackageDimensionOptions
+    public class StripePackageDimensionOptions : INestedOptions
     {
-        [JsonProperty("height")]
+        [JsonProperty("package_dimensions[height]")]
         public decimal? Height { get; set; }
 
-        [JsonProperty("length")]
+        [JsonProperty("package_dimensions[length]")]
         public decimal? Length { get; set; }
 
-        [JsonProperty("weight")]
+        [JsonProperty("package_dimensions[weight]")]
         public decimal? Weight { get; set; }
 
-        [JsonProperty("width")]
+        [JsonProperty("package_dimensions[width]")]
         public decimal? Width { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Skus/StripeInventoryOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeInventoryOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeInventoryOptions : INestedOptions
+    {
+        [JsonProperty("inventory[quantity]")]
+        public int? Quantity { get; set; }
+
+        [JsonProperty("inventory[type]")]
+        public string Type { get; set; }
+
+        [JsonProperty("inventory[value]")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Skus/StripeSkuCreateOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuCreateOptions.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSkuCreateOptions : StripeSkuSharedOptions
+    {
+        /// <summary>
+        /// The identifier for the SKU. Must be unique. If not provided, an identifier will be randomly generated.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Skus/StripeSkuListOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuListOptions.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Stripe
+{
+    public class StripeSkuListOptions : StripeListOptions
+    {
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        [JsonProperty("attributes")]
+        public Dictionary<string, string> Attributes { get; set; }
+
+        [JsonProperty("array:ids")]
+        public string[] Ids { get; set; }
+
+        [JsonProperty("in_stock")]
+        public bool? InStock { get; set; }
+
+        [JsonProperty("product")]
+        public string Product { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Skus/StripeSkuService.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuService.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeSkuService : StripeBasicService<StripeSku>
+    {
+        public StripeSkuService(string apiKey = null) : base(apiKey) { }
+
+
+
+        // Sync
+        public virtual StripeSku Create(StripeSkuCreateOptions options, StripeRequestOptions requestOptions = null)
+        {
+            return Post($"{Urls.BaseUrl}/skus", requestOptions, options);
+        }
+
+        public virtual StripeSku Get(string skuId, StripeRequestOptions requestOptions = null)
+        {
+            return GetEntity($"{Urls.BaseUrl}/skus/{skuId}", requestOptions);
+        }
+
+        public virtual StripeSku Update(string skuId, StripeSkuUpdateOptions options, StripeRequestOptions requestOptions = null)
+        {
+            return Post($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, options);
+        }
+
+        public virtual StripeList<StripeSku> List(StripeSkuListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            return GetEntityList($"{Urls.BaseUrl}/skus", requestOptions, listOptions);
+        }
+
+        public virtual StripeDeleted Delete(string skuId, StripeRequestOptions requestOptions = null)
+        {
+            return DeleteEntity($"{Urls.BaseUrl}/skus/{skuId}", requestOptions);
+        }
+
+
+
+        // Async
+        public virtual Task<StripeSku> CreateAsync(StripeSkuCreateOptions options, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PostAsync($"{Urls.BaseUrl}/skus", requestOptions, cancellationToken, options);
+        }
+
+        public virtual Task<StripeSku> GetAsync(string skuId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return GetEntityAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken);
+        }
+
+        public virtual Task<StripeSku> UpdateAsync(string skuId, StripeSkuUpdateOptions options, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PostAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken, options);
+        }
+
+        public virtual Task<StripeList<StripeSku>> ListAsync(StripeSkuListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return GetEntityListAsync($"{Urls.BaseUrl}/skus", requestOptions, cancellationToken, listOptions);
+        }
+
+        public virtual Task<StripeDeleted> DeleteAsync(string skuId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DeleteEntityAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Skus/StripeSkuSharedOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuSharedOptions.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public abstract class StripeSkuSharedOptions
+    {
+        /// <summary>
+        /// Whether or not the SKU is currently available for purchase. Defaults to true.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// A dictionary of attributes and values for the attributes defined by the product. If, for example, a product’s attributes are ["size", "gender"], a valid SKU has the following dictionary of attributes: {"size": "Medium", "gender": "Unisex"}.
+        /// This dictionary encoding is handled in a custom parser in DictionaryPlugin.cs
+        /// </summary>
+        [JsonProperty("attributes")]
+        public Dictionary<string, string> Attributes { get; set; }
+
+        /// <summary>
+        /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// The URL of an image for this SKU, meant to be displayable to the customer.
+        /// </summary>
+        [JsonProperty("image")]
+        public string image { get; set; }
+
+        /// <summary>
+        /// Description of the SKU’s inventory.
+        /// </summary>
+        [JsonProperty("inventory")]
+        public StripeInventoryOptions Inventory { get; set; }
+
+        /// <summary>
+        /// Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The dimensions of this SKU for shipping purposes.
+        /// </summary>
+        [JsonProperty("package_dimensions")]
+        public StripePackageDimensionOptions PackageDimensions { get; set; }
+
+        /// <summary>
+        /// The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a 0-decimal currency).
+        /// </summary>
+        [JsonProperty("price")]
+        public int Price { get; set; }
+
+        /// <summary>
+        /// The ID of the product this SKU is associated with. The product must be currently active.
+        /// </summary>
+        [JsonProperty("product")]
+        public string Product { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Skus/StripeSkuUpdateOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuUpdateOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Stripe
+{
+    public class StripeSkuUpdateOptions : StripeSkuSharedOptions
+    {
+    }
+}


### PR DESCRIPTION
This PR adds support for SKU APIs and fixes https://github.com/stripe/stripe-dotnet/issues/916 along with an encoding issue for the Product resource.

* Before this fix, the `package_dimensions` parameters were not encoded properly. Instead, we sent a string set to `Stripe.StripePackageDimensionOptions` instead of being a sub-hash with the expected value. The first commit fixes the issue by creating a dedicated class that inherits from `INestedOptions` and sends each parameter as the right sub-hash by forcing the name in `JsonProperty`.
* The product tests now also clean up after themselves at the end. This avoids filling up accounts with data we never use.
* Add support for creating and updating SKU with a shared resource
* Add support for inventory update via `INestedOptions`. This is required for the class to be encoded properly when sent to the API
* Add custom handler for `attributes` in the `DictionaryPlugin.cs`. This was used for `fraud_details` and `metadata` before. Since `attributes` is a dictionary on SKU, we need a custom parser to encode each property.
* Add test suite to ensure complex parameters such as `package_dimensions` are passed to the API and well tested.
* Removes hardcoded sku id in the test suite and dynamically create one now. This avoids manual changes to the library when testing locally. The corresponding product/sku can't be deleted as they are used in the order.

r? @brandur-stripe 