### PR TITLE
URL-encode IDs of resources with user-settable IDs

### DIFF
--- a/src/Stripe.net/Services/Customers/StripeCustomerService.cs
+++ b/src/Stripe.net/Services/Customers/StripeCustomerService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
@@ -27,7 +28,7 @@ namespace Stripe
         public virtual StripeCustomer Get(string customerId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeCustomer>.MapFromJson(
-                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Customers}/{customerId}", false),
+                Requestor.GetString(this.ApplyAllParameters(null, $"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -35,7 +36,7 @@ namespace Stripe
         public virtual StripeCustomer Update(string customerId, StripeCustomerUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeCustomer>.MapFromJson(
-                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Customers}/{customerId}", false),
+                Requestor.PostString(this.ApplyAllParameters(updateOptions, $"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}", false),
                 SetupRequestOptions(requestOptions))
             );
         }
@@ -43,7 +44,7 @@ namespace Stripe
         public virtual StripeDeleted Delete(string customerId, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                Requestor.Delete($"{Urls.Customers}/{customerId}",
+                Requestor.Delete($"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}",
                 SetupRequestOptions(requestOptions))
              );
         }
@@ -70,7 +71,7 @@ namespace Stripe
         public virtual async Task<StripeCustomer> GetAsync(string customerId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeCustomer>.MapFromJson(
-                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Customers}/{customerId}", false),
+                await Requestor.GetStringAsync(this.ApplyAllParameters(null, $"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken).ConfigureAwait(false)
             );
@@ -79,7 +80,7 @@ namespace Stripe
         public virtual async Task<StripeCustomer> UpdateAsync(string customerId, StripeCustomerUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeCustomer>.MapFromJson(
-                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Customers}/{customerId}", false),
+                await Requestor.PostStringAsync(this.ApplyAllParameters(updateOptions, $"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}", false),
                 SetupRequestOptions(requestOptions),
                 cancellationToken).ConfigureAwait(false)
             );
@@ -88,7 +89,7 @@ namespace Stripe
         public virtual async Task<StripeDeleted> DeleteAsync(string customerId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeDeleted>.MapFromJson(
-                await Requestor.DeleteAsync($"{Urls.Customers}/{customerId}",
+                await Requestor.DeleteAsync($"{Urls.Customers}/{WebUtility.UrlEncode(customerId)}",
                 SetupRequestOptions(requestOptions),
                 cancellationToken).ConfigureAwait(false)
             );

--- a/src/Stripe.net/Services/Products/StripeProductService.cs
+++ b/src/Stripe.net/Services/Products/StripeProductService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
@@ -20,12 +21,12 @@ namespace Stripe
 
         public virtual StripeProduct Get(string productId, StripeRequestOptions requestOptions = null)
         {
-            return GetEntity($"{Urls.BaseUrl}/products/{productId}", requestOptions);
+            return GetEntity($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions);
         }
 
         public virtual StripeProduct Update(string productId, StripeProductUpdateOptions options, StripeRequestOptions requestOptions = null)
         {
-            return Post($"{Urls.BaseUrl}/products/{productId}", requestOptions, options);
+            return Post($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, options);
         }
 
         public virtual StripeList<StripeProduct> List(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null)
@@ -35,7 +36,7 @@ namespace Stripe
 
         public virtual StripeDeleted Delete(string productId, StripeRequestOptions requestOptions = null)
         {
-            return DeleteEntity($"{Urls.BaseUrl}/products/{productId}", requestOptions);
+            return DeleteEntity($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions);
         }
 
 
@@ -48,12 +49,12 @@ namespace Stripe
 
         public virtual Task<StripeProduct> GetAsync(string productId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetEntityAsync($"{Urls.BaseUrl}/products/{productId}", requestOptions, cancellationToken);
+            return GetEntityAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken);
         }
 
         public virtual Task<StripeProduct> UpdateAsync(string productId, StripeProductUpdateOptions options, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PostAsync($"{Urls.BaseUrl}/products/{productId}", requestOptions, cancellationToken, options);
+            return PostAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken, options);
         }
 
         public virtual Task<StripeList<StripeProduct>> ListAsync(StripeProductListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -63,7 +64,7 @@ namespace Stripe
 
         public virtual Task<StripeDeleted> DeleteAsync(string productId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return DeleteEntityAsync($"{Urls.BaseUrl}/products/{productId}", requestOptions, cancellationToken);
+            return DeleteEntityAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Skus/StripeSkuService.cs
+++ b/src/Stripe.net/Services/Skus/StripeSkuService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Stripe.Infrastructure;
@@ -22,12 +23,12 @@ namespace Stripe
 
         public virtual StripeSku Get(string skuId, StripeRequestOptions requestOptions = null)
         {
-            return GetEntity($"{Urls.BaseUrl}/skus/{skuId}", requestOptions);
+            return GetEntity($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions);
         }
 
         public virtual StripeSku Update(string skuId, StripeSkuUpdateOptions options, StripeRequestOptions requestOptions = null)
         {
-            return Post($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, options);
+            return Post($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, options);
         }
 
         public virtual StripeList<StripeSku> List(StripeSkuListOptions listOptions = null, StripeRequestOptions requestOptions = null)
@@ -37,7 +38,7 @@ namespace Stripe
 
         public virtual StripeDeleted Delete(string skuId, StripeRequestOptions requestOptions = null)
         {
-            return DeleteEntity($"{Urls.BaseUrl}/skus/{skuId}", requestOptions);
+            return DeleteEntity($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions);
         }
 
 
@@ -50,12 +51,12 @@ namespace Stripe
 
         public virtual Task<StripeSku> GetAsync(string skuId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetEntityAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken);
+            return GetEntityAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken);
         }
 
         public virtual Task<StripeSku> UpdateAsync(string skuId, StripeSkuUpdateOptions options, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return PostAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken, options);
+            return PostAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken, options);
         }
 
         public virtual Task<StripeList<StripeSku>> ListAsync(StripeSkuListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -65,7 +66,7 @@ namespace Stripe
 
         public virtual Task<StripeDeleted> DeleteAsync(string skuId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return DeleteEntityAsync($"{Urls.BaseUrl}/skus/{skuId}", requestOptions, cancellationToken);
+            return DeleteEntityAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

URL-encode IDs of resources with user-settable IDs. You already took care of coupons and plans in #1029, this takes care of the remaining ones.

No tests because you already tested this in #1029 and there's really no reason it would work any differently for different resources.

Fixes #1027.
