### PR TITLE
Remove unneeded parameters on `SourceCard`

### DIFF
--- a/src/Stripe.net/Services/_sources/SourceCard.cs
+++ b/src/Stripe.net/Services/_sources/SourceCard.cs
@@ -6,59 +6,82 @@ namespace Stripe
 {
     public class SourceCard : INestedOptions
     {
+        /// <summary>
+        /// The type of payment source. Should be "card".
+        /// </summary>
         [JsonProperty("source[object]")]
         internal string Object => "card";
 
-        [JsonProperty("source[number]")]
-        public string Number { get; set; }
-
-        [JsonProperty("source[exp_month]")]
-        public int ExpirationMonth { get; set; }
-
-        [JsonProperty("source[exp_year]")]
-        public int ExpirationYear { get; set; }
-
-        [JsonProperty("source[cvc]")]
-        public string Cvc { get; set; }
-
-        [JsonProperty("source[name]")]
-        public string Name { get; set; }
-
-        [JsonProperty("source[address_line1]")]
-        public string AddressLine1 { get; set; }
-
-        [JsonProperty("source[address_line2]")]
-        public string AddressLine2 { get; set; }
-
+        /// <summary>
+        /// City/District/Suburb/Town/Village.
+        /// </summary>
         [JsonProperty("source[address_city]")]
         public string AddressCity { get; set; }
 
-        [JsonProperty("source[address_zip]")]
-        public string AddressZip { get; set; }
-
-        [JsonProperty("source[address_state]")]
-        public string AddressState { get; set; }
-
+        /// <summary>
+        /// Billing address country, if provided when creating card.
+        /// </summary>
         [JsonProperty("source[address_country]")]
         public string AddressCountry { get; set; }
 
-        [JsonProperty("source[description]")]
-        public string Description { get; set; }
+        /// <summary>
+        /// Address line 1 (Street address/PO Box/Company name).
+        /// </summary>
+        [JsonProperty("source[address_line1]")]
+        public string AddressLine1 { get; set; }
 
+        /// <summary>
+        /// Address line 2 (Apartment/Suite/Unit/Building).
+        /// </summary>
+        [JsonProperty("source[address_line2]")]
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// State/County/Province/Region.
+        /// </summary>
+        [JsonProperty("source[address_state]")]
+        public string AddressState { get; set; }
+
+        /// <summary>
+        /// Zip/Postal Code.
+        /// </summary>
+        [JsonProperty("source[address_zip]")]
+        public string AddressZip { get; set; }
+
+        /// <summary>
+        /// USUALLY REQUIRED: Card security code. Highly recommended to always include this value, but it's only required for accounts based in European countries.
+        /// </summary>
+        [JsonProperty("source[cvc]")]
+        public string Cvc { get; set; }
+
+        /// <summary>
+        /// REQUIRED: Two digit number representing the card's expiration month.
+        /// </summary>
+        [JsonProperty("source[exp_month]")]
+        public int ExpirationMonth { get; set; }
+
+        /// <summary>
+        /// REQUIRED: Two or four digit number representing the card's expiration year.
+        /// </summary>
+        [JsonProperty("source[exp_year]")]
+        public int ExpirationYear { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.
+        /// </summary>
         [JsonProperty("source[metadata]")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        [JsonProperty("source[capture]")]
-        public bool? Capture { get; set; }
+        /// <summary>
+        /// Cardholder's full name.
+        /// </summary>
+        [JsonProperty("source[name]")]
+        public string Name { get; set; }
 
-        [JsonProperty("source[statement_descriptor]")]
-        public string StatementDescriptor { get; set; }
-
-        [JsonProperty("source[destination]")]
-        public string Destination { get; set; }
-
-        // application_fee
-
-        // shipping
+        /// <summary>
+        /// REQUIRED: The card number, as a string without any separators.
+        /// </summary>
+        [JsonProperty("source[number]")]
+        public string Number { get; set; }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

`SourceCard` is the class used to store raw card parameters in charge creation requests, customer creation & update requests, card creation requests, and subscription creation & update requests. (It's unrelated to the sources API.)

This PR:
- removes the `capture`, `destination` and `statement_descriptor` parameters (none of which are supported by the API in card hashes)
- reorders the other parameters alphabetically
- adds documentation for each parameter

Fixes #1112.
