### PR TITLE
Amount for invoice item is now optional

### DIFF
--- a/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/StripeInvoiceItemCreateOptions.cs
@@ -6,7 +6,7 @@
     public class StripeInvoiceItemCreateOptions : StripeBaseOptions, ISupportMetadata
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/1254

r? @ob-stripe 
cc @stripe/api-libraries 