### PR TITLE
(WIP) Consider improving StripeEvent polymorphic reference

### DIFF
--- a/src/Stripe.Tests.XUnit/events/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/events/_fixture.cs
@@ -7,7 +7,7 @@ namespace Stripe.Tests.Xunit
     public class events_fixture
     {
         // this was sent in the header Stripe-Signature along with the body of event.json in a test webhook
-        internal string StripeSignature => "t=1493329224,v1=dca14f723dfa3bf47a310c3d6c3aff8bdb2534263d051dd2613ece097b8bdea4,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
+        internal string StripeSignature => "t=1493329224,v1=eb27ce0245b4a641852b443c47054f6ca2719048270028ce9fcf240c8c77f9e6,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef";
         internal int EventTimestamp => 1493329224;
         internal string StripeJson { get; set; }
         internal string StripeSecret => "whsec_H68eTX02a4bCbiQOOoSAsIytOvuWZrQC";

--- a/src/Stripe.Tests.XUnit/events/event.json
+++ b/src/Stripe.Tests.XUnit/events/event.json
@@ -1,43 +1,89 @@
 ﻿{
-  "id": "evt_1ADKLLLWlyqCpbLp0qRyqExL",
-  "object": "event",
-  "account": "acct_CONNECT",
-  "api_version": "2017-05-25",
-  "created": 1493329207,
-  "data": {
-    "object": {
-      "id": "ii_1ACxoELWlyqCpbLpBSzyGWHX",
-      "object": "invoiceitem",
-      "amount": 1000,
-      "currency": "usd",
-      "customer": "cus_AY3wPzBBv9DU2H",
-      "date": 1493242586,
-      "description": "Test Invoice Item",
-      "discountable": false,
-      "invoice": "in_1ADKLKLWlyqCpbLpMhrRBk7u",
-      "livemode": false,
-      "metadata": {
-        "A": "Value-A",
-        "B": "Value-B"
-      },
-      "period": {
-        "start": 1493242586,
-        "end": 1493242586
-      },
-      "plan": null,
-      "proration": false,
-      "quantity": null,
-      "subscription": null
+    "id": "evt_1C3T3NDTLHiiDklrSQa8SGw8",
+    "object": "event",
+    "account": "acct_CONNECT",
+    "api_version": "2017-05-25",
+    "created": 1520532081,
+    "data": {
+        "object": {
+            "id": "ch_1C3T3MDTLHiiDklrEkWcj4XK",
+            "object": "charge",
+            "amount": 1000,
+            "amount_refunded": 0,
+            "application": "ca_8JqC6RrO75GM2pIx953mFymukVxpJt4n",
+            "application_fee": null,
+            "balance_transaction": "txn_1C3T3MDTLHiiDklrjexvdDXi",
+            "captured": true,
+            "created": 1520532080,
+            "currency": "usd",
+            "customer": null,
+            "description": null,
+            "destination": null,
+            "dispute": null,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {},
+            "invoice": null,
+            "livemode": false,
+            "metadata": {},
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+                "network_status": "approved_by_network",
+                "reason": null,
+                "risk_level": "normal",
+                "seller_message": "Payment complete.",
+                "type": "authorized"
+            },
+            "paid": true,
+            "receipt_email": null,
+            "receipt_number": null,
+            "refunded": false,
+            "refunds": {
+                "object": "list",
+                "data": [],
+                "has_more": false,
+                "total_count": 0,
+                "url": "/v1/charges/ch_1C3T3MDTLHiiDklrEkWcj4XK/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+                "id": "card_1C3T3MDTLHiiDklrqMvU11LV",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": null,
+                "cvc_check": null,
+                "dynamic_last4": null,
+                "exp_month": 8,
+                "exp_year": 2019,
+                "fingerprint": "Kbj9I52SHFWqQm4w",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {},
+                "name": null,
+                "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "status": "succeeded",
+            "transfer_group": null
+        }
     },
-    "previous_attributes": {
-      "invoice": null
-    }
-  },
-  "livemode": false,
-  "pending_webhooks": 2,
-  "request": {
-    "id": "req_FAKE",
-    "idempotency_key": "placeholder"
-  },
-  "type": "invoiceitem.updated"
+    "livemode": false,
+    "pending_webhooks": 1,
+    "request": {
+        "id": "req_FAKE",
+        "idempotency_key": "placeholder"
+    },
+    "type": "charge.succeeded"
 }

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -76,7 +76,7 @@ namespace Stripe.Tests.Xunit
             int ReasonablyCloseTime = fixture.EventTimestamp;
             ConstructedEvent = StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret, ReasonablyCloseTime);
 
-            StripeCharge Charge = ConstructedEvent.Data.Object.ToObject(typeof(StripeCharge));
+            StripeCharge Charge = (StripeCharge)ConstructedEvent.Data;
             Charge.Amount.Should().Be(1000);
             Charge.Currency.Should().Be("usd");
             Charge.Source.Id.Should().Be("card_1C3T3MDTLHiiDklrqMvU11LV");

--- a/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
+++ b/src/Stripe.Tests.XUnit/events/when_constructing_an_event.cs
@@ -69,5 +69,19 @@ namespace Stripe.Tests.Xunit
 
             exception.Message.Should().Be("The webhook cannot be processed because the signature cannot be safely calculated.");
         }
+
+        [Fact]
+        public void its_data_can_be_cast_to_a_charge_object()
+        {
+            int ReasonablyCloseTime = fixture.EventTimestamp;
+            ConstructedEvent = StripeEventUtility.ConstructEvent(fixture.StripeJson, fixture.StripeSignature, fixture.StripeSecret, ReasonablyCloseTime);
+
+            StripeCharge Charge = ConstructedEvent.Data.Object.ToObject(typeof(StripeCharge));
+            Charge.Amount.Should().Be(1000);
+            Charge.Currency.Should().Be("usd");
+            Charge.Source.Id.Should().Be("card_1C3T3MDTLHiiDklrqMvU11LV");
+            Charge.Source.Card.Brand.Should().Be("Visa");
+        }
+
     }
 }

--- a/src/Stripe.net/Entities/StripeEventData.cs
+++ b/src/Stripe.net/Entities/StripeEventData.cs
@@ -9,5 +9,9 @@ namespace Stripe
 
 		[JsonProperty("previous_attributes")]
 		public dynamic PreviousAttributes { get; set; }
+
+		public static explicit operator StripeCharge(StripeEventData evt) {
+			return evt.Object.ToObject(typeof(StripeCharge));
+		}
 	}
 }


### PR DESCRIPTION
Currently in order to do something useful with a webhook event's data you need to jump through a few hoops:

```c#
StripeEvent event = StripeEventUtility.ConstructEvent(…);

// ConstructedEvent.Data.Object contains the event details
// Since JSON.NET parsed *all* of the event JSON, this is a Newtonsoft.Json.Linq.JToken object[1]
// Since we've already registered the Stripe.NET deserializers we can dynamically
// cast this into the type of object we need.

if (event.Type == "charge.successful") {
   StripeCharge Charge = ConstructedEvent.Data.Object.ToObject(typeof(StripeCharge));
}
else if (event.Type == …) {
  …
}
```

I don't like this approach for two reasons:

1. You end up with an if/else type ladder (or switch) mapping event types to entity types. This feels like something that could be encoded better, possibly by customizing StripeEvent's deserializer.
2. In order to get the type of object you *actually* want, you have to also know internal details of the StripeEventData object as well as how JSON.NET works internally, which feels like two leaky abstractions.

I'm not sure what approach we'd favor long-run for #1, but for the second I propose this as an API:

```c#
StripeEvent event = StripeEventUtility.ConstructEvent(…);

if (event.Type == "charge.successful") {
   StripeCharge Charge = (StripeCharge)ConstructedEvent.Data;
}
else if (event.Type == …) {
  …
}
```

This is actually pretty easy to accomplish with by defining an explicit conversion operator[2] for each kind of object that can be included in StripeEventData, and also has the nice property of causing a compile-time warning if one attempts to cast to a type of object that can't occur in an event's payload. I wrote an example in this PR. The downside is that this requires one conversion method per event payload type.

I'm also not sure that event type -> event payload type is well mapped in the API, which might be a future enhancement for the OpenAPI spec.

This PR is mainly speculative, but I'd love thoughts on this line of improvement.

At the very least I want to commit the example of how to typecast `event.Data.Object` so that we can use it as a reference later on.

[1] https://www.newtonsoft.com/json/help/html/M_Newtonsoft_Json_Linq_JToken_ToObject.htm
[2] https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/explicit