### PR TITLE
Add support for internal properties on the Card resource

### DIFF
--- a/src/Stripe.net/Entities/StripeCard.cs
+++ b/src/Stripe.net/Entities/StripeCard.cs
@@ -128,5 +128,15 @@ namespace Stripe
 
         [JsonProperty("tokenization_method")]
         public string TokenizationMethod { get; set; }
+
+        // The properties below are for internal use only and not returned as part of standard API requests.
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("iin")]
+        public string IIN { get; set; }
+
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
     }
 }


### PR DESCRIPTION
Those new properties are for internal use but we do need them in stripe-dotnet. We have shipped them a long time ago in stripe-go too: https://github.com/stripe/stripe-go/pull/221

r? @ob-stripe 
cc @stripe/api-libraries 

