### PR TITLE
Properly encode the resource id when sending those in the URL

### DIFF
--- a/src/Stripe.Tests.XUnit/coupons/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/coupons/_fixture.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Stripe.Tests.Xunit
+{
+    public class coupons_fixture : IDisposable
+    {
+        public StripeCouponCreateOptions CouponCreateOptions { get; set; }
+        public StripeCouponUpdateOptions CouponUpdateOptions { get; set; }
+
+        public StripeCoupon Coupon { get; set; }
+        public StripeCoupon CouponRetrieved { get; set; }
+        public StripeCoupon CouponUpdated { get; set; }
+        public StripeDeleted CouponDeleted { get; set; }
+        public StripeList<StripeCoupon> CouponsList { get; }
+
+        public coupons_fixture()
+        {
+            CouponCreateOptions = new StripeCouponCreateOptions() {
+              Id = "test-coupon-" + Guid.NewGuid().ToString(),
+              PercentOff = 25,
+              Duration = "repeating",
+              DurationInMonths = 3,
+            };
+
+            CouponUpdateOptions = new StripeCouponUpdateOptions {
+              Metadata = new Dictionary<string, string>{{"key_1", "value_1"}}
+            };
+
+            var service = new StripeCouponService(Cache.ApiKey);
+            Coupon = service.Create(CouponCreateOptions);
+            CouponRetrieved = service.Get(Coupon.Id);
+            CouponUpdated = service.Update(Coupon.Id, CouponUpdateOptions);
+            CouponsList = service.List();
+            CouponDeleted = service.Delete(Coupon.Id);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Stripe.Tests.XUnit/coupons/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/coupons/_fixture.cs
@@ -17,7 +17,7 @@ namespace Stripe.Tests.Xunit
         public coupons_fixture()
         {
             CouponCreateOptions = new StripeCouponCreateOptions() {
-              Id = "test-coupon-" + Guid.NewGuid().ToString(),
+              Id = "test-coupon-" + Guid.NewGuid().ToString() + " ",
               PercentOff = 25,
               Duration = "repeating",
               DurationInMonths = 3,

--- a/src/Stripe.Tests.XUnit/coupons/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/coupons/_fixture.cs
@@ -17,10 +17,12 @@ namespace Stripe.Tests.Xunit
         public coupons_fixture()
         {
             CouponCreateOptions = new StripeCouponCreateOptions() {
-              Id = "test-coupon-" + Guid.NewGuid().ToString() + " ",
-              PercentOff = 25,
-              Duration = "repeating",
-              DurationInMonths = 3,
+                // Add a space at the end to ensure the ID is properly URL encoded
+                // when passed in the URL for other methods
+                Id = "test-coupon-" + Guid.NewGuid().ToString() + " ",
+                PercentOff = 25,
+                Duration = "repeating",
+                DurationInMonths = 3,
             };
 
             CouponUpdateOptions = new StripeCouponUpdateOptions {

--- a/src/Stripe.Tests.XUnit/coupons/creating_and_updating_coupons.cs
+++ b/src/Stripe.Tests.XUnit/coupons/creating_and_updating_coupons.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_and_updating_coupons : IClassFixture<coupons_fixture>
+    {
+        private readonly coupons_fixture fixture;
+
+        public creating_and_updating_coupons(coupons_fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void created_has_the_right_details()
+        {
+            fixture.Coupon.Id.Should().Be(fixture.CouponCreateOptions.Id);
+            fixture.Coupon.PercentOff.Should().Be(fixture.CouponCreateOptions.PercentOff);
+            fixture.Coupon.Duration.Should().Be(fixture.CouponCreateOptions.Duration);
+            fixture.Coupon.DurationInMonths.Should().Be(fixture.CouponCreateOptions.DurationInMonths);
+        }
+
+        [Fact]
+        public void updated_has_the_right_defails()
+        {
+            fixture.CouponUpdated.Id.Should().Be(fixture.Coupon.Id);
+            fixture.CouponUpdated.Metadata.Keys.Should().BeEquivalentTo(fixture.CouponUpdateOptions.Metadata.Keys);
+        }
+
+        [Fact]
+        public void retrieved_has_the_right_id()
+        {
+            fixture.CouponRetrieved.Id.Should().Be(fixture.Coupon.Id);
+        }
+
+        [Fact]
+        public void deleted_has_the_right_details()
+        {
+            fixture.CouponDeleted.Id.Should().Be(fixture.Coupon.Id);
+            fixture.CouponDeleted.Deleted.Should().Be(true);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/coupons/creating_and_updating_coupons.cs
+++ b/src/Stripe.Tests.XUnit/coupons/creating_and_updating_coupons.cs
@@ -24,7 +24,7 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
-        public void updated_has_the_right_defails()
+        public void updated_has_the_right_details()
         {
             fixture.CouponUpdated.Id.Should().Be(fixture.Coupon.Id);
             fixture.CouponUpdated.Metadata.Keys.Should().BeEquivalentTo(fixture.CouponUpdateOptions.Metadata.Keys);

--- a/src/Stripe.Tests.XUnit/coupons/when_listing_coupons.cs
+++ b/src/Stripe.Tests.XUnit/coupons/when_listing_coupons.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Stripe.Tests.Xunit;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class when_listing_coupons : IClassFixture<coupons_fixture>
+    {
+        private readonly coupons_fixture fixture;
+        StripeList<StripeCoupon> result;
+
+        public when_listing_coupons(coupons_fixture fixture)
+        {
+            this.fixture = fixture;
+            result = fixture.CouponsList;
+        }
+
+
+        [Fact]
+        public void list_is_iterable()
+        {
+            var count = 0;
+            IEnumerable<StripeCoupon> enumerable = result as IEnumerable<StripeCoupon>;
+            foreach (var obj in enumerable)
+            {
+                count += 1;
+            }
+            Assert.Equal(result.ToList().Count > 0, true);
+            Assert.Equal(result.ToList().Count, count);
+
+        }
+
+        [Fact]
+        public void list_contents_equal()
+        {
+
+            var datahash = new HashSet<String>();
+            foreach (var obj in result.Data)
+            {
+                datahash.Add(obj.Id);
+            }
+
+            var enumhash = new HashSet<String>();
+            IEnumerable<StripeCoupon> enumerable = result as IEnumerable<StripeCoupon>;
+            foreach (var obj in enumerable)
+            {
+                enumhash.Add(obj.Id);
+            }
+
+            Assert.Equal(datahash, enumhash);
+        }
+
+
+        [Fact]
+        public void list_contains_extra_attributes()
+        {
+            Assert.NotNull(result.Object);
+            Assert.Equal(result.Object, "list");
+            Assert.NotNull(result.Data);
+            Assert.NotNull(result.Url);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/plans/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/plans/_fixture.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace Stripe.Tests.Xunit
+{
+    public class plans_fixture : IDisposable
+    {
+        public StripePlanCreateOptions PlanCreateOptions { get; set; }
+        public StripePlanUpdateOptions PlanUpdateOptions { get; set; }
+
+        public StripePlan Plan { get; set; }
+        public StripePlan PlanRetrieved { get; set; }
+        public StripePlan PlanUpdated { get; set; }
+        public StripeDeleted PlanDeleted { get; set; }
+        public StripeList<StripePlan> PlansList { get; }
+
+        public plans_fixture()
+        {
+            PlanCreateOptions = new StripePlanCreateOptions() {
+                // Add a space at the end to ensure the ID is properly URL encoded
+                // when passed in the URL for other methods
+                Id = "test-plan-" + Guid.NewGuid().ToString() + " ",
+                Name = "plan-name",
+                Amount = 5000,
+                Currency = "usd",
+                Interval = "month",
+            };
+
+            PlanUpdateOptions = new StripePlanUpdateOptions {
+              Name = "plan-name-2"
+            };
+
+            var service = new StripePlanService(Cache.ApiKey);
+            Plan = service.Create(PlanCreateOptions);
+            PlanRetrieved = service.Get(Plan.Id);
+            PlanUpdated = service.Update(Plan.Id, PlanUpdateOptions);
+            PlansList = service.List();
+            PlanDeleted = service.Delete(Plan.Id);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Stripe.Tests.XUnit/plans/when_creating_and_updating_plans.cs
+++ b/src/Stripe.Tests.XUnit/plans/when_creating_and_updating_plans.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_and_updating_plans : IClassFixture<plans_fixture>
+    {
+        private readonly plans_fixture fixture;
+
+        public creating_and_updating_plans(plans_fixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void created_has_the_right_details()
+        {
+            fixture.Plan.Id.Should().Be(fixture.PlanCreateOptions.Id);
+            fixture.Plan.Name.Should().Be(fixture.PlanCreateOptions.Name);
+            fixture.Plan.Amount.Should().Be(fixture.PlanCreateOptions.Amount);
+            fixture.Plan.Currency.Should().Be(fixture.PlanCreateOptions.Currency);
+            fixture.Plan.Interval.Should().Be(fixture.PlanCreateOptions.Interval);
+        }
+
+        [Fact]
+        public void updated_has_the_right_details()
+        {
+            fixture.PlanUpdated.Id.Should().Be(fixture.Plan.Id);
+            fixture.PlanUpdated.Name.Should().BeEquivalentTo(fixture.PlanUpdateOptions.Name);
+        }
+
+        [Fact]
+        public void retrieved_has_the_right_id()
+        {
+            fixture.PlanRetrieved.Id.Should().Be(fixture.Plan.Id);
+        }
+
+        [Fact]
+        public void deleted_has_the_right_details()
+        {
+            fixture.PlanDeleted.Id.Should().Be(fixture.Plan.Id);
+            fixture.PlanDeleted.Deleted.Should().Be(true);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Coupons/StripeCouponService.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponService.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
+using System.Net;
 
 namespace Stripe
 {
@@ -23,7 +24,7 @@ namespace Stripe
         public virtual StripeCoupon Update(string couponId, StripeCouponUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeCoupon>.MapFromJson(
-                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Coupons}/{couponId}", false),
+                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -31,7 +32,7 @@ namespace Stripe
         public virtual StripeCoupon Get(string couponId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeCoupon>.MapFromJson(
-                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Coupons}/{couponId}", false),
+                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -39,7 +40,7 @@ namespace Stripe
         public virtual StripeDeleted Delete(string couponId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                Requestor.Delete(this.ApplyAllParameters(null, $"{Urls.Coupons}/{couponId}", false),
+                Requestor.Delete(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }

--- a/src/Stripe.net/Services/Coupons/StripeCouponService.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponService.cs
@@ -68,7 +68,7 @@ namespace Stripe
         public virtual async Task<StripeCoupon> UpdateAsync(string couponId, StripeCouponUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeCoupon>.MapFromJson(
-                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Coupons}/{couponId}", false),
+                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
@@ -77,7 +77,7 @@ namespace Stripe
         public virtual async Task<StripeCoupon> GetAsync(string couponId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeCoupon>.MapFromJson(
-                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{couponId}", false),
+                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
@@ -86,7 +86,7 @@ namespace Stripe
         public virtual async Task<StripeDeleted> DeleteAsync(string couponId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{couponId}", false),
+                await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );

--- a/src/Stripe.net/Services/Plans/StripePlanService.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanService.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
+using System.Net;
 
 namespace Stripe
 {
@@ -23,7 +24,7 @@ namespace Stripe
         public virtual StripePlan Get(string planId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripePlan>.MapFromJson(
-                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Plans}/{planId}", false),
+                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -31,7 +32,7 @@ namespace Stripe
         public virtual StripeDeleted Delete(string planId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                Requestor.Delete($"{Urls.Plans}/{planId}",
+                Requestor.Delete($"{Urls.Plans}/{WebUtility.UrlEncode(planId)}",
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -39,7 +40,7 @@ namespace Stripe
         public virtual StripePlan Update(string planId, StripePlanUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripePlan>.MapFromJson(
-                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Plans}/{planId}", false),
+                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -67,7 +68,7 @@ namespace Stripe
         public virtual async Task<StripePlan> GetAsync(string planId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripePlan>.MapFromJson(
-                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Plans}/{planId}", false),
+                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
@@ -76,7 +77,7 @@ namespace Stripe
         public virtual async Task<StripeDeleted> DeleteAsync(string planId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                await Requestor.DeleteAsync($"{Urls.Plans}/{planId}",
+                await Requestor.DeleteAsync($"{Urls.Plans}/{WebUtility.UrlEncode(planId)}",
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );
@@ -85,7 +86,7 @@ namespace Stripe
         public virtual async Task<StripePlan> UpdateAsync(string planId, StripePlanUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripePlan>.MapFromJson(
-                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Plans}/{planId}", false),
+                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken)
             );


### PR DESCRIPTION
Most of our APIs pass a given object's id in the URL. For example to retrieve a coupon you use `GET /v1/coupons/COUPON_ID` and to delete a plan you use `DELETE /v1/plans/PLAN_ID`. At the moment though, the library passes the raw string directly in the URL instead of properly encoding it as we do in other libraries such as stripe-go [here](https://github.com/stripe/stripe-go/blob/master/coupon/client.go#L57).

Since the Plan and Coupon resources' ids can be chosen by the merchant, those have to be properly URL-encoded before being used. This PR fixes the issue for the Coupon and Plan resources after the bug report in https://github.com/stripe/stripe-dotnet/issues/1027.

This also adds tests for Plan and Coupon to the XUnit test suite.

This is likely a **breaking change** as users might have already fixed this in their own code by URL-encoding the id.