### PR TITLE
Properly encode DueDate

### DIFF
--- a/src/Stripe.Tests.XUnit/invoices/creating_and_updating_invoices_with_manual_invoicing.cs
+++ b/src/Stripe.Tests.XUnit/invoices/creating_and_updating_invoices_with_manual_invoicing.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -31,7 +32,7 @@ namespace Stripe.Tests.Xunit
             var InvoiceCreateOptions = new StripeInvoiceCreateOptions
             {
                 Billing = StripeBilling.SendInvoice,
-                DaysUntilDue = 7,
+                DueDate = DateTime.UtcNow.AddDays(10),
             };
             InvoiceCreated = invoiceService.Create(Customer.Id, InvoiceCreateOptions);
 

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Stripe.Infrastructure;
 
 namespace Stripe
 {
@@ -27,8 +28,10 @@ namespace Stripe
         /// <summary>
         /// The date on which payment for this invoice is due. Only valid for invoices where billing=send_invoice.
         /// </summary>
-        [JsonProperty("due_date")]
         public DateTime? DueDate { get; set; }
+
+        [JsonProperty("due_date")]
+        internal long? DueDateInternal => DueDate?.ConvertDateTimeToEpoch();
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }


### PR DESCRIPTION
r? @fred-stripe 
cc @stripe/api-libraries 

Fixes #1052.

`DueDate` was not properly encoded as a UNIX timestamp when creating an invoice. This is now fixed.

(We ought to write an encoding plugin to handle `DateTime`s everywhere transparently, but this is a quick fix to unblock #1052.)
