### PR TITLE
BaseStripeTest class with stripe-mock setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ image: Visual Studio 2017
 
 environment:
   STRIPE_TEST_SK: sk_test_eBgAzVoEpJKfYjD9nf2YoyMM
+  # If you bump this, don't forget to bump `MinimumMockVersion` in `BaseStripeTest.cs` as well.
   STRIPE_MOCK_VERSION: 0.19.0
 
 deploy:
@@ -12,14 +13,20 @@ deploy:
   on:
     appveyor_repo_tag: true
 
+cache:
+  - stripe-mock -> appveyor.yml
+
 install:
   - ps: |
-      New-Item -Path . -Name "stripe-mock" -ItemType "directory" | Out-Null
-      wget "https://github.com/stripe/stripe-mock/releases/download/v$($env:STRIPE_MOCK_VERSION)/stripe-mock_$($env:STRIPE_MOCK_VERSION)_windows_amd64.tar.gz" -OutFile "$($pwd)\stripe-mock\stripe-mock.tar.gz"
-      7z.exe e -y -o"stripe-mock" "stripe-mock\stripe-mock.tar.gz" | Out-Null
-      7z.exe x -y -o"stripe-mock" "stripe-mock\stripe-mock.tar" | Out-Null
+      If(!(Test-Path "stripe-mock"))
+      {
+        New-Item -Path . -Name "stripe-mock" -ItemType "directory" -Force | Out-Null
+        wget "https://github.com/stripe/stripe-mock/releases/download/v$($env:STRIPE_MOCK_VERSION)/stripe-mock_$($env:STRIPE_MOCK_VERSION)_windows_amd64.tar.gz" -OutFile "$($pwd)\stripe-mock\stripe-mock.tar.gz"
+        7z.exe e -y -o"stripe-mock" "stripe-mock\stripe-mock.tar.gz" | Out-Null
+        7z.exe x -y -o"stripe-mock" "stripe-mock\stripe-mock.tar" | Out-Null
+      }
       $app = Start-Process -FilePath "stripe-mock\stripe-mock.exe" -NoNewWindow -PassThru
-      Write-Host ("`nstripe-mock running, Id = $($app.Id)`n") -ForegroundColor Green
+      Write-Host ("stripe-mock running, Id = $($app.Id)`n") -ForegroundColor Green
 
 before_build:
   - ps: Write-Host $("`n               HOST INFORMATION               `n") -BackgroundColor DarkCyan
@@ -36,12 +43,15 @@ build_script:
   - dotnet build -c Debug src\Stripe.net
   - dotnet build src\Stripe.net.Tests -c Debug
   - dotnet build src\Stripe.Tests.Xunit -c Debug
+  - dotnet build src\StripeTests -c Debug
 
 after_build:
   - ps: Write-Host $("`n               PACKING UP               `n") -BackgroundColor DarkCyan
   - dotnet pack -c Release src\Stripe.net
 
 test_script:
+  - ps: Write-Host $("`n               RUNNING THE NEW XUNIT + STRIPE-MOCK TESTS               `n") -BackgroundColor DarkCyan
+  - dotnet test src\StripeTests\StripeTests.csproj
   - ps: Write-Host $("`n               RUNNING THE XUNIT TESTS               `n") -BackgroundColor DarkCyan
   - dotnet test src\Stripe.Tests.XUnit\Stripe.Tests.XUnit.csproj
   - ps: Write-Host $("`n               RUNNING THE MSPEC TESTS               `n") -BackgroundColor DarkCyan

--- a/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
+++ b/src/Stripe.Tests.XUnit/Stripe.Tests.XUnit.csproj
@@ -19,10 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />

--- a/src/Stripe.net.sln
+++ b/src/Stripe.net.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stripe.net.Tests", "Stripe.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stripe.Tests.XUnit", "Stripe.Tests.XUnit\Stripe.Tests.XUnit.csproj", "{44C779DD-9683-47B1-9600-95D053628E05}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StripeTests", "StripeTests\StripeTests.csproj", "{75F3AA23-C708-4408-AFD0-D7FA354E031B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Stripe.net/Properties/InternalsVisibleTo.cs
+++ b/src/Stripe.net/Properties/InternalsVisibleTo.cs
@@ -2,3 +2,4 @@
 
 [assembly: InternalsVisibleTo("Stripe.net.Tests")]
 [assembly: InternalsVisibleTo("Stripe.Tests.XUnit")]
+[assembly: InternalsVisibleTo("StripeTests")]

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -1,0 +1,150 @@
+namespace StripeTests
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+
+    using Stripe;
+
+    public class BaseStripeTest
+    {
+        /// <value>Minimum required version of stripe-mock</value>
+        /// <remarks>
+        /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in appveyor.yml as well.
+        /// </remarks>
+        private const string MockMinimumVersion = "0.19.0";
+
+        private static string port;
+
+        // Lazy initializer to ensure that initialization is run only once even when running tests
+        // in parallel.
+        private static Lazy<object> initializer = new Lazy<object>(InitStripeMock);
+
+        public BaseStripeTest()
+        {
+            // This triggers the lazy initialization. We don't actually care about the value of
+            // initialized (it will be null anyway), but simply writing `initializer.Value` is not
+            // a valid statement in C#.
+            var initialized = initializer.Value;
+        }
+
+        /// <summary>
+        /// Gets fixture data from stripe-mock for a resource expected to be at the given API path.
+        /// stripe-mock ignores whether IDs are actually valid, so it's only important to make sure
+        /// that the route exists, rather than the actual resource. It's common to use a symbolic
+        /// ID stand-in like <code>ch_123</code>
+        /// </summary>
+        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
+        /// <returns>Fixture data encoded as JSON</returns>
+        protected static string GetFixture(string path)
+        {
+            return GetFixture(path, null);
+        }
+
+        /// <summary>
+        /// Gets fixture data with expansions specified. Expansions are specified the same way as
+        /// they are in the normal API like <code>customer</code> or <code>data.customer</code>.
+        /// Use the special <code>*</code> character to specify that all fields should be
+        /// expanded.
+        /// </summary>
+        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
+        /// <param name="expansions">Set of expansions that should be applied</param>
+        /// <returns>Fixture data encoded as JSON</returns>
+        protected static string GetFixture(string path, string[] expansions)
+        {
+            string url = $"http://localhost:{port}{path}";
+
+            if (expansions != null)
+            {
+                string query = string.Join("&", expansions.Select(x => $"expand[]={x}").ToArray());
+                url += $"?{query}";
+            }
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization
+                    = new System.Net.Http.Headers.AuthenticationHeaderValue(
+                        "Bearer",
+                        "sk_test_123");
+
+                HttpResponseMessage response;
+
+                try
+                {
+                    response = client.GetAsync(url).Result;
+                }
+                catch (Exception)
+                {
+                    throw new Exception(
+                        $"Couldn't reach stripe-mock at `localhost:{port}`. "
+                        + "Is it running? Please see README for setup instructions.");
+                }
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new Exception(
+                        $"stripe-mock returned status code: {response.StatusCode}.");
+                }
+
+                return response.Content.ReadAsStringAsync().Result;
+            }
+        }
+
+        /// <summary>
+        /// Checks that stripe-mock is running and that it's a recent enough version.
+        /// </summary>
+        private static object InitStripeMock()
+        {
+            port = Environment.GetEnvironmentVariable("STRIPE_MOCK_PORT") ?? "12111";
+            string url = $"http://localhost:{port}";
+
+            using (HttpClient client = new HttpClient())
+            {
+                HttpResponseMessage response;
+
+                try
+                {
+                    response = client.GetAsync(url).Result;
+                }
+                catch (Exception)
+                {
+                    throw new Exception(
+                        $"Couldn't reach stripe-mock at `localhost:{port}`. "
+                        + "Is it running? Please see README for setup instructions.");
+                }
+
+                string version = response.Headers.GetValues("Stripe-Mock-Version").FirstOrDefault();
+
+                if (!version.Equals("master") &&
+                    (CompareVersions(version, MockMinimumVersion) > 0))
+                {
+                    throw new Exception(
+                        $"Your version of stripe-mock ({version}) is too old. The minimum "
+                        + $"version to run this test suite is {MockMinimumVersion}. Please see its "
+                        + "repository for upgrade instructions.");
+                }
+            }
+
+            StripeConfiguration.SetApiBase($"http://localhost:{port}/v1");
+            StripeConfiguration.SetUploadsBase($"http://localhost:{port}/v1");
+            StripeConfiguration.SetApiKey("sk_test_123");
+
+            return null;
+        }
+
+        /// <summary>
+        /// Compares two version strings.
+        /// </summary>
+        /// <param name="a">A version string (e.g. "1.2.3").</param>
+        /// <param name="b">Another version string.</param>
+        /// <returns>-1 if a > b, 1 if a < b, 0 if a == b</returns>
+        private static int CompareVersions(string a, string b)
+        {
+            var version1 = new Version(a);
+            var version2 = new Version(b);
+            return version2.CompareTo(version1);
+        }
+    }
+}

--- a/src/StripeTests/Entities/StripeCouponTest.cs
+++ b/src/StripeTests/Entities/StripeCouponTest.cs
@@ -1,0 +1,24 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class StripeCouponTest : BaseStripeTest
+    {
+        [Fact]
+        public void Deserialize()
+        {
+            string json = GetFixture("/v1/coupons/co_123");
+            var coupon = Mapper<StripeCoupon>.MapFromJson(json);
+            Assert.NotNull(coupon);
+            Assert.IsType<StripeCoupon>(coupon);
+            Assert.NotNull(coupon.Id);
+            Assert.Equal("coupon", coupon.Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/Coupons/StripeCouponCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Coupons/StripeCouponCreateOptionsTest.cs
@@ -1,0 +1,33 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class StripeCouponCreateOptionsTest : BaseStripeTest
+    {
+        private StripeCouponService service;
+
+        public StripeCouponCreateOptionsTest()
+        {
+            this.service = new StripeCouponService();
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var options = new StripeCouponCreateOptions()
+            {
+                PercentOff = 25,
+                Duration = "forever",
+            };
+
+            var url = this.service.ApplyAllParameters(options, string.Empty, false);
+            Assert.Equal("?percent_off=25&duration=forever", url);
+        }
+    }
+}

--- a/src/StripeTests/Services/Coupons/StripeCouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/StripeCouponServiceTest.cs
@@ -1,0 +1,112 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class StripeCouponServiceTest : BaseStripeTest
+    {
+        private const string CouponId = "co_123";
+
+        private StripeCouponService service;
+        private StripeCouponCreateOptions createOptions;
+        private StripeCouponUpdateOptions updateOptions;
+        private StripeCouponListOptions listOptions;
+
+        public StripeCouponServiceTest()
+        {
+            this.service = new StripeCouponService();
+
+            this.createOptions = new StripeCouponCreateOptions()
+            {
+                PercentOff = 25,
+                Duration = "forever",
+            };
+
+            this.updateOptions = new StripeCouponUpdateOptions()
+            {
+                Metadata = new Dictionary<string, string>()
+                {
+                    { "key", "value" },
+                },
+            };
+
+            this.listOptions = new StripeCouponListOptions()
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var coupon = this.service.Create(this.createOptions);
+            Assert.NotNull(coupon);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var coupon = await this.service.CreateAsync(this.createOptions);
+            Assert.NotNull(coupon);
+        }
+
+        [Fact]
+        public void Delete()
+        {
+            var deleted = this.service.Delete(CouponId);
+            Assert.NotNull(deleted);
+        }
+
+        [Fact]
+        public async Task DeleteAsync()
+        {
+            var deleted = await this.service.DeleteAsync(CouponId);
+            Assert.NotNull(deleted);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var coupon = this.service.Get(CouponId);
+            Assert.NotNull(coupon);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var coupon = await this.service.GetAsync(CouponId);
+            Assert.NotNull(coupon);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var coupons = this.service.List(this.listOptions);
+            Assert.NotNull(coupons);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var coupons = await this.service.ListAsync(this.listOptions);
+            Assert.NotNull(coupons);
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var coupon = this.service.Update(CouponId, this.updateOptions);
+            Assert.NotNull(coupon);
+        }
+
+        [Fact]
+        public async Task UpdateAsync()
+        {
+            var coupon = await this.service.UpdateAsync(CouponId, this.updateOptions);
+            Assert.NotNull(coupon);
+        }
+    }
+}

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <AssemblyName>StripeTests</AssemblyName>
+    <PackageId>StripeTests</PackageId>
+    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stripe.net\Stripe.net.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\_stylecop\StyleCopRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
r? @remi-stripe @brandur-stripe 
cc @stripe/api-libraries 

Adds a `BaseStripeTest` class that takes care of setting up and tearing down all the stripe-mock stuff.

Also adds a `StripeCouponServiceTest` to illustrate how to use `BaseStripeTest` and hopefully serve as a template for other tests.

`StripeCouponServiceTest` implements `IClassFixture<BaseStripeTest>` rather than just `BaseStripeTest` so that the initialization is done once for the entire class rather than for every test. 

Unfortunately, because the base URLs can only be set globally, I had to disable parallel test execution by grouping all tests in the same collection (by default, tests are grouped by class [0]). One alternative would be to add the ability to provide the base URLs in `StripeRequestOptions` (as can already be done for the API key) and pass an instance with the correct values in all the stripe-mock tests.

[0] https://xunit.github.io/docs/running-tests-in-parallel.html#runners-and-test-frameworks
