### PR TITLE
Add support for /v1/exchange_rates API requests

### DIFF
--- a/src/Stripe.Tests.XUnit/exchange_rates/when_getting_exchange_rates.cs
+++ b/src/Stripe.Tests.XUnit/exchange_rates/when_getting_exchange_rates.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Stripe.Tests.Xunit;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Stripe.Tests.XUnit
+{
+    public class when_getting_exchange_rates
+    {
+        StripeExchangeRates result;
+
+        public when_getting_exchange_rates()
+        {
+            result = new StripeExchangeRatesService(Cache.ApiKey).Get("usd");
+        }
+
+        [Fact]
+        public void it_should_have_rates()
+        {
+            result.Rates.Should().NotBeNull();
+            result.Rates.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void it_should_have_rates_for_eur()
+        {
+            result.Rates["eur"].Should().BeGreaterThan(0);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/exchange_rates/when_listing_exchange_rates.cs
+++ b/src/Stripe.Tests.XUnit/exchange_rates/when_listing_exchange_rates.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Stripe.Tests.Xunit;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Stripe.Tests.XUnit
+{
+    public class when_listing_exchange_rates
+    {
+        StripeList<StripeExchangeRates> result;
+
+        public when_listing_exchange_rates()
+        {
+            result = new StripeExchangeRatesService(Cache.ApiKey).List(new StripeListOptions { Limit = 3 });
+        }
+
+        [Fact]
+        public void list_is_iterable()
+        {
+            var count = 0;
+            IEnumerable<StripeExchangeRates> enumerable = result as IEnumerable<StripeExchangeRates>;
+            foreach (var obj in enumerable)
+            {
+                count += 1;
+            }
+            Assert.Equal(result.ToList().Count, 3);
+            Assert.Equal(result.ToList().Count, count);
+        }
+    }
+}

--- a/src/Stripe.net/Entities/StripeExchangeRates.cs
+++ b/src/Stripe.net/Entities/StripeExchangeRates.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeExchangeRates : StripeEntityWithId
+    {
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        [JsonProperty("rates")]
+        public Dictionary<string, decimal> Rates { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Urls.cs
+++ b/src/Stripe.net/Infrastructure/Urls.cs
@@ -32,6 +32,8 @@
 
         public static string Events => BaseUrl + "/events";
 
+        public static string ExchangeRates => BaseUrl + "/exchange_rates";
+
         public static string Recipients => BaseUrl + "/recipients";
 
         public static string Subscriptions => BaseUrl + "/subscriptions";

--- a/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
@@ -29,6 +29,9 @@ namespace Stripe
         [JsonProperty("destination[amount]")]
         public int? DestinationAmount { get; set; }
 
+        [JsonProperty("exchange_rate")]
+        public decimal? ExchangeRate { get; set; }
+
         /// <summary>
         /// Email address that will receive an email receipt confirming the transaction.
         /// </summary>

--- a/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
@@ -48,6 +48,9 @@ namespace Stripe
         [JsonProperty("destination[amount]")]
         public int? DestinationAmount { get; set; }
 
+        [JsonProperty("exchange_rate")]
+        public decimal? ExchangeRate { get; set; }
+
         /// <summary>
         /// A string that identifies this transaction as part of a group. See the Connect documentation for details.
         /// </summary>

--- a/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
@@ -8,6 +8,9 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonProperty("exchange_rate")]
+        public decimal? ExchangeRate { get; set; }
+
         [JsonProperty("fraud_details")]
         public Dictionary<string, string> FraudDetails { get; set; }
 

--- a/src/Stripe.net/Services/ExchangeRates/StripeExchangeRatesService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/StripeExchangeRatesService.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe.Infrastructure;
+
+namespace Stripe
+{
+    public class StripeExchangeRatesService : StripeService
+    {
+        public StripeExchangeRatesService(string apiKey = null) : base(apiKey) { }
+
+
+
+        //Sync
+        public virtual StripeExchangeRates Get(string currency, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeExchangeRates>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(null, $"{Urls.ExchangeRates}/{currency}"),
+                    SetupRequestOptions(requestOptions)
+                )
+            );
+        }
+
+        public virtual StripeList<StripeExchangeRates> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeList<StripeExchangeRates>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, $"{Urls.ExchangeRates}", true),
+                    SetupRequestOptions(requestOptions)
+                )
+            );
+        }
+
+
+
+        //Async
+        public virtual async Task<StripeExchangeRates> GetAsync(string currency, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeExchangeRates>.MapFromJson(
+                await Requestor.GetStringAsync(
+                    this.ApplyAllParameters(null, $"{Urls.ExchangeRates}/{currency}"),
+                    SetupRequestOptions(requestOptions),
+                    cancellationToken
+                )
+            );
+        }
+
+        public virtual async Task<StripeList<StripeExchangeRates>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeList<StripeExchangeRates>>.MapFromJson(
+                await Requestor.GetStringAsync(
+                    this.ApplyAllParameters(listOptions, $"{Urls.ExchangeRates}", true),
+                    SetupRequestOptions(requestOptions),
+                    cancellationToken
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints as well as passing the exchange_rate parameter in charge creation/update/capture requests.
