### PR TITLE
Support for ACH Credit Transfer and source_transactions

### DIFF
--- a/src/Stripe.Tests.XUnit/sources/creating_ach_credit_transfer_sources_and_listing_transactions.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_ach_credit_transfer_sources_and_listing_transactions.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_ach_credit_transfers_sources_and_listing_transactions
+    {
+        public StripeSource Source { get; }
+        public StripeList<StripeSourceTransaction> Transactions { get; }
+
+        public creating_ach_credit_transfers_sources_and_listing_transactions()
+        {
+            var SourceCreateOptions = new StripeSourceCreateOptions
+            {
+                Type = StripeSourceType.AchCreditTransfer,
+                Currency = "usd",
+                Owner = new StripeSourceOwner
+                {
+                    Email = "amount_4242@example.com"
+                }
+            };
+
+            var sourceService = new StripeSourceService(Cache.ApiKey);
+            var sourceTransactionService = new StripeSourceTransactionService(Cache.ApiKey);
+
+            Source = sourceService.Create(SourceCreateOptions);
+            Transactions = sourceTransactionService.List(Source.Id);
+        }
+
+        [Fact]
+        public void source_is_not_null()
+        {
+            Source.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void source_has_correct_type()
+        {
+            Source.Type.Should().Be(StripeSourceType.AchCreditTransfer);
+        }
+
+        [Fact]
+        public void transactions_is_not_null()
+        {
+            Transactions.Should().NotBeNull();
+        }
+    }
+}

--- a/src/Stripe.net/Constants/StripeSourceType.cs
+++ b/src/Stripe.net/Constants/StripeSourceType.cs
@@ -2,6 +2,7 @@
 {
     public static class StripeSourceType
     {
+        public const string AchCreditTransfer = "ach_credit_transfer";
         public const string Bancontact = "bancontact";
         public const string Bitcoin = "bitcoin";
         public const string Card = "card";

--- a/src/Stripe.net/Entities/SourceTransactions/StripeSourceTransaction.cs
+++ b/src/Stripe.net/Entities/SourceTransactions/StripeSourceTransaction.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeSourceTransaction : StripeEntityWithId
+    {
+        [JsonProperty("object")]
+        public string Object => "source_transaction";
+
+        [JsonProperty("amount")]
+        public int? Amount { get; set; }
+
+        [JsonProperty("created")]
+        [JsonConverter(typeof(StripeDateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("customer_data")]
+        public string CustomerData { get; set; }
+
+        [JsonProperty("livemode")]
+        public bool LiveMode { get; set; }
+
+        [JsonProperty("source")]
+        public string Source { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("ach_credit_transfer")]
+        public StripeSourceTransactionAchCreditTransfer AchCreditTransfer { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SourceTransactions/StripeSourceTransactionAchCreditTransfer.cs
+++ b/src/Stripe.net/Entities/SourceTransactions/StripeSourceTransactionAchCreditTransfer.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSourceTransactionAchCreditTransfer : StripeEntity
+    {
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Sources/StripeSource.cs
+++ b/src/Stripe.net/Entities/Sources/StripeSource.cs
@@ -106,6 +106,9 @@ namespace Stripe
 
         // Type-specific attributes
 
+        [JsonProperty("ach_credit_transfer")]
+        public StripeSourceAchCreditTransfer AchCreditTransfer { get; set; }
+
         [JsonProperty("bancontact")]
         public StripeBancontact Bancontact { get; set; }
 

--- a/src/Stripe.net/Entities/Sources/StripeSourceAchCreditTransfer.cs
+++ b/src/Stripe.net/Entities/Sources/StripeSourceAchCreditTransfer.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeSourceAchCreditTransfer : StripeEntity
+    {
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+
+        [JsonProperty("swift_code")]
+        public string SwiftCode { get; set; }
+    }
+} 

--- a/src/Stripe.net/Services/SourceTransactions/StripeSourceTransactionListOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/StripeSourceTransactionListOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class StripeSourceTransactionsListOptions : StripeListOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SourceTransactions/StripeSourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/StripeSourceTransactionService.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeSourceTransactionService : StripeBasicService<StripeSourceTransaction>
+    {
+        public StripeSourceTransactionService(string apiKey = null) : base(apiKey) { }
+
+
+
+        // Sync
+        public virtual StripeList<StripeSourceTransaction> List(string sourceId, StripeSourceTransactionsListOptions options = null, StripeRequestOptions requestOptions = null)
+        {
+            return GetEntityList($"{Urls.BaseUrl}/sources/{sourceId}/source_transactions", requestOptions, options);
+        }
+
+
+
+        // Async
+        public virtual Task<StripeList<StripeSourceTransaction>> ListAsync(string sourceId, StripeSourceTransactionsListOptions options = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return GetEntityListAsync($"{Urls.BaseUrl}/sources/{sourceId}/source_transactions", requestOptions, cancellationToken, options);
+        }
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe 

Adds support for `ach_credit_transfer` sources as well as for the `/v1/sources/src_.../source_transactions` endpoint.
