### PR TITLE
Add support for expanding application on charge objects

### DIFF
--- a/src/Stripe.Tests.XUnit/connect/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/connect/_fixture.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Stripe.Tests.Xunit
+{
+    public class connect_fixture : IDisposable
+    {
+        public StripeAccount Account { get; }
+        public StripeCharge Charge { get; }
+        public StripeApplicationFee ApplicationFee { get; }
+
+        public connect_fixture()
+        {
+            var accountService = new StripeAccountService(Cache.ApiKey);
+            var accountCreateOptions = new StripeAccountCreateOptions
+            {
+                DefaultCurrency = "usd",
+                Email = "cu_xxxxxx@gmail.com",
+                Type = StripeAccountType.Custom
+            };
+            Account = accountService.Create(accountCreateOptions);
+
+            var chargeService = new StripeChargeService(Cache.ApiKey);
+            chargeService.ExpandApplication = true;
+            chargeService.ExpandApplicationFee = true;
+            Charge = chargeService.Create(
+                new StripeChargeCreateOptions
+                {
+                    SourceTokenOrExistingSourceId = "tok_visa",
+                    ApplicationFee = 10,
+                    Amount = 100,
+                    Currency = "usd"
+                }, 
+                new StripeRequestOptions
+                {
+                    StripeConnectAccountId = Account.Id
+                }
+            );
+
+            var applicationFeeService = new StripeApplicationFeeService(Cache.ApiKey);
+            applicationFeeService.ExpandApplication = true;
+            ApplicationFee = applicationFeeService.Get(Charge.ApplicationFeeId);
+        }
+
+        public void Dispose()
+        {
+            new StripeAccountService(Cache.ApiKey).Delete(Account.Id);
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/connect/when_charging_from_managed_account.cs
+++ b/src/Stripe.Tests.XUnit/connect/when_charging_from_managed_account.cs
@@ -4,48 +4,27 @@ using Xunit;
 
 namespace Stripe.Tests.Xunit
 {
-    public class charging_from_another_account
+    public class charging_from_another_account : IClassFixture<connect_fixture>
     {
-        private StripeApplicationFee _appFee;
+        private readonly connect_fixture fixture;
 
-        public charging_from_another_account()
+        public charging_from_another_account(connect_fixture fixture)
         {
-            var anotherAccount = new StripeAccountService(Cache.ApiKey).Create(new StripeAccountCreateOptions
-                {
-                    DefaultCurrency = "usd",
-                    Email = "cu_xxxxxx@gmail.com",
-                    Type = StripeAccountType.Custom
-            }
-            );
+            this.fixture = fixture;
+        }
 
-            var chargeService = new StripeChargeService(Cache.ApiKey);
-            chargeService.ExpandApplicationFee = true;
-
-            var charge = chargeService.Create(
-                new StripeChargeCreateOptions
-                {
-                    SourceTokenOrExistingSourceId = "tok_visa",
-                    ApplicationFee = 10,
-                    Amount = 100,
-                    Currency = "usd"
-                }, 
-                new StripeRequestOptions
-                {
-                    StripeConnectAccountId = anotherAccount.Id
-                }
-            );
-
-            var appFeeService = new StripeApplicationFeeService(Cache.ApiKey);
-            appFeeService.ExpandApplication = true;
-
-            _appFee = appFeeService.Get(charge.ApplicationFeeId);
+        [Fact]
+        public void it_should_have_connected_app_on_charge()
+        {
+            this.fixture.Charge.ApplicationId.Should().StartWith("ca_");
+            this.fixture.Charge.Application.Should().NotBeNull();
         }
 
         [Fact]
         public void it_should_have_connected_app_on_app_fee()
         {
-            _appFee.ApplicationId.Should().StartWith("ca_");
-            _appFee.Application.Should().NotBeNull();
+            this.fixture.ApplicationFee.ApplicationId.Should().StartWith("ca_");
+            this.fixture.ApplicationFee.Application.Should().NotBeNull();
         }
     }
 }

--- a/src/Stripe.net/Services/Charges/StripeChargeService.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeService.cs
@@ -8,6 +8,7 @@ namespace Stripe
     {
         public StripeChargeService(string apiKey = null) : base(apiKey) { }
 
+        public bool ExpandApplication { get; set; }
         public bool ExpandApplicationFee { get; set; }
         public bool ExpandBalanceTransaction { get; set; }
         public bool ExpandCustomer { get; set; }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add support for expanding `application` attribute on charge objects

Fixes #1073.
