### PR TITLE
Fix Appveyor badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Stripe.net [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf?branch=master&svg=true)](https://ci.appveyor.com/project/stripe-appveyor-ci/stripe-dotnet) [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
+# Stripe.net [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet) [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
 
 The official Stripe library, supporting .NET Standard 1.2+, .NET Core 1.0+, and .NET Framework 4.5+
 


### PR DESCRIPTION
I've renamed the account from `stripe-appveyor-ci` to just `stripe` for a prettier URL :)
