### PR TITLE
Enable XML documentation

### DIFF
--- a/src/Stripe.net/Entities/_contracts/ISupportMetadata.cs
+++ b/src/Stripe.net/Entities/_contracts/ISupportMetadata.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
 
     /// <summary>
-    /// Interface that identifies entities with a Metadata property of type <see cref="Dictionary{string,string}" />.
+    /// Interface that identifies entities with a Metadata property of type <see cref="Dictionary{String, String}" />.
     /// </summary>
     public interface ISupportMetadata
     {

--- a/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCaptureOptions.cs
@@ -39,7 +39,14 @@ namespace Stripe
         public string ReceiptEmail { get; set; }
 
         /// <summary>
-        /// An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. As an example, if your website is RunClub and the item you're charging for is a race ticket, you may want to specify a statement_descriptor of RunClub 5K race ticket. The statement description may not include <>"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.
+        /// An arbitrary string to be displayed on your customer's credit card statement. This may
+        /// be up to 22 characters. As an example, if your website is <c>RunClub</c> and the item
+        /// you're charging for is a race ticket, you may want to specify a
+        /// <c>statement_descriptor</c> of <c>RunClub 5K race ticket</c>. The statement description
+        /// may not include <c>&lt;&gt;"'</c> characters, and will appear on your customer's
+        /// statement in capital letters. Non-ASCII characters are automatically stripped. While
+        /// most banks display this information consistently, some may display it incorrectly or not
+        /// at all.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/StripeChargeCreateOptions.cs
@@ -100,7 +100,14 @@
         public SourceCard SourceCard { get; set; }
 
         /// <summary>
-        /// An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. As an example, if your website is RunClub and the item you're charging for is a race ticket, you may want to specify a statement_descriptor of RunClub 5K race ticket. The statement description may not include <>"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.
+        /// An arbitrary string to be displayed on your customer's credit card statement. This may
+        /// be up to 22 characters. As an example, if your website is <c>RunClub</c> and the item
+        /// you're charging for is a race ticket, you may want to specify a
+        /// <c>statement_descriptor</c> of <c>RunClub 5K race ticket</c>. The statement description
+        /// may not include <c>&lt;&gt;"'</c> characters, and will appear on your customer's
+        /// statement in capital letters. Non-ASCII characters are automatically stripped. While
+        /// most banks display this information consistently, some may display it incorrectly or not
+        /// at all.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -44,14 +44,33 @@
         public bool? Prorate { get; set; }
 
         /// <summary>
-        /// ID of a Token or a Source, as returned by <see cref="https://stripe.com/docs/elements">Elements</see>. You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing <c>source</c> will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the <see cref="https://stripe.com/docs/api#create_card">card creation API</see> to add the card and then the <see cref="https://stripe.com/docs/api#update_customer">customer update API</see> to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.
+        /// ID of a Token or a Source, as returned by
+        /// <see href="https://stripe.com/docs/elements">Elements</see>. You must provide a source
+        /// if the customer does not already have a valid source attached, and you are subscribing
+        /// the customer to be charged automatically for a plan that is not free. Passing
+        /// <c>source</c> will create a new source object, make it the customer default source, and
+        /// delete the old customer default if one exists. If you want to add an additional source,
+        /// instead use the
+        /// <see href="https://stripe.com/docs/api#create_card">card creation API</see> to add the
+        /// card and then the <see href="https://stripe.com/docs/api#update_customer">customer
+        /// update API</see> to set it as the default. Whenever you attach a card to a customer,
+        /// Stripe will automatically validate the card.
         /// <para>If you use Source, you cannot use SourceCard also.</para>
         /// </summary>
         [JsonProperty("source")]
         public string Source { get; set; }
 
         /// <summary>
-        /// <see cref="SourceCard"/> instance containing a user’s credit card details. You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing <c>source</c> will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the <see cref="https://stripe.com/docs/api#create_card">card creation API</see> to add the card and then the <see cref="https://stripe.com/docs/api#update_customer">customer update API</see> to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card.
+        /// <see cref="SourceCard"/> instance containing a user’s credit card details. You must
+        /// provide a source if the customer does not already have a valid source attached, and you
+        /// are subscribing the customer to be charged automatically for a plan that is not free.
+        /// Passing <c>source</c> will create a new source object, make it the customer default
+        /// source, and delete the old customer default if one exists. If you want to add an
+        /// additional source, instead use the
+        /// <see href="https://stripe.com/docs/api#create_card">card creation API</see> to add the
+        /// card and then the <see href="https://stripe.com/docs/api#update_customer">customer
+        /// update API</see> to set it as the default. Whenever you attach a card to a customer,
+        /// Stripe will automatically validate the card.
         /// <para>If you use SourceCard, you cannot use Source also.</para>
         /// </summary>
         [JsonProperty("source")]

--- a/src/Stripe.net/Services/Topups/StripeTopupCreateOptions.cs
+++ b/src/Stripe.net/Services/Topups/StripeTopupCreateOptions.cs
@@ -30,11 +30,19 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// The ID of a source to transfer funds from. For most users, this should be left
+        /// unspecified which will use the bank account that was set up in the dashboard for the
+        /// specified currency. In test mode, this can be a test bank token (see
+        /// <see href="https://stripe.com/docs/connect/testing#testing-top-ups">Testing
+        /// Top-ups</see>).
+        /// </summary>
         [JsonProperty("source")]
         public string SourceId { get; set; }
 
         /// <summary>
-        /// An arbitrary string to be displayed on your bank statement. This may be up to 22 characters. The statement description may not include <>"' characters, and will appear on your bank statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all.
+        /// Extra information about a top-up for the source’s bank statement. Limited to 15 ASCII
+        /// characters.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -19,6 +19,7 @@
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.2' ">$(PackageTargetFallback);netcoreapp1.0</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.2' ">1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <!--

--- a/src/_stylecop/StyleCopRules.ruleset
+++ b/src/_stylecop/StyleCopRules.ruleset
@@ -8,13 +8,11 @@
     <Rule Id="SA1401" Action="None" />
 
     <!--
-      Keep those rules disabled as it would force a header for each file
+      Keep this rule disabled as it would force a header for each file
       and a copyright.
        - SA1633: FileMustHaveHeader
-       - SA1652: SA1652EnableXmlDocumentationOutput
     -->
     <Rule Id="SA1633" Action="None" />
-    <Rule Id="SA1652" Action="None" />
 
     <!--
       Keep those rules disabled as we actively use region in the code
@@ -30,5 +28,19 @@
       Fixing it would be a breaking change.
     -->
     <Rule Id="SA1300" Action="None" />
+
+    <!--
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      SA1600: ElementsMustBeDocumented
+      SA1601: PartialElementsMustBeDocumented
+      SA1602: EnumerationItemsMustBeDocumented
+      SA1623: PropertySummaryDocumentationMustMatchAccessors
+      Documentation related warnings. We should fix those in the future.
+    -->
+    <Rule Id="CS1591" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1623" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Generates the XML documentation file. Even though few of our classes are properly documented, it's better than nothing.

Partially fixes #1261.
