### PR TITLE
Default to application/octet-stream

### DIFF
--- a/src/Stripe.net/Infrastructure/MimeTypes.cs
+++ b/src/Stripe.net/Infrastructure/MimeTypes.cs
@@ -19,7 +19,7 @@ namespace Stripe.Infrastructure
                     return "image/png";
 
                 default:
-                    return null;
+                    return "application/octet-stream";
             }
         }
     }

--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -179,6 +179,11 @@ namespace Stripe.Infrastructure
         {
             requestMessage.Headers.ExpectContinue = true;
 
+            if (string.IsNullOrEmpty(fileName))
+            {
+                fileName = "blob";
+            }
+
             var fileContent = new StreamContent(fileStream);
             fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
             {


### PR DESCRIPTION
r? @fred-stripe 
cc @stripe/api-libraries 

Fixes #1053.

We could even remove `MimeTypes.cs` entirely and just use `application/octet-stream` always. This is what the Python library does ([here](https://github.com/stripe/stripe-python/blob/f948b8b95b6df5b57c7444a05d6c83c8c5e6a0ac/stripe/multipart_data_generator.py#L32)).

I've also set a default value for the filename, as the API does require one (cf. https://github.com/stripe/stripe-python/issues/227 for more context).