### PR TITLE
Make "exchange rate" singular

### DIFF
--- a/src/Stripe.Tests.XUnit/exchange_rates/when_getting_an_exchange_rate.cs
+++ b/src/Stripe.Tests.XUnit/exchange_rates/when_getting_an_exchange_rate.cs
@@ -7,13 +7,13 @@ using Xunit;
 
 namespace Stripe.Tests.XUnit
 {
-    public class when_getting_exchange_rates
+    public class when_getting_an_exchange_rate
     {
-        StripeExchangeRates result;
+        StripeExchangeRate result;
 
-        public when_getting_exchange_rates()
+        public when_getting_an_exchange_rate()
         {
-            result = new StripeExchangeRatesService(Cache.ApiKey).Get("usd");
+            result = new StripeExchangeRateService(Cache.ApiKey).Get("usd");
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace Stripe.Tests.XUnit
         }
 
         [Fact]
-        public void it_should_have_rates_for_eur()
+        public void it_should_have_rate_for_eur()
         {
             result.Rates["eur"].Should().BeGreaterThan(0);
         }

--- a/src/Stripe.Tests.XUnit/exchange_rates/when_listing_exchange_rates.cs
+++ b/src/Stripe.Tests.XUnit/exchange_rates/when_listing_exchange_rates.cs
@@ -9,18 +9,18 @@ namespace Stripe.Tests.XUnit
 {
     public class when_listing_exchange_rates
     {
-        StripeList<StripeExchangeRates> result;
+        StripeList<StripeExchangeRate> result;
 
         public when_listing_exchange_rates()
         {
-            result = new StripeExchangeRatesService(Cache.ApiKey).List(new StripeListOptions { Limit = 3 });
+            result = new StripeExchangeRateService(Cache.ApiKey).List(new StripeListOptions { Limit = 3 });
         }
 
         [Fact]
         public void list_is_iterable()
         {
             var count = 0;
-            IEnumerable<StripeExchangeRates> enumerable = result as IEnumerable<StripeExchangeRates>;
+            IEnumerable<StripeExchangeRate> enumerable = result as IEnumerable<StripeExchangeRate>;
             foreach (var obj in enumerable)
             {
                 count += 1;

--- a/src/Stripe.net/Entities/StripeExchangeRate.cs
+++ b/src/Stripe.net/Entities/StripeExchangeRate.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeExchangeRates : StripeEntityWithId
+    public class StripeExchangeRate : StripeEntityWithId
     {
         [JsonProperty("object")]
         public string Object { get; set; }

--- a/src/Stripe.net/Services/ExchangeRates/StripeExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/StripeExchangeRateService.cs
@@ -5,16 +5,16 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeExchangeRatesService : StripeService
+    public class StripeExchangeRateService : StripeService
     {
-        public StripeExchangeRatesService(string apiKey = null) : base(apiKey) { }
+        public StripeExchangeRateService(string apiKey = null) : base(apiKey) { }
 
 
 
         //Sync
-        public virtual StripeExchangeRates Get(string currency, StripeRequestOptions requestOptions = null)
+        public virtual StripeExchangeRate Get(string currency, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeExchangeRates>.MapFromJson(
+            return Mapper<StripeExchangeRate>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(null, $"{Urls.ExchangeRates}/{currency}"),
                     SetupRequestOptions(requestOptions)
@@ -22,9 +22,9 @@ namespace Stripe
             );
         }
 
-        public virtual StripeList<StripeExchangeRates> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeExchangeRate> List(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null)
         {
-            return Mapper<StripeList<StripeExchangeRates>>.MapFromJson(
+            return Mapper<StripeList<StripeExchangeRate>>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(listOptions, $"{Urls.ExchangeRates}", true),
                     SetupRequestOptions(requestOptions)
@@ -35,9 +35,9 @@ namespace Stripe
 
 
         //Async
-        public virtual async Task<StripeExchangeRates> GetAsync(string currency, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeExchangeRate> GetAsync(string currency, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeExchangeRates>.MapFromJson(
+            return Mapper<StripeExchangeRate>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(null, $"{Urls.ExchangeRates}/{currency}"),
                     SetupRequestOptions(requestOptions),
@@ -46,9 +46,9 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<StripeList<StripeExchangeRates>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeExchangeRate>> ListAsync(StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<StripeList<StripeExchangeRates>>.MapFromJson(
+            return Mapper<StripeList<StripeExchangeRate>>.MapFromJson(
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.ExchangeRates}", true),
                     SetupRequestOptions(requestOptions),


### PR DESCRIPTION
We've recently tweaked the very new exchange rates API somewhat so that
a single "exchange rate" resource becomes singular instead of plural.
This is so that it falls into convention with all the other resources in
the API.

I jumped the gun a little bit of merging the .NET pull request, so this
one goes back through and amends a few places that were using a plural
exchange rate so that they're now singular.

Apparently we got a little lucky because 11.7.0 (the version I sent this
out under) apparently never made it to Nuget (possibly a build failure
which I'll have to look into separately). But anyway, it's safe to
release this without a breaking change because there is no official
package release with the other API.

r? @ob-stripe
cc @stripe/api-libraries