### PR TITLE
Add missing parameter `aggregate_usage`

### DIFF
--- a/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/StripePlanCreateOptions.cs
@@ -11,6 +11,9 @@ namespace Stripe
         [JsonProperty("active")]
         public bool? Active { get; set; }
 
+        [JsonProperty("aggregate_usage")]
+        public string AggregateUsage { get; set; }
+
         [JsonProperty("amount")]
         public int? Amount { get; set; }
 


### PR DESCRIPTION
I (hopefully) added support for the parameter aggregate_usage when creating a plan and the parameter tax_percent when creating a subscription.

From the example at https://stripe.com/docs/billing/subscriptions/taxes it seems that tax_percent should be a decimal. I hope this is correct, since I lack any big picture overview of the API.

Finally, I might add that I have not run the test suit since I do most development on linux, and the test suit did not seem to compile.