### PR TITLE
Add cancel support for topups

### DIFF
--- a/src/Stripe.net/Services/Topups/StripeTopupService.cs
+++ b/src/Stripe.net/Services/Topups/StripeTopupService.cs
@@ -15,35 +15,28 @@ namespace Stripe
 
         public bool ExpandSource { get; set; }
 
+        public virtual StripeTopup Cancel(string topupId, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeTopup>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(null, $"{Urls.Topups}/{topupId}/cancel", false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<StripeTopup> CancelAsync(string topupId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<StripeTopup>.MapFromJson(
+                await Requestor.PostStringAsync(
+                    this.ApplyAllParameters(null, $"{Urls.Topups}/{topupId}/cancel", false),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
+        }
+
         public virtual StripeTopup Create(StripeTopupCreateOptions createOptions, StripeRequestOptions requestOptions = null)
         {
             return Mapper<StripeTopup>.MapFromJson(
                 Requestor.PostString(
                     this.ApplyAllParameters(createOptions, Urls.Topups, false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeTopup Get(string topupId, StripeRequestOptions requestOptions = null)
-        {
-            return Mapper<StripeTopup>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(null, $"{Urls.Topups}/{topupId}", false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeList<StripeTopup> List(StripeTopupListOptions listOptions = null, StripeRequestOptions requestOptions = null)
-        {
-            return Mapper<StripeList<StripeTopup>>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(listOptions, Urls.Topups, true),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeTopup Update(string topupId, StripeTopupUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
-        {
-            return Mapper<StripeTopup>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(updateOptions, $"{Urls.Topups}/{topupId}", false),
                     this.SetupRequestOptions(requestOptions)));
         }
 
@@ -56,6 +49,14 @@ namespace Stripe
                     cancellationToken));
         }
 
+        public virtual StripeTopup Get(string topupId, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeTopup>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(null, $"{Urls.Topups}/{topupId}", false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
         public virtual async Task<StripeTopup> GetAsync(string topupId, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeTopup>.MapFromJson(
@@ -65,6 +66,14 @@ namespace Stripe
                     cancellationToken));
         }
 
+        public virtual StripeList<StripeTopup> List(StripeTopupListOptions listOptions = null, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeList<StripeTopup>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, Urls.Topups, true),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
         public virtual async Task<StripeList<StripeTopup>> ListAsync(StripeTopupListOptions listOptions = null, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeList<StripeTopup>>.MapFromJson(
@@ -72,6 +81,14 @@ namespace Stripe
                     this.ApplyAllParameters(listOptions, Urls.Topups, true),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken));
+        }
+
+        public virtual StripeTopup Update(string topupId, StripeTopupUpdateOptions updateOptions, StripeRequestOptions requestOptions = null)
+        {
+            return Mapper<StripeTopup>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(updateOptions, $"{Urls.Topups}/{topupId}", false),
+                    this.SetupRequestOptions(requestOptions)));
         }
 
         public virtual async Task<StripeTopup> UpdateAsync(string topupId, StripeTopupUpdateOptions updateOptions, StripeRequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/StripeTests/Services/Topups/StripeTopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/StripeTopupServiceTest.cs
@@ -41,6 +41,22 @@ namespace StripeTests
         }
 
         [Fact]
+        public void Cancel()
+        {
+            var topup = this.service.Cancel(TopupId);
+            Assert.NotNull(topup);
+            Assert.Equal("topup", topup.Object);
+        }
+
+        [Fact]
+        public async Task CancelAsync()
+        {
+            var topup = await this.service.CancelAsync(TopupId);
+            Assert.NotNull(topup);
+            Assert.Equal("topup", topup.Object);
+        }
+
+        [Fact]
         public void Create()
         {
             var topup = this.service.Create(this.createOptions);


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @foresthu-stripe 

Add cancel support for topups.

I've also alphabetized methods in `StripeTopupService`.