### PR TITLE
Add support for multi-level Expand feature

### DIFF
--- a/src/Stripe.Tests.XUnit/_infrastructure/expanding_resources.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/expanding_resources.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using FluentAssertions;
+using Xunit;
+using Stripe.Infrastructure;
+
+namespace Stripe.Tests.Xunit
+{
+    public class expanding_resources
+    {
+        public class TestOptions : StripeBaseOptions
+        {
+            [JsonProperty("a_string")]
+            public string AString { get; set; }
+        }
+
+        public class TestService : StripeService
+        {
+            public TestService() : base(null)
+            {
+            }
+        }
+
+        public TestService Service { get; }
+
+        public expanding_resources()
+        {
+            Service = new TestService();
+        }
+
+        [Fact]
+        public void can_expand_resources()
+        {
+            var obj = new TestOptions
+            {
+                AString = "foo",
+            };
+            obj.AddExpand("example1.subexample1");
+            obj.AddExpand("example2");
+            obj.AddExpand("example3.subexample3");
+
+            var url = Service.ApplyAllParameters(obj, "", false);
+            url.Should().Be("?a_string=foo&expand[]=example1.subexample1&expand[]=example2&expand[]=example3.subexample3");
+        }
+    }
+}

--- a/src/Stripe.Tests.XUnit/charges/when_creating_charges_with_multiple_expand.cs
+++ b/src/Stripe.Tests.XUnit/charges/when_creating_charges_with_multiple_expand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class when_creating_charges_with_multiple_expand
+    {
+        private static StripeCharge Charge;
+
+        public when_creating_charges_with_multiple_expand()
+        {
+            var accountService = new StripeAccountService(Cache.ApiKey);
+            var account = accountService.Create(new StripeAccountCreateOptions
+            {
+                Type = StripeAccountType.Custom
+            });
+
+            var chargeOptions = new StripeChargeCreateOptions
+            {
+                SourceTokenOrExistingSourceId = "tok_visa",
+                ApplicationFee = 10,
+                Amount = 100,
+                Currency = "usd",
+                Destination = account.Id,
+            };
+            chargeOptions.AddExpand("balance_transaction");
+            chargeOptions.AddExpand("transfer.balance_transaction.source");
+            chargeOptions.AddExpand("destination");
+
+            Charge = new StripeChargeService(Cache.ApiKey).Create(chargeOptions);
+
+            accountService.Delete(account.Id);
+        }
+
+
+        [Fact]
+        public void should_have_all_objects_expanded()
+        {
+            Charge.BalanceTransactionId.Should().Be(Charge.BalanceTransaction.Id);
+            Charge.DestinationId.Should().Be(Charge.Destination.Id);
+            Charge.Transfer.BalanceTransaction.Source.Id.Should().Be(Charge.Transfer.Id);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe.net/Infrastructure/ParameterBuilder.cs
@@ -39,6 +39,9 @@ namespace Stripe.Infrastructure
                     var key = WebUtility.UrlEncode(pair.Key);
                     RequestStringBuilder.ApplyParameterToRequestString(ref requestString, key, pair.Value);
                 }
+                foreach (var value in obj.Expand) {
+                    RequestStringBuilder.ApplyParameterToRequestString(ref requestString, "expand[]", value);
+                }
             }
 
             if (service != null)

--- a/src/Stripe.net/Services/StripeBaseOptions.cs
+++ b/src/Stripe.net/Services/StripeBaseOptions.cs
@@ -9,5 +9,12 @@ namespace Stripe
         }
 
         public Dictionary<string, string> ExtraParams = new Dictionary<string, string>();
+
+
+        public void AddExpand(string value) {
+            Expand.Add(value);
+        }
+
+        public List<string> Expand = new List<string>();
     }
 }


### PR DESCRIPTION
All options class now have the ability to pass a list of properties to expand. Until then, we had to add the `ExpandXXXX` property to the service and it only supported one level.

One downside is that this could cause crashes if you're on a version of the library that does not expand a specific property to be expandable.

The way I added this means that it is not a breaking change and both versions are supported. It would likely be best to remove the old way afterwards (or in this PR) to avoid conflicts though.

r? @ob-stripe 
cc @stripe/api-libraries 