### PR TITLE
Properly handle bank account token deserialization

### DIFF
--- a/src/Stripe.Tests.XUnit/tokens/creating_a_bank_account_token.cs
+++ b/src/Stripe.Tests.XUnit/tokens/creating_a_bank_account_token.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Stripe.Tests.Xunit;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class creating_a_bank_account_token
+    {
+        private StripeToken Token { get; set; }
+
+        public creating_a_bank_account_token()
+        {
+            Token = new StripeTokenService(Cache.ApiKey).CreateAsync(
+                new StripeTokenCreateOptions
+                {
+                    BankAccount = new BankAccountOptions
+                    {
+                        AccountNumber = "000123456789",
+                        Country = "US",
+                        Currency = "USD",
+                        RoutingNumber = "110000000",
+                    }
+                }
+            ).Result;
+        }
+
+        [Fact]
+        public void not_null()
+        {
+            Token.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void has_relevant_properties_set()
+        {
+            Token.Id.Should().NotBeNull();
+            Token.StripeBankAccount.Id.Should().NotBeNull();
+            Token.StripeBankAccount.Last4.Should().Be("6789");
+            Token.StripeBankAccount.RoutingNumber.Should().Be("110000000");
+        }
+    }
+}

--- a/src/Stripe.net/Entities/StripeToken.cs
+++ b/src/Stripe.net/Entities/StripeToken.cs
@@ -9,33 +9,8 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        // TODO: use a single property to map bank_account to a StripeBankAccount object
-        [JsonProperty("bank_account[id]")]
-        public string BankAccountId { get; set; }
-
-        [JsonProperty("bank_account[object]")]
-        public string BankAccountObject { get; set; }
-
-        [JsonProperty("bank_account[country]")]
-        public string BankAccountCountry { get; set; }
-
-        [JsonProperty("bank_account[currency]")]
-        public string BankAccountCurrency { get; set; }
-
-        [JsonProperty("bank_account[last4]")]
-        public string BankAccountLast4 { get; set; }
-
-        [JsonProperty("bank_account[status]")]
-        public string BankAccountStatus { get; set; }
-
-        [JsonProperty("bank_account[bank_name]")]
-        public string BankAccountName { get; set; }
-
-        [JsonProperty("bank_account[fingerprint]")]
-        public string BankAccountFingerprint { get; set; }
-
-        [JsonProperty("bank_account[routing_number]")]
-        public string BankAccountRoutingNumber { get; set; }
+        [JsonProperty("bank_account")]
+        public StripeBankAccount StripeBankAccount { get; set; }
 
         [JsonProperty("card")]
         public StripeCard StripeCard { get; set; }


### PR DESCRIPTION
The current resource is not deserialized properly. I think the `xxx[yyy]` only works on options classes (for parameters) and not on deserialization.

This fixes https://github.com/stripe/stripe-dotnet/issues/1175 by deserializing the object to the existing `StripeBankAccount` class instead.

r? @brandur-stripe 
cc @stripe/api-libraries 