### PR TITLE
Change the namespace of StripeListOptionsWithCreated

### DIFF
--- a/src/Stripe.net/Services/Orders/StripeOrderListOptions.cs
+++ b/src/Stripe.net/Services/Orders/StripeOrderListOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Stripe.net;
 
 namespace Stripe
 {

--- a/src/Stripe.net/StripeListOptionsWithCreated.cs
+++ b/src/Stripe.net/StripeListOptionsWithCreated.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using Stripe.Infrastructure;
 
-namespace Stripe.net
+namespace Stripe
 {
     public class StripeListOptionsWithCreated : StripeListOptions
     {


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/1206

r? @ob-stripe 
cc @stripe/api-libraries 

Not sure if this is a breaking change though.