### PR TITLE
Fix signatures in `InvoiceService` and `RefundService`

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -7,17 +7,33 @@
 
     public class InvoiceCreateOptions : BaseOptions, ISupportMetadata
     {
+        /// <summary>
+        /// A fee in cents that will be applied to the invoice and transferred to the application
+        /// owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account
+        /// header in order to take an application fee. For more information, see the application
+        /// fees <see href="https://stripe.com/docs/connect/subscriptions#working-with-invoices">documentation</see>.
+        /// </summary>
         [JsonProperty("application_fee")]
         public int? ApplicationFee { get; set; }
 
         /// <summary>
-        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to charge_automatically.
+        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
+        /// this invoice using the default source attached to the customer. When sending an invoice,
+        /// Stripe will email this invoice to the customer with payment instructions. Defaults to
+        /// <c>charge_automatically</c>.
         /// </summary>
         [JsonProperty("billing")]
         public Billing? Billing { get; set; }
 
         /// <summary>
-        /// The number of days from which the invoice is created until it is due. Only valid for invoices where billing=send_invoice.
+        /// REQUIRED
+        /// </summary>
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// The number of days from which the invoice is created until it is due. Only valid for
+        /// invoices where <c>billing=send_invoice</c>.
         /// </summary>
         [JsonProperty("days_until_due")]
         public int? DaysUntilDue { get; set; }
@@ -26,7 +42,8 @@
         public string Description { get; set; }
 
         /// <summary>
-        /// The date on which payment for this invoice is due. Only valid for invoices where billing=send_invoice.
+        /// The date on which payment for this invoice is due. Only valid for invoices where
+        /// <c>billing=send_invoice</c>.
         /// </summary>
         [JsonProperty("due_date")]
         public DateTime? DueDate { get; set; }
@@ -34,12 +51,26 @@
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// Extra information about a charge for the customer’s credit card statement. It must
+        /// contain at least one letter. If not specified and this invoice is part of a
+        /// subscription, the default <c>statement_descriptor</c> will be set to the first
+        /// subscription item’s product’s <c>statement_descriptor</c>.
+        /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
+        /// <summary>
+        /// The ID of the subscription to invoice. If not set, the created invoice will include all
+        /// pending invoice items for the customer. If set, the created invoice will exclude pending
+        /// invoice items that pertain to other subscriptions.
+        /// </summary>
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 
+        /// <summary>
+        /// The percent tax rate applied to the invoice, represented as a decimal number.
+        /// </summary>
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -23,73 +23,28 @@
 
         public bool ExpandSubscription { get; set; }
 
+        public virtual Invoice Create(InvoiceCreateOptions createOptions = null, RequestOptions requestOptions = null)
+        {
+            return Mapper<Invoice>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(createOptions, Urls.Invoices, false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<Invoice> CreateAsync(InvoiceCreateOptions createOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<Invoice>.MapFromJson(
+                await Requestor.PostStringAsync(
+                    this.ApplyAllParameters(createOptions, Urls.Invoices, false),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
+        }
+
         public virtual Invoice Get(string invoiceId, RequestOptions requestOptions = null)
         {
             return Mapper<Invoice>.MapFromJson(
                 Requestor.GetString(
                     this.ApplyAllParameters(null, $"{Urls.Invoices}/{invoiceId}", false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual Invoice Upcoming(string customerId, UpcomingInvoiceOptions upcomingOptions = null, RequestOptions requestOptions = null)
-        {
-            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming", "customer", customerId);
-
-            return Mapper<Invoice>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(upcomingOptions, url, false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual Invoice Update(string invoiceId, InvoiceUpdateOptions updateOptions, RequestOptions requestOptions = null)
-        {
-            return Mapper<Invoice>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(updateOptions, $"{Urls.Invoices}/{invoiceId}", false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual Invoice Pay(string invoiceId, InvoicePayOptions payOptions, RequestOptions requestOptions = null)
-        {
-            return Mapper<Invoice>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(payOptions, $"{Urls.Invoices}/{invoiceId}/pay", false),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeList<Invoice> List(InvoiceListOptions listOptions = null, RequestOptions requestOptions = null)
-        {
-            return Mapper<StripeList<Invoice>>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(listOptions, Urls.Invoices, true),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions listOptions = null, RequestOptions requestOptions = null)
-        {
-            return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/{invoiceId}/lines", true),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(string customerId, UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null)
-        {
-            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
-
-            return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(listOptions, url, true),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual Invoice Create(string customerId, InvoiceCreateOptions createOptions = null, RequestOptions requestOptions = null)
-        {
-            var url = ParameterBuilder.ApplyParameterToUrl(Urls.Invoices, "customer", customerId);
-
-            return Mapper<Invoice>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(createOptions, url, false),
                     this.SetupRequestOptions(requestOptions)));
         }
 
@@ -102,33 +57,12 @@
                     cancellationToken).ConfigureAwait(false));
         }
 
-        public virtual async Task<Invoice> UpcomingAsync(string customerId, UpcomingInvoiceOptions upcomingOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual StripeList<Invoice> List(InvoiceListOptions listOptions = null, RequestOptions requestOptions = null)
         {
-            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming", "customer", customerId);
-
-            return Mapper<Invoice>.MapFromJson(
-                await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(upcomingOptions, url, false),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
-        }
-
-        public virtual async Task<Invoice> UpdateAsync(string invoiceId, InvoiceUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return Mapper<Invoice>.MapFromJson(
-                await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(updateOptions, $"{Urls.Invoices}/{invoiceId}", false),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
-        }
-
-        public virtual async Task<Invoice> PayAsync(string invoiceId, InvoicePayOptions payOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return Mapper<Invoice>.MapFromJson(
-                await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(payOptions, $"{Urls.Invoices}/{invoiceId}/pay", false),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
+            return Mapper<StripeList<Invoice>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, Urls.Invoices, true),
+                    this.SetupRequestOptions(requestOptions)));
         }
 
         public virtual async Task<StripeList<Invoice>> ListAsync(InvoiceListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -140,6 +74,14 @@
                     cancellationToken).ConfigureAwait(false));
         }
 
+        public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions listOptions = null, RequestOptions requestOptions = null)
+        {
+            return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/{invoiceId}/lines", true),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
         public virtual async Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string invoiceId, InvoiceListLineItemsOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
@@ -149,24 +91,70 @@
                     cancellationToken).ConfigureAwait(false));
         }
 
-        public virtual async Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(string customerId, UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null)
         {
-            var url = ParameterBuilder.ApplyParameterToUrl($"{Urls.Invoices}/upcoming/lines", "customer", customerId);
+            return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/upcoming/lines", true),
+                    this.SetupRequestOptions(requestOptions)));
+        }
 
+        public virtual async Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
             return Mapper<StripeList<InvoiceLineItem>>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(listOptions, url, true),
+                    this.ApplyAllParameters(listOptions, $"{Urls.Invoices}/upcoming/lines", true),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken).ConfigureAwait(false));
         }
 
-        public virtual async Task<Invoice> CreateAsync(string customerId, InvoiceCreateOptions createOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Invoice Pay(string invoiceId, InvoicePayOptions payOptions, RequestOptions requestOptions = null)
         {
-            var url = ParameterBuilder.ApplyParameterToUrl(Urls.Invoices, "customer", customerId);
+            return Mapper<Invoice>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(payOptions, $"{Urls.Invoices}/{invoiceId}/pay", false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
 
+        public virtual async Task<Invoice> PayAsync(string invoiceId, InvoicePayOptions payOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
             return Mapper<Invoice>.MapFromJson(
                 await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(createOptions, url),
+                    this.ApplyAllParameters(payOptions, $"{Urls.Invoices}/{invoiceId}/pay", false),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
+        }
+
+        public virtual Invoice Upcoming(UpcomingInvoiceOptions upcomingOptions = null, RequestOptions requestOptions = null)
+        {
+            return Mapper<Invoice>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(upcomingOptions, $"{Urls.Invoices}/upcoming", false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions upcomingOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<Invoice>.MapFromJson(
+                await Requestor.GetStringAsync(
+                    this.ApplyAllParameters(upcomingOptions, $"{Urls.Invoices}/upcoming", false),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
+        }
+
+        public virtual Invoice Update(string invoiceId, InvoiceUpdateOptions updateOptions, RequestOptions requestOptions = null)
+        {
+            return Mapper<Invoice>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(updateOptions, $"{Urls.Invoices}/{invoiceId}", false),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<Invoice> UpdateAsync(string invoiceId, InvoiceUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<Invoice>.MapFromJson(
+                await Requestor.PostStringAsync(
+                    this.ApplyAllParameters(updateOptions, $"{Urls.Invoices}/{invoiceId}", false),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken).ConfigureAwait(false));
         }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -7,42 +7,129 @@
 
     public class UpcomingInvoiceOptions : BaseOptions
     {
+        /// <summary>
+        /// The code of the coupon to apply. If <c>subscription</c> or <c>subscription_items</c> is
+        /// provided, the invoice returned will preview updating or creating a subscription with
+        /// that coupon. Otherwise, it will preview applying that coupon to the customer for the
+        /// next upcoming invoice from among the customer’s subscriptions. The invoice can be
+        /// previewed without a coupon by passing this value as an empty string.
+        /// </summary>
         [JsonProperty("coupon")]
         public string CouponId { get; set; }
 
+        /// <summary>
+        /// REQUIRED
+        /// </summary>
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// List of invoice items to add or update in the upcoming invoice preview.
+        /// </summary>
         [JsonProperty("invoice_items")]
         public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
 
+        #region SubscriptionBillingCycleAnchor
+
         /// <summary>
-        /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
+        /// For new subscriptions, a future timestamp to anchor the subscription’s
+        /// <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
+        /// This is used to determine the date of the first full invoice, and, for plans with
+        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.For
+        /// existing subscriptions, the value can only be set to <c>now</c> or <c>unchanged</c>.
         /// </summary>
-        [JsonProperty("subscription_billing_cycle_anchor")]
         public DateTime? SubscriptionBillingCycleAnchor { get; set; }
 
+        public bool SubscriptionBillingCycleAnchorNow { get; set; }
+
+        public bool SubscriptionBillingCycleAnchorUnchanged { get; set; }
+
+        [JsonProperty("subscription_billing_cycle_anchor")]
+        internal string SubscriptionBillingCycleAnchorInternal
+        {
+            get
+            {
+                if (this.SubscriptionBillingCycleAnchorNow)
+                {
+                    return "now";
+                }
+
+                if (this.SubscriptionBillingCycleAnchorUnchanged)
+                {
+                    return "unchanged";
+                }
+
+                return this.SubscriptionBillingCycleAnchor?.ConvertDateTimeToEpoch().ToString();
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Boolean indicating whether this subscription should cancel at the end of the current
+        /// period.
+        /// </summary>
+        [JsonProperty("subscription_cancel_at_period_end")]
+        public bool? SubscriptionCancelAtPeriodEnd { get; set; }
+
+        /// <summary>
+        /// The identifier of the subscription for which you’d like to retrieve the upcoming
+        /// invoice. If not provided, but a <c>subscription_items</c> is provided, you will preview
+        /// creating a subscription with those items. If neither <c>subscription</c> nor
+        /// <c>subscription_items</c> is provided, you will retrieve the next upcoming invoice from
+        /// among the customer’s subscriptions.
+        /// </summary>
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 
+        /// <summary>
+        /// List of subscription items, each with an attached plan.
+        /// </summary>
         [JsonProperty("subscription_items")]
         public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
 
-        [JsonProperty("subscription_plan")]
-        public string SubscriptionPlanId { get; set; }
-
+        /// <summary>
+        /// If previewing an update to a subscription, this decides whether the preview will show
+        /// the result of applying prorations or not. If set, one of <c>subscription_items</c> or
+        /// <c>subscription</c>, and one of <c>subscription_items</c> or
+        /// <c>subscription_trial_end</c> are required.
+        /// </summary>
         [JsonProperty("subscription_prorate")]
         public bool? SubscriptionProrate { get; set; }
 
+        /// <summary>
+        /// If previewing an update to a subscription, and doing proration,
+        /// <c>subscription_proration_date</c> forces the proration to be calculated as though the
+        /// update was done at the specified time. The time given must be within the current
+        /// subscription period, and cannot be before the subscription was on its current plan. If
+        /// set, <c>subscription</c>, and one of <c>subscription_items</c>, or
+        /// <c>subscription_trial_end</c> are required. Also, <c>subscription_proration</c> cannot
+        /// be set to false.
+        /// </summary>
         [JsonProperty("subscription_proration_date")]
         public DateTime? SubscriptionProrationDate { get; set; }
 
-        [JsonProperty("subscription_quantity")]
-        public int? SubscriptionQuantity { get; set; }
-
+        /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// that tax percent. If set, one of <c>subscription_items</c> or
+        /// <c>subscription is required</c>.
+        /// </summary>
         [JsonProperty("subscription_tax_percent")]
         public decimal? SubscriptionTaxPercent { get; set; }
 
+        /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// that trial end. If set, one of <c>subscription_items</c> or <c>subscription</c> is
+        /// required.
+        /// </summary>
         [JsonProperty("subscription_trial_end")]
         public DateTime? SubscriptionTrialEnd { get; set; }
 
+        /// <summary>
+        /// Indicates if a plan’s <c>trial_period_days</c> should be applied to the subscription.
+        /// Setting <c>subscription_trial_end</c> per subscription is preferred, and this defaults
+        /// to <c>false</c>. Setting this flag to <c>true</c> together with
+        /// <c>subscription_trial_end</c> is not allowed.
+        /// </summary>
         [JsonProperty("subscription_trial_from_plan")]
         public bool? SubscriptionTrialFromPlan { get; set; }
     }

--- a/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
@@ -5,19 +5,56 @@
 
     public class RefundCreateOptions : BaseOptions, ISupportMetadata
     {
+        /// <summary>
+        /// A positive integer in cents representing how much of this charge to refund. Can refund
+        /// only up to the remaining, unrefunded amount of the charge.
+        /// </summary>
         [JsonProperty("amount")]
         public int? Amount { get; set; }
 
-        [JsonProperty("refund_application_fee")]
-        public bool? RefundApplicationFee { get; set; }
+        /// <summary>
+        /// REQUIRED. The identifier of the charge to refund.
+        /// </summary>
+        [JsonProperty("charge")]
+        public string ChargeId { get; set; }
 
-        [JsonProperty("reverse_transfer")]
-        public bool? ReverseTransfer { get; set; }
+        /// <summary>
+        /// A set of key-value pairs that you can attach to a <c>Refund</c> object. This can be
+        /// useful for storing additional information about the refund in a structured format. You
+        /// can unset individual keys if you POST an empty value for that key. You can clear all
+        /// keys if you POST an empty value for <c>metadata</c>
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// String indicating the reason for the refund. If set, possible values are
+        /// <c>duplicate</c>, <c>fraudulent</c>, and <c>requested_by_customer</c>. If you believe
+        /// the charge to be fraudulent, specifying <c>fraudulent</c> as the reason will add the
+        /// associated card and email to your
+        /// <see href="https://stripe.com/docs/radar/lists">blocklists</see>, and will also help us
+        /// improve our fraud detection algorithms.
+        /// </summary>
         [JsonProperty("reason")]
         public string Reason { get; set; }
 
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
+        /// <summary>
+        /// Boolean indicating whether the application fee should be refunded when refunding this
+        /// charge. If a full charge refund is given, the full application fee will be refunded.
+        /// Otherwise, the application fee will be refunded in an amount proportional to the amount
+        /// of the charge refunded.
+        /// An application fee can be refunded only by the application that created the charge.
+        /// </summary>
+        [JsonProperty("refund_application_fee")]
+        public bool? RefundApplicationFee { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether the transfer should be reversed when refunding this charge.
+        /// The transfer will be reversed proportionally to the amount being refunded (either the
+        /// entire or partial amount).
+        /// A transfer can be reversed only by the application that created the charge.
+        /// </summary>
+        [JsonProperty("reverse_transfer")]
+        public bool? ReverseTransfer { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -8,6 +8,8 @@
 
     public class RefundService : StripeService
     {
+        private static string classUrl = Urls.BaseUrl + "/refunds";
+
         public RefundService()
             : base(null)
         {
@@ -24,70 +26,70 @@
 
         public bool ExpandFailureBalanceTransaction { get; set; }
 
-        public virtual Refund Create(string chargeId, RefundCreateOptions createOptions = null, RequestOptions requestOptions = null)
+        public virtual Refund Create(RefundCreateOptions createOptions = null, RequestOptions requestOptions = null)
         {
             return Mapper<Refund>.MapFromJson(
                 Requestor.PostString(
-                    this.ApplyAllParameters(createOptions, $"{Urls.Charges}/{chargeId}/refunds", false),
+                    this.ApplyAllParameters(createOptions, classUrl, false),
                     this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<Refund> CreateAsync(RefundCreateOptions createOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<Refund>.MapFromJson(
+                await Requestor.PostStringAsync(
+                    this.ApplyAllParameters(createOptions, classUrl, false),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
         }
 
         public virtual Refund Get(string refundId, RequestOptions requestOptions = null)
         {
             return Mapper<Refund>.MapFromJson(
                 Requestor.GetString(
-                    this.ApplyAllParameters(null, $"{Urls.BaseUrl}/refunds/{refundId}"),
+                    this.ApplyAllParameters(null, $"{classUrl}/{refundId}"),
                     this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual Refund Update(string refundId, RefundUpdateOptions updateOptions, RequestOptions requestOptions = null)
-        {
-            return Mapper<Refund>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/refunds/{refundId}"),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual StripeList<Refund> List(RefundListOptions listOptions = null, RequestOptions requestOptions = null)
-        {
-            return Mapper<StripeList<Refund>>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/refunds", true),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        public virtual async Task<Refund> CreateAsync(string chargeId, RefundCreateOptions createOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return Mapper<Refund>.MapFromJson(
-                await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(createOptions, $"{Urls.Charges}/{chargeId}/refunds", false),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
         }
 
         public virtual async Task<Refund> GetAsync(string refundId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<Refund>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(null, $"{Urls.BaseUrl}/refunds/{refundId}"),
+                    this.ApplyAllParameters(null, $"{classUrl}/{refundId}"),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken).ConfigureAwait(false));
         }
 
-        public virtual async Task<Refund> UpdateAsync(string refundId, RefundUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual StripeList<Refund> List(RefundListOptions listOptions = null, RequestOptions requestOptions = null)
         {
-            return Mapper<Refund>.MapFromJson(
-                await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(updateOptions, $"{Urls.BaseUrl}/refunds/{refundId}"),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
+            return Mapper<StripeList<Refund>>.MapFromJson(
+                Requestor.GetString(
+                    this.ApplyAllParameters(listOptions, classUrl, true),
+                    this.SetupRequestOptions(requestOptions)));
         }
 
         public virtual async Task<StripeList<Refund>> ListAsync(RefundListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Mapper<StripeList<Refund>>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(listOptions, $"{Urls.BaseUrl}/refunds", true),
+                    this.ApplyAllParameters(listOptions, classUrl, true),
+                    this.SetupRequestOptions(requestOptions),
+                    cancellationToken).ConfigureAwait(false));
+        }
+
+        public virtual Refund Update(string refundId, RefundUpdateOptions updateOptions, RequestOptions requestOptions = null)
+        {
+            return Mapper<Refund>.MapFromJson(
+                Requestor.PostString(
+                    this.ApplyAllParameters(updateOptions, $"{classUrl}/{refundId}"),
+                    this.SetupRequestOptions(requestOptions)));
+        }
+
+        public virtual async Task<Refund> UpdateAsync(string refundId, RefundUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Mapper<Refund>.MapFromJson(
+                await Requestor.PostStringAsync(
+                    this.ApplyAllParameters(updateOptions, $"{classUrl}/{refundId}"),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken).ConfigureAwait(false));
         }

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -8,7 +8,6 @@ namespace StripeTests
 
     public class InvoiceServiceTest : BaseStripeTest
     {
-        private const string CustomerId = "cus_123";
         private const string InvoiceId = "in_123";
 
         private InvoiceService service;
@@ -25,6 +24,7 @@ namespace StripeTests
 
             this.createOptions = new InvoiceCreateOptions()
             {
+                CustomerId = "cus_123",
                 TaxPercent = 12.5m,
             };
 
@@ -54,6 +54,7 @@ namespace StripeTests
 
             this.upcomingOptions = new UpcomingInvoiceOptions()
             {
+                CustomerId = "cus_123",
                 SubscriptionId = "sub_123",
             };
         }
@@ -61,7 +62,7 @@ namespace StripeTests
         [Fact]
         public void Create()
         {
-            var invoice = this.service.Create(CustomerId, this.createOptions);
+            var invoice = this.service.Create(this.createOptions);
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -69,7 +70,7 @@ namespace StripeTests
         [Fact]
         public async Task CreateAsync()
         {
-            var invoice = await this.service.CreateAsync(CustomerId, this.createOptions);
+            var invoice = await this.service.CreateAsync(this.createOptions);
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -133,7 +134,7 @@ namespace StripeTests
         [Fact]
         public void ListUpcomingLineItems()
         {
-            var invoices = this.service.ListUpcomingLineItems(CustomerId, this.upcomingOptions);
+            var invoices = this.service.ListUpcomingLineItems(this.upcomingOptions);
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -143,7 +144,7 @@ namespace StripeTests
         [Fact]
         public async Task ListUpcomingLineItemsAsync()
         {
-            var invoices = await this.service.ListUpcomingLineItemsAsync(CustomerId, this.upcomingOptions);
+            var invoices = await this.service.ListUpcomingLineItemsAsync(this.upcomingOptions);
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -169,7 +170,7 @@ namespace StripeTests
         [Fact]
         public void Upcoming()
         {
-            var invoice = this.service.Upcoming(CustomerId, this.upcomingOptions);
+            var invoice = this.service.Upcoming(this.upcomingOptions);
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -177,7 +178,7 @@ namespace StripeTests
         [Fact]
         public async Task UpcomingAsync()
         {
-            var invoice = await this.service.UpcomingAsync(CustomerId, this.upcomingOptions);
+            var invoice = await this.service.UpcomingAsync(this.upcomingOptions);
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -8,7 +8,6 @@ namespace StripeTests
 
     public class RefundServiceTest : BaseStripeTest
     {
-        private const string ChargeId = "ch_123";
         private const string RefundId = "re_123";
 
         private RefundService service;
@@ -23,6 +22,7 @@ namespace StripeTests
             this.createOptions = new RefundCreateOptions()
             {
                 Amount = 123,
+                ChargeId = "ch_123",
             };
 
             this.updateOptions = new RefundUpdateOptions()
@@ -42,7 +42,7 @@ namespace StripeTests
         [Fact]
         public void Create()
         {
-            var refund = this.service.Create(ChargeId, this.createOptions);
+            var refund = this.service.Create(this.createOptions);
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -50,7 +50,7 @@ namespace StripeTests
         [Fact]
         public async Task CreateAsync()
         {
-            var refund = await this.service.CreateAsync(ChargeId, this.createOptions);
+            var refund = await this.service.CreateAsync(this.createOptions);
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes signatures in `InvoiceService` and `RefundService` so that  required parameters are passed in options classes rather than as their own arguments.

Also a bunch of cleanup:
- organize fields / methods alphabetically
- updated fields in `UpcomingInvoiceOptions`
- added XML comments