### PR TITLE
Subscription creation only allow a timestamp for billing_cycle_anchor

### DIFF
--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
@@ -7,29 +7,11 @@ namespace Stripe
 {
     public class StripeSubscriptionCreateOptions : SubscriptionSharedOptions
     {
-        #region BillingCycleAnchor
         /// <summary>
         /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
-        public DateTime? BillingCycleAnchor { get; set; }
-        public bool BillingCycleAnchorNow { get; set; }
-        public bool BillingCycleAnchorUnchanged { get; set; }
-
         [JsonProperty("billing_cycle_anchor")]
-        internal string BillingCycleAnchorInternal
-        {
-            get
-            {
-                if (BillingCycleAnchorNow)
-                    return "now";
-
-                if (BillingCycleAnchorUnchanged)
-                    return "unchanged";
-
-                return BillingCycleAnchor?.ConvertDateTimeToEpoch().ToString();
-            }
-        }
-        #endregion
+        public DateTime? BillingCycleAnchor { get; set; }
 
         /// <summary>
         /// REQUIRED: The identifier of the customer to subscribe.


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/805

r? @ob-stripe 
cc @stripe/api-libraries 

