### PR TITLE
Add support for more Expand and change Outcome to be auto expanded

### DIFF
--- a/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
+++ b/src/Stripe.Tests.XUnit/charges/creating_updating_and_capturing_charges.cs
@@ -69,6 +69,13 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void charge_has_outcome_filled()
+        {
+            fixture.Charge.Outcome.NetworkStatus.Should().NotBeNull();
+            fixture.Charge.Outcome.RiskLevel.Should().NotBeNull();
+        }
+
+        [Fact]
         public void updated_has_the_right_description()
         {
             fixture.UpdatedCharge.Description.Should().Be(fixture.ChargeUpdateOptions.Description);

--- a/src/Stripe.Tests.XUnit/skus/when_listing_skus.cs
+++ b/src/Stripe.Tests.XUnit/skus/when_listing_skus.cs
@@ -68,7 +68,7 @@ namespace Stripe.Tests.Xunit
         {
             fixture.SkuList.Data.Count.Should().Be(1);
             fixture.SkuList.Data.First().Id.Should().Be(fixture.SkuTwo.Id);
-            fixture.SkuList.Data.First().Product.Should().Be(fixture.Product.Id);
+            fixture.SkuList.Data.First().ProductId.Should().Be(fixture.Product.Id);
         }
     }
 }

--- a/src/Stripe.net/Entities/StripeAccount.cs
+++ b/src/Stripe.net/Entities/StripeAccount.cs
@@ -10,8 +10,21 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("business_logo")]
+        #region Expandable BusinessLogo
         public string BusinessLogoFileId { get; set; }
+
+        [JsonIgnore]
+        public StripeFileUpload BusinessLogo { get; set; }
+
+        [JsonProperty("business_logo")]
+        internal object InternalBusinessLogo
+        {
+            set
+            {
+                StringOrObject<StripeFileUpload>.Map(value, s => BusinessLogoFileId = s, o => BusinessLogo = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("business_name")]
         public string BusinessName { get; set; }

--- a/src/Stripe.net/Entities/StripeApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/StripeApplicationFeeRefund.cs
@@ -13,8 +13,21 @@ namespace Stripe
         [JsonProperty("amount")]
         public int Amount { get; set; }
 
+        #region Expandable Balance Transaction
+        public string BalanceTransactionId { get; set; }
+
+        [JsonIgnore]
+        public StripeBalanceTransaction BalanceTransaction { get; set; }
+
         [JsonProperty("balance_transaction")]
-        public string BalanceTransaction { get; set; }
+        internal object InternalBalanceTransaction
+        {
+            set
+            {
+                StringOrObject<StripeBalanceTransaction>.Map(value, s => BalanceTransactionId = s, o => BalanceTransaction = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("created")]
         [JsonConverter(typeof(StripeDateTimeConverter))]
@@ -23,8 +36,21 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        #region Expandable Fee
+        public string FeeId { get; set; }
+
+        [JsonIgnore]
+        public StripeApplicationFee Fee { get; set; }
+
         [JsonProperty("fee")]
-        public string Fee { get; set; }
+        internal object InternalFee
+        {
+            set
+            {
+                StringOrObject<StripeApplicationFee>.Map(value, s => FeeId = s, o => Fee = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Entities/StripeCharge.cs
+++ b/src/Stripe.net/Entities/StripeCharge.cs
@@ -218,25 +218,30 @@ namespace Stripe
         }
         #endregion
 
-        // order - requires orders to be expandable
-        [JsonProperty("order")]
-        public string Order { get; set; }
-
-        #region Expandable Outcome
-        public string OutcomeId { get; set; }
+        #region Expandable Order
+        /// <summary>
+        /// ID of the order this charge is for if one exists.
+        /// </summary>
+        public string OrderId { get; set; }
 
         [JsonIgnore]
-        public StripeOutcome Outcome { get; set; }
+        public StripeOrder Order { get; set; }
 
-        [JsonProperty("outcome")]
-        internal object InternalOutcome
+        [JsonProperty("order")]
+        internal object InternalOrder
         {
             set
             {
-                StringOrObject<StripeOutcome>.Map(value, s => OutcomeId = s, o => Outcome = o);
+                StringOrObject<StripeOrder>.Map(value, s => OrderId = s, o => Order = o);
             }
         }
         #endregion
+
+        /// <summary>
+        /// Details about whether the payment was accepted, and why.
+        /// </summary>
+        [JsonProperty("outcome")]
+        public StripeOutcome Outcome { get; set; }
 
         /// <summary>
         /// true if the charge succeeded, or was successfully authorized for later capture.

--- a/src/Stripe.net/Entities/StripeInvoice.cs
+++ b/src/Stripe.net/Entities/StripeInvoice.cs
@@ -128,8 +128,21 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
-        [JsonProperty("subscription")]
+        #region Expandable Subscription
         public string SubscriptionId { get; set; }
+
+        [JsonIgnore]
+        public StripeSubscription Subscription { get; set; }
+
+        [JsonProperty("subscription")]
+        internal object InternalSubscription
+        {
+            set
+            {
+                StringOrObject<StripeSubscription>.Map(value, s => SubscriptionId = s, o => Subscription = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("subscription_proration_date")]
         [JsonConverter(typeof(StripeDateTimeConverter))]

--- a/src/Stripe.net/Entities/StripeInvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/StripeInvoiceLineItem.cs
@@ -76,8 +76,21 @@ namespace Stripe
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
-        [JsonProperty("subscription")]
+        #region Expandable Subscription
         public string SubscriptionId { get; set; }
+
+        [JsonIgnore]
+        public StripeSubscription Subscription { get; set; }
+
+        [JsonProperty("subscription")]
+        internal object InternalSubscription
+        {
+            set
+            {
+                StringOrObject<StripeSubscription>.Map(value, s => SubscriptionId = s, o => Subscription = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("subscription_item")]
         public string SubscriptionItem { get; set; }

--- a/src/Stripe.net/Entities/StripeOutcome.cs
+++ b/src/Stripe.net/Entities/StripeOutcome.cs
@@ -23,10 +23,10 @@ namespace Stripe
         public string RiskLevel { get; set; }
 
         /// <summary>
-        /// An enumerated value indicating a more detailed explanation of the outcome’s type. See understanding declines for details.
+        /// The ID of the Radar rule that matched the payment, if applicable.
         /// </summary>
         [JsonProperty("rule")]
-        public string Rule { get; set; }
+        public string RuleId { get; set; }
 
         /// <summary>
         /// A human-readable description of the outcome type and reason, designed for you (the recipient of the payment), not your customer.

--- a/src/Stripe.net/Entities/StripeSku.cs
+++ b/src/Stripe.net/Entities/StripeSku.cs
@@ -71,11 +71,24 @@ namespace Stripe
         [JsonProperty("price")]
         public int Price { get; set; }
 
+        #region Expandable Product
         /// <summary>
         /// The ID of the product this SKU is associated with. The product must be currently active.
         /// </summary>
+        public string ProductId { get; set; }
+
+        [JsonIgnore]
+        public StripeProduct Product { get; set; }
+
         [JsonProperty("product")]
-        public string Product { get; set; }
+        internal object InternalProduct
+        {
+            set
+            {
+                StringOrObject<StripeProduct>.Map(value, s => ProductId = s, o => Product = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("updated")]
         [JsonConverter(typeof(StripeDateTimeConverter))]

--- a/src/Stripe.net/Entities/StripeTransfer.cs
+++ b/src/Stripe.net/Entities/StripeTransfer.cs
@@ -39,11 +39,37 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        #region Expandable Destination
+        public string DestinationId { get; set; }
+
+        [JsonIgnore]
+        public StripeAccount Destination { get; set; }
+
         [JsonProperty("destination")]
-        public string Destination { get; set; }
+        internal object InternalDestination
+        {
+            set
+            {
+                StringOrObject<StripeAccount>.Map(value, s => DestinationId = s, o => Destination = o);
+            }
+        }
+        #endregion
+
+        #region Expandable Destination Payment
+        public string DestinationPaymentId { get; set; }
+
+        [JsonIgnore]
+        public StripeCharge DestinationPayment { get; set; }
 
         [JsonProperty("destination_payment")]
-        public string DestinationPayment { get; set; }
+        internal object InternalDestinationPayment
+        {
+            set
+            {
+                StringOrObject<StripeCharge>.Map(value, s => DestinationPaymentId = s, o => DestinationPayment = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("livemode")]
         public bool LiveMode { get; set; }
@@ -57,8 +83,21 @@ namespace Stripe
         [JsonProperty("reversed")]
         public bool Reversed { get; set; }
 
-        [JsonProperty("source_transaction")]
+        #region Expandable Source Transaction
         public string SourceTransactionId { get; set; }
+
+        [JsonIgnore]
+        public StripeCharge SourceTransaction { get; set; }
+
+        [JsonProperty("source_transaction")]
+        internal object InternalSourceTransaction
+        {
+            set
+            {
+                StringOrObject<StripeCharge>.Map(value, s => SourceTransactionId = s, o => SourceTransaction = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("source_type")]
         public string SourceType { get; set; }

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -10,6 +10,8 @@ namespace Stripe
         public StripeAccountService() : base(null) { }
         public StripeAccountService(string apiKey) : base(apiKey) { }
 
+        public bool ExpandBusinessLogo { get; set; }
+
 
 
         //Sync

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/StripeApplicationFeeRefundService.cs
@@ -10,6 +10,11 @@ namespace Stripe
         public StripeApplicationFeeRefundService() : base(null) { }
         public StripeApplicationFeeRefundService(string apiKey) : base(apiKey) { }
 
+        public bool ExpandBalanceTransaction { get; set; }
+        public bool ExpandFee { get; set; }
+
+
+
         // Sync
         public virtual StripeApplicationFeeRefund Create(string applicationFeeId, StripeApplicationFeeRefundCreateOptions createOptions = null, StripeRequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
@@ -14,6 +14,7 @@ namespace Stripe
         public bool ExpandApplication { get; set; }
         public bool ExpandBalanceTransaction { get; set; }
         public bool ExpandCharge { get; set; }
+        public bool ExpandOriginatingTransaction { get; set; }
 
 
 

--- a/src/Stripe.net/Services/Charges/StripeChargeService.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeService.cs
@@ -14,13 +14,13 @@ namespace Stripe
         public bool ExpandBalanceTransaction { get; set; }
         public bool ExpandCustomer { get; set; }
         public bool ExpandDestination { get; set; }
-        public bool ExpandInvoice { get; set; }
-        public bool ExpandReview { get; set; }
-        public bool ExpandTransfer { get; set; }
-        public bool ExpandOnBehalfOf { get; set; }
-        public bool ExpandSourceTransfer { get; set; }
         public bool ExpandDispute { get; set; }
-        public bool ExpandOutcome { get; set; }
+        public bool ExpandInvoice { get; set; }
+        public bool ExpandOnBehalfOf { get; set; }
+        public bool ExpandOrder { get; set; }
+        public bool ExpandReview { get; set; }
+        public bool ExpandSourceTransfer { get; set; }
+        public bool ExpandTransfer { get; set; }
 
 
 

--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
@@ -12,6 +12,7 @@ namespace Stripe
 
         public bool ExpandCustomer { get; set; }
         public bool ExpandInvoice { get; set; }
+        public bool ExpandSubscription { get; set; }
 
 
 

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
@@ -12,6 +12,7 @@ namespace Stripe
 
         public bool ExpandCharge { get; set; }
         public bool ExpandCustomer { get; set; }
+        public bool ExpandSubscription { get; set; }
 
 
 

--- a/src/Stripe.net/Services/Orders/StripeOrderService.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderService.cs
@@ -10,6 +10,9 @@ namespace Stripe
         public StripeOrderService() : base(null) { }
         public StripeOrderService(string apiKey) : base(apiKey) { }
 
+        public bool ExpandCharge { get; set; }
+        public bool ExpandCustomer { get; set; }
+
 
 
         // Sync

--- a/src/Stripe.net/Services/Payouts/StripePayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/StripePayoutService.cs
@@ -11,8 +11,8 @@ namespace Stripe
         public StripePayoutService(string apiKey) : base(apiKey) { }
 
         public bool ExpandBalanceTransaction { get; set; }
-        public bool ExpandFailureBalanceTransaction { get; set; }
         public bool ExpandDestination { get; set; }
+        public bool ExpandFailureBalanceTransaction { get; set; }
 
 
 

--- a/src/Stripe.net/Services/Refunds/StripeRefundService.cs
+++ b/src/Stripe.net/Services/Refunds/StripeRefundService.cs
@@ -13,6 +13,7 @@ namespace Stripe
 
         public bool ExpandBalanceTransaction { get; set; }
         public bool ExpandCharge { get; set; }
+        public bool ExpandFailureBalanceTransaction { get; set; }
 
 
 

--- a/src/Stripe.net/Services/Skus/StripeSkuService.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuService.cs
@@ -10,6 +10,8 @@ namespace Stripe
         public StripeSkuService() : base(null) { }
         public StripeSkuService(string apiKey) : base(apiKey) { }
 
+        public bool ExpandProduct { get; set; }
+
 
 
         // Sync

--- a/src/Stripe.net/Services/Transfers/StripeTransferService.cs
+++ b/src/Stripe.net/Services/Transfers/StripeTransferService.cs
@@ -11,6 +11,9 @@ namespace Stripe
         public StripeTransferService(string apiKey) : base(apiKey) { }
 
         public bool ExpandBalanceTransaction { get; set; }
+        public bool ExpandDestination { get; set; }
+        public bool ExpandDestinationPayment { get; set; }
+        public bool ExpandSourceTransaction { get; set; }
 
 
 


### PR DESCRIPTION
Expand support has been improved:
* Account: BusinessLogo
* ApplicationFee: OriginatingTransaction
* ApplicationFeeRefund: BalanceTransaction, Fee
* Charge: Order
* Invoice: Subscription
* InvoiceItem: Subscription
* Order: Charge, Customer
* Refund: FailureBalanceTransaction
* SKU: Product
* Transfer: Destination, DestinationPayment, SourceTransaction

Modified Outcome on the Charge resource to be automatically expanded and renamed Rule to RuleId as this is not expanded by default as of API version 2017-02-14.

This fixes https://github.com/stripe/stripe-dotnet/issues/741

r? @ob-stripe 
cc @stripe/api-libraries 