### PR TITLE
Added ability to set tax on upcoming invoice request

### DIFF
--- a/src/Stripe.net.Tests/invoices/when_getting_an_upcoming_invoice_with_options.cs
+++ b/src/Stripe.net.Tests/invoices/when_getting_an_upcoming_invoice_with_options.cs
@@ -27,6 +27,7 @@ namespace Stripe.Tests
             {
                 SubscriptionId = _stripeCustomer.Subscriptions.Data.First().Id,
                 SubscriptionPlanId = _stripePlan.Id,
+                SubscriptionTaxPercent = 17.5m,
             };
         };
 
@@ -41,5 +42,8 @@ namespace Stripe.Tests
 
         It should_have_the_correct_plan_amount = () =>
             _stripeInvoice.StripeInvoiceLineItems.Data.First().Amount.ShouldEqual(_stripePlan.Amount.Value);
+
+        It should_have_the_correct_tax_amount = () =>
+            _stripeInvoice.TaxPercent.ShouldEqual(_stripeUpcomingInvoiceOptions.SubscriptionTaxPercent);
     }
 }

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -36,6 +36,9 @@ namespace Stripe
         [JsonProperty("subscription_quantity")]
         public int? SubscriptionQuantity { get; set; }
 
+        [JsonProperty("subscription_tax_percent")]
+        public decimal? SubscriptionTaxPercent { get; set; }
+
         public DateTime? SubscriptionTrialEnd { get; set; }
 
         [JsonProperty("subscription_trial_end")]

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -53,6 +53,9 @@ namespace Stripe
             }
         }
 
+        [JsonProperty("subscription_trial_from_plan")]
+        public bool? SubscriptionTrialFromPlan { get; set; }
+
         // this will actually send subscription_items. this is to flag it for the middleware
         // to process it as a plugin
         [JsonProperty("subscription_items_array_invoice")]


### PR DESCRIPTION
The stripe api has the ability to set a tax rate on the upcoming invoice request
https://stripe.com/docs/api#upcoming_invoice-subscription_tax_percent

This pull request adds this property to the StripeUpcomingInvoiceOptions class.