### PR TITLE
follow secure coding BP, fix (#993)

### DIFF
--- a/src/Stripe.Tests.XUnit/events/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/events/_fixture.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace Stripe.Tests.Xunit
+{
+    public class events_fixture
+    {
+        // this was sent in the header Stripe-Signature along with the body of event.json in a test webhook
+        internal string StripeSignature => "t=1493329224,v1=dca14f723dfa3bf47a310c3d6c3aff8bdb2534263d051dd2613ece097b8bdea4,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
+        internal string StripeJson { get; set; }
+        internal string StripeSecret => "whsec_H68eTX02a4bCbiQOOoSAsIytOvuWZrQC";
+
+        public events_fixture()
+        {
+            StripeJson = new StreamReader(
+                typeof(when_constructing_an_event).GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit.events.event.json"),
+                Encoding.UTF8
+            ).ReadToEnd();
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -1,46 +1,76 @@
-﻿using System.IO;
-using System.Reflection;
-using System.Text;
+﻿using System;
 using FluentAssertions;
 using Xunit;
 
 namespace Stripe.Tests.Xunit
 {
-    public class when_constructing_an_event
+    public class when_constructing_an_event : IClassFixture<events_fixture>
     {
-        // this was sent in the header Stripe-Signature along with the body of event.json in a test webhook
-        private static string StripeSignature => "t=1493329224,v1=dca14f723dfa3bf47a310c3d6c3aff8bdb2534263d051dd2613ece097b8bdea4,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
-        private static string StripeJson { get; set; }
-        private static string StripeSecret => "whsec_H68eTX02a4bCbiQOOoSAsIytOvuWZrQC";
-
+        private readonly events_fixture fixture;
         public StripeEvent ConstructedEvent { get; set; }
 
-        public when_constructing_an_event()
+        public when_constructing_an_event(events_fixture fixture)
         {
-            StripeJson = new StreamReader(
-                typeof(when_constructing_an_event).GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit.events.event.json"),
-                Encoding.UTF8
-            ).ReadToEnd();
+            this.fixture = fixture;
+        }
 
-            // this throws an error because the tolerance was higher than allowed
-            // ConstructedEvent = StripeEventUtility.ConstructEvent(StripeJson, StripeSignature, StripeSecret);
+        [Fact]
+        public void it_should_throw_with_outdated_timestamp()
+        {
+            // This throws an error because the tolerance is higher than allowed
+            var exception = Assert.Throws<Exception>(() =>
+                StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret)
+            );
 
-            // override the event utility from looking at utc now to 300 seconds in front of the timestamp in the header
-            StripeEventUtility.EpochUtcNowOverride = 1493329524;
-
-            ConstructedEvent = StripeEventUtility.ConstructEvent(StripeJson, StripeSignature, StripeSecret);
-
-            // this throws an error that the signature doesn't match one in the headers
-            //ConstructedEventBadJson = StripeEventUtility.ConstructEvent(StripeJson + "/n", StripeSignature, StripeSecret);
+            exception.Message.Should().Be("The webhook cannot be processed because the current timestamp is above the allowed tolerance.");
         }
 
         [Fact]
         public void it_should_validate_with_right_data()
         {
+            // Override the event utility to prevent it from looking at UTC now and use a fixed valid timestamp in the past
+            StripeEventUtility.EpochUtcNowOverride = 1493329524;
+
+            ConstructedEvent = StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret);
+
             ConstructedEvent.Should().NotBeNull();
             ConstructedEvent.Request.Id.Should().Be("req_FAKE");
             ConstructedEvent.Request.IdempotencyKey.Should().Be("placeholder");
             ConstructedEvent.Account.Should().Be("acct_CONNECT");
+
+            // Clean up to prevent unexpected behaviour in other facts
+            StripeEventUtility.EpochUtcNowOverride = null;
+        }
+
+        [Fact]
+        public void it_should_throw_with_incorrect_signature()
+        {
+            // This throws an error because the original JSON message is modified
+            var exception = Assert.Throws<Exception>(() =>
+                StripeEventUtility.ConstructEvent(fixture.StripeJson + "this_changes_the_json", fixture.StripeSignature, fixture.StripeSecret)
+            );
+
+            exception.Message.Should().Be("The signature for the webhook is not present in the Stripe-Signature header.");
+        }
+
+        [Fact]
+        public void it_should_throw_with_invalid_unicode_in_secret()
+        {
+            var exception = Assert.Throws<Exception>(() =>
+                StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret + "\ud802")
+            );
+
+            exception.Message.Should().Be("The webhook cannot be processed because the signature cannot be safely calculated.");
+        }
+
+        [Fact]
+        public void it_should_throw_with_invalid_unicode_in_message()
+        {
+            var exception = Assert.Throws<Exception>(() =>
+                StripeEventUtility.ConstructEvent(fixture.StripeJson + "\ud802", fixture.StripeSignature, fixture.StripeSecret)
+            );
+
+            exception.Message.Should().Be("The webhook cannot be processed because the signature cannot be safely calculated.");
         }
     }
 }


### PR DESCRIPTION
I created a fresh PR for #993. I am quite certain the changes shouldn't affect other tests so I am not sure why they are still failing because of a missing API key. 

The tests related to constructing the event are passing. Please let me know if there is anything I can do. Thanks.