### PR TITLE
Fix the Coupon resource as percent_off is now a decimal

### DIFF
--- a/src/Stripe.net/Entities/StripeCoupon.cs
+++ b/src/Stripe.net/Entities/StripeCoupon.cs
@@ -39,7 +39,7 @@
         public string Name { get; set; }
 
         [JsonProperty("percent_off")]
-        public int? PercentOff { get; set; }
+        public decimal? PercentOff { get; set; }
 
         [JsonProperty("redeem_by")]
         [JsonConverter(typeof(StripeDateTimeConverter))]


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1265

While this is a breaking change, it's currently broken in the current version so I think a minor would be fine.

I wonder if we can/should pull the broken version in this case (and in related cases)

r? @brandur-stripe 
cc @stripe/api-libraries 
