### PR TITLE
Move BankAccountOptions to the Stripe namespace

### DIFF
--- a/src/Stripe.net/Services/_sources_token/BankAccountOptions.cs
+++ b/src/Stripe.net/Services/_sources_token/BankAccountOptions.cs
@@ -1,26 +1,28 @@
 ﻿using Newtonsoft.Json;
-using Stripe;
 
-public class BankAccountOptions : INestedOptions
+namespace Stripe
 {
-    [JsonProperty("bank_account")]
-    public string TokenId { get; set; }
+    public class BankAccountOptions : INestedOptions
+    {
+        [JsonProperty("bank_account")]
+        public string TokenId { get; set; }
 
-    [JsonProperty("bank_account[account_holder_name]")]
-    public string AccountHolderName { get; set; }
+        [JsonProperty("bank_account[account_holder_name]")]
+        public string AccountHolderName { get; set; }
 
-    [JsonProperty("bank_account[account_holder_type]")]
-    public string AccountHolderType { get; set; }
+        [JsonProperty("bank_account[account_holder_type]")]
+        public string AccountHolderType { get; set; }
 
-    [JsonProperty("bank_account[account_number]")]
-    public string AccountNumber { get; set; }
+        [JsonProperty("bank_account[account_number]")]
+        public string AccountNumber { get; set; }
 
-    [JsonProperty("bank_account[country]")]
-    public string Country { get; set; }
+        [JsonProperty("bank_account[country]")]
+        public string Country { get; set; }
 
-    [JsonProperty("bank_account[currency]")]
-    public string Currency { get; set; }
+        [JsonProperty("bank_account[currency]")]
+        public string Currency { get; set; }
 
-    [JsonProperty("bank_account[routing_number]")]
-    public string RoutingNumber { get; set; }
+        [JsonProperty("bank_account[routing_number]")]
+        public string RoutingNumber { get; set; }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1190

r? @brandur-stripe 
cc @stripe/api-libraries 

Do you think it's a breaking change? I don't know much about namespaces in .NET. If not, let's leave as is, if it is we likely should rename the class to start with `Stripe` to be cleaner.