### PR TITLE
Properly encode billing cycle anchor to a timestamp

### DIFF
--- a/src/Stripe.Tests.XUnit/subscriptions/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/subscriptions/_fixture.cs
@@ -23,7 +23,8 @@ namespace Stripe.Tests.Xunit
                 {
                     new StripeSubscriptionItemOption { PlanId = Cache.GetPlan().Id, Quantity = 1 },
                     new StripeSubscriptionItemOption { PlanId = Cache.GetPlan("silver").Id, Quantity = 2 }
-                }
+                },
+                BillingCycleAnchor = DateTime.UtcNow.AddDays(1),
             };
 
             var service = new StripeSubscriptionService(Cache.ApiKey);

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
@@ -10,8 +10,18 @@ namespace Stripe
         /// <summary>
         /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
-        [JsonProperty("billing_cycle_anchor")]
         public DateTime? BillingCycleAnchor { get; set; }
+
+        [JsonProperty("billing_cycle_anchor")]
+        internal long? BillingCycleAnchorInternal
+        {
+            get
+            {
+                if (!BillingCycleAnchor.HasValue) return null;
+
+                return EpochTime.ConvertDateTimeToEpoch(BillingCycleAnchor.Value);
+            }
+        }
 
         /// <summary>
         /// REQUIRED: The identifier of the customer to subscribe.


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1161

r? @ob-stripe 
cc @stripe/api-libraries 