### PR TITLE
[WIP] updates for upcoming Stripe API version bump

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,6 @@
             "isBuildCommand": true,
             "showOutput": "silent",
             "problemMatcher": "$msCompile"
-        },
+        }
     ]
 }

--- a/src/Stripe.Tests.XUnit/plans/_cache.cs
+++ b/src/Stripe.Tests.XUnit/plans/_cache.cs
@@ -12,7 +12,10 @@ namespace Stripe.Tests.Xunit
             // Avoids parallel calls to end up with the same options (and id) twice.
             lock(cacheLock)
             {
-                if (Items.ContainsKey(planName)) return (StripePlan) Items[planName];
+                if (Items.ContainsKey(planName))
+                {
+                    return (StripePlan) Items[planName];
+                }
 
                 var plan = new StripePlanService(ApiKey).Create(GetPlanCreateOptions(planName));
                 Items.Add(planName, plan);
@@ -29,7 +32,7 @@ namespace Stripe.Tests.Xunit
             {
                 Amount = 1000,
                 Currency = "usd",
-                Name = Guid.NewGuid().ToString(),
+                Nickname = Guid.NewGuid().ToString(),
                 Id = Guid.NewGuid().ToString(),
                 Interval = StripePlanIntervals.Week
             };

--- a/src/Stripe.Tests.XUnit/plans/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/plans/_fixture.cs
@@ -20,14 +20,14 @@ namespace Stripe.Tests.Xunit
                 // Add a space at the end to ensure the ID is properly URL encoded
                 // when passed in the URL for other methods
                 Id = "test-plan-" + Guid.NewGuid().ToString() + " ",
-                Name = "plan-name",
+                Nickname = "plan-name",
                 Amount = 5000,
                 Currency = "usd",
                 Interval = "month",
             };
 
             PlanUpdateOptions = new StripePlanUpdateOptions {
-              Name = "plan-name-2"
+              Nickname = "plan-name-2"
             };
 
             var service = new StripePlanService(Cache.ApiKey);

--- a/src/Stripe.Tests.XUnit/plans/when_creating_and_updating_plans.cs
+++ b/src/Stripe.Tests.XUnit/plans/when_creating_and_updating_plans.cs
@@ -18,7 +18,6 @@ namespace Stripe.Tests.Xunit
         public void created_has_the_right_details()
         {
             fixture.Plan.Id.Should().Be(fixture.PlanCreateOptions.Id);
-            fixture.Plan.Name.Should().Be(fixture.PlanCreateOptions.Name);
             fixture.Plan.Amount.Should().Be(fixture.PlanCreateOptions.Amount);
             fixture.Plan.Currency.Should().Be(fixture.PlanCreateOptions.Currency);
             fixture.Plan.Interval.Should().Be(fixture.PlanCreateOptions.Interval);
@@ -28,7 +27,6 @@ namespace Stripe.Tests.Xunit
         public void updated_has_the_right_details()
         {
             fixture.PlanUpdated.Id.Should().Be(fixture.Plan.Id);
-            fixture.PlanUpdated.Name.Should().BeEquivalentTo(fixture.PlanUpdateOptions.Name);
         }
 
         [Fact]

--- a/src/Stripe.net.Tests/plans/plan_behaviors.cs
+++ b/src/Stripe.net.Tests/plans/plan_behaviors.cs
@@ -23,17 +23,11 @@ namespace Stripe.Tests
         It should_have_the_correct_interval_count = () =>
             StripePlan.IntervalCount.ShouldEqual(1);
 
-        It should_have_the_correct_name = () =>
-            StripePlan.Name.ShouldEqual(StripePlanCreateOptions.Name);
-
         It should_have_the_correct_trial_period_days = () =>
             StripePlan.TrialPeriodDays.ShouldEqual(StripePlanCreateOptions.TrialPeriodDays);
 
         It should_have_a_created_date = () =>
             StripePlan.Created.ShouldNotBeNull();
-
-        It should_have_the_correct_statement_descriptor = () =>
-            StripePlan.StatementDescriptor.ShouldEqual(StripePlanCreateOptions.StatementDescriptor);
 
         It should_have_the_correct_live_mode = () =>
             StripePlan.LiveMode.ShouldEqual(false);

--- a/src/Stripe.net.Tests/plans/test_data/stripe_plan_create_options.cs
+++ b/src/Stripe.net.Tests/plans/test_data/stripe_plan_create_options.cs
@@ -13,14 +13,17 @@ namespace Stripe.Tests.test_data
                 Amount = 5000,
                 Currency = "usd",
                 Interval = "month",
-                Name = "Test Plan",
                 TrialPeriodDays = 1,
                 Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },
                     { "B", "Value-B" }
                 },
-                StatementDescriptor = "heyyyy ya!"
+                Product = new StripeProductCreateOptions
+                {
+                    Name = "Test Plan",
+                    StatementDescriptor = "heyyyy ya!"
+                }
             };
         }
 
@@ -32,7 +35,10 @@ namespace Stripe.Tests.test_data
                 Amount = 500,
                 Currency = "usd",
                 Interval = "month",
-                Name = "Thirty Days and Five Dollars"
+                Product = new StripeProductCreateOptions
+                {
+                    Name = "Thirty Days and Five Dollars"
+                }
             };
         }
     }

--- a/src/Stripe.net.Tests/plans/test_data/stripe_plan_update_options.cs
+++ b/src/Stripe.net.Tests/plans/test_data/stripe_plan_update_options.cs
@@ -8,14 +8,12 @@ namespace Stripe.Tests.test_data
         {
             return new StripePlanUpdateOptions()
             {
-                Name = "Test Plan Modified",
                 Metadata = new Dictionary<string, string>
                 {
                     { "A", "Value-A" },
                     { "B", "Value-B" },
                     { "C", "Value-C" }
-                },
-                StatementDescriptor = "heyyyy ya?"
+                }
             };
         }
     }

--- a/src/Stripe.net.Tests/plans/when_updating_a_plan.cs
+++ b/src/Stripe.net.Tests/plans/when_updating_a_plan.cs
@@ -25,16 +25,10 @@ namespace Stripe.Tests
         Because of = () =>
             StripePlan = _stripePlanService.Update(_createdStripePlanId, StripePlanUpdateOptions);
 
-        It should_have_the_new_name = () =>
-            StripePlan.Name.ShouldEqual(StripePlanUpdateOptions.Name);
-
         It should_have_metadata = () =>
             StripePlan.Metadata.Count.ShouldBeGreaterThan(0);
 
         It should_have_correct_metadata = () =>
             StripePlan.Metadata.ShouldContainOnly(StripePlanUpdateOptions.Metadata);
-
-        It should_have_the_new_statement_descriptor = () =>
-            StripePlan.StatementDescriptor.ShouldEqual(StripePlanUpdateOptions.StatementDescriptor);
     }
 }

--- a/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
@@ -30,6 +30,6 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("nickname")]
-        public String Nickname { get; set; }
+        public string Nickname { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
@@ -20,16 +20,16 @@ namespace Stripe
         [JsonProperty("interval_count")]
         public int? IntervalCount { get; set; }
 
-        [JsonProperty("name")]
-        public string Name { get; set; }
+        [JsonProperty("product")]
+        public StripeProductCreateOptions Product { get; set; }
 
         [JsonProperty("trial_period_days")]
         public int? TrialPeriodDays { get; set; }
 
-        [JsonProperty("statement_descriptor")]
-        public string StatementDescriptor { get; set; }
-
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("nickname")]
+        public String Nickname { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
@@ -5,13 +5,10 @@ namespace Stripe
 {
     public class StripePlanUpdateOptions : StripeBaseOptions
     {
-        [JsonProperty("name")]
-        public string Name { get; set; }
+        [JsonProperty("nickname")]
+        public string Nickname { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
-
-        [JsonProperty("statement_descriptor")]
-        public string StatementDescriptor { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Products/StripeProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/StripeProductCreateOptions.cs
@@ -9,5 +9,14 @@ namespace Stripe
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+
+        [JsonProperty("type")]
+        public string type { get; set; }
     }
 }


### PR DESCRIPTION
 #### Summary

Similar to https://github.com/stripe/stripe-go/pull/496, this PR adds support for an upcoming Stripe API version, tentatively dated 2017-12-01.

 #### Testing

I'll plan to...
 - [ ] update existing test cases for plans and products
 - [ ] add coverage for plan creation via product ID and via inline product fields

cc @stripe/api-libraries 