### PR TITLE
Retrieve fulfiled from the correct JSON property and rename property

### DIFF
--- a/src/Stripe.net/Entities/StripeStatusTransitions.cs
+++ b/src/Stripe.net/Entities/StripeStatusTransitions.cs
@@ -11,7 +11,7 @@ namespace Stripe
         public DateTime? Canceled { get; set; }
 
         [JsonConverter(typeof(StripeDateTimeConverter))]
-        [JsonProperty("fulfilled")]
+        [JsonProperty("fulfiled")]
         public DateTime? Fulfilled { get; set; }
 
         [JsonConverter(typeof(StripeDateTimeConverter))]

--- a/src/Stripe.net/Entities/StripeStatusTransitions.cs
+++ b/src/Stripe.net/Entities/StripeStatusTransitions.cs
@@ -12,7 +12,7 @@ namespace Stripe
 
         [JsonConverter(typeof(StripeDateTimeConverter))]
         [JsonProperty("fulfiled")]
-        public DateTime? Fulfilled { get; set; }
+        public DateTime? Fulfiled { get; set; }
 
         [JsonConverter(typeof(StripeDateTimeConverter))]
         [JsonProperty("paid")]


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/1085.

This changes the property name for an Order status transition in `StripeStatusTransitions`