### PR TITLE
Add support for expanding outcome.rule on a charge

### DIFF
--- a/src/Stripe.net/Entities/StripeOutcome.cs
+++ b/src/Stripe.net/Entities/StripeOutcome.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Stripe.Infrastructure;
 
 namespace Stripe
 {
@@ -22,11 +23,24 @@ namespace Stripe
         [JsonProperty("risk_level")]
         public string RiskLevel { get; set; }
 
+        #region Expandable Rule
         /// <summary>
         /// The ID of the Radar rule that matched the payment, if applicable.
         /// </summary>
-        [JsonProperty("rule")]
         public string RuleId { get; set; }
+
+        [JsonIgnore]
+        public StripeOutcomeRule Rule { get; set; }
+
+        [JsonProperty("rule")]
+        internal object InternalOutcomeRule
+        {
+            set
+            {
+                StringOrObject<StripeOutcomeRule>.Map(value, s => RuleId = s, o => Rule = o);
+            }
+        }
+        #endregion
 
         /// <summary>
         /// A human-readable description of the outcome type and reason, designed for you (the recipient of the payment), not your customer.

--- a/src/Stripe.net/Entities/StripeOutcomeRule.cs
+++ b/src/Stripe.net/Entities/StripeOutcomeRule.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Stripe
+{
+    public class StripeOutcomeRule : StripeEntityWithId
+    {
+        [JsonProperty("action")]
+        public string Action { get; set; }
+
+        [JsonProperty("predicate")]
+        public string Predicate { get; set; }
+    }
+}


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @spastorelli-stripe @gh-stripe 

This ensures that a Charge can be deserialized if `outcome[rule]` is already expanded. Before this we only supported a string for this field preventing older API versions from expanding this field or deserializing a `charge.*` event on older API versions.

I don't think we can reliably add tests for this one since it's Radar related so I punted.