### PR TITLE
Minor webhook signing improvements

### DIFF
--- a/src/Stripe.Tests.XUnit/events/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/events/_fixture.cs
@@ -8,6 +8,7 @@ namespace Stripe.Tests.Xunit
     {
         // this was sent in the header Stripe-Signature along with the body of event.json in a test webhook
         internal string StripeSignature => "t=1493329224,v1=dca14f723dfa3bf47a310c3d6c3aff8bdb2534263d051dd2613ece097b8bdea4,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
+        internal int EventTimestamp => 1493329224;
         internal string StripeJson { get; set; }
         internal string StripeSecret => "whsec_H68eTX02a4bCbiQOOoSAsIytOvuWZrQC";
 

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -28,18 +28,15 @@ namespace Stripe.Tests.Xunit
         [Fact]
         public void it_should_validate_with_right_data()
         {
-            // Override the event utility to prevent it from looking at UTC now and use a fixed valid timestamp in the past
-            StripeEventUtility.EpochUtcNowOverride = 1493329524;
+            // A timestamp within the default tolerance of 300 seconds
+            int ReasonablyCloseTime = fixture.EventTimestamp + 120;
 
-            ConstructedEvent = StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret);
+            ConstructedEvent = StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret, ReasonablyCloseTime);
 
             ConstructedEvent.Should().NotBeNull();
             ConstructedEvent.Request.Id.Should().Be("req_FAKE");
             ConstructedEvent.Request.IdempotencyKey.Should().Be("placeholder");
             ConstructedEvent.Account.Should().Be("acct_CONNECT");
-
-            // Clean up to prevent unexpected behaviour in other facts
-            StripeEventUtility.EpochUtcNowOverride = null;
         }
 
         [Fact]

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -18,7 +18,7 @@ namespace Stripe.Tests.Xunit
         public void it_should_throw_with_outdated_timestamp()
         {
             // This throws an error because the tolerance is higher than allowed
-            var exception = Assert.Throws<Exception>(() =>
+            var exception = Assert.Throws<StripeException>(() =>
                 StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret)
             );
 
@@ -46,7 +46,7 @@ namespace Stripe.Tests.Xunit
         public void it_should_throw_with_incorrect_signature()
         {
             // This throws an error because the original JSON message is modified
-            var exception = Assert.Throws<Exception>(() =>
+            var exception = Assert.Throws<StripeException>(() =>
                 StripeEventUtility.ConstructEvent(fixture.StripeJson + "this_changes_the_json", fixture.StripeSignature, fixture.StripeSecret)
             );
 
@@ -56,7 +56,7 @@ namespace Stripe.Tests.Xunit
         [Fact]
         public void it_should_throw_with_invalid_unicode_in_secret()
         {
-            var exception = Assert.Throws<Exception>(() =>
+            var exception = Assert.Throws<StripeException>(() =>
                 StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret + "\ud802")
             );
 
@@ -66,7 +66,7 @@ namespace Stripe.Tests.Xunit
         [Fact]
         public void it_should_throw_with_invalid_unicode_in_message()
         {
-            var exception = Assert.Throws<Exception>(() =>
+            var exception = Assert.Throws<StripeException>(() =>
                 StripeEventUtility.ConstructEvent(fixture.StripeJson + "\ud802", fixture.StripeSignature, fixture.StripeSecret)
             );
 

--- a/src/Stripe.net/Infrastructure/Public/StripeException.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeException.cs
@@ -13,6 +13,14 @@ namespace Stripe
         { 
         }
 
+        public StripeException(string message) : base(message)
+        {
+        }
+
+        public StripeException(string message, Exception err) : base(message, err)
+        {
+        }
+
         public StripeException(HttpStatusCode httpStatusCode, StripeError stripeError, string message) : base(message)
         {
             HttpStatusCode = httpStatusCode;

--- a/src/Stripe.net/Services/Events/StripeEventUtility.cs
+++ b/src/Stripe.net/Services/Events/StripeEventUtility.cs
@@ -11,7 +11,6 @@ namespace Stripe
 {
     public static class StripeEventUtility
     {
-        internal static long? EpochUtcNowOverride { get; set; }
         internal static readonly UTF8Encoding SafeUTF8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
         public static StripeEvent ParseEvent(string json)
@@ -25,6 +24,11 @@ namespace Stripe
         }
 
         public static StripeEvent ConstructEvent(string json, string stripeSignatureHeader, string secret, int tolerance = 300)
+        {
+            return ConstructEvent(json, stripeSignatureHeader, secret, tolerance, DateTime.UtcNow.ConvertDateTimeToEpoch());
+        }
+
+        public static StripeEvent ConstructEvent(string json, string stripeSignatureHeader, string secret, int tolerance, long utcNow)
         {
             var signatureItems = parseStripeSignature(stripeSignatureHeader);
             var signature = string.Empty;
@@ -41,7 +45,6 @@ namespace Stripe
             if (!isSignaturePresent(signature, signatureItems["v1"]))
                 throw new StripeException("The signature for the webhook is not present in the Stripe-Signature header.");
 
-            var utcNow = EpochUtcNowOverride ?? DateTime.UtcNow.ConvertDateTimeToEpoch();
             var webhookUtc = Convert.ToInt32(signatureItems["t"].FirstOrDefault());
 
             if (utcNow - webhookUtc > tolerance)

--- a/src/Stripe.net/Services/Events/StripeEventUtility.cs
+++ b/src/Stripe.net/Services/Events/StripeEventUtility.cs
@@ -35,17 +35,17 @@ namespace Stripe
             }
             catch (EncoderFallbackException ex)
             {
-               throw new Exception("The webhook cannot be processed because the signature cannot be safely calculated.", ex);
+               throw new StripeException("The webhook cannot be processed because the signature cannot be safely calculated.", ex);
             }
 
             if (!isSignaturePresent(signature, signatureItems["v1"]))
-                throw new Exception("The signature for the webhook is not present in the Stripe-Signature header.");
+                throw new StripeException("The signature for the webhook is not present in the Stripe-Signature header.");
 
             var utcNow = EpochUtcNowOverride ?? DateTime.UtcNow.ConvertDateTimeToEpoch();
             var webhookUtc = Convert.ToInt32(signatureItems["t"].FirstOrDefault());
 
             if (utcNow - webhookUtc > tolerance)
-                throw new Exception("The webhook cannot be processed because the current timestamp is above the allowed tolerance.");
+                throw new StripeException("The webhook cannot be processed because the current timestamp is above the allowed tolerance.");
 
             return Mapper<StripeEvent>.MapFromJson(json);
         }


### PR DESCRIPTION
Two improvements here:

- (minor) `ConstructEvent` now throws a `StripeException` instead of a generic `Exception`, which prevents calling code from catching non-SDK related errors when constructing events.
- (minor) Refactor the test suite to eliminate the `EpochUtcNowOverride` class member, which was only used by the test suite.

I had to add a couple more constructors to `StripeException`, as the existing constructor was only for errors during HTTP requests. As a bigger project I'd like to see us leave `StripeException` as a generic exception and derive an `StripeHTTPException` class from `StripeException`, which would cleanly break up the class responsibilities. It'd also allow us to add custom exception formatting and better surface non-200 HTTP responses and API error messages.

r? @ob-stripe 
cc @stripe/api-libraries @rpaul-stripe 
