### PR TITLE
Make Paid optional

### DIFF
--- a/src/Stripe.net/Services/Invoices/StripeInvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceListOptions.cs
@@ -26,7 +26,7 @@ namespace Stripe
         /// A filter on the list based on the object paid field.
         /// </summary>
         [JsonProperty("paid")]
-        public bool Paid { get; set; }
+        public bool? Paid { get; set; }
         
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }


### PR DESCRIPTION
r? @anelder-stripe 
cc @stripe/api-libraries 

Makes `Paid` optional, otherwise it defaults to `paid=false` in every invoice listing request.
