### PR TITLE
Missing and un-mapped properties

### DIFF
--- a/src/Stripe.net/Entities/StripeInvoice.cs
+++ b/src/Stripe.net/Entities/StripeInvoice.cs
@@ -37,6 +37,7 @@
         [JsonProperty("billing")]
         public StripeBilling? Billing { get; set; }
 
+        [JsonProperty("billing_reason")]
         public string BillingReason { get; set; }
 
         #region Expandable Charge

--- a/src/Stripe.net/Entities/StripeProduct.cs
+++ b/src/Stripe.net/Entities/StripeProduct.cs
@@ -110,5 +110,11 @@
         /// </summary>
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        /// <summary>
+        /// This represents a unit of this product, such as a seat or API call, on customers' receipts and invoices.
+        /// </summary>
+        [JsonProperty("unit_label")]
+        public string UnitLabel { get; set; }
     }
 }


### PR DESCRIPTION
I noticed that there was no property for `UnitLabel` being mapped from `unit_label` on StripeProduct. So, I have added this in.

There was also no JSON mapping on StripeInvoice to map the `billing_reason` JSON property to the `BillingReason` property on the `StripeIncvoice` class. So, I have updated this to include the mapping for this too.