### PR TITLE
Add support for authorization_code on the Charge resource

### DIFF
--- a/src/Stripe.net/Entities/StripeCharge.cs
+++ b/src/Stripe.net/Entities/StripeCharge.cs
@@ -374,5 +374,9 @@
         /// </summary>
         [JsonProperty("transfer_group")]
         public string TransferGroup { get; set; }
+
+        // The properties below are for internal use only and not returned as part of standard API requests.
+        [JsonProperty("authorization_code")]
+        public string AuthorizationCode { get; set; }
     }
 }


### PR DESCRIPTION
Note that this property is internal and not usually returned in the API.

r? @ob-stripe 
cc @stripe/api-libraries 