### PR TITLE
Add support for `product` on the Plan Update API

### DIFF
--- a/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanUpdateOptions.cs
@@ -13,5 +13,8 @@ namespace Stripe
 
         [JsonProperty("nickname")]
         public string Nickname { get; set; }
+
+        [JsonProperty("product")]
+        public string ProductId { get; set; }
     }
 }


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This fixes https://github.com/stripe/stripe-dotnet/issues/1202
I have confirmed that stripe-go already supports this (it shares one struct for create/update/etc.)