### PR TITLE
Add support for mandate/receiver hash on source creation/update

### DIFF
--- a/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceCreateOptions.cs
@@ -70,6 +70,12 @@
         public string ThreeDSecureCardOrSourceId { get; set; }
 
         /// <summary>
+        /// Information about a mandate possiblity attached to a source object (generally for bank debits) as well as its acceptance status.
+        /// </summary>
+        [JsonProperty("mandate")]
+        public StripeSourceMandateOptions Mandate { get; set; }
+
+        /// <summary>
         /// A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format.
         /// </summary>
         [JsonProperty("metadata")]
@@ -94,6 +100,12 @@
         /// </summary>
         [JsonProperty("[redirect][return_url]")]
         public string RedirectReturnUrl { get; set; }
+
+        /// <summary>
+        /// Optional parameters for the receiver flow. Can be set only if the source is a receiver.
+        /// </summary>
+        [JsonProperty("receiver")]
+        public StripeSourceReceiverOptions Receiver { get; set; }
 
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Sources/StripeSourceMandateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceMandateOptions.cs
@@ -1,0 +1,37 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class StripeSourceMandateOptions : INestedOptions
+    {
+        public DateTime? MandateAcceptanceDate { get; set; }
+
+        [JsonProperty("mandate[acceptance][date]")]
+        internal long? MandateAcceptanceDateInternal
+        {
+            get
+            {
+                if (!this.MandateAcceptanceDate.HasValue)
+                {
+                    return null;
+                }
+
+                return EpochTime.ConvertDateTimeToEpoch(this.MandateAcceptanceDate.Value);
+            }
+        }
+
+        [JsonProperty("mandate[acceptance][ip]")]
+        public string MandateAcceptanceIp { get; set; }
+
+        [JsonProperty("mandate[acceptance][status]")]
+        public string MandateAcceptanceStatus { get; set; }
+
+        [JsonProperty("mandate[acceptance][user_agent]")]
+        public string MandateAcceptanceUserAgent { get; set; }
+
+        [JsonProperty("mandate[notification_method]")]
+        public string MandateNotificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Sources/StripeSourceReceiverOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceReceiverOptions.cs
@@ -1,0 +1,10 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class StripeSourceReceiverOptions : INestedOptions
+    {
+        [JsonProperty("receiver[refund_attributes_method]")]
+        public string RefundAttributesMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceUpdateOptions.cs
@@ -7,6 +7,12 @@
     public class StripeSourceUpdateOptions : StripeBaseOptions, ISupportMetadata
     {
         /// <summary>
+        /// Information about a mandate possiblity attached to a source object (generally for bank debits) as well as its acceptance status.
+        /// </summary>
+        [JsonProperty("mandate")]
+        public StripeSourceMandateOptions Mandate { get; set; }
+
+        /// <summary>
         /// A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format. You can unset individual keys if you POST an empty value for that key. You can clear all keys if you POST an empty value for metadata.
         /// </summary>
         [JsonProperty("metadata")]

--- a/src/StripeTests/Services/Sources/StripeSourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/StripeSourceServiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -22,7 +23,19 @@ namespace StripeTests
             this.createOptions = new StripeSourceCreateOptions
             {
                 Type = StripeSourceType.AchCreditTransfer,
-                Currency = "usd"
+                Currency = "usd",
+                Mandate = new StripeSourceMandateOptions
+                {
+                    MandateAcceptanceDate = DateTime.Parse("Mon, 01 Jan 2001 00:00:00Z"),
+                    MandateAcceptanceIp = "127.0.0.1",
+                    MandateAcceptanceStatus = "accepted",
+                    MandateAcceptanceUserAgent = "User-Agent",
+                    MandateNotificationMethod = "manual",
+                },
+                Receiver = new StripeSourceReceiverOptions
+                {
+                    RefundAttributesMethod = "manual",
+                },
             };
 
             this.updateOptions = new StripeSourceUpdateOptions


### PR DESCRIPTION
This mirrors what we did for stripe-go here: https://github.com/stripe/stripe-go/pull/686

I think it's worth keeping the extra parameters in the tests as it gives a good example of passing a date and just making sure that does not break in the future when we fix the nested options approach.

r? @ob-stripe 
cc @stripe/api-libraries 