### PR TITLE
Upcoming now has `invoice_items` and subscription_billing_cycle_anchor`

### DIFF
--- a/src/Stripe.Tests.XUnit/invoices/retrieving_upcoming_invoice.cs
+++ b/src/Stripe.Tests.XUnit/invoices/retrieving_upcoming_invoice.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class retrieving_upcoming_invoice
+    {
+        public StripeInvoice InvoiceUpcoming { get; }
+
+        public retrieving_upcoming_invoice()
+        {
+            var customerService = new StripeCustomerService(Cache.ApiKey);
+            var invoiceItemService = new StripeInvoiceItemService(Cache.ApiKey);
+            var invoiceService = new StripeInvoiceService(Cache.ApiKey);
+
+            var CustomerCreateOptions = new StripeCustomerCreateOptions
+            {
+                SourceToken = "tok_visa",
+            };
+            var Customer = customerService.Create(CustomerCreateOptions);
+
+            var InvoiceItemCreateOptions = new StripeInvoiceItemCreateOptions
+            {
+                Amount = 1000,
+                Currency = "usd",
+                CustomerId = Customer.Id
+            };
+            var InvoiceItem = invoiceItemService.Create(InvoiceItemCreateOptions);
+
+            var UpcomingInvoiceOptions = new StripeUpcomingInvoiceOptions
+            {
+                InvoiceItems = new List<StripeInvoiceUpcomingInvoiceItemOption> {
+                    new StripeInvoiceUpcomingInvoiceItemOption {
+                        Amount = 1001,
+                        Currency = "usd",
+                    },
+                    new StripeInvoiceUpcomingInvoiceItemOption {
+                        Amount = 1002,
+                        InvoiceItemId = InvoiceItem.Id,
+                    },
+                },
+            };
+            InvoiceUpcoming = invoiceService.Upcoming(Customer.Id, UpcomingInvoiceOptions);
+        }
+
+        [Fact]
+        public void invoice_upcoming_has_correct_information()
+        {
+            InvoiceUpcoming.Should().NotBeNull();
+            InvoiceUpcoming.StripeInvoiceLineItems.Should().NotBeNull();
+            InvoiceUpcoming.StripeInvoiceLineItems.Data.Count.Should().Be(2);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceUpcomingInvoiceItemOption.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeInvoiceUpcomingInvoiceItemOption : INestedOptions
+    {
+        [JsonProperty("amount")]
+        public int Amount { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("discountable")]
+        public bool Discountable { get; set; }
+
+        [JsonProperty("invoiceitem")]
+        public string InvoiceItemId { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -10,6 +10,25 @@ namespace Stripe
         [JsonProperty("coupon")]
         public string CouponId { get; set; }
 
+        [JsonProperty("invoice_items")]
+        public List<StripeInvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
+
+        /// <summary>
+        /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
+        /// </summary>
+        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
+
+        [JsonProperty("subscription_billing_cycle_anchor")]
+        internal long? SubscriptionBillingCycleAnchorInternal
+        {
+            get
+            {
+                if (!SubscriptionBillingCycleAnchor.HasValue) return null;
+
+                return EpochTime.ConvertDateTimeToEpoch(SubscriptionBillingCycleAnchor.Value);
+            }
+        }
+
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

Random but we really should revamp the library to handle nested options without having to write boilerplate code like the plugin system.