### PR TITLE
Convert StripeSubscriptionUpdateOptions.CancelAtPeriodEnd to property

### DIFF
--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
@@ -31,7 +31,7 @@ namespace Stripe
         /// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with <see href="https://stripe.com/docs/api#upcoming_invoice">upcoming invoice</see> endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]
-        public bool? CancelAtPeriodEnd;
+        public bool? CancelAtPeriodEnd { get; set; }
 
         /// <summary>
         /// List of subscription items, each with an attached plan.


### PR DESCRIPTION
CancelAtPeriodEnd was a field and therefore not being output to request
body as only properties are serialized