### PR TITLE
Improve parameter encoding

### DIFF
--- a/src/Stripe.Tests.XUnit/_infrastructure/encoding_parameters.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/encoding_parameters.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using FluentAssertions;
+using Xunit;
+using Stripe.Infrastructure;
+
+namespace Stripe.Tests.Xunit
+{
+    public class encoding_parameters
+    {
+        public class TestObject
+        {
+            [JsonProperty("an_int")]
+            public int? AnInt { get; set; }
+
+            [JsonProperty("a_string")]
+            public string AString { get; set; }
+
+            [JsonProperty("a_dict")]
+            public Dictionary<string, string> ADict { get; set; }
+
+            [JsonProperty("a_list")]
+            public int[] AList { get; set; }
+        }
+
+        public class UnencodableObject
+        {
+            [JsonProperty("dict_int_keys")]
+            public Dictionary<int, string> DictIntKeys { get; set; }
+
+            [JsonProperty("dict_int_values")]
+            public Dictionary<string, int> DictIntValues { get; set; }
+        }
+
+        public class TestService : StripeService
+        {
+            public TestService() : base(null)
+            {
+            }
+        }
+
+        public TestService Service { get; }
+
+        public encoding_parameters()
+        {
+            Service = new TestService();
+        }
+
+        [Fact]
+        public void parameters_should_be_encoded()
+        {
+            var obj = new TestObject
+            {
+                AnInt = 3,
+                AString = "+foo?",
+                ADict = new Dictionary<string, string>
+                {
+                    {"a", "A"},
+                    {"b", "B"},
+                },
+                AList = new int[] { 1, 2 },
+            };
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?an_int=3&a_string=%2Bfoo%3F&a_dict[a]=A&a_dict[b]=B&a_list[]=1&a_list[]=2");
+        }
+
+        [Fact]
+        public void empty_strings_should_be_encoded()
+        {
+            var obj = new TestObject
+            {
+                AString = "",
+            };
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?a_string=");
+        }
+
+        [Fact]
+        public void dictionary_keys_should_be_encoded()
+        {
+            var obj = new TestObject
+            {
+                ADict = new Dictionary<string, string>
+                {
+                    {"invoice #", "1234"},
+                },
+            };
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?a_dict[invoice+%23]=1234");
+        }
+
+        [Fact]
+        public void dictionary_values_should_be_encoded()
+        {
+            var obj = new TestObject
+            {
+                ADict = new Dictionary<string, string>
+                {
+                    {"invoice", "#1234"},
+                },
+            };
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?a_dict[invoice]=%231234");
+        }
+
+        [Fact]
+        public void throws_if_dictionary_keys_are_not_strings()
+        {
+            var obj = new UnencodableObject
+            {
+                DictIntKeys = new Dictionary<int, string>
+                {
+                    {1, "one"},
+                },
+            };
+
+            var exception = Assert.Throws<System.ArgumentException>(() =>
+                Service.ApplyAllParameters(obj, "", false)
+            );
+
+            exception.Message.Should().Contain("Expected System.String as dictionary key type");
+        }
+
+        [Fact]
+        public void throws_if_dictionary_values_are_not_strings()
+        {
+            var obj = new UnencodableObject
+            {
+                DictIntValues = new Dictionary<string, int>
+                {
+                    {"one", 1},
+                },
+            };
+
+            var exception = Assert.Throws<System.ArgumentException>(() =>
+                Service.ApplyAllParameters(obj, "", false)
+            );
+
+            exception.Message.Should().Contain("Expected System.String as dictionary value type");
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/products/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/products/_fixture.cs
@@ -27,7 +27,8 @@ namespace Stripe.Tests.Xunit
                     Length = 100,
                     Weight = 100,
                     Width = 100,
-                }
+                },
+                Attributes = new string[] { "color", "size" },
             };
 
             ProductTwoCreateOptions = new StripeProductCreateOptions

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/ArrayPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/ArrayPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -9,14 +10,14 @@ namespace Stripe.Infrastructure.Middleware
     {
         public bool Parse(ref string requestString, JsonPropertyAttribute attribute, PropertyInfo property, object propertyValue, object propertyParent)
         {
-            if (!attribute.PropertyName.Contains("array:")) return false;
+            // Check if the property is an array
+            var type = property.PropertyType;
+            if (!type.GetTypeInfo().IsArray) return false;
 
             var values = ((IEnumerable) propertyValue).Cast<object>().Select(x => x.ToString()).ToArray();
 
-            var key = attribute.PropertyName.Replace("array:", "") + "[]";
-            
             foreach (var value in values)
-                RequestStringBuilder.ApplyParameterToRequestString(ref requestString, key, value);
+                RequestStringBuilder.ApplyParameterToRequestString(ref requestString, $"{attribute.PropertyName}[]", value);
 
             return true;
         }

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/DictionaryPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/DictionaryPlugin.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using Newtonsoft.Json;
 
@@ -9,13 +10,25 @@ namespace Stripe.Infrastructure.Middleware
     {
         public bool Parse(ref string requestString, JsonPropertyAttribute attribute, PropertyInfo property, object propertyValue, object propertyParent)
         {
-            if (!attribute.PropertyName.Contains("metadata") && !attribute.PropertyName.Contains("fraud_details") && !attribute.PropertyName.Contains("attributes")) return false;
+            // Check if the property is a Dictionary
+            var type = property.PropertyType;
+            if (!type.GetTypeInfo().IsGenericType) return false;
+            if (type.GetTypeInfo().GetGenericTypeDefinition() != typeof(Dictionary<,>)) return false;
+
+            // Ensure that key and value types are both string
+            var keyType = type.GetTypeInfo().GenericTypeArguments[0];
+            if (keyType != typeof(string))
+                throw new System.ArgumentException($"Expected {typeof(string).ToString()} as dictionary key type, got {keyType.ToString()}");
+
+            var valueType = type.GetTypeInfo().GenericTypeArguments[1];
+            if (valueType != typeof(string))
+                throw new System.ArgumentException($"Expected {typeof(string).ToString()} as dictionary value type, got {valueType.ToString()}");
 
             var dictionary = (Dictionary<string, string>) propertyValue;
             if (dictionary == null) return true;
 
             foreach (var key in dictionary.Keys)
-                RequestStringBuilder.ApplyParameterToRequestString(ref requestString, $"{attribute.PropertyName}[{key}]", dictionary[key]);
+                RequestStringBuilder.ApplyParameterToRequestString(ref requestString, $"{attribute.PropertyName}[{WebUtility.UrlEncode(key)}]", dictionary[key]);
 
             return true;
         }

--- a/src/Stripe.net/Services/Orders/StripeOrderListOptions.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderListOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
         /// <summary>
         /// Only return orders with the given IDs.
         /// </summary>
-        [JsonProperty("array:ids")]
+        [JsonProperty("ids")]
         public string[] Ids { get; set; }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Stripe
         /// <summary>
         /// Only return orders with the given upstream order IDs.
         /// </summary>
-        [JsonProperty("array:upstream_ids")]
+        [JsonProperty("upstream_ids")]
         public string[] UpstreamIds { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Products/StripeProductListOptions.cs
+++ b/src/Stripe.net/Services/Products/StripeProductListOptions.cs
@@ -7,7 +7,7 @@ namespace Stripe
         [JsonProperty("active")]
         public bool? Active { get; set; }
 
-        [JsonProperty("array:ids")]
+        [JsonProperty("ids")]
         public string[] Ids { get; set; }
 
         [JsonProperty("shippable")]

--- a/src/Stripe.net/Services/Products/StripeProductSharedOptions.cs
+++ b/src/Stripe.net/Services/Products/StripeProductSharedOptions.cs
@@ -14,7 +14,7 @@ namespace Stripe
         /// <summary>
         /// A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g. ["color", "size"]).
         /// </summary>
-        [JsonProperty("array:attributes")]
+        [JsonProperty("attributes")]
         public string[] Attributes { get; set; }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Stripe
         /// <summary>
         /// An array of Connect application names or identifiers that should not be able to order the SKUs for this product.
         /// </summary>
-        [JsonProperty("array:deactivate_on")]
+        [JsonProperty("deactivate_on")]
         public string[] DeactivateOn { get; set; }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Stripe
         /// <summary>
         /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
         /// </summary>
-        [JsonProperty("array:images")]
+        [JsonProperty("images")]
         public string[] Images { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Services/Skus/StripeSkuListOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuListOptions.cs
@@ -11,7 +11,7 @@ namespace Stripe
         [JsonProperty("attributes")]
         public Dictionary<string, string> Attributes { get; set; }
 
-        [JsonProperty("array:ids")]
+        [JsonProperty("ids")]
         public string[] Ids { get; set; }
 
         [JsonProperty("in_stock")]


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #1042.

This PR adds general improvements to parameter encoding:

- dictionary keys are now properly URL-encoded

- all dictionaries are now automatically correctly encoded (got rid of the special-casing based on parameter names in `DictionaryPlugin`)

- all arrays are now automatically correctly encoded (got rid of the special-casing based on prefixing the parameter names with `array:`)

- added some tests
