### PR TITLE
Support for passing arbitrary parameters

### DIFF
--- a/src/Stripe.Tests.XUnit/_infrastructure/adding_extra_parameters.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/adding_extra_parameters.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using FluentAssertions;
+using Xunit;
+using Stripe.Infrastructure;
+
+namespace Stripe.Tests.Xunit
+{
+    public class adding_extra_parameters
+    {
+        public class TestOptions : StripeBaseOptions
+        {
+            [JsonProperty("a_string")]
+            public string AString { get; set; }
+        }
+
+        public class TestService : StripeService
+        {
+            public TestService() : base(null)
+            {
+            }
+        }
+
+        public TestService Service { get; }
+
+        public adding_extra_parameters()
+        {
+            Service = new TestService();
+        }
+
+        [Fact]
+        public void can_add_extra_parameters()
+        {
+            var obj = new TestOptions
+            {
+                AString = "foo",
+            };
+            obj.AddExtraParam("extra_param", "some_value");
+            obj.AddExtraParam("another_extra_param", "some_other_value");
+
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?a_string=foo&extra_param=some_value&another_extra_param=some_other_value");
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/_infrastructure/encoding_and_decoding_enums.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/encoding_and_decoding_enums.cs
@@ -21,7 +21,7 @@ namespace Stripe.Tests.Xunit
             TestTwo,
         }
 
-        public class TestObject
+        public class TestObject : StripeBaseOptions
         {
             [JsonProperty("enum")]
             public TestEnum? Enum { get; set; }

--- a/src/Stripe.Tests.XUnit/_infrastructure/encoding_parameters.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/encoding_parameters.cs
@@ -11,7 +11,7 @@ namespace Stripe.Tests.Xunit
 {
     public class encoding_parameters
     {
-        public class TestObject
+        public class TestObject : StripeBaseOptions
         {
             [JsonProperty("an_int")]
             public int? AnInt { get; set; }
@@ -26,7 +26,7 @@ namespace Stripe.Tests.Xunit
             public int[] AList { get; set; }
         }
 
-        public class UnencodableObject
+        public class UnencodableObject : StripeBaseOptions
         {
             [JsonProperty("dict_int_keys")]
             public Dictionary<int, string> DictIntKeys { get; set; }

--- a/src/Stripe.net.Tests/infrastructure/test_data/sample_object.cs
+++ b/src/Stripe.net.Tests/infrastructure/test_data/sample_object.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe.Tests.test_data
 {
-    public class sample_object
+    public class sample_object : StripeBaseOptions
     {
         public sample_object()
         {

--- a/src/Stripe.net/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe.net/Infrastructure/ParameterBuilder.cs
@@ -10,7 +10,7 @@ namespace Stripe.Infrastructure
 {
     internal static class ParameterBuilder
     {
-        public static string ApplyAllParameters(this StripeService service, object obj, string url, bool isListMethod = false)
+        public static string ApplyAllParameters(this StripeService service, StripeBaseOptions obj, string url, bool isListMethod = false)
         {
             // store the original url from the service call into requestString (e.g. https://api.stripe.com/v1/accounts/account_id)
             // before the stripe attributes get applied. all of the attributes that will get passed to stripe will be applied to this string,
@@ -32,6 +32,12 @@ namespace Stripe.Infrastructure
                         else
                             RequestStringBuilder.ProcessPlugins(ref requestString, attribute, property, value, obj);
                     }
+                }
+
+                foreach (KeyValuePair<string, string> pair in obj.ExtraParams)
+                {
+                    var key = WebUtility.UrlEncode(pair.Key);
+                    RequestStringBuilder.ApplyParameterToRequestString(ref requestString, key, pair.Value);
                 }
             }
 

--- a/src/Stripe.net/Services/3DSecure/Stripe3DSecureCreateOptions.cs
+++ b/src/Stripe.net/Services/3DSecure/Stripe3DSecureCreateOptions.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class Stripe3DSecureCreateOptions
+    public class Stripe3DSecureCreateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int Amount { get; set; }

--- a/src/Stripe.net/Services/Account/StripeAccountRejectOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountRejectOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeAccountRejectOptions
+    public class StripeAccountRejectOptions : StripeBaseOptions
     {
         [JsonProperty("reason")]
         public string Reason { get; set; }

--- a/src/Stripe.net/Services/Account/StripeAccountSharedOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountSharedOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public abstract class StripeAccountSharedOptions
+    public abstract class StripeAccountSharedOptions : StripeBaseOptions
     {
         [JsonProperty("business_logo")]
         public string BusinessLogoFileId { get; set; }

--- a/src/Stripe.net/Services/ApplePayDomains/StripeApplePayDomainCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/StripeApplePayDomainCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeApplePayDomainCreateOptions
+    public class StripeApplePayDomainCreateOptions : StripeBaseOptions
     {
         /// <summary>
         /// Domain to add as an Apple Pay Domain

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeApplicationFeeRefundCreateOptions
+    public class StripeApplicationFeeRefundCreateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int Amount { get; set; }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundUpdateOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeApplicationFeeRefundUpdateOptions
+    public class StripeApplicationFeeRefundUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountCreateOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class BankAccountCreateOptions
+    public class BankAccountCreateOptions : StripeBaseOptions
     {
         [JsonProperty("source")]
         public string SourceToken { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountUpdateOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class BankAccountUpdateOptions
+    public class BankAccountUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("account_holder_name")]
         public string AccountHolderName { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class BankAccountVerifyOptions
+    public class BankAccountVerifyOptions : StripeBaseOptions
     {
         [JsonProperty("amounts[]")]
         public int AmountOne { get; set; }

--- a/src/Stripe.net/Services/Cards/StripeCardCreateOptions.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeCardCreateOptions
+    public class StripeCardCreateOptions : StripeBaseOptions
     {
         [JsonProperty("source")]
         public string SourceToken { get; set; }

--- a/src/Stripe.net/Services/Cards/StripeCardUpdateOptions.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeCardUpdateOptions
+    public class StripeCardUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("exp_month")]
         public int? ExpirationMonth { get; set; }

--- a/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeChargeCaptureOptions
+    public class StripeChargeCaptureOptions : StripeBaseOptions
     {
         /// <summary>
         /// Amount to capture on the authorization

--- a/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeChargeCreateOptions
+    public class StripeChargeCreateOptions : StripeBaseOptions
     {
         /// <summary>
         /// A positive integer in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a 0-decimal currency) representing how much to charge the card. The minimum amount is $0.50 US or equivalent in charge currency.

--- a/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeChargeUpdateOptions
+    public class StripeChargeUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Coupons/StripeCouponCreateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponCreateOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeCouponCreateOptions
+    public class StripeCouponCreateOptions : StripeBaseOptions
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Coupons/StripeCouponUpdateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeCouponUpdateOptions
+    public class StripeCouponUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerCreateOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeCustomerCreateOptions
+    public class StripeCustomerCreateOptions : StripeBaseOptions
     {
         [JsonProperty("account_balance")]
         public int? AccountBalance { get; set; }

--- a/src/Stripe.net/Services/Customers/StripeCustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerUpdateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeCustomerUpdateOptions
+    public class StripeCustomerUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("account_balance")]
         public int? AccountBalance { get; set; }

--- a/src/Stripe.net/Services/Disputes/StripeDisputeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Disputes/StripeDisputeUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeDisputeUpdateOptions
+    public class StripeDisputeUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("evidence[access_activity_log]")]
         public string AccessActivityLog { get; set; }

--- a/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/StripeEphemeralKeyCreateOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeEphemeralKeyCreateOptions
+    public class StripeEphemeralKeyCreateOptions : StripeBaseOptions
     {
         [JsonProperty("customer")]
         public string CustomerId { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeInvoiceItemCreateOptions
+    public class StripeInvoiceItemCreateOptions : StripeBaseOptions
     {
         [JsonProperty("customer")]
         public string CustomerId { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeInvoiceItemUpdateOptions
+    public class StripeInvoiceItemUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int? Amount { get; set; }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeInvoiceCreateOptions
+    public class StripeInvoiceCreateOptions : StripeBaseOptions
     {
         [JsonProperty("application_fee")]
         public int? ApplicationFee { get; set; }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceSubscriptionItemOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeInvoiceSubscriptionItemOptions
+    public class StripeInvoiceSubscriptionItemOptions : StripeBaseOptions
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceUpdateOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public class StripeInvoiceUpdateOptions
+    public class StripeInvoiceUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("application_fee")]
         public int? ApplicationFee { get; set; }

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Stripe
 {
-    public class StripeUpcomingInvoiceOptions
+    public class StripeUpcomingInvoiceOptions : StripeBaseOptions
     {
         [JsonProperty("coupon")]
         public string CouponId { get; set; }

--- a/src/Stripe.net/Services/OAuth/StripeOAuthTokenCreateOptions.cs
+++ b/src/Stripe.net/Services/OAuth/StripeOAuthTokenCreateOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeOAuthTokenCreateOptions
+    public class StripeOAuthTokenCreateOptions : StripeBaseOptions
     {
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/src/Stripe.net/Services/Orders/StripeOrderCreateOptions.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeOrderCreateOptions
+    public class StripeOrderCreateOptions : StripeBaseOptions
     {
         /// <summary>
         /// REQUIRED: Three-letter ISO currency code, in lowercase. Must be a supported currency.

--- a/src/Stripe.net/Services/Orders/StripeOrderPayOptions.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderPayOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeOrderPayOptions
+    public class StripeOrderPayOptions : StripeBaseOptions
     {
         /// <summary>
         /// The ID of an existing customer that will be charged in this request.

--- a/src/Stripe.net/Services/Orders/StripeOrderUpdateOptions.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeOrderUpdateOptions
+    public class StripeOrderUpdateOptions : StripeBaseOptions
     {
         /// <summary>
         /// A coupon code that represents a discount to be applied to this order. Must be one-time duration and in tbe same currency as the order.

--- a/src/Stripe.net/Services/Payouts/StripePayoutCreateOptions.cs
+++ b/src/Stripe.net/Services/Payouts/StripePayoutCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripePayoutCreateOptions
+    public class StripePayoutCreateOptions : StripeBaseOptions
     {
         /// <summary>
         /// REQUIRED

--- a/src/Stripe.net/Services/Payouts/StripePayoutUpdateOptions.cs
+++ b/src/Stripe.net/Services/Payouts/StripePayoutUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripePayoutUpdateOptions
+    public class StripePayoutUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripePlanCreateOptions
+    public class StripePlanCreateOptions : StripeBaseOptions
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripePlanUpdateOptions
+    public class StripePlanUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Services/Products/StripeProductSharedOptions.cs
+++ b/src/Stripe.net/Services/Products/StripeProductSharedOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public abstract class StripeProductSharedOptions
+    public abstract class StripeProductSharedOptions : StripeBaseOptions
     {
         /// <summary>
         /// Whether or not the product is currently available for purchase. Defaults to true.

--- a/src/Stripe.net/Services/Refunds/StripeRefundCreateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/StripeRefundCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeRefundCreateOptions
+    public class StripeRefundCreateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int? Amount { get; set; }

--- a/src/Stripe.net/Services/Refunds/StripeRefundUpdateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/StripeRefundUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeRefundUpdateOptions
+    public class StripeRefundUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Skus/StripeSkuSharedOptions.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuSharedOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public abstract class StripeSkuSharedOptions
+    public abstract class StripeSkuSharedOptions : StripeBaseOptions
     {
         /// <summary>
         /// Whether or not the SKU is currently available for purchase. Defaults to true.

--- a/src/Stripe.net/Services/Sources/StripeSourceAttachOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceAttachOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeSourceAttachOptions
+    public class StripeSourceAttachOptions : StripeBaseOptions
     {
         /// <summary>
         /// REQUIRED: The identifier of the source to be attached.

--- a/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeSourceCreateOptions
+    public class StripeSourceCreateOptions : StripeBaseOptions
     {
         /// <summary>
         /// REQUIRED: The type of the source to create. One of type <see cref="StripeSourceType"/>

--- a/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeSourceUpdateOptions
+    public class StripeSourceUpdateOptions : StripeBaseOptions
     {
         /// <summary>
         /// A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format. You can unset individual keys if you POST an empty value for that key. You can clear all keys if you POST an empty value for metadata.

--- a/src/Stripe.net/Services/StripeBaseOptions.cs
+++ b/src/Stripe.net/Services/StripeBaseOptions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Stripe
+{
+    public class StripeBaseOptions
+    {
+        public void AddExtraParam(string key, string value) {
+            ExtraParams.Add(key, value);
+        }
+
+        public Dictionary<string, string> ExtraParams = new Dictionary<string, string>();
+    }
+}

--- a/src/Stripe.net/Services/StripeBasicService.cs
+++ b/src/Stripe.net/Services/StripeBasicService.cs
@@ -14,7 +14,7 @@ namespace Stripe
         // it allows us to refactor slowly and build new services easier.
 
         // Sync
-        public EntityReturned GetEntity(string url, StripeRequestOptions requestOptions, object options = null)
+        public EntityReturned GetEntity(string url, StripeRequestOptions requestOptions, StripeBaseOptions options = null)
         {
             return Mapper<EntityReturned>.MapFromJson(
                 Requestor.GetString(
@@ -24,7 +24,7 @@ namespace Stripe
             );
         }
 
-        public StripeList<EntityReturned> GetEntityList(string url, StripeRequestOptions requestOptions, object options = null)
+        public StripeList<EntityReturned> GetEntityList(string url, StripeRequestOptions requestOptions, StripeBaseOptions options = null)
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 Requestor.GetString(
@@ -34,7 +34,7 @@ namespace Stripe
             );
         }
 
-        public EntityReturned Post(string url, StripeRequestOptions requestOptions, object options = null)
+        public EntityReturned Post(string url, StripeRequestOptions requestOptions, StripeBaseOptions options = null)
         {
             return Mapper<EntityReturned>.MapFromJson(
                 Requestor.PostString(
@@ -44,7 +44,7 @@ namespace Stripe
             );
         }
 
-        public virtual StripeDeleted DeleteEntity(string url, StripeRequestOptions requestOptions, object options = null)
+        public virtual StripeDeleted DeleteEntity(string url, StripeRequestOptions requestOptions, StripeBaseOptions options = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
                 Requestor.Delete(
@@ -57,7 +57,7 @@ namespace Stripe
 
 
         // Async
-        public virtual async Task<EntityReturned> GetEntityAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
+        public virtual async Task<EntityReturned> GetEntityAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, StripeBaseOptions options = null)
         {
             return Mapper<EntityReturned>.MapFromJson(
                 await Requestor.GetStringAsync(
@@ -68,7 +68,7 @@ namespace Stripe
             );
         }
 
-        public virtual async Task<StripeList<EntityReturned>> GetEntityListAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
+        public virtual async Task<StripeList<EntityReturned>> GetEntityListAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, StripeBaseOptions options = null)
         {
             return Mapper<StripeList<EntityReturned>>.MapFromJson(
                 await Requestor.GetStringAsync(
@@ -79,7 +79,7 @@ namespace Stripe
             );
         }
 
-        public async Task<EntityReturned> PostAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
+        public async Task<EntityReturned> PostAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, StripeBaseOptions options = null)
         {
             return Mapper<EntityReturned>.MapFromJson(
                 await Requestor.PostStringAsync(
@@ -90,7 +90,7 @@ namespace Stripe
             );
         }
 
-        public async Task<StripeDeleted> DeleteEntityAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, object options = null)
+        public async Task<StripeDeleted> DeleteEntityAsync(string url, StripeRequestOptions requestOptions, CancellationToken cancellationToken, StripeBaseOptions options = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync(

--- a/src/Stripe.net/Services/StripeListOptions.cs
+++ b/src/Stripe.net/Services/StripeListOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeListOptions
+    public class StripeListOptions : StripeBaseOptions
     {
         /// <summary>
         /// A limit on the number of objects to be returned. Limit can range between 1 and 100 items.

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
@@ -4,7 +4,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public abstract class SubscriptionItemSharedOptions
+    public abstract class SubscriptionItemSharedOptions : StripeBaseOptions
     {
         /// <summary>
         /// REQUIRED: The identifier of the plan to add to the subscription.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -5,7 +5,7 @@ using Stripe.Infrastructure;
 
 namespace Stripe
 {
-    public abstract class SubscriptionSharedOptions
+    public abstract class SubscriptionSharedOptions : StripeBaseOptions
     {
         [JsonProperty("application_fee_percent")]
         public decimal? ApplicationFeePercent { get; set; }

--- a/src/Stripe.net/Services/Tokens/StripeTokenCreateOptions.cs
+++ b/src/Stripe.net/Services/Tokens/StripeTokenCreateOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeTokenCreateOptions
+    public class StripeTokenCreateOptions : StripeBaseOptions
     {
         [JsonProperty("customer")]
         public string CustomerId { get; set; }

--- a/src/Stripe.net/Services/TransferReversals/StripeTransferReversalCreateOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/StripeTransferReversalCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeTransferReversalCreateOptions
+    public class StripeTransferReversalCreateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int Amount { get; set; }

--- a/src/Stripe.net/Services/TransferReversals/StripeTransferReversalUpdateOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/StripeTransferReversalUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeTransferReversalUpdateOptions
+    public class StripeTransferReversalUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferCreateOptions.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeTransferCreateOptions
+    public class StripeTransferCreateOptions : StripeBaseOptions
     {
         [JsonProperty("amount")]
         public int Amount { get; set; }

--- a/src/Stripe.net/Services/Transfers/StripeTransferUpdateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferUpdateOptions.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Stripe
 {
-    public class StripeTransferUpdateOptions
+    public class StripeTransferUpdateOptions : StripeBaseOptions
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/_refactor/StripeCreditCardOptions.cs
+++ b/src/Stripe.net/Services/_refactor/StripeCreditCardOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Stripe
 {
-    public class StripeCreditCardOptions : INestedOptions
+    public class StripeCreditCardOptions : StripeBaseOptions, INestedOptions
     {
         [JsonProperty("card")]
         public string TokenId { get; set; }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

This PR adds support for passing arbitrary parameters when making API requests. If the `Options` class inherit from `StripeParamsBase`, users can call `AddExtraParam` to add arbitrary key/value pairs to the request.
