### PR TITLE
[WIP] Move part of the test suite to stripe-mock

### DIFF
--- a/src/Stripe.Tests.XUnit/coupons_new/coupons.cs
+++ b/src/Stripe.Tests.XUnit/coupons_new/coupons.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Stripe.Tests.Xunit
+{
+    public class coupon_test
+    {
+        private string previousApiBase;
+        private readonly string resourceId = "co_123";
+        private StripeCouponService service;
+
+        public coupon_test()
+        {
+            this.service = new StripeCouponService(Cache.ApiKey);
+            this.previousApiBase = StripeConfiguration.GetApiBase();
+            StripeConfiguration.SetApiBase("http://localhost:12111/v1");
+        }
+
+        ~coupon_test()
+        {
+            StripeConfiguration.SetApiBase(this.previousApiBase);
+        }
+
+        [Fact]
+        public void create_succeeds()
+        {
+            var options = new StripeCouponCreateOptions() {
+                // Add a space at the end to ensure the ID is properly URL encoded
+                // when passed in the URL for other methods
+                Id = "co_123 ",
+                PercentOff = 25,
+                Duration = "repeating",
+                DurationInMonths = 3,
+            };
+
+            var coupon = service.Create(options);
+
+            Assert.NotNull(coupon);
+            coupon.Id.Should().Be(options.Id);
+            coupon.PercentOff.Should().Be(options.PercentOff);
+            coupon.Duration.Should().Be(options.Duration);
+            coupon.DurationInMonths.Should().Be(options.DurationInMonths);
+        }
+
+        [Fact]
+        public void update_succeeds()
+        {
+            var options = new StripeCouponUpdateOptions {
+              Metadata = new Dictionary<string, string>{{"key_1", "value_1"}}
+            };
+
+            var coupon = service.Update(resourceId, options);
+
+            Assert.NotNull(coupon);
+            coupon.Id.Should().Be(resourceId);
+            // stripe-mock does not update metadata so we can't verify this part
+        }
+
+        [Fact]
+        public void get_succeeds()
+        {
+            var coupon = service.Get(resourceId);
+
+            Assert.NotNull(coupon);
+            coupon.Id.Should().Be(resourceId);
+        }
+
+        [Fact]
+        public void delete_succeeds()
+        {
+            var coupon = service.Delete(resourceId);
+
+            Assert.NotNull(coupon);
+            coupon.Deleted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void list_succeeds()
+        {
+            var coupons = service.List();
+
+            Assert.NotNull(coupons);
+
+            var count = 0;
+            IEnumerable<StripeCoupon> enumerable = coupons as IEnumerable<StripeCoupon>;
+            foreach (var obj in enumerable)
+            {
+                count += 1;
+            }
+            Assert.Equal(coupons.ToList().Count > 0, true);
+            Assert.Equal(coupons.ToList().Count, count);
+
+            var datahash = new HashSet<string>();
+            foreach (var obj in coupons.Data)
+            {
+                datahash.Add(obj.Id);
+            }
+
+            var enumhash = new HashSet<string>();
+            IEnumerable<StripeCoupon> enumerable2 = coupons as IEnumerable<StripeCoupon>;
+            foreach (var obj in enumerable2)
+            {
+                enumhash.Add(obj.Id);
+            }
+
+            Assert.Equal(datahash, enumhash);
+
+            Assert.NotNull(coupons.Object);
+            Assert.Equal(coupons.Object, "list");
+            Assert.NotNull(coupons.Data);
+            Assert.NotNull(coupons.Url);
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to move part of the test suite to stripe-mock for the resource that it handles without issues.

This uses a trick which configures stripe-mock for that specific test and then goes back to the normal API endpoint for other tests. Thanks to @ob-stripe for the idea for a better approach than just rewriting  the entire test suite at once.

cc @stripe/api-libraries 