### PR TITLE
Add `object=card` to request when listing cards on customer

### DIFF
--- a/src/Stripe.Tests.XUnit/cards/listing_cards_on_customer.cs
+++ b/src/Stripe.Tests.XUnit/cards/listing_cards_on_customer.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class listing_cards_on_customer
+    {
+        public StripeList<StripeCard> ListCards { get; }
+
+        public listing_cards_on_customer()
+        {
+            var customerService = new StripeCustomerService(Cache.ApiKey);
+            var bankAccountService = new BankAccountService(Cache.ApiKey);
+            var cardService = new StripeCardService(Cache.ApiKey);
+
+            var CustomerCreateOptions = new StripeCustomerCreateOptions
+            {
+                Email = "jenny@example.com",
+                SourceToken = "tok_visa",
+            };
+            var Customer = customerService.Create(CustomerCreateOptions);
+
+            var BankAccountCreateOptions = new BankAccountCreateOptions
+            {
+                SourceBankAccount = new SourceBankAccount()
+                {
+                    RoutingNumber = "110000000",
+                    AccountNumber = "000123456789",
+                    Country = "US",
+                    Currency = "usd",
+                    AccountHolderName = "Jenny Rosen",
+                    AccountHolderType = BankAccountHolderType.Individual,
+                }
+            };
+            var BankAccount = bankAccountService.Create(Customer.Id, BankAccountCreateOptions);
+
+            ListCards = cardService.List(Customer.Id);
+        }
+
+        [Fact]
+        public void list_contains_only_one_element()
+        {
+            ListCards.Data.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void list_element_is_a_card()
+        {
+            var card = ListCards.Data[0];
+            card.Object.Should().Be("card");
+            card.Brand.Should().Be("Visa");
+        }
+    }
+}

--- a/src/Stripe.net/Services/Cards/StripeCardListOptions.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardListOptions.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeCardListOptions : StripeListOptions
+    {
+        [JsonProperty("object")]
+        internal string Object => "card";
+    }
+}

--- a/src/Stripe.net/Services/Cards/StripeCardService.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardService.cs
@@ -65,9 +65,13 @@ namespace Stripe
             );
         }
 
-        public virtual StripeList<StripeCard> List(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null)
+        public virtual StripeList<StripeCard> List(string customerOrRecipientId, StripeCardListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null)
         {
             var url = SetupUrl(customerOrRecipientId, isRecipient);
+
+            if (listOptions == null) {
+                listOptions = new StripeCardListOptions();
+            }
 
             return Mapper<StripeList<StripeCard>>.MapFromJson(
                 Requestor.GetString(this.ApplyAllParameters(listOptions, url, true),
@@ -133,9 +137,13 @@ namespace Stripe
                 );
         }
 
-        public virtual async Task<StripeList<StripeCard>> ListAsync(string customerOrRecipientId, StripeListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<StripeList<StripeCard>> ListAsync(string customerOrRecipientId, StripeCardListOptions listOptions = null, bool isRecipient = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var url = SetupUrl(customerOrRecipientId, isRecipient);
+
+            if (listOptions == null) {
+                listOptions = new StripeCardListOptions();
+            }
 
             return Mapper<StripeList<StripeCard>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes #989.

This PR fixes `StripeCardService.List / ListAsync` so that it only returns card objects.

This is a breaking change as the interface for both list methods was modified to use the new `StripeCardListOptions` class. Ideally we should release this along with #1072 to avoid multiple major version bumps.
