### PR TITLE
Custom Url configuration

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -18,6 +18,9 @@ namespace Stripe
         public static TimeSpan? HttpTimeSpan { get; set; }
 
         private static string _apiKey;
+        private static string _apiBase;
+        private static string _uploadsBase;
+        private static string _connectBase;
 
         static StripeConfiguration()
         {
@@ -39,6 +42,48 @@ namespace Stripe
         public static void SetApiKey(string newApiKey)
         {
             _apiKey = newApiKey;
+        }
+
+        internal static string GetApiBase()
+        {
+            if (string.IsNullOrEmpty(_apiBase))
+            {
+                _apiBase = Urls.DefaultBaseUrl;
+            }
+            return _apiBase;
+        }
+
+        public static void SetApiBase(string baseUrl)
+        {
+            _apiBase = baseUrl;
+        }
+
+        internal static string GetUploadsBase()
+        {
+            if (string.IsNullOrEmpty(_uploadsBase))
+            {
+                _uploadsBase = Urls.DefaultBaseUploadsUrl;
+            }
+            return _uploadsBase;
+        }
+
+        public static void SetUploadsBase(string baseUrl)
+        {
+            _uploadsBase = baseUrl;
+        }
+
+        internal static string GetConnectBase()
+        {
+            if (string.IsNullOrEmpty(_connectBase))
+            {
+                _connectBase = Urls.DefaultBaseConnectUrl;
+            }
+            return _connectBase;
+        }
+
+        public static void SetConnectBase(string baseUrl)
+        {
+            _connectBase = baseUrl;
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/Urls.cs
+++ b/src/Stripe.net/Infrastructure/Urls.cs
@@ -2,7 +2,9 @@
 {
     internal static class Urls
     {
-        internal static string BaseUrl => "https://api.stripe.com/v1";
+        internal static string DefaultBaseUrl => "https://api.stripe.com/v1";
+
+        internal static string BaseUrl => StripeConfiguration.GetApiBase();
 
         public static string Invoices => BaseUrl + "/invoices";
 
@@ -46,9 +48,13 @@
 
         public static string OAuthDeauthorize => BaseConnectUrl + "/oauth/deauthorize";
 
-        private static string BaseConnectUrl => "https://connect.stripe.com";
+        internal static string DefaultBaseConnectUrl => "https://connect.stripe.com";
 
-        private static string BaseUploadsUrl => "https://uploads.stripe.com/v1";
+        private static string BaseConnectUrl => StripeConfiguration.GetConnectBase();
+
+        internal static string DefaultBaseUploadsUrl => "https://uploads.stripe.com/v1";
+
+        private static string BaseUploadsUrl => StripeConfiguration.GetUploadsBase();
 
         public static string FileUploads => BaseUploadsUrl + "/files";
     }


### PR DESCRIPTION
#1102 

* adds configuration options for apiBase, uploadsBase, connectBase

allows consumers of the library to easily override the base urls for the stripe api to allow for easier testing (for example, with the stripe-mock service)