### PR TITLE
Add support for document_back

### DIFF
--- a/src/Stripe.Tests.XUnit/accounts/_fixture.cs
+++ b/src/Stripe.Tests.XUnit/accounts/_fixture.cs
@@ -19,8 +19,15 @@ namespace Stripe.Tests.Xunit
         {
             // create a file to attach to the additional owner as a verification document
             var fileService = new StripeFileUploadService(Cache.ApiKey);
-            var fileStream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit._resources.bumble.jpg");
-            var file = fileService.Create("bumble.jpg", fileStream, StripeFilePurpose.IdentityDocument);
+            var additionalOwnerFileStream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit._resources.bumble.jpg");
+            var additionalOwnerFileStreamBack = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit._resources.bumble.jpg");
+            var verificationFileStream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit._resources.bumble.jpg");
+            var verificationFileStreamBack = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Stripe.Tests.XUnit._resources.bumble.jpg");
+
+            var additionalOwnerFile = fileService.Create("bumble.jpg", additionalOwnerFileStream, StripeFilePurpose.IdentityDocument);
+            var additionalOwnerFileBack = fileService.Create("bumble_back.jpg", additionalOwnerFileStreamBack, StripeFilePurpose.IdentityDocument);
+            var verificationOwnerFile = fileService.Create("bumble.jpg", verificationFileStream, StripeFilePurpose.IdentityDocument);
+            var verificationOwnerFileBack = fileService.Create("bumble_back.jpg", verificationFileStreamBack, StripeFilePurpose.IdentityDocument);
 
             AccountCreateOptions = new StripeAccountCreateOptions
             {
@@ -46,7 +53,8 @@ namespace Stripe.Tests.Xunit
                             FirstName = "Bumble", LastName = "B",
                             // Ensure the owner is older than 18 to avoid API issues.
                             BirthDay = 29, BirthMonth = 8, BirthYear = 1980,
-                            VerificationDocument = file.Id
+                            VerificationDocument = additionalOwnerFile.Id,
+                            VerificationDocumentBack = additionalOwnerFileBack.Id
                         },
                         new StripeAccountAdditionalOwner
                         {
@@ -55,7 +63,9 @@ namespace Stripe.Tests.Xunit
                             Line1 ="B", Line2 = "C", PostalCode = "27635",
                             Country = "US"
                         }
-                    }
+                    },
+                    VerificationDocumentFileId = verificationOwnerFile.Id,
+                    VerificationDocumentFileBackId = verificationOwnerFileBack.Id
                 }
             };
 

--- a/src/Stripe.Tests.XUnit/accounts/creating_and_updating_accounts.cs
+++ b/src/Stripe.Tests.XUnit/accounts/creating_and_updating_accounts.cs
@@ -22,6 +22,13 @@ namespace Stripe.Tests.Xunit
         }
 
         [Fact]
+        public void created_has_legal_entity_verification_document()
+        {
+            fixture.Account.LegalEntity.LegalEntityVerification.DocumentId.Should().NotBeNull();
+            fixture.Account.LegalEntity.LegalEntityVerification.DocumentIdBack.Should().NotBeNull();
+        }
+
+        [Fact]
         public void created_has_addditional_owners()
         {
             fixture.Account.LegalEntity.AdditionalOwners.Should().NotBeNull();
@@ -37,6 +44,7 @@ namespace Stripe.Tests.Xunit
         public void created_has_the_verification_document()
         {
             fixture.Account.LegalEntity.AdditionalOwners.First().LegalEntityVerification.DocumentId.Should().NotBeNullOrEmpty();
+            fixture.Account.LegalEntity.AdditionalOwners.First().LegalEntityVerification.DocumentIdBack.Should().NotBeNullOrEmpty();
         }
 
         [Fact]

--- a/src/Stripe.net/Entities/StripeLegalEntityVerification.cs
+++ b/src/Stripe.net/Entities/StripeLegalEntityVerification.cs
@@ -13,13 +13,10 @@ namespace Stripe
 
         #region Expandable Document
         public string DocumentId { get; set; }
-        public string DocumentIdBack { get; set; }
 
         [JsonIgnore]
         public StripeFileUpload Document { get; set; }
 
-        [JsonIgnore]
-        public StripeFileUpload DocumentBack { get; set; }
 
         [JsonProperty("document")]
         internal object InternalDocument
@@ -29,6 +26,13 @@ namespace Stripe
                 StringOrObject<StripeFileUpload>.Map(value, s => DocumentId = s, o => Document = o);
             }
         }
+        #endregion
+
+        #region Expandable Document Back
+        public string DocumentIdBack { get; set; }
+
+        [JsonIgnore]
+        public StripeFileUpload DocumentBack { get; set; }
 
         [JsonProperty("document_back")]
         internal object InternalDocumentBack

--- a/src/Stripe.net/Entities/StripeLegalEntityVerification.cs
+++ b/src/Stripe.net/Entities/StripeLegalEntityVerification.cs
@@ -13,9 +13,13 @@ namespace Stripe
 
         #region Expandable Document
         public string DocumentId { get; set; }
+        public string DocumentIdBack { get; set; }
 
         [JsonIgnore]
         public StripeFileUpload Document { get; set; }
+
+        [JsonIgnore]
+        public StripeFileUpload DocumentBack { get; set; }
 
         [JsonProperty("document")]
         internal object InternalDocument
@@ -23,6 +27,15 @@ namespace Stripe
             set
             {
                 StringOrObject<StripeFileUpload>.Map(value, s => DocumentId = s, o => Document = o);
+            }
+        }
+
+        [JsonProperty("document_back")]
+        internal object InternalDocumentBack
+        {
+            set
+            {
+                StringOrObject<StripeFileUpload>.Map(value, s => DocumentIdBack = s, o => DocumentBack = o);
             }
         }
         #endregion

--- a/src/Stripe.net/Services/Account/StripeAccountAdditionalOwner.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountAdditionalOwner.cs
@@ -39,5 +39,8 @@ namespace Stripe
 
         [JsonProperty("verification[document]")]
         public string VerificationDocument { get; set; }
+
+        [JsonProperty("verification[document_back]")]
+        public string VerificationDocumentBack { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Account/StripeAccountLegalEntityOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountLegalEntityOptions.cs
@@ -221,6 +221,9 @@ namespace Stripe
         [JsonProperty("legal_entity[verification][document]")]
         public string VerificationDocumentFileId { get; set; }
 
+        [JsonProperty("legal_entity[verification][document_back]")]
+        public string VerificationDocumentFileBackId { get; set; }
+
         #endregion
 
         #region Additional Owners


### PR DESCRIPTION
With the introduction of the document_back parameter for both [additional owners](https://stripe.com/docs/api#account_object-legal_entity-additional_owners-verification-document_back) and the [representative](https://stripe.com/docs/api#account_object-legal_entity-verification-document_back) we can now update the back of photo IDs 🎉 

This PR includes wrappers and tests for the associated wrappers.