### PR TITLE
Support for attaching and detaching sources to/from customers

### DIFF
--- a/src/Stripe.Tests.XUnit/sources/attaching_and_detaching_sources.cs
+++ b/src/Stripe.Tests.XUnit/sources/attaching_and_detaching_sources.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class attaching_and_detaching_sources
+    {
+        public StripeCustomer Customer { get; }
+        public StripeSource SourceAttached { get; }
+        public StripeSource SourceDetached { get; }
+
+        public attaching_and_detaching_sources()
+        {
+            var SourceCardCreateOptions = new StripeSourceCreateOptions
+            {
+                Type = StripeSourceType.Card,
+                Token = "tok_visa"
+            };
+
+            var CustomerCreateOptions = new StripeCustomerCreateOptions
+            {
+                Email = "source-attach-detach@example.com",
+            };
+
+            var sourceService = new StripeSourceService(Cache.ApiKey);
+            var customerService = new StripeCustomerService(Cache.ApiKey);
+
+            var SourceCard = sourceService.Create(SourceCardCreateOptions);
+            Customer = customerService.Create(CustomerCreateOptions);
+
+            var SourceAttachOptions = new StripeSourceAttachOptions
+            {
+                Source = SourceCard.Id
+            };
+
+            SourceAttached = sourceService.Attach(Customer.Id, SourceAttachOptions);
+            SourceDetached = sourceService.Detach(Customer.Id, SourceAttached.Id);
+        }
+
+        [Fact]
+        public void source_attached_should_not_be_null()
+        {
+            SourceAttached.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void source_attached_should_have_the_correct_customer_id()
+        {
+            SourceAttached.Customer.Should().Be(Customer.Id);
+        }
+
+        [Fact]
+        public void source_detached_should_not_be_null()
+        {
+            SourceDetached.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void source_detached_should_not_have_a_customer_id()
+        {
+            SourceDetached.Customer.Should().BeNull();
+        }
+    }
+}

--- a/src/Stripe.net/Entities/Sources/StripeSource.cs
+++ b/src/Stripe.net/Entities/Sources/StripeSource.cs
@@ -42,6 +42,12 @@ namespace Stripe
         public string Currency { get; set; }
 
         /// <summary>
+        /// The customer to which the source is attached, if any.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+
+        /// <summary>
         /// The authentication flow of the source. Flow is one of redirect, receiver, code_verification, none.
         /// </summary>
         [JsonProperty("flow")]

--- a/src/Stripe.net/Services/Sources/StripeSourceAttachOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceAttachOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSourceAttachOptions
+    {
+        /// <summary>
+        /// REQUIRED: The identifier of the source to be attached.
+        /// </summary>
+        [JsonProperty("source")]
+        public string Source { get; set; }
+
+        [JsonProperty("validate")]
+        public bool? Validate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Sources/StripeSourceService.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceService.cs
@@ -26,11 +26,19 @@ namespace Stripe
             return Post($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, options);
         }
 
-        // not available :(
-        //public virtual StripeDeleted Delete(string sourceId, StripeRequestOptions requestOptions = null)
-        //{
-        //    return DeleteEntity($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions);
-        //}
+        public virtual StripeSource Attach(string customerId, StripeSourceAttachOptions attachOptions, StripeRequestOptions requestOptions = null)
+        {
+            return Post($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, attachOptions);
+        }
+
+        public virtual StripeSource Detach(string customerId, string sourceId, StripeRequestOptions requestOptions = null)
+        {
+            var url = $"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}";
+
+            return Mapper<StripeSource>.MapFromJson(
+                Requestor.Delete(url, SetupRequestOptions(requestOptions))
+            );
+        }
 
 
 
@@ -50,10 +58,20 @@ namespace Stripe
             return PostAsync($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, cancellationToken, options);
         }
 
-        // not available :(
-        //public virtual Task<StripeDeleted> DeleteAsync(string sourceId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        //{
-        //    return DeleteEntityAsync($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, cancellationToken);
-        //}
+        public virtual Task<StripeSource> AttachAsync(string customerId, StripeSourceAttachOptions options, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+        }
+
+        public virtual async Task<StripeSource> DetachAsync(string customerId, string sourceId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var url = $"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}";
+
+            return Mapper<StripeSource>.MapFromJson(
+                await Requestor.DeleteAsync(url, 
+                    SetupRequestOptions(requestOptions),
+                    cancellationToken)
+                );
+        }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe @will-stripe 

Adds support for attaching and detaching source objects to/from customer objects.

Attaching a source looks like this:

```csharp
var SourceAttachOptions = new StripeSourceAttachOptions
{
  Source = "src_..."
};

var sourceService = new StripeSourceService();
StripeSource SourceAttached = sourceService.Attach("cus_...", SourceAttachOptions);
```

Detaching a source looks like this:

```csharp
var sourceService = new StripeSourceService();
StripeSource SourceDetached = sourceService.Detach("cus_...", "src_...");
```
