### PR TITLE
Use parser plugins during SubscriptionItemUpdatedPlugin item creation

### DIFF
--- a/src/Stripe.Tests.XUnit/subscriptions/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/subscriptions/_fixture.cs
@@ -37,7 +37,12 @@ namespace Stripe.Tests.Xunit
                 Items = new List<StripeSubscriptionItemUpdateOption>
                 {
                     new StripeSubscriptionItemUpdateOption { Id = Subscription.Items.Data[0].Id, Deleted = true },
-                    new StripeSubscriptionItemUpdateOption { Id = Subscription.Items.Data[1].Id, Quantity = 5 }
+                    new StripeSubscriptionItemUpdateOption
+                    {
+                        Id = Subscription.Items.Data[1].Id,
+                        Quantity = 5,
+                        Metadata = new Dictionary<string, string>{ {"key", "value"} }
+                    }
                 }
             };
 

--- a/src/Stripe.Tests.XUnit/subscriptions/creating_and_updating_subscriptions.cs
+++ b/src/Stripe.Tests.XUnit/subscriptions/creating_and_updating_subscriptions.cs
@@ -58,6 +58,18 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void updated_has_metadata_keys()
+        {
+            fixture.SubscriptionUpdated.Items.Data[0].Metadata.Should().ContainKeys(fixture.SubscriptionUpdateOptions.Items[1].Metadata.Keys);
+        }
+
+        [Fact]
+        public void updated_has_metadata_values()
+        {
+            fixture.SubscriptionUpdated.Items.Data[0].Metadata.Should().ContainValues(fixture.SubscriptionUpdateOptions.Items[1].Metadata.Values);
+        }
+
+        [Fact]
         public void ended_should_not_be_null()
         {
             fixture.SubscriptionEnded.Should().NotBeNull();

--- a/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/SubscriptionItemUpdatedPlugin.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/ParserPlugin/SubscriptionItemUpdatedPlugin.cs
@@ -27,9 +27,9 @@ namespace Stripe.Infrastructure.Middleware
                     // it must have a json attribute matching stripe's key, and only one
                     var attr = prop.GetCustomAttributes<JsonPropertyAttribute>().SingleOrDefault();
                     if (attr == null) continue;
-
-                    RequestStringBuilder.ApplyParameterToRequestString(ref requestString,
-                        $"items[{itemIndex}][{attr.PropertyName}]", value.ToString());
+                    // a JsonPropertyAttribute is required to supply a property name to parser plugins.
+                    var indexedItemAttribute = new JsonPropertyAttribute($"items[{itemIndex}][{attr.PropertyName}]");
+                    RequestStringBuilder.ProcessPlugins(ref requestString, indexedItemAttribute, prop, value, propertyParent);
                 }
 
                 itemIndex++;


### PR DESCRIPTION
This PR makes the SubscriptionItemPlugin use the parser plugins in RequestStringBuilder when creating request values for items in subscription update. This solves an issue with the input metadata parsing. The Metadata dictionary property needs to be parsed by DictionaryParserPlugin to create a valid Stripe request.
An inline JsonPropertyAttribute is created, which isn't pretty. Any other change would require a larger refactor. 
I had to run the project locally with XUnit 2.3.0 due to Visual Studio issues, so the testcode should probably be validated on XUnit 2.2.0.

Fixes #1142.