### PR TITLE
Adds the `FailureReason` property to `StripeRedirect`

### DIFF
--- a/src/Stripe.net/Entities/Sources/StripeRedirect.cs
+++ b/src/Stripe.net/Entities/Sources/StripeRedirect.cs
@@ -5,6 +5,12 @@ namespace Stripe
     public class StripeRedirect : StripeEntity
     {
         /// <summary>
+        /// The failure reason for the redirect. One of <see cref="StripeRedirectFailureReason" />.
+        /// </summary>
+        [JsonProperty("failure_reason")]
+        public StripeRedirectFailureReason? FailureReason { get; set; }
+
+        /// <summary>
         /// The URL you provide to redirect the customer to after they authenticated their payment.
         /// </summary>
         [JsonProperty("return_url")]

--- a/src/Stripe.net/Enums/StripeRedirectFailureReason.cs
+++ b/src/Stripe.net/Enums/StripeRedirectFailureReason.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace Stripe
+{
+    /// <summary>
+    /// An enum describing the reason for a failed redirect.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum StripeRedirectFailureReason
+    {
+        /// <summary>
+        /// Indicates that the authentication failed or the transaction was declined.
+        /// </summary>
+        [EnumMember(Value = "declined")]
+        Declined,
+
+        /// <summary>
+        /// Indicates that the redirect failed due to a technical error.
+        /// </summary>
+        [EnumMember(Value = "processing_error")]
+        ProcessingError,
+
+        /// <summary>
+        /// Indicates that the user aborted or dropped out of the redirect flow.
+        /// </summary>
+        [EnumMember(Value = "user_abort")]
+        UserAbort,
+    }
+}


### PR DESCRIPTION
We're currently missing the `FailureReason` property which is documented
here [1]. This patch adds it.

Fixes #1118.

[1] https://stripe.com/docs/api#source_object-redirect-failure_reason

r? @ob-stripe