### PR TITLE
Move to the latest API version

### DIFF
--- a/src/Stripe.net/Entities/Sources/StripeRedirect.cs
+++ b/src/Stripe.net/Entities/Sources/StripeRedirect.cs
@@ -11,7 +11,7 @@ namespace Stripe
         public string ReturnUrl { get; set; }
 
         /// <summary>
-        /// The status of the redirect, either pending, succeeded or failed.
+        /// The status of the redirect, either not_required, pending, succeeded or failed.
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -7,7 +7,7 @@ namespace Stripe
 {
     public static class StripeConfiguration
     {
-        public static string StripeApiVersion = "2017-06-05";
+        public static string StripeApiVersion = "2017-12-14";
         public static string StripeNetVersion { get; }
 
         /// <summary>


### PR DESCRIPTION
Per the [upgrades documentation](https://stripe.com/docs/upgrades?since=2017-06-05#api-changelog) no change imply a change in the code itself.

It's still a breaking change as some properties will now behave differently for all integrations.

r? @ob-stripe 