### PR TITLE
Fix warnings in StripeTests project

### DIFF
--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -199,7 +199,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void decoding_should_throw_if_value_not_declared_in_enum()
+        public void ThrowsIfValueNotDeclaredInEnum()
         {
             var json = "{\"enum\": \"unknown_value\"}";
 

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -32,5 +32,6 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\_stylecop\StyleCopRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\_stylecop\StripeTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 </Project>

--- a/src/_stylecop/StripeTests.ruleset
+++ b/src/_stylecop/StripeTests.ruleset
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for Stripe.net" ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!--
+      CS0618: 'member' is obsolete: 'text'
+      We may want to test obsolete stuff.
+    -->
+    <Rule Id="CS0618" Action="None" />
+
+    <!--
+      SA1633: FileMustHaveHeader
+      SA1652: EnableXmlDocumentationOutput
+      Documentation related warnings, not applicable to tests.
+    -->
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Adds a second set of rules specifically for the `StripeTests` project.
