### PR TITLE
Alphabetize fields

### DIFF
--- a/src/Stripe.net/Entities/Sources/StripeSource.cs
+++ b/src/Stripe.net/Entities/Sources/StripeSource.cs
@@ -53,9 +53,6 @@ namespace Stripe
         [JsonProperty("flow")]
         public string Flow { get; set; }
 
-        [JsonProperty("ideal")]
-        public StripeIdeal Ideal { get; set; }
-
         [JsonProperty("livemode")]
         public bool LiveMode { get; set; }
 
@@ -83,23 +80,7 @@ namespace Stripe
         [JsonProperty("redirect")]
         public StripeRedirect Redirect { get; set; }
 
-        [JsonProperty("bitcoin")]
-        public StripeBitcoin Bitcoin { get; set; }
-
-        [JsonProperty("bancontact")]
-        public StripeBancontact Bancontact { get; set; }
-
-        [JsonProperty("sepa_debit")]
-        public StripeSepaDebit SepaDebit { get; set; }
-
-        [JsonProperty("sofort")]
-        public StripeSofort Sofort { get; set; }
-
-        [JsonProperty("card")]
-        public StripeSourceCard Card { get; set; }
-
-        [JsonProperty("three_d_secure")]
-        public StripeThreeDSecure ThreeDSecure { get; set; }
+        // TODO: add statement_descriptor
 
         /// <summary>
         /// The status of the charge, one of canceled, chargeable, consumed, failed, or pending. Only chargeable source objects can be used to create a charge.
@@ -118,5 +99,28 @@ namespace Stripe
         /// </summary>
         [JsonProperty("usage")]
         public string Usage { get; set; }
+
+        // Type-specific attributes
+
+        [JsonProperty("bancontact")]
+        public StripeBancontact Bancontact { get; set; }
+
+        [JsonProperty("bitcoin")]
+        public StripeBitcoin Bitcoin { get; set; }
+
+        [JsonProperty("card")]
+        public StripeSourceCard Card { get; set; }
+
+        [JsonProperty("ideal")]
+        public StripeIdeal Ideal { get; set; }
+
+        [JsonProperty("sepa_debit")]
+        public StripeSepaDebit SepaDebit { get; set; }
+
+        [JsonProperty("sofort")]
+        public StripeSofort Sofort { get; set; }
+
+        [JsonProperty("three_d_secure")]
+        public StripeThreeDSecure ThreeDSecure { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeApplicationFee.cs
+++ b/src/Stripe.net/Entities/StripeApplicationFee.cs
@@ -9,9 +9,6 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
         #region Expandable Account
         public string AccountId { get; set; }
 
@@ -88,6 +85,9 @@ namespace Stripe
 
         [JsonProperty("currency")]
         public string Currency { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
 
         #region Expandable Originating Transaction
         public string OriginatingTransactionId { get; set; }

--- a/src/Stripe.net/Entities/StripeApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/StripeApplicationFeeRefund.cs
@@ -13,15 +13,15 @@ namespace Stripe
         [JsonProperty("amount")]
         public int Amount { get; set; }
 
+        [JsonProperty("balance_transaction")]
+        public string BalanceTransaction { get; set; }
+
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }
-
-        [JsonProperty("balance_transaction")]
-        public string BalanceTransaction { get; set; }
 
         [JsonProperty("fee")]
         public string Fee { get; set; }

--- a/src/Stripe.net/Entities/StripeBalance.cs
+++ b/src/Stripe.net/Entities/StripeBalance.cs
@@ -5,11 +5,13 @@ namespace Stripe
 {
     public class StripeBalance : StripeEntity
     {
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
         [JsonProperty("available")]
         public List<StripeBalanceAmount> Available { get; set; }
+
+        // TODO: add connect_reserved
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
 
         [JsonProperty("pending")]
         public List<StripeBalanceAmount> Pending { get; set; }

--- a/src/Stripe.net/Entities/StripeBalanceAmount.cs
+++ b/src/Stripe.net/Entities/StripeBalanceAmount.cs
@@ -9,5 +9,7 @@ namespace Stripe
 
         [JsonProperty("currency")]
         public string Currency { get; set; }
+
+        // TODO: add source_types
     }
  }

--- a/src/Stripe.net/Entities/StripeBalanceTransaction.cs
+++ b/src/Stripe.net/Entities/StripeBalanceTransaction.cs
@@ -24,6 +24,9 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
         [JsonProperty("fee")]
         public int Fee { get; set; }
 
@@ -32,15 +35,6 @@ namespace Stripe
 
         [JsonProperty("net")]
         public int Net { get; set; }
-
-        [JsonProperty("status")]
-        public string Status { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
 
         #region Expandable Source
         public string SourceId { get; set; }
@@ -57,5 +51,11 @@ namespace Stripe
             }
         }
         #endregion
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeBankAccount.cs
+++ b/src/Stripe.net/Entities/StripeBankAccount.cs
@@ -12,11 +12,14 @@ namespace Stripe
         [JsonProperty("account")]
         public string AccountId { get; set; }
 
+        [JsonProperty("account_holder_name")]
+        public string AccountHolderName { get; set; }
+
         [JsonProperty("account_holder_type")]
         public string AccountHolderType { get; set; }
 
-        [JsonProperty("account_holder_name")]
-        public string AccountHolderName { get; set; }
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
 
         [JsonProperty("country")]
         public string Country { get; set; }
@@ -30,22 +33,19 @@ namespace Stripe
         [JsonProperty("default_for_currency")]
         public bool DefaultForCurrency { get; set; }
 
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
         [JsonProperty("last4")]
         public string Last4 { get; set; }
-
-        [JsonProperty("status")]
-        public string Status { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        [JsonProperty("bank_name")]
-        public string BankName { get; set; }
-
-        [JsonProperty("fingerprint")]
-        public string Fingerprint { get; set; }
-
         [JsonProperty("routing_number")]
         public string RoutingNumber { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeCard.cs
+++ b/src/Stripe.net/Entities/StripeCard.cs
@@ -9,20 +9,21 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("brand")]
-        public string Brand { get; set; }
+        #region Expandable Account
+        public string AccountId { get; set; }
 
-        [JsonProperty("exp_month")]
-        public int ExpirationMonth { get; set; }
+        [JsonIgnore]
+        public StripeAccount Account { get; set; }
 
-        [JsonProperty("exp_year")]
-        public int ExpirationYear { get; set; }
-
-        [JsonProperty("funding")]
-        public string Funding { get; set; }
-
-        [JsonProperty("last4")]
-        public string Last4 { get; set; }
+        [JsonProperty("account")]
+        internal object InternalAccount
+        {
+            set
+            {
+                StringOrObject<StripeAccount>.Map(value, s => AccountId = s, o => Account = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("address_city")]
         public string AddressCity { get; set; }
@@ -51,45 +52,14 @@ namespace Stripe
         [JsonProperty("available_payout_methods")]
         public string[] AvailablePayoutMethods { get; set; }
 
+        [JsonProperty("brand")]
+        public string Brand { get; set; }
+
         [JsonProperty("country")]
         public string Country { get; set; }
 
-        [JsonProperty("cvc_check")]
-        public string CvcCheck { get; set; }
-
-        [JsonProperty("dynamic_last4")]
-        public string DynamicLast4 { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("three_d_secure")]
-        public string ThreeDSecure { get; set; }
-
-        [JsonProperty("tokenization_method")]
-        public string TokenizationMethod { get; set; }
-
-        [JsonProperty("fingerprint")]
-        public string Fingerprint { get; set; }
-
-        #region Expandable Recipient
-        public string RecipientId { get; set; }
-
-        [JsonIgnore]
-        public StripeRecipient Recipient { get; set; }
-
-        [JsonProperty("recipient")]
-        internal object InternalRecipient
-        {
-            set
-            {
-                StringOrObject<StripeRecipient>.Map(value, s => RecipientId = s, o => Recipient = o);
-            }
-        }
-        #endregion
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
 
         #region Expandable Customer
         public string CustomerId { get; set; }
@@ -107,26 +77,56 @@ namespace Stripe
         }
         #endregion
 
-        #region Expandable Account
-        public string AccountId { get; set; }
+        [JsonProperty("cvc_check")]
+        public string CvcCheck { get; set; }
+
+        [JsonProperty("default_for_currency")]
+        public bool DefaultForCurrency { get; set; }
+
+        [JsonProperty("dynamic_last4")]
+        public string DynamicLast4 { get; set; }
+
+        [JsonProperty("exp_month")]
+        public int ExpirationMonth { get; set; }
+
+        [JsonProperty("exp_year")]
+        public int ExpirationYear { get; set; }
+
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        [JsonProperty("funding")]
+        public string Funding { get; set; }
+
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        #region Expandable Recipient
+        public string RecipientId { get; set; }
 
         [JsonIgnore]
-        public StripeAccount Account { get; set; }
+        public StripeRecipient Recipient { get; set; }
 
-        [JsonProperty("account")]
-        internal object InternalAccount
+        [JsonProperty("recipient")]
+        internal object InternalRecipient
         {
             set
             {
-                StringOrObject<StripeAccount>.Map(value, s => AccountId = s, o => Account = o);
+                StringOrObject<StripeRecipient>.Map(value, s => RecipientId = s, o => Recipient = o);
             }
         }
         #endregion
 
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+        [JsonProperty("three_d_secure")]
+        public string ThreeDSecure { get; set; }
 
-        [JsonProperty("default_for_currency")]
-        public bool DefaultForCurrency { get; set; }
+        [JsonProperty("tokenization_method")]
+        public string TokenizationMethod { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeCharge.cs
+++ b/src/Stripe.net/Entities/StripeCharge.cs
@@ -22,7 +22,7 @@ namespace Stripe
         [JsonProperty("amount_refunded")]
         public int AmountRefunded { get; set; }
 
-        // application
+        // TODO: add application
 
         #region Expandable Application Fee
         public string ApplicationFeeId { get; set; }
@@ -118,7 +118,6 @@ namespace Stripe
             }
         }
         #endregion
-
 
         #region Expandable Dispute
         public string DisputeId { get; set; }

--- a/src/Stripe.net/Entities/StripeCoupon.cs
+++ b/src/Stripe.net/Entities/StripeCoupon.cs
@@ -10,24 +10,24 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
+        [JsonProperty("amount_off")]
+        public int? AmountOff { get; set; }
 
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
 
-        [JsonProperty("duration")]
-        public string Duration { get; set; }
-
-        [JsonProperty("amount_off")]
-        public int? AmountOff { get; set; }
-
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        [JsonProperty("duration")]
+        public string Duration { get; set; }
+
         [JsonProperty("duration_in_months")]
         public int? DurationInMonths { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
 
         [JsonProperty("max_redemptions")]
         public int? MaxRedemptions { get; set; }

--- a/src/Stripe.net/Entities/StripeCustomer.cs
+++ b/src/Stripe.net/Entities/StripeCustomer.cs
@@ -17,6 +17,12 @@ namespace Stripe
         public int AccountBalance { get; set; }
 
         /// <summary>
+        /// Warning: this is not in the documentation
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+        public StripeList<CustomerBankAccount> CustomerBankAccounts { get; set; }
+
+        /// <summary>
         /// The customer’s VAT identification number
         /// </summary>
         [JsonProperty("business_vat_id")]
@@ -25,12 +31,6 @@ namespace Stripe
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
-
-        /// <summary>
-        /// Warning: this is not in the documentation
-        /// </summary>
-        [JsonProperty("bank_accounts")]
-        public StripeList<CustomerBankAccount> CustomerBankAccounts { get; set; }
 
         /// <summary>
         /// The currency the customer can be charged in for recurring billing purposes
@@ -88,6 +88,12 @@ namespace Stripe
         public string DefaultSourceType { get; set; }
 
         /// <summary>
+        /// Warning: this is not in the documentation
+        /// </summary>
+        [JsonProperty("deleted")]
+        public bool? Deleted { get; set; }
+
+        /// <summary>
         /// Whether or not the latest charge for the customer’s latest invoice has failed
         /// </summary>
         [JsonProperty("delinquent")]
@@ -128,11 +134,5 @@ namespace Stripe
         /// </summary>
         [JsonProperty("subscriptions")]
         public StripeList<StripeSubscription> Subscriptions { get; set; }
-
-        /// <summary>
-        /// Warning: this is not in the documentation
-        /// </summary>
-        [JsonProperty("deleted")]
-        public bool? Deleted { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeDiscount.cs
+++ b/src/Stripe.net/Entities/StripeDiscount.cs
@@ -28,6 +28,14 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("end")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? End { get; set; }
+
+        [JsonProperty("start")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? Start { get; set; }
+
         #region Expandable Subscription
         public string SubscriptionId { get; set; }
 
@@ -43,13 +51,5 @@ namespace Stripe
             }
         }
         #endregion
-
-        [JsonProperty("start")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime? Start { get; set; }
-
-        [JsonProperty("end")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime? End { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeDispute.cs
+++ b/src/Stripe.net/Entities/StripeDispute.cs
@@ -10,11 +10,11 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
         [JsonProperty("amount")]
         public int? Amount { get; set; }
+
+        [JsonProperty("balance_transactions")]
+        public List<StripeBalanceTransaction> BalanceTransactions { get; set; }
 
         #region Expandable Charge
         public string ChargeId { get; set; }
@@ -39,15 +39,6 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        [JsonProperty("reason")]
-        public string Reason { get; set; }
-
-        [JsonProperty("status")]
-        public string Status { get; set; }
-
-        [JsonProperty("balance_transactions")]
-        public List<StripeBalanceTransaction> BalanceTransactions { get; set; }
-
         [JsonProperty("evidence")]
         public StripeEvidence Evidence { get; set; }
 
@@ -57,7 +48,16 @@ namespace Stripe
         [JsonProperty("is_charge_refundable")]
         public bool IsChargeRefundable { get; set; }
 
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeEphemeralKey.cs
+++ b/src/Stripe.net/Entities/StripeEphemeralKey.cs
@@ -10,17 +10,6 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
-        [JsonProperty("created")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime Created { get; set; }
-
-        [JsonProperty("expires")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime Expires { get; set; }
-
         [JsonProperty("associated_objects")]
         public List<StripeEphemeralKeyAssociatedObject> AssociatedObjects { get; set; }
 
@@ -31,5 +20,16 @@ namespace Stripe
         public string RawJson {
             get { return this.StripeResponse?.ResponseJson; }
         }
+
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("expires")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Expires { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -4,28 +4,32 @@ namespace Stripe
 {
     public class StripeError : StripeEntity
     {
-        [JsonProperty("type")]
-        public string ErrorType { get; set; }
+        // For regular API errors:
 
-        [JsonProperty("message")]
-        public string Message { get; set; }
+        [JsonProperty("charge")]
+        public string ChargeId { get; set; }
 
         [JsonProperty("code")]
         public string Code { get; set; }
 
+        [JsonProperty("decline_code")]
+        public string DeclineCode { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
         [JsonProperty("param")]
         public string Parameter { get; set; }
+
+        [JsonProperty("type")]
+        public string ErrorType { get; set; }
+
+        // For OAuth Errors:
 
         [JsonProperty("error")]
         public string Error { get; set; }
 
         [JsonProperty("error_description")]
         public string ErrorDescription { get; set; }
-
-        [JsonProperty("charge")]
-        public string ChargeId { get; set; }
-
-        [JsonProperty("decline_code")]
-        public string DeclineCode { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeEvent.cs
+++ b/src/Stripe.net/Entities/StripeEvent.cs
@@ -6,11 +6,12 @@ namespace Stripe
 {
     public class StripeEvent : StripeEntityWithId
     {
-        [JsonProperty("type")]
-        public string Type { get; set; }
+        // TODO: add object
 
         [JsonProperty("account")]
         public string Account { get; set; }
+
+        // TODO: add api_version
 
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
@@ -43,5 +44,8 @@ namespace Stripe
             }
         }
         #endregion
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeEventData.cs
+++ b/src/Stripe.net/Entities/StripeEventData.cs
@@ -4,10 +4,10 @@ namespace Stripe
 {
 	public class StripeEventData : StripeEntity
 	{
+        [JsonProperty("object")]
+        public dynamic Object { get; set; }
+
 		[JsonProperty("previous_attributes")]
 		public dynamic PreviousAttributes { get; set; }
-
-		[JsonProperty("object")]
-		public dynamic Object { get; set; }
 	}
 }

--- a/src/Stripe.net/Entities/StripeFee.cs
+++ b/src/Stripe.net/Entities/StripeFee.cs
@@ -7,16 +7,16 @@ namespace Stripe
         [JsonProperty("amount")]
         public int Amount { get; set; }
 
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
         [JsonProperty("application")]
         public string Application { get; set; }
 
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeFileUpload.cs
+++ b/src/Stripe.net/Entities/StripeFileUpload.cs
@@ -13,16 +13,16 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
 
-        [JsonProperty("size")]
-        public int Size { get; set; }
-
         [JsonProperty("purpose")]
         public string Purpose { get; set; }
 
-        [JsonProperty("Url")]
-        public string Url { get; set; }
+        [JsonProperty("size")]
+        public int Size { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("Url")] // TODO: should be "url"
+        public string Url { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeInvoice.cs
+++ b/src/Stripe.net/Entities/StripeInvoice.cs
@@ -10,11 +10,11 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
         [JsonProperty("amount_due")]
         public int AmountDue { get; set; }
+
+        [JsonProperty("application_fee")]
+        public int? ApplicationFee { get; set; }
 
         [JsonProperty("attempt_count")]
         public int AttemptCount { get; set; }
@@ -27,6 +27,22 @@ namespace Stripe
         /// </summary>
         [JsonProperty("billing")]
         public StripeBilling? Billing { get; set; }
+
+        #region Expandable Charge
+        public string ChargeId { get; set; }
+
+        [JsonIgnore]
+        public StripeCharge Charge { get; set; }
+
+        [JsonProperty("charge")]
+        internal object InternalCharge
+        {
+            set
+            {
+                StringOrObject<StripeCharge>.Map(value, s => ChargeId = s, o => Charge = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("closed")]
         public bool? Closed { get; set; }
@@ -54,6 +70,12 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime? Date { get; set; }
 
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("discount")]
+        public StripeDiscount StripeDiscount { get; set; }
+
         /// <summary>
         /// The date on which payment for this invoice is due. This value will be null for invoices where billing=charge_automatically.
         /// </summary>
@@ -61,11 +83,24 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime? DueDate { get; set; }
 
+        [JsonProperty("ending_balance")]
+        public int? EndingBalance { get; set; }
+
         [JsonProperty("forgiven")]
         public bool? Forgiven { get; set; }
 
         [JsonProperty("lines")]
         public StripeList<StripeInvoiceLineItem> StripeInvoiceLineItems { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("next_payment_attempt")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? NextPaymentAttempt { get; set; }
 
         /// <summary>
         /// A unique, identifying string that appears on emails sent to the customer for this invoice.
@@ -84,49 +119,11 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime PeriodStart { get; set; }
 
-        [JsonProperty("starting_balance")]
-        public int StartingBalance { get; set; }
-
-        [JsonProperty("subtotal")]
-        public int Subtotal { get; set; }
-
-        [JsonProperty("total")]
-        public int Total { get; set; }
-
-        [JsonProperty("application_fee")]
-        public int? ApplicationFee { get; set; }
-
-        #region Expandable Charge
-        public string ChargeId { get; set; }
-
-        [JsonIgnore]
-        public StripeCharge Charge { get; set; }
-
-        [JsonProperty("charge")]
-        internal object InternalCharge
-        {
-            set
-            {
-                StringOrObject<StripeCharge>.Map(value, s => ChargeId = s, o => Charge = o);
-            }
-        }
-        #endregion
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonProperty("discount")]
-        public StripeDiscount StripeDiscount { get; set; }
-
-        [JsonProperty("ending_balance")]
-        public int? EndingBalance { get; set; }
-
-        [JsonProperty("next_payment_attempt")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime? NextPaymentAttempt { get; set; }
-
         [JsonProperty("receipt_number")]
         public string ReceiptNumber { get; set; }
+
+        [JsonProperty("starting_balance")]
+        public int StartingBalance { get; set; }
 
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
@@ -134,17 +131,22 @@ namespace Stripe
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 
-        [JsonProperty("webhooks_delivered_at")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime? WebhooksDeliveredAt { get; set; }
+        // TODO: add subscription_proration_date
 
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
+        [JsonProperty("subtotal")]
+        public int Subtotal { get; set; }
 
         [JsonProperty("tax")]
         public int? Tax { get; set; }
 
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
+
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        [JsonProperty("webhooks_delivered_at")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? WebhooksDeliveredAt { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeInvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/StripeInvoiceLineItem.cs
@@ -10,9 +10,6 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
         [JsonProperty("amount")]
         public int Amount { get; set; }
 
@@ -39,14 +36,11 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Date { get; set; }
 
-        [JsonProperty("discountable")]
-        public bool Discountable { get; set; }
-
-        [JsonProperty("proration")]
-        public bool Proration { get; set; }
-
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        [JsonProperty("discountable")]
+        public bool Discountable { get; set; }
 
         #region Expandable Invoice
         public string InvoiceId { get; set; }
@@ -64,11 +58,20 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        [JsonProperty("period")]
+        public StripePeriod StripePeriod { get; set; }
+
         [JsonProperty("plan")]
         public StripePlan Plan { get; set; }
+
+        [JsonProperty("proration")]
+        public bool Proration { get; set; }
 
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
@@ -76,8 +79,7 @@ namespace Stripe
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 
-        [JsonProperty("period")]
-        public StripePeriod StripePeriod { get; set; }
+        // TODO: add subscription_item
 
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/StripeLegalEntity.cs
+++ b/src/Stripe.net/Entities/StripeLegalEntity.cs
@@ -62,6 +62,8 @@ namespace Stripe
         [JsonProperty("last_name_kanji")]
         public string LastNameKanji { get; set; }
 
+        // TODO: add maiden_name
+
         [JsonProperty("personal_address")]
         public StripeAddress PersonalAddress { get; set; }
 
@@ -74,8 +76,12 @@ namespace Stripe
         [JsonProperty("personal_id_number_provided")]
         public bool PersonalIdNumberProvided { get; set; }
 
+        // TODO: add phone_number
+
         [JsonProperty("ssn_last_4_provided")]
         public bool SocialSecurityNumberLastFourProvided { get; set; }
+
+        // TODO: add tax_id_registrar
 
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/StripeManagedAccountKeys.cs
+++ b/src/Stripe.net/Entities/StripeManagedAccountKeys.cs
@@ -4,10 +4,10 @@ namespace Stripe
 {
     public class StripeCustomAccountKeys : StripeEntity
     {
-        [JsonProperty("secret")]
-        public string Secret { get; set; }
-
         [JsonProperty("publishable")]
         public string Publishable { get; set; }
+
+        [JsonProperty("secret")]
+        public string Secret { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripePayout.cs
+++ b/src/Stripe.net/Entities/StripePayout.cs
@@ -34,6 +34,31 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        // TODO: add description
+
+        #region Expandable Destination
+        public string DestinationId { get; set; }
+
+        [JsonIgnore]
+        public Source Destination { get; set; }
+
+        [JsonProperty("destination")]
+        internal object InternalDestination
+        {
+            set
+            {
+                StringOrObject<Source>.Map(value, s => DestinationId = s, o => Destination = o);
+            }
+        }
+        #endregion
+
         #region Expandable Cancellation Balance Transaction
         /// <summary>
         /// If the payout failed or was canceled, this will be the ID of the balance transaction that reversed the initial balance transaction, and puts the funds from the failed payout back in your balance.
@@ -49,29 +74,6 @@ namespace Stripe
             set
             {
                 StringOrObject<StripeBalanceTransaction>.Map(value, s => FailureBalanceTransactionId = s, o => FailureBalanceTransaction = o);
-            }
-        }
-        #endregion
-
-        [JsonProperty("created")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime Created { get; set; }
-
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
-
-        #region Expandable Destination
-        public string DestinationId { get; set; }
-
-        [JsonIgnore]
-        public Source Destination { get; set; }
-
-        [JsonProperty("destination")]
-        internal object InternalDestination
-        {
-            set
-            {
-                StringOrObject<Source>.Map(value, s => DestinationId = s, o => Destination = o);
             }
         }
         #endregion

--- a/src/Stripe.net/Entities/StripePlan.cs
+++ b/src/Stripe.net/Entities/StripePlan.cs
@@ -7,18 +7,17 @@ namespace Stripe
 {
     public class StripePlan : StripeEntityWithId
     {
-        [JsonProperty("name")]
-        public string Name { get; set; }
+        // TODO: add object
 
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
+        [JsonProperty("amount")]
+        public int Amount { get; set; }
 
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
 
-        [JsonProperty("amount")]
-        public int Amount { get; set; }
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
 
         [JsonProperty("interval")]
         public string Interval { get; set; }
@@ -29,13 +28,16 @@ namespace Stripe
         [JsonProperty("livemode")]
         public bool LiveMode { get; set; }
 
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
         [JsonProperty("trial_period_days")]
         public int? TrialPeriodDays { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeRecipient.cs
+++ b/src/Stripe.net/Entities/StripeRecipient.cs
@@ -10,39 +10,15 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
-        [JsonProperty("created")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime Created { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
         [JsonProperty("active_account")]
         public StripeRecipientActiveAccount ActiveAccount { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonProperty("email")]
-        public string Email { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
-
-        [JsonProperty("migrated_to")]
-        public string MigratedTo { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
 
         [JsonProperty("cards")]
         public StripeList<StripeCard> StripeCardList { get; set; }
 
-        [JsonProperty("verified")]
-        public bool Verified { get; set; }
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
 
         #region Expandable Default Card
         public string StripeDefaultCardId { get; set; }
@@ -59,5 +35,31 @@ namespace Stripe
             }
         }
         #endregion
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("migrated_to")]
+        public string MigratedTo { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        // TODO: add rolled_back_from
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("verified")]
+        public bool Verified { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeRecipientActiveAccount.cs
+++ b/src/Stripe.net/Entities/StripeRecipientActiveAccount.cs
@@ -8,6 +8,9 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
         [JsonProperty("country")]
         public string Country { get; set; }
 
@@ -17,26 +20,23 @@ namespace Stripe
         [JsonProperty("default_for_currency")]
         public bool DefaultForCurrency { get; set; }
 
-        [JsonProperty("last4")]
-        public string Last4 { get; set; }
-
-        [JsonProperty("status")]
-        public string Status { get; set; }
-
-        [JsonProperty("bank_name")]
-        public string BankName { get; set; }
+        [JsonProperty("disabled")]
+        public bool? Disabled { get; set; }
 
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
 
-        [JsonProperty("routing_number")]
-        public string RoutingNumber { get; set; }
-
-        [JsonProperty("disabled")]
-        public bool? Disabled { get; set; }
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
 
         [JsonProperty("validated")]
         public bool? Validated { get; set; }

--- a/src/Stripe.net/Entities/StripeRefund.cs
+++ b/src/Stripe.net/Entities/StripeRefund.cs
@@ -13,13 +13,6 @@ namespace Stripe
         [JsonProperty("amount")]
         public int Amount { get; set; }
 
-        [JsonProperty("created")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime Created { get; set; }
-
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
-
         #region Expandable Balance Transaction
         public string BalanceTransactionId { get; set; }
 
@@ -52,6 +45,20 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        // TODO: add failure_balance_transaction
+
+        // TODO: add failure_reason
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -60,9 +67,6 @@ namespace Stripe
 
         [JsonProperty("receipt_number")]
         public string ReceiptNumber { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
 
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Entities/StripeSubscription.cs
+++ b/src/Stripe.net/Entities/StripeSubscription.cs
@@ -67,6 +67,11 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime? EndedAt { get; set; }
 
+        [JsonProperty("items")]
+        public StripeList<StripeSubscriptionItem> Items { get; set; }
+
+        // TODO: add livemode
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -82,9 +87,6 @@ namespace Stripe
 
         [JsonProperty("status")]
         public string Status { get; set; }
-
-        [JsonProperty("items")]
-        public StripeList<StripeSubscriptionItem> Items { get; set; }
 
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }

--- a/src/Stripe.net/Entities/StripeSubscriptionItem.cs
+++ b/src/Stripe.net/Entities/StripeSubscriptionItem.cs
@@ -14,13 +14,13 @@ namespace Stripe
         [JsonConverter(typeof(StripeDateTimeConverter))]
         public DateTime Created { get; set; }
 
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
         [JsonProperty("plan")]
         public StripePlan Plan { get; set; }
 
         [JsonProperty("quantity")]
         public int Quantity { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/StripeToken.cs
+++ b/src/Stripe.net/Entities/StripeToken.cs
@@ -9,19 +9,6 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("livemode")]
-        public bool LiveMode { get; set; }
-
-        [JsonProperty("created")]
-        [JsonConverter(typeof(StripeDateTimeConverter))]
-        public DateTime? Created { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
-        [JsonProperty("used")]
-        public bool? Used { get; set; }
-
         [JsonProperty("bank_account[id]")]
         public string BankAccountId { get; set; }
 
@@ -52,6 +39,22 @@ namespace Stripe
         [JsonProperty("card")]
         public StripeCard StripeCard { get; set; }
 
+        // TODO: add client_ip
+
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime? Created { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("used")]
+        public bool? Used { get; set; }
+
+        // TODO: remove
         [Obsolete("This property is not valid on tokens and will be removed in a later version.")]
         [JsonProperty("description")]
         public string Description { get; set; }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR reorders the field names on all entities to appear in the same order as in the API reference (e.g. `object` followed by the fields in alphabetical order).

To keep the PR simple, I haven't modified anything besides changing the order of the fields in the source, but I've added a few "TODO" comments to note fields that are currently missing and should be added.
