### PR TITLE
 Handle `DateTime`s directly in the encoder

### DIFF
--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -98,6 +98,15 @@
 
                 flatParams.Add(new Parameter(keyPrefix, paramValue));
             }
+            else if (value is DateTime)
+            {
+                flatParams = new List<Parameter>();
+                DateTime? dateTime = (DateTime)value;
+                if (dateTime.HasValue)
+                {
+                    flatParams.Add(new Parameter(keyPrefix, dateTime?.ConvertDateTimeToEpoch().ToString()));
+                }
+            }
             else if (value == null)
             {
                 flatParams = new List<Parameter>();

--- a/src/Stripe.net/Services/Account/StripeAccountSharedOptions.cs
+++ b/src/Stripe.net/Services/Account/StripeAccountSharedOptions.cs
@@ -69,21 +69,8 @@
 
         #region Tos Acceptance
 
-        public DateTime? TosAcceptanceDate { get; set; }
-
         [JsonProperty("tos_acceptance[date]")]
-        internal long? TosAcceptanceDateInternal
-        {
-            get
-            {
-                if (!this.TosAcceptanceDate.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.TosAcceptanceDate.Value);
-            }
-        }
+        public DateTime? TosAcceptanceDate { get; set; }
 
         [JsonProperty("tos_acceptance[ip]")]
         public string TosAcceptanceIp { get; set; }

--- a/src/Stripe.net/Services/Coupons/StripeCouponCreateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/StripeCouponCreateOptions.cs
@@ -34,20 +34,7 @@
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        public DateTime? RedeemBy { get; set; }
-
         [JsonProperty("redeem_by")]
-        internal long? RedeemByInternal
-        {
-            get
-            {
-                if (!this.RedeemBy.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.RedeemBy.Value);
-            }
-        }
+        public DateTime? RedeemBy { get; set; }
     }
 }

--- a/src/Stripe.net/Services/FileLinks/StripeFileLinkSharedOptions.cs
+++ b/src/Stripe.net/Services/FileLinks/StripeFileLinkSharedOptions.cs
@@ -10,21 +10,8 @@ namespace Stripe
         /// <summary>
         /// A future timestamp after which the link will no longer be usable.
         /// </summary>
-        public DateTime? ExpiresAt { get; set; }
-
         [JsonProperty("expires_at")]
-        internal long? ExpiresAtInternal
-        {
-            get
-            {
-                if (!this.ExpiresAt.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.ExpiresAt.Value);
-            }
-        }
+        public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// Set of key-value pairs that you can attach to an object. This can be useful for storing

--- a/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeInvoiceCreateOptions.cs
@@ -28,10 +28,8 @@
         /// <summary>
         /// The date on which payment for this invoice is due. Only valid for invoices where billing=send_invoice.
         /// </summary>
-        public DateTime? DueDate { get; set; }
-
         [JsonProperty("due_date")]
-        internal long? DueDateInternal => this.DueDate?.ConvertDateTimeToEpoch();
+        public DateTime? DueDate { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/StripeUpcomingInvoiceOptions.cs
@@ -16,21 +16,8 @@
         /// <summary>
         /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
-        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
-
         [JsonProperty("subscription_billing_cycle_anchor")]
-        internal long? SubscriptionBillingCycleAnchorInternal
-        {
-            get
-            {
-                if (!this.SubscriptionBillingCycleAnchor.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.SubscriptionBillingCycleAnchor.Value);
-            }
-        }
+        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
 
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
@@ -44,21 +31,8 @@
         [JsonProperty("subscription_prorate")]
         public bool? SubscriptionProrate { get; set; }
 
-        public DateTime? SubscriptionProrationDate { get; set; }
-
         [JsonProperty("subscription_proration_date")]
-        internal long? SubscriptionProrationDateInternal
-        {
-            get
-            {
-                if (!this.SubscriptionProrationDate.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.SubscriptionProrationDate.Value);
-            }
-        }
+        public DateTime? SubscriptionProrationDate { get; set; }
 
         [JsonProperty("subscription_quantity")]
         public int? SubscriptionQuantity { get; set; }
@@ -66,21 +40,8 @@
         [JsonProperty("subscription_tax_percent")]
         public decimal? SubscriptionTaxPercent { get; set; }
 
-        public DateTime? SubscriptionTrialEnd { get; set; }
-
         [JsonProperty("subscription_trial_end")]
-        internal long? SubscriptionTrialEndInternal
-        {
-            get
-            {
-                if (!this.SubscriptionTrialEnd.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.SubscriptionTrialEnd.Value);
-            }
-        }
+        public DateTime? SubscriptionTrialEnd { get; set; }
 
         [JsonProperty("subscription_trial_from_plan")]
         public bool? SubscriptionTrialFromPlan { get; set; }

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ParametersOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ParametersOptions.cs
@@ -13,37 +13,11 @@ namespace Stripe.Reporting
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        [JsonProperty("interval_end")]
         public DateTime? IntervalEnd { get; set; }
 
-        [JsonProperty("interval_end")]
-        internal long? IntervalEndInternal
-        {
-            get
-            {
-                if (!this.IntervalEnd.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.IntervalEnd.Value);
-            }
-        }
-
-        public DateTime? IntervalStart { get; set; }
-
         [JsonProperty("interval_start")]
-        internal long? IntervalStartInternal
-        {
-            get
-            {
-                if (!this.IntervalStart.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.IntervalStart.Value);
-            }
-        }
+        public DateTime? IntervalStart { get; set; }
 
         [JsonProperty("payout")]
         public string Payout { get; set; }

--- a/src/Stripe.net/Services/Sources/StripeSourceMandateOptions.cs
+++ b/src/Stripe.net/Services/Sources/StripeSourceMandateOptions.cs
@@ -6,21 +6,8 @@ namespace Stripe
 
     public class StripeSourceMandateOptions : INestedOptions
     {
-        public DateTime? MandateAcceptanceDate { get; set; }
-
         [JsonProperty("acceptance[date]")]
-        internal long? MandateAcceptanceDateInternal
-        {
-            get
-            {
-                if (!this.MandateAcceptanceDate.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.MandateAcceptanceDate.Value);
-            }
-        }
+        public DateTime? MandateAcceptanceDate { get; set; }
 
         [JsonProperty("acceptance[ip]")]
         public string MandateAcceptanceIp { get; set; }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
@@ -21,21 +21,8 @@
         /// <summary>
         /// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the upcoming invoice endpoint.
         /// </summary>
-        public DateTime? ProrationDate { get; set; }
-
         [JsonProperty("proration_date")]
-        internal long? ProrationDateInternal
-        {
-            get
-            {
-                if (!this.ProrationDate.HasValue)
-                {
-                    return null;
-                }
-
-                return this.ProrationDate.Value.ConvertDateTimeToEpoch();
-            }
-        }
+        public DateTime? ProrationDate { get; set; }
 
         /// <summary>
         /// The quantity you’d like to apply to the subscription item you’re creating.

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionCreateOptions.cs
@@ -10,21 +10,8 @@
         /// <summary>
         /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
-        public DateTime? BillingCycleAnchor { get; set; }
-
         [JsonProperty("billing_cycle_anchor")]
-        internal long? BillingCycleAnchorInternal
-        {
-            get
-            {
-                if (!this.BillingCycleAnchor.HasValue)
-                {
-                    return null;
-                }
-
-                return EpochTime.ConvertDateTimeToEpoch(this.BillingCycleAnchor.Value);
-            }
-        }
+        public DateTime? BillingCycleAnchor { get; set; }
 
         /// <summary>
         /// REQUIRED: The identifier of the customer to subscribe.

--- a/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/StripeSubscriptionUpdateOptions.cs
@@ -44,15 +44,10 @@
         [JsonProperty("items")]
         public List<StripeSubscriptionItemUpdateOption> Items { get; set; }
 
-        #region ProrationDate
-
         /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current period.
         /// </summary>
-        public DateTime? ProrationDate { get; set; }
-
         [JsonProperty("proration_date")]
-        internal string ProrationDateInternal => this.ProrationDate?.ConvertDateTimeToEpoch().ToString();
-        #endregion
+        public DateTime? ProrationDate { get; set; }
     }
 }

--- a/src/Stripe.net/Services/UsageRecords/StripeUsageRecordCreateOptions.cs
+++ b/src/Stripe.net/Services/UsageRecords/StripeUsageRecordCreateOptions.cs
@@ -13,13 +13,8 @@
         [JsonIgnore]
         public string SubscriptionItem { get; set; }
 
-        public DateTime Timestamp { get; set; }
-
         [JsonProperty("timestamp")]
-        internal string TimestampInternal
-        {
-            get { return this.Timestamp.ConvertDateTimeToEpoch().ToString(); }
-        }
+        public DateTime Timestamp { get; set; }
 
         [JsonProperty("quantity")]
         public int Quantity { get; set; }

--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -133,6 +133,16 @@ namespace StripeTests
                     want = "?bool=False&date_filter[lt]=946702800&date_filter[gte]=946684800&decimal=0&enum=test_one&int=0"
                 },
 
+                // DateTimeNullable
+                new
+                {
+                    data = new TestOptions
+                    {
+                        DateTimeNullable = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
+                    },
+                    want = "?bool=False&datetime_nullable=946684800&decimal=0&enum=test_one&int=0"
+                },
+
                 // Decimal
                 new
                 {

--- a/src/StripeTests/Infrastructure/TestData/TestOptions.cs
+++ b/src/StripeTests/Infrastructure/TestData/TestOptions.cs
@@ -35,6 +35,9 @@ namespace StripeTests.Infrastructure.TestData
         [JsonProperty("date_filter")]
         public StripeDateFilter DateFilter { get; set; }
 
+        [JsonProperty("datetime_nullable")]
+        public DateTime? DateTimeNullable { get; set; }
+
         [JsonProperty("decimal")]
         public decimal Decimal { get; set; }
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Handle `DateTime`s directly in the encoder, and update all `DateTime`s fields in options classes so that the conversion to long/string is no longer done internally (except for those that also have special values like `"now"`).
