### PR TITLE
Change StripeDateTimeConverter to write epoch not MS /Date(.)/ format

### DIFF
--- a/src/Stripe.Tests.XUnit/_infrastructure/datetime_json_converter.cs
+++ b/src/Stripe.Tests.XUnit/_infrastructure/datetime_json_converter.cs
@@ -1,0 +1,48 @@
+using System;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Stripe.Infrastructure;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class datetime_json_converter
+    {
+        [Fact]
+        public void should_roundtrip_datetimes()
+        {
+            var obj = new TestObject
+            {
+                Date = RoundedDate()
+            };
+
+            var reloaded = JsonConvert.DeserializeObject<TestObject>(JsonConvert.SerializeObject(obj));
+            reloaded.Date.Should().Be(obj.Date);
+        }
+
+        [Fact]
+        public void should_handle_null()
+        {
+            var obj = new TestObject
+            {
+                Date = null
+            };
+
+            var reloaded = JsonConvert.DeserializeObject<TestObject>(JsonConvert.SerializeObject(obj));
+            reloaded.Date.Should().BeNull();
+        }
+
+        private static DateTime RoundedDate()
+        {
+            var date = DateTime.UtcNow;
+
+            return date.AddTicks( -1 * (date.Ticks % TimeSpan.TicksPerSecond));
+        }
+
+        public class TestObject
+        {
+            [JsonConverter(typeof(StripeDateTimeConverter))]
+            public DateTime? Date { get; set; }
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/JsonConverters/StripeDateTimeConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/StripeDateTimeConverter.cs
@@ -8,7 +8,10 @@ namespace Stripe.Infrastructure
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteRawValue(@"""\/Date(" + EpochTime.ConvertDateTimeToEpoch((DateTime)value).ToString() + @")\/""");
+            if (value == null)
+                writer.WriteNull();
+            else
+                writer.WriteRawValue(((DateTime)value).ConvertDateTimeToEpoch().ToString());
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)


### PR DESCRIPTION
This closes #208 that I created over 3 years ago. I'm using Stripe on another project and have run into the same issue.

Stripe API does not support the /Date(...)/ format the JSON converter writes, which is why this converter is not placed on properties that are written to Stripe, only those that are read-only.

This PR allows the objects returned from Stripe to be stored locally as JSON and then rehydrated. We do this to have a cache locally of some of the objects to avoid repeated calls to Stripe to get the required information.