### PR TITLE
Added ConfigureAwait(false) to all awaited tasks.

### DIFF
--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -61,8 +61,8 @@ namespace Stripe.Infrastructure
 
         private static StripeResponse ExecuteRequest(HttpRequestMessage requestMessage)
         {
-            var response = HttpClient.SendAsync(requestMessage).Result;
-            var responseText = response.Content.ReadAsStringAsync().Result;
+            var response = HttpClient.SendAsync(requestMessage).ConfigureAwait(false).GetAwaiter().GetResult();
+            var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
             var result = BuildResponseData(response, responseText);
 
@@ -105,14 +105,15 @@ namespace Stripe.Infrastructure
 
         private static async Task<StripeResponse> ExecuteRequestAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = await HttpClient.SendAsync(requestMessage, cancellationToken);
+            var response = await HttpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var result = BuildResponseData(response, await response.Content.ReadAsStringAsync());
+            var result = BuildResponseData(response, responseText);
 
             if (response.IsSuccessStatusCode)
                 return result;
 
-            throw BuildStripeException(result, response.StatusCode, requestMessage.RequestUri.AbsoluteUri, await response.Content.ReadAsStringAsync());
+            throw BuildStripeException(result, response.StatusCode, requestMessage.RequestUri.AbsoluteUri, responseText);
         }
 
 

--- a/src/Stripe.net/Services/Account/StripeAccountService.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountService.cs
@@ -80,7 +80,7 @@ namespace Stripe
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, $"{Urls.BaseUrl}/accounts", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -91,13 +91,13 @@ namespace Stripe
             return Mapper<StripeList<StripeAccount>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, path, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
-        public virtual async Task<StripeAccount> GetAsync(StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeAccount> GetAsync(StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await GetAsync(string.Empty, requestOptions, cancellationToken);
+            return GetAsync(string.Empty, requestOptions, cancellationToken);
         }
 
         public virtual async Task<StripeAccount> GetAsync(string accountId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -107,7 +107,7 @@ namespace Stripe
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, path, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -116,7 +116,7 @@ namespace Stripe
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/accounts/{accountId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -125,7 +125,7 @@ namespace Stripe
             return Mapper<StripeAccount>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(rejectOptions, $"{Urls.BaseUrl}/accounts/{accountId}/reject", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -134,7 +134,7 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.BaseUrl}/accounts/{accountId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/StripeApplicationFeeService.cs
@@ -55,7 +55,7 @@ namespace Stripe
             return Mapper<StripeApplicationFee>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.ApplicationFees}/{applicationFeeId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -67,7 +67,7 @@ namespace Stripe
                 url = ParameterBuilder.ApplyParameterToUrl(url, "amount", refundAmount.Value.ToString());
 
             return Mapper<StripeApplicationFee>.MapFromJson(
-                await Requestor.PostStringAsync(url, SetupRequestOptions(requestOptions), cancellationToken)
+                await Requestor.PostStringAsync(url, SetupRequestOptions(requestOptions), cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -76,7 +76,7 @@ namespace Stripe
             return Mapper<StripeList<StripeApplicationFee>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.ApplicationFees, true),
                 SetupRequestOptions(requestOptions), 
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Balance/StripeBalanceService.cs
+++ b/src/Stripe.net/Services/Balance/StripeBalanceService.cs
@@ -44,7 +44,7 @@ namespace Stripe
         public virtual async Task<StripeBalance> GetAsync(StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeBalance>.MapFromJson(
-                await Requestor.GetStringAsync(Urls.Balance, SetupRequestOptions(requestOptions), cancellationToken)
+                await Requestor.GetStringAsync(Urls.Balance, SetupRequestOptions(requestOptions), cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -52,8 +52,8 @@ namespace Stripe
         {
             return Mapper<StripeBalanceTransaction>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.BalanceTransactions}/{id}", false),
-                SetupRequestOptions(requestOptions), 
-                cancellationToken)
+                SetupRequestOptions(requestOptions),
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -62,7 +62,7 @@ namespace Stripe
             return Mapper<StripeList<StripeBalanceTransaction>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(options, Urls.BalanceTransactions, true),
                     SetupRequestOptions(requestOptions),
-                    cancellationToken)
+                    cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -85,7 +85,7 @@ namespace Stripe
                     this.ApplyAllParameters(createOptions, $"{Urls.BaseUrl}/customers/{customerId}/bank_accounts"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -96,7 +96,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -107,7 +107,7 @@ namespace Stripe
                     this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -118,7 +118,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -129,7 +129,7 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/customers/{customerId}/bank_accounts", true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -140,7 +140,7 @@ namespace Stripe
                     this.ApplyAllParameters(verifyoptions, $"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}/verify"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Cards/StripeCardService.cs
+++ b/src/Stripe.net/Services/Cards/StripeCardService.cs
@@ -90,7 +90,7 @@ namespace Stripe
             return Mapper<StripeCard>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -101,7 +101,7 @@ namespace Stripe
             return Mapper<StripeCard>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -112,7 +112,7 @@ namespace Stripe
             return Mapper<StripeCard>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -123,7 +123,7 @@ namespace Stripe
             return Mapper<StripeCard>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -134,7 +134,7 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync(url, 
                     SetupRequestOptions(requestOptions),
-                    cancellationToken)
+                    cancellationToken).ConfigureAwait(false)
                 );
         }
 
@@ -149,7 +149,7 @@ namespace Stripe
             return Mapper<StripeList<StripeCard>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 

--- a/src/Stripe.net/Services/Charges/StripeChargeService.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeService.cs
@@ -73,7 +73,7 @@ namespace Stripe
             return Mapper<StripeCharge>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.Charges, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -82,7 +82,7 @@ namespace Stripe
             return Mapper<StripeCharge>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Charges}/{chargeId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -91,7 +91,7 @@ namespace Stripe
             return Mapper<StripeCharge>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Charges}/{chargeId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -100,7 +100,7 @@ namespace Stripe
             return Mapper<StripeList<StripeCharge>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Charges, true),
                     SetupRequestOptions(requestOptions),
-                    cancellationToken)
+                    cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -109,7 +109,7 @@ namespace Stripe
             return Mapper<StripeCharge>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(captureOptions, $"{Urls.Charges}/{chargeId}/capture", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -43,7 +43,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.CountrySpecs}/{country}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -54,7 +54,7 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, $"{Urls.CountrySpecs}", true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Coupons/StripeCouponService.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponService.cs
@@ -62,7 +62,7 @@ namespace Stripe
             return Mapper<StripeCoupon>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.Coupons, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -71,7 +71,7 @@ namespace Stripe
             return Mapper<StripeCoupon>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -80,7 +80,7 @@ namespace Stripe
             return Mapper<StripeCoupon>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -89,7 +89,7 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync(this.ApplyAllParameters(null, $"{Urls.Coupons}/{WebUtility.UrlEncode(couponId)}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -98,7 +98,7 @@ namespace Stripe
             return Mapper<StripeList<StripeCoupon>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Coupons, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerService.cs
@@ -63,7 +63,7 @@ namespace Stripe
             return Mapper<StripeCustomer>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.Customers, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -72,7 +72,7 @@ namespace Stripe
             return Mapper<StripeCustomer>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Customers}/{customerId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -81,7 +81,7 @@ namespace Stripe
             return Mapper<StripeCustomer>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Customers}/{customerId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -90,7 +90,7 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync($"{Urls.Customers}/{customerId}",
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -99,7 +99,7 @@ namespace Stripe
             return Mapper<StripeList<StripeCustomer>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Customers, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Disputes/StripeDisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/StripeDisputeService.cs
@@ -39,9 +39,9 @@ namespace Stripe
 
 
         // Async
-        public virtual async Task<StripeDispute> GetAsync(string disputeId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeDispute> GetAsync(string disputeId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await GetEntityAsync($"{Urls.Disputes}/{disputeId}", requestOptions, cancellationToken);
+            return GetEntityAsync($"{Urls.Disputes}/{disputeId}", requestOptions, cancellationToken);
         }
 
         public virtual Task<StripeDispute> UpdateAsync(string disputeId, StripeDisputeUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -49,14 +49,14 @@ namespace Stripe
             return PostAsync($"{Urls.Disputes}/{disputeId}", requestOptions, cancellationToken, updateOptions);
         }
 
-        public virtual async Task<StripeDispute> CloseAsync(string disputeId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeDispute> CloseAsync(string disputeId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await PostAsync($"{Urls.Disputes}/{disputeId}/close", requestOptions, cancellationToken);
+            return PostAsync($"{Urls.Disputes}/{disputeId}/close", requestOptions, cancellationToken);
         }
 
-        public virtual async Task<StripeList<StripeDispute>> ListAsync(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeDispute>> ListAsync(StripeDisputeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await GetEntityListAsync(Urls.Disputes, requestOptions, cancellationToken, listOptions);
+            return GetEntityListAsync(Urls.Disputes, requestOptions, cancellationToken, listOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Events/StripeEventService.cs
+++ b/src/Stripe.net/Services/Events/StripeEventService.cs
@@ -37,7 +37,7 @@ namespace Stripe
             return Mapper<StripeEvent>.MapFromJson(
                 await Requestor.GetStringAsync($"{Urls.Events}/{eventId}",
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -46,7 +46,7 @@ namespace Stripe
             return Mapper<StripeList<StripeEvent>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Events, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/ExchangeRates/StripeExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/StripeExchangeRateService.cs
@@ -43,7 +43,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.ExchangeRates}/{currency}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -54,7 +54,7 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, $"{Urls.ExchangeRates}", true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/FileUploads/StripeFileUploadService.cs
+++ b/src/Stripe.net/Services/FileUploads/StripeFileUploadService.cs
@@ -47,7 +47,7 @@ namespace Stripe
         public virtual async Task<StripeFileUpload> CreateAsync(string fileName, Stream fileStream, string purpose, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeFileUpload>.MapFromJson(
-                await Requestor.PostFileAsync(Urls.FileUploads, fileName, fileStream, purpose, SetupRequestOptions(requestOptions), cancellationToken)
+                await Requestor.PostFileAsync(Urls.FileUploads, fileName, fileStream, purpose, SetupRequestOptions(requestOptions), cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -58,7 +58,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.FileUploads}/{fileUploadId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -69,7 +69,7 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, Urls.FileUploads, true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemService.cs
@@ -65,7 +65,7 @@ namespace Stripe
             return Mapper<StripeInvoiceLineItem>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.InvoiceItems, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -74,7 +74,7 @@ namespace Stripe
             return Mapper<StripeInvoiceLineItem>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.InvoiceItems}/{invoiceItemId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -83,7 +83,7 @@ namespace Stripe
             return Mapper<StripeInvoiceLineItem>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.InvoiceItems}/{invoiceItemId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -92,8 +92,8 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync($"{Urls.InvoiceItems}/{invoiceItemId}",
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
-                );
+                cancellationToken).ConfigureAwait(false)
+            );
         }
 
         public virtual async Task<StripeList<StripeInvoiceLineItem>> ListAsync(StripeInvoiceItemListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -101,7 +101,7 @@ namespace Stripe
             return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.InvoiceItems, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceService.cs
@@ -95,7 +95,7 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Invoices}/{invoiceId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -106,7 +106,7 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(upcomingOptions, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -115,7 +115,7 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Invoices}/{invoiceId}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -124,7 +124,7 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(null, $"{Urls.Invoices}/{invoiceId}/pay", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -133,7 +133,7 @@ namespace Stripe
             return Mapper<StripeList<StripeInvoice>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Invoices, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -143,7 +143,7 @@ namespace Stripe
                 await Requestor.GetStringAsync(
                     this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/{invoiceId}/lines", true),
                     SetupRequestOptions(requestOptions), 
-                    cancellationToken)
+                    cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -154,7 +154,7 @@ namespace Stripe
             return Mapper<StripeList<StripeInvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -165,7 +165,7 @@ namespace Stripe
             return Mapper<StripeInvoice>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, url),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/OAuth/StripeOAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/StripeOAuthTokenService.cs
@@ -38,7 +38,7 @@ namespace Stripe
             return Mapper<StripeOAuthToken>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.OAuthToken, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -49,7 +49,7 @@ namespace Stripe
 
             return Mapper<StripeOAuthDeauthorize>.MapFromJson(
                 await Requestor.PostStringAsync(url, SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Plans/StripePlanService.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanService.cs
@@ -63,7 +63,7 @@ namespace Stripe
             return Mapper<StripePlan>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.Plans, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -72,7 +72,7 @@ namespace Stripe
             return Mapper<StripePlan>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -81,7 +81,7 @@ namespace Stripe
             return Mapper<StripeDeleted>.MapFromJson(
                 await Requestor.DeleteAsync($"{Urls.Plans}/{WebUtility.UrlEncode(planId)}",
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -90,7 +90,7 @@ namespace Stripe
             return Mapper<StripePlan>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Plans}/{WebUtility.UrlEncode(planId)}", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -99,7 +99,7 @@ namespace Stripe
             return Mapper<StripeList<StripePlan>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Plans, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Refunds/StripeRefundService.cs
+++ b/src/Stripe.net/Services/Refunds/StripeRefundService.cs
@@ -64,7 +64,7 @@ namespace Stripe
             return Mapper<StripeRefund>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, $"{Urls.Charges}/{chargeId}/refunds", false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -75,7 +75,7 @@ namespace Stripe
                     this.ApplyAllParameters(null, $"{Urls.BaseUrl}/refunds/{refundId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -86,7 +86,7 @@ namespace Stripe
                     this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/refunds/{refundId}"),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -97,7 +97,7 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/refunds", true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Sources/StripeSourceService.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceService.cs
@@ -84,7 +84,7 @@ namespace Stripe
             return Mapper<StripeSource>.MapFromJson(
                 await Requestor.DeleteAsync(url, 
                     SetupRequestOptions(requestOptions),
-                    cancellationToken)
+                    cancellationToken).ConfigureAwait(false)
                 );
         }
 
@@ -99,7 +99,7 @@ namespace Stripe
             return Mapper<StripeList<StripeSource>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, url, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/StripeBasicService.cs
+++ b/src/Stripe.net/Services/StripeBasicService.cs
@@ -65,7 +65,7 @@ namespace Stripe
                     this.ApplyAllParameters(options, url),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -76,7 +76,7 @@ namespace Stripe
                     this.ApplyAllParameters(options, url, true),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -87,7 +87,7 @@ namespace Stripe
                     this.ApplyAllParameters(options, url),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -98,7 +98,7 @@ namespace Stripe
                     this.ApplyAllParameters(options, url),
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
              );
         }
 

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.Obsolete.cs
@@ -48,25 +48,25 @@ namespace Stripe
 
         //Async
         [Obsolete("GetAsync with customerId is deprecated, use GetAsync without the customerId.")]
-        public virtual async Task<StripeSubscription> GetAsync(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeSubscription> GetAsync(string customerId, string subscriptionId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await GetAsync(subscriptionId, requestOptions, cancellationToken);
+            return GetAsync(subscriptionId, requestOptions, cancellationToken);
         }
 
         [Obsolete("UpdateAsync with customerId is deprecated, use UpdateAsync without the customerId.")]
-        public virtual async Task<StripeSubscription> UpdateAsync(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeSubscription> UpdateAsync(string customerId, string subscriptionId, StripeSubscriptionUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await UpdateAsync(subscriptionId, updateOptions, requestOptions, cancellationToken);
+            return UpdateAsync(subscriptionId, updateOptions, requestOptions, cancellationToken);
         }
 
         [Obsolete("CancelAsync with customerId is deprecated, use CancelAsync without the customerId.")]
-        public virtual async Task<StripeSubscription> CancelAsync(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeSubscription> CancelAsync(string customerId, string subscriptionId, bool cancelAtPeriodEnd = false, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await CancelAsync(subscriptionId, cancelAtPeriodEnd, requestOptions, cancellationToken);
+            return CancelAsync(subscriptionId, cancelAtPeriodEnd, requestOptions, cancellationToken);
         }
 
         [Obsolete("ListAsync with customerId is deprecated, use ListAsync without the customerId.")]
-        public virtual async Task<StripeList<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<StripeSubscription>> ListAsync(string customerId, StripeListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var options = new StripeSubscriptionListOptions
             {
@@ -80,7 +80,7 @@ namespace Stripe
                 options.Limit = listOptions.Limit;
             }
 
-            return await ListAsync(options, requestOptions, cancellationToken);
+            return ListAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionService.cs
@@ -88,7 +88,7 @@ namespace Stripe
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(null, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -100,7 +100,7 @@ namespace Stripe
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.PostStringAsync(ParameterBuilder.ApplyParameterToUrl(url, "plan", planId),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -114,7 +114,7 @@ namespace Stripe
                     url,
                     SetupRequestOptions(requestOptions),
                     cancellationToken
-                )
+                ).ConfigureAwait(false)
             );
         }
 
@@ -125,7 +125,7 @@ namespace Stripe
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, url, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -137,7 +137,7 @@ namespace Stripe
             return Mapper<StripeSubscription>.MapFromJson(
                 await Requestor.DeleteAsync(url,
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -146,7 +146,7 @@ namespace Stripe
             return Mapper<StripeList<StripeSubscription>>.MapFromJson(
                 await Requestor.GetStringAsync(this.ApplyAllParameters(listOptions, Urls.Subscriptions, true),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }

--- a/src/Stripe.net/Services/Tokens/StripeTokenService.cs
+++ b/src/Stripe.net/Services/Tokens/StripeTokenService.cs
@@ -36,7 +36,7 @@ namespace Stripe
             return Mapper<StripeToken>.MapFromJson(
                 await Requestor.PostStringAsync(this.ApplyAllParameters(createOptions, Urls.Tokens, false),
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
 
@@ -45,7 +45,7 @@ namespace Stripe
             return Mapper<StripeToken>.MapFromJson(
                 await Requestor.GetStringAsync($"{Urls.Tokens}/{tokenId}",
                 SetupRequestOptions(requestOptions),
-                cancellationToken)
+                cancellationToken).ConfigureAwait(false)
             );
         }
     }


### PR DESCRIPTION
This PR adds `ConfigureAwait(false)` to all awaited tasks, throughout the library. It is not necessary to add this to tasks that are not awaited, so in that regard, I also took the opportunity to optimize a few methods that had the `async` keyword only because they were awaiting a task before returning it. Now, all library methods only await tasks when necessary, and simply return the task directly otherwise.

Fixes #1141 