### PR TITLE
Add support for top-level statement descriptor for all sources

### DIFF
--- a/src/Stripe.Tests.XUnit/sources/creating_and_updating_bancontact_source.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_and_updating_bancontact_source.cs
@@ -6,27 +6,29 @@ namespace Stripe.Tests.Xunit
     public class creating_and_updating_bancontact_source
     {
         private StripeSource Source { get; set; }
+        private StripeSourceCreateOptions SourceCreateOptions { get; set; }
 
         public creating_and_updating_bancontact_source()
         {
-            var options = new StripeSourceCreateOptions
+            SourceCreateOptions = new StripeSourceCreateOptions
             {
                 Type = StripeSourceType.Bancontact,
                 Amount = 500,
                 Currency = "eur",
                 Owner = new StripeSourceOwner { Name = "Joe Biden" },
                 RedirectReturnUrl = "http://no.where/webhooks",
-                BancontactStatementDescriptor = "test statement descriptor",
+                StatementDescriptor = "test statement descriptor",
                 BancontactPreferredLanguage = "FR"
             };
 
-            Source = new StripeSourceService(Cache.ApiKey).Create(options);
+            Source = new StripeSourceService(Cache.ApiKey).Create(SourceCreateOptions);
         }
 
         [Fact]
         public void source_has_correct_parameters()
         {
             Source.Should().NotBeNull();
+            Source.StatementDescriptor.Should().Be(SourceCreateOptions.StatementDescriptor);
             Source.Bancontact.Should().NotBeNull();
             Source.Bancontact.PreferredLanguage.Should().Be("FR");
         }

--- a/src/Stripe.Tests.XUnit/sources/creating_and_updating_ideal_source.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_and_updating_ideal_source.cs
@@ -6,25 +6,28 @@ namespace Stripe.Tests.Xunit
     public class creating_and_updating_ideal_source
     {
         private StripeSource Source { get; set; }
+        private StripeSourceCreateOptions SourceCreateOptions { get; set; }
 
         public creating_and_updating_ideal_source()
         {
-            var options = new StripeSourceCreateOptions
+            SourceCreateOptions = new StripeSourceCreateOptions
             {
                 Type = StripeSourceType.Ideal,
                 IdealBank = "ing",
-                IdealStatementDescriptor = "finished",
+                StatementDescriptor = "finished",
                 Amount = 2001,
                 Currency = "eur",
                 RedirectReturnUrl = "http://no.where/webhooks"
             };
 
-            Source = new StripeSourceService(Cache.ApiKey).Create(options);
+            Source = new StripeSourceService(Cache.ApiKey).Create(SourceCreateOptions);
         }
 
         [Fact]
         public void source_has_correct_parameters()
         {
+            Source.Should().NotBeNull();
+            Source.StatementDescriptor.ShouldBeEquivalentTo(SourceCreateOptions.StatementDescriptor);
             Source.Ideal.Should().NotBeNull();
             Source.Ideal.Bank.ShouldBeEquivalentTo("ing");
         }

--- a/src/Stripe.Tests.XUnit/sources/creating_and_updating_sofort_source.cs
+++ b/src/Stripe.Tests.XUnit/sources/creating_and_updating_sofort_source.cs
@@ -6,26 +6,29 @@ namespace Stripe.Tests.Xunit
     public class creating_and_updating_sofort_source
     {
         private StripeSource Source { get; set; }
+        private StripeSourceCreateOptions SourceCreateOptions { get; set; }
 
         public creating_and_updating_sofort_source()
         {
-            var options = new StripeSourceCreateOptions
+            SourceCreateOptions = new StripeSourceCreateOptions
             {
                 Type = StripeSourceType.Sofort,
                 SofortCountry = "DE",
-                SofortStatementDescriptor = "soforty!",
+                StatementDescriptor = "soforty!",
                 Amount = 500,
                 Currency = "eur",
                 RedirectReturnUrl = "http://no.where/webhooks"
             };
 
-            Source = new StripeSourceService(Cache.ApiKey).Create(options);
+            Source = new StripeSourceService(Cache.ApiKey).Create(SourceCreateOptions);
         }
 
         [Fact]
         public void source_has_correct_parameters()
         {
             Source.Should().NotBeNull();
+            Source.StatementDescriptor.Should().Be(SourceCreateOptions.StatementDescriptor);
+            Source.Sofort.Should().NotBeNull();
             Source.Sofort.Country.Should().Be("DE");
         }
     }

--- a/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
@@ -35,26 +35,17 @@ namespace Stripe
         [JsonProperty("bancontact[preferred_language]")]
         public string BancontactPreferredLanguage { get; set; }
 
-        [JsonProperty("bancontact[statement_descriptor]")]
-        public string BancontactStatementDescriptor { get; set; }
-
         [JsonProperty("card")]
         public StripeCreditCardOptions Card { get; set; }
 
         [JsonProperty("ideal[bank]")]
         public string IdealBank { get; set; }
 
-        [JsonProperty("ideal[statement_descriptor]")]
-        public string IdealStatementDescriptor { get; set; }
-
         [JsonProperty("sepa_debit[iban]")]
         public string SepaDebitIban { get; set; }
 
         [JsonProperty("sofort[country]")]
         public string SofortCountry { get; set; }
-
-        [JsonProperty("sofort[statement_descriptor]")]
-        public string SofortStatementDescriptor { get; set; }
 
         [JsonProperty("[three_d_secure][customer]")]
         public string ThreeDSecureCustomer { get; set; }
@@ -80,6 +71,9 @@ namespace Stripe
         /// </summary>
         [JsonProperty("[redirect][return_url]")]
         public string RedirectReturnUrl { get; set; }
+
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
 
         /// <summary>
         /// An optional token used to create the source. When passed, token properties will override source parameters.


### PR DESCRIPTION
This removes the type-specific statement descriptor as it is now supported as a top level parameter and moves every type to `StatementDescriptor`.

Fixes https://github.com/stripe/stripe-dotnet/issues/1088

r? @ob-stripe 
cc @stripe/api-libraries 