### PR TITLE
Fix ScheduledQueryRun naming

### DIFF
--- a/src/Stripe.net/Entities/Sigma/ScheduledQueryRun.cs
+++ b/src/Stripe.net/Entities/Sigma/ScheduledQueryRun.cs
@@ -1,4 +1,4 @@
-﻿namespace Stripe
+﻿namespace Stripe.Sigma
 {
     using System;
     using Newtonsoft.Json;

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunListOptions.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunListOptions.cs
@@ -1,10 +1,10 @@
-﻿namespace Stripe
+﻿namespace Stripe.Sigma
 {
     using System;
     using System.Collections.Generic;
     using System.Text;
 
-    public class ScheduledQueryListOptions : ListOptions
+    public class ScheduledQueryRunListOptions : ListOptions
     {
     }
 }

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -1,17 +1,17 @@
-﻿namespace Stripe
+﻿namespace Stripe.Sigma
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class ScheduledQueryService : BasicService<ScheduledQueryRun>
+    public class ScheduledQueryRunService : BasicService<ScheduledQueryRun>
     {
-        public ScheduledQueryService()
+        public ScheduledQueryRunService()
             : base(null)
         {
         }
 
-        public ScheduledQueryService(string apiKey)
+        public ScheduledQueryRunService(string apiKey)
             : base(apiKey)
         {
         }
@@ -21,7 +21,7 @@
             return this.GetEntity($"{Urls.BaseUrl}/sigma/scheduled_query_runs/{queryRunId}", requestOptions);
         }
 
-        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetEntityList($"{Urls.BaseUrl}/sigma/scheduled_query_runs", requestOptions, listOptions);
         }
@@ -31,7 +31,7 @@
             return this.GetEntityAsync($"{Urls.BaseUrl}/sigma/scheduled_query_runs/{queryRunId}", requestOptions, cancellationToken);
         }
 
-        public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetEntityListAsync($"{Urls.BaseUrl}/sigma/scheduled_query_runs", requestOptions, cancellationToken, listOptions);
         }

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -6,6 +6,8 @@
 
     public class ScheduledQueryRunService : BasicService<ScheduledQueryRun>
     {
+        private static string classUrl = Urls.BaseUrl + "/sigma/scheduled_query_runs";
+
         public ScheduledQueryRunService()
             : base(null)
         {
@@ -16,24 +18,24 @@
         {
         }
 
-        public virtual ScheduledQueryRun Get(string queryRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual ScheduledQueryRun Get(string queryRunId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/sigma/scheduled_query_runs/{queryRunId}", requestOptions);
-        }
-
-        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.GetEntityList($"{Urls.BaseUrl}/sigma/scheduled_query_runs", requestOptions, listOptions);
+            return this.GetEntity($"{classUrl}/{queryRunId}", requestOptions);
         }
 
         public virtual Task<ScheduledQueryRun> GetAsync(string queryRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/sigma/scheduled_query_runs/{queryRunId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync($"{classUrl}/{queryRunId}", requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntityList(classUrl, requestOptions, listOptions);
         }
 
         public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/sigma/scheduled_query_runs", requestOptions, cancellationToken, listOptions);
+            return this.GetEntityListAsync(classUrl, requestOptions, cancellationToken, listOptions);
         }
     }
 }

--- a/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
+++ b/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
@@ -1,4 +1,4 @@
-namespace StripeTests
+namespace StripeTests.Sigma
 {
     using System;
     using System.Collections.Generic;
@@ -6,6 +6,7 @@ namespace StripeTests
 
     using Newtonsoft.Json;
     using Stripe;
+    using Stripe.Sigma;
     using Xunit;
 
     public class ScheduledQueryRunTest : BaseStripeTest

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -3,21 +3,21 @@ namespace StripeTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    using Stripe;
+    using Stripe.Sigma;
     using Xunit;
 
-    public class ScheduledQueryServiceTest : BaseStripeTest
+    public class ScheduledQueryRunServiceTest : BaseStripeTest
     {
         private const string ScheduledQueryId = "sqr_123";
 
-        private ScheduledQueryService service;
-        private ScheduledQueryListOptions listOptions;
+        private ScheduledQueryRunService service;
+        private ScheduledQueryRunListOptions listOptions;
 
-        public ScheduledQueryServiceTest()
+        public ScheduledQueryRunServiceTest()
         {
-            this.service = new ScheduledQueryService();
+            this.service = new ScheduledQueryRunService();
 
-            this.listOptions = new ScheduledQueryListOptions()
+            this.listOptions = new ScheduledQueryRunListOptions()
             {
                 Limit = 1,
             };


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

- Renames `ScheduledQuery*` to `ScheduledQueryRun*`.
- Creates a `Stripe.Sigma` namespace for `ScheduledQueryRun` entity / service / options classes
- Renames files accordingly

