### PR TITLE
Allow use of System.Console from .NET Core/Standard

### DIFF
--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -21,6 +21,21 @@
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
 
+  <!--
+       .NET Core (and the .NET Standard) refactors the API's surface so that it
+       exists in a collection of smaller assemblies. As part of traditional
+       .NET (e.g., net45), System.Console existed as part of the standard
+       System assembly, but for the new standard it was added to its own.
+
+       Here we conditionally include System.Console for the .NET Standard
+       target (which also allows us to use it in .NET Core).
+
+       Reference: https://github.com/dotnet/corefx/issues/683
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
+    <PackageReference Include="System.Console" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
.NET Core refactors some of the traditional assemblies so that they
exist in smaller components with more specialized responsibility. One
API that moved is `System.Console` which used to exist as part of the
standard `System`, but now exists at its own package (see [1] for
reference).

Here we tell our `.vsproj` to conditionally include the `System.Console`
package for the version of .NET Standard that we're using. This also
allows it to be used under .NET Core.

I don't think this will be harmful in any way, and having access to
writing to output can be pretty useful, so I think it makes sense to
pull this in.

[1] https://github.com/dotnet/corefx/issues/683

cc @ob-stripe @remi-stripe @pantera-stripe