### PR TITLE
Make all value types in options classes nullable

### DIFF
--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundCreateOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public class ApplicationFeeRefundCreateOptions : BaseOptions, ISupportMetadata
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
@@ -5,9 +5,9 @@
     public class BankAccountVerifyOptions : BaseOptions
     {
         [JsonProperty("amounts[]")]
-        public int AmountOne { get; set; }
+        public int? AmountOne { get; set; }
 
         [JsonProperty("amounts[]")]
-        public int AmountTwo { get; set; }
+        public int? AmountTwo { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Charges/ChargeLevel3Options.cs
+++ b/src/Stripe.net/Services/Charges/ChargeLevel3Options.cs
@@ -21,6 +21,6 @@ namespace Stripe
         public string ShippingFromZip { get; set; }
 
         [JsonProperty("shipping_amount")]
-        public int ShippingAmount { get; set; }
+        public int? ShippingAmount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
@@ -18,7 +18,7 @@
         public string Description { get; set; }
 
         [JsonProperty("discountable")]
-        public bool Discountable { get; set; }
+        public bool? Discountable { get; set; }
 
         [JsonProperty("invoice")]
         public string InvoiceId { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
@@ -12,7 +12,7 @@
         public string Description { get; set; }
 
         [JsonProperty("discountable")]
-        public bool Discountable { get; set; }
+        public bool? Discountable { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public class InvoiceUpcomingInvoiceItemOption : INestedOptions
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }
@@ -15,7 +15,7 @@ namespace Stripe
         public string Description { get; set; }
 
         [JsonProperty("discountable")]
-        public bool Discountable { get; set; }
+        public bool? Discountable { get; set; }
 
         [JsonProperty("invoiceitem")]
         public string InvoiceItemId { get; set; }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
@@ -8,10 +8,10 @@ namespace Stripe.Issuing
         public DateFilter Created { get; set; }
 
         [JsonProperty("email")]
-        public int Email { get; set; }
+        public string Email { get; set; }
 
         [JsonProperty("phone_number")]
-        public int PhoneNumber { get; set; }
+        public string PhoneNumber { get; set; }
 
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
@@ -12,9 +12,9 @@ namespace Stripe.Issuing
         public List<string> BlockedCategories { get; set; }
 
         [JsonProperty("max_amount")]
-        public int MaxAmount { get; set; }
+        public int? MaxAmount { get; set; }
 
         [JsonProperty("max_approvals")]
-        public int MaxApprovals { get; set; }
+        public int? MaxApprovals { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
@@ -11,10 +11,10 @@ namespace Stripe.Issuing
         public DateFilter Created { get; set; }
 
         [JsonProperty("exp_month")]
-        public int ExpMonth { get; set; }
+        public int? ExpMonth { get; set; }
 
         [JsonProperty("exp_year")]
-        public int ExpYear { get; set; }
+        public int? ExpYear { get; set; }
 
         [JsonProperty("last4")]
         public string Last4 { get; set; }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe.Issuing
     public class DisputeCreateOptions : CardholderSharedOptions
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("evidence")]
         public EvidenceOptions Evidence { get; set; }

--- a/src/Stripe.net/Services/Payouts/PayoutCreateOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutCreateOptions.cs
@@ -9,7 +9,7 @@
         /// REQUIRED
         /// </summary>
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         /// <summary>
         /// REQUIRED

--- a/src/Stripe.net/Services/Plans/PlanTierOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanTierOptions.cs
@@ -7,7 +7,7 @@
     public class PlanTierOptions : INestedOptions
     {
         [JsonProperty("unit_amount")]
-        public int UnitAmount { get; set; }
+        public int? UnitAmount { get; set; }
 
         #region UpTo
         public UpToOption UpTo { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanTransformUsageOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanTransformUsageOptions.cs
@@ -5,7 +5,7 @@
     public class PlanTransformUsageOptions : INestedOptions
     {
         [JsonProperty("divide_by")]
-        public int DivideBy { get; set; }
+        public int? DivideBy { get; set; }
 
         [JsonProperty("round")]
         public string Round { get; set; }

--- a/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
@@ -52,7 +52,7 @@
         /// The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a 0-decimal currency).
         /// </summary>
         [JsonProperty("price")]
-        public int Price { get; set; }
+        public int? Price { get; set; }
 
         /// <summary>
         /// The ID of the product this SKU is associated with. The product must be currently active.

--- a/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
+++ b/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     public class ThreeDSecureCreateOptions : BaseOptions
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalCreateOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalCreateOptions.cs
@@ -7,7 +7,7 @@
     public class TransferReversalCreateOptions : BaseOptions, ISupportMetadata
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Transfers/TransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/TransferCreateOptions.cs
@@ -7,7 +7,7 @@
     public class TransferCreateOptions : BaseOptions, ISupportMetadata
     {
         [JsonProperty("amount")]
-        public int Amount { get; set; }
+        public int? Amount { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }

--- a/src/Stripe.net/Services/UsageRecords/UsageRecordCreateOptions.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordCreateOptions.cs
@@ -14,9 +14,9 @@
         public string SubscriptionItem { get; set; }
 
         [JsonProperty("timestamp")]
-        public DateTime Timestamp { get; set; }
+        public DateTime? Timestamp { get; set; }
 
         [JsonProperty("quantity")]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
     }
 }

--- a/src/Stripe.net/Services/_refactor/CardCreateNestedOptions.cs
+++ b/src/Stripe.net/Services/_refactor/CardCreateNestedOptions.cs
@@ -58,13 +58,13 @@
         /// REQUIRED: Two digit number representing the card's expiration month.
         /// </summary>
         [JsonProperty("exp_month")]
-        public int ExpirationMonth { get; set; }
+        public int? ExpirationMonth { get; set; }
 
         /// <summary>
         /// REQUIRED: Two or four digit number representing the card's expiration year.
         /// </summary>
         [JsonProperty("exp_year")]
-        public int ExpirationYear { get; set; }
+        public int? ExpirationYear { get; set; }
 
         /// <summary>
         /// A set of key/value pairs that you can attach to a card object. It can be useful for storing additional information about the card in a structured format.

--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -51,7 +51,7 @@ namespace StripeTests
                 new
                 {
                     data = new TestOptions { },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0"
+                    want = string.Empty
                 },
 
                 // Array
@@ -61,7 +61,7 @@ namespace StripeTests
                     {
                             Array = new string[] { "1", "2", "3" },
                     },
-                    want = "?array[0]=1&array[1]=2&array[2]=3&bool=False&decimal=0&enum=test_one&int=0"
+                    want = "?array[0]=1&array[1]=2&array[2]=3"
                 },
                 new
                 {
@@ -69,7 +69,7 @@ namespace StripeTests
                     {
                             Array = new string[] { },
                     },
-                    want = "?array=&bool=False&decimal=0&enum=test_one&int=0"
+                    want = "?array="
                 },
 
                 // Bool
@@ -79,7 +79,7 @@ namespace StripeTests
                     {
                         Bool = false,
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0"
+                    want = "?bool=False"
                 },
                 new
                 {
@@ -87,25 +87,7 @@ namespace StripeTests
                     {
                         Bool = true,
                     },
-                    want = "?bool=True&decimal=0&enum=test_one&int=0"
-                },
-
-                // BoolNullable
-                new
-                {
-                    data = new TestOptions
-                    {
-                        BoolNullable = false,
-                    },
-                    want = "?bool=False&bool_nullable=False&decimal=0&enum=test_one&int=0"
-                },
-                new
-                {
-                    data = new TestOptions
-                    {
-                        BoolNullable = true,
-                    },
-                    want = "?bool=False&bool_nullable=True&decimal=0&enum=test_one&int=0"
+                    want = "?bool=True"
                 },
 
                 // DateFilter
@@ -118,7 +100,7 @@ namespace StripeTests
                             EqualTo = DateTime.Parse("Sat, 01 Jan 2000 05:00:00Z"),
                         }
                     },
-                    want = "?bool=False&date_filter=946702800&decimal=0&enum=test_one&int=0"
+                    want = "?date_filter=946702800"
                 },
                 new
                 {
@@ -130,17 +112,17 @@ namespace StripeTests
                             GreaterThanOrEqual = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
                         }
                     },
-                    want = "?bool=False&date_filter[lt]=946702800&date_filter[gte]=946684800&decimal=0&enum=test_one&int=0"
+                    want = "?date_filter[lt]=946702800&date_filter[gte]=946684800"
                 },
 
-                // DateTimeNullable
+                // DateTime
                 new
                 {
                     data = new TestOptions
                     {
-                        DateTimeNullable = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
+                        DateTime = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
                     },
-                    want = "?bool=False&datetime_nullable=946684800&decimal=0&enum=test_one&int=0"
+                    want = "?datetime=946684800"
                 },
 
                 // Decimal
@@ -150,7 +132,7 @@ namespace StripeTests
                     {
                         Decimal = 1.2345m,
                     },
-                    want = "?bool=False&decimal=1.2345&enum=test_one&int=0"
+                    want = "?decimal=1.2345"
                 },
                 new
                 {
@@ -158,25 +140,7 @@ namespace StripeTests
                     {
                         Decimal = 0.0m,
                     },
-                    want = "?bool=False&decimal=0.0&enum=test_one&int=0"
-                },
-
-                // DecimalNullable
-                new
-                {
-                    data = new TestOptions
-                    {
-                        DecimalNullable = 1.2345m,
-                    },
-                    want = "?bool=False&decimal=0&decimal_nullable=1.2345&enum=test_one&int=0"
-                },
-                new
-                {
-                    data = new TestOptions
-                    {
-                        DecimalNullable = 0.0m,
-                    },
-                    want = "?bool=False&decimal=0&decimal_nullable=0.0&enum=test_one&int=0"
+                    want = "?decimal=0.0"
                 },
 
                 // Dictionary
@@ -186,7 +150,7 @@ namespace StripeTests
                     {
                             Dictionary = new Dictionary<string, object> { { "foo", "bar" } },
                     },
-                    want = "?bool=False&decimal=0&dictionary[foo]=bar&enum=test_one&int=0"
+                    want = "?dictionary[foo]=bar"
                 },
                 new
                 {
@@ -194,7 +158,7 @@ namespace StripeTests
                     {
                             Dictionary = new Dictionary<string, object> { { "empty", string.Empty } },
                     },
-                    want = "?bool=False&decimal=0&dictionary[empty]=&enum=test_one&int=0"
+                    want = "?dictionary[empty]="
                 },
                 new
                 {
@@ -205,7 +169,7 @@ namespace StripeTests
                                 { "foo", new Dictionary<string, object> { { "bar", "baz" } } },
                             },
                     },
-                    want = "?bool=False&decimal=0&dictionary[foo][bar]=baz&enum=test_one&int=0"
+                    want = "?dictionary[foo][bar]=baz"
                 },
 
                 // Enum
@@ -215,7 +179,7 @@ namespace StripeTests
                     {
                         Enum = TestOptions.TestEnum.TestOne,
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0"
+                    want = "?enum=test_one"
                 },
                 new
                 {
@@ -223,25 +187,7 @@ namespace StripeTests
                     {
                         Enum = TestOptions.TestEnum.TestTwo,
                     },
-                    want = "?bool=False&decimal=0&enum=TestTwo&int=0"
-                },
-
-                // EnumNullable
-                new
-                {
-                    data = new TestOptions
-                    {
-                        EnumNullable = TestOptions.TestEnum.TestOne,
-                    },
-                    want = "?bool=False&decimal=0&enum=test_one&enum_nullable=test_one&int=0"
-                },
-                new
-                {
-                    data = new TestOptions
-                    {
-                        EnumNullable = TestOptions.TestEnum.TestTwo,
-                    },
-                    want = "?bool=False&decimal=0&enum=test_one&enum_nullable=TestTwo&int=0"
+                    want = "?enum=TestTwo"
                 },
 
                 // Int
@@ -251,7 +197,7 @@ namespace StripeTests
                     {
                         Int = 123,
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=123"
+                    want = "?int=123"
                 },
                 new
                 {
@@ -259,25 +205,7 @@ namespace StripeTests
                     {
                         Int = 0,
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0"
-                },
-
-                // IntNullable
-                new
-                {
-                    data = new TestOptions
-                    {
-                        IntNullable = 123,
-                    },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&int_nullable=123"
-                },
-                new
-                {
-                    data = new TestOptions
-                    {
-                        IntNullable = 0,
-                    },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&int_nullable=0"
+                    want = "?int=0"
                 },
 
                 // List
@@ -287,7 +215,7 @@ namespace StripeTests
                     {
                             List = new List<object> { "foo", "bar" },
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&list[0]=foo&list[1]=bar"
+                    want = "?list[0]=foo&list[1]=bar"
                 },
                 new
                 {
@@ -295,7 +223,7 @@ namespace StripeTests
                     {
                             List = new List<object> { string.Empty, 0 },
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&list[0]=&list[1]=0"
+                    want = "?list[0]=&list[1]=0"
                 },
                 new
                 {
@@ -303,7 +231,7 @@ namespace StripeTests
                     {
                             List = new List<object> { },
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&list="
+                    want = "?list="
                 },
                 new
                 {
@@ -315,7 +243,7 @@ namespace StripeTests
                                 new Dictionary<string, object> { { "foo", "baz" } },
                             },
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&list[0][foo]=bar&list[1][foo]=baz"
+                    want = "?list[0][foo]=bar&list[1][foo]=baz"
                 },
 
                 // String
@@ -325,7 +253,7 @@ namespace StripeTests
                     {
                         String = "foo",
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&string=foo"
+                    want = "?string=foo"
                 },
                 new
                 {
@@ -333,7 +261,7 @@ namespace StripeTests
                     {
                         String = string.Empty,
                     },
-                    want = "?bool=False&decimal=0&enum=test_one&int=0&string="
+                    want = "?string="
                 },
             };
 

--- a/src/StripeTests/Infrastructure/TestData/TestOptions.cs
+++ b/src/StripeTests/Infrastructure/TestData/TestOptions.cs
@@ -27,37 +27,25 @@ namespace StripeTests.Infrastructure.TestData
         public string[] Array { get; set; }
 
         [JsonProperty("bool")]
-        public bool Bool { get; set; }
-
-        [JsonProperty("bool_nullable")]
-        public bool? BoolNullable { get; set; }
+        public bool? Bool { get; set; }
 
         [JsonProperty("date_filter")]
         public DateFilter DateFilter { get; set; }
 
-        [JsonProperty("datetime_nullable")]
-        public DateTime? DateTimeNullable { get; set; }
+        [JsonProperty("datetime")]
+        public DateTime? DateTime { get; set; }
 
         [JsonProperty("decimal")]
-        public decimal Decimal { get; set; }
-
-        [JsonProperty("decimal_nullable")]
-        public decimal? DecimalNullable { get; set; }
+        public decimal? Decimal { get; set; }
 
         [JsonProperty("dictionary")]
         public Dictionary<string, object> Dictionary { get; set; }
 
         [JsonProperty("enum")]
-        public TestEnum Enum { get; set; }
-
-        [JsonProperty("enum_nullable")]
-        public TestEnum? EnumNullable { get; set; }
+        public TestEnum? Enum { get; set; }
 
         [JsonProperty("int")]
-        public int Int { get; set; }
-
-        [JsonProperty("int_nullable")]
-        public int? IntNullable { get; set; }
+        public int? Int { get; set; }
 
         [JsonProperty("list")]
         public List<object> List { get; set; }

--- a/src/StripeTests/NullableValueTypes.cs
+++ b/src/StripeTests/NullableValueTypes.cs
@@ -1,0 +1,98 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using Microsoft.Extensions.DependencyModel;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+#if NETCOREAPP1_1
+    public class NullableValueTypes
+    {
+        [Fact]
+        public void EnsureAllValueTypesAreNullable()
+        {
+            List<string> results = new List<string>();
+
+            // Get all classes that implement INestedOptions
+            var type = typeof(INestedOptions);
+            var optionsClasses = GetReferencingAssemblies("Stripe.net")
+                .SelectMany(assembly => assembly.ExportedTypes)
+                .Where(p => type.IsAssignableFrom(p));
+
+            foreach (Type optionsClass in optionsClasses)
+            {
+                foreach (PropertyInfo property in optionsClass.GetProperties())
+                {
+                    var propType = property.PropertyType;
+
+                    // Skip properties that don't have a `JsonProperty` attribute
+                    var attribute = property.GetCustomAttribute<JsonPropertyAttribute>();
+                    if (attribute == null)
+                    {
+                        continue;
+                    }
+
+                    // Skip non-value types
+                    if (!propType.GetTypeInfo().IsValueType)
+                    {
+                        continue;
+                    }
+
+                    // Skip value types that are already nullable
+                    if (propType.GetTypeInfo().IsGenericType &&
+                        propType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        continue;
+                    }
+
+                    results.Add($"{optionsClass.Name}.{property.Name}");
+                }
+            }
+
+            if (results.Any())
+            {
+                // Sort results alphabetically
+                results = results.OrderBy(i => i).ToList();
+
+                // Display our own error message (because Assert.Empty truncates the results)
+                Console.WriteLine("Found non-nullable value types:");
+                foreach (string item in results)
+                {
+                    Console.WriteLine($"- {item}");
+                }
+
+                // Actually fail test
+                Assert.True(false, "Found at least one non-nullable value type");
+            }
+        }
+
+        private static IEnumerable<Assembly> GetReferencingAssemblies(string assemblyName)
+        {
+            var assemblies = new List<Assembly>();
+            var dependencies = DependencyContext.Default.RuntimeLibraries;
+            foreach (var library in dependencies)
+            {
+                if (IsCandidateLibrary(library, assemblyName))
+                {
+                    var assembly = Assembly.Load(new AssemblyName(library.Name));
+                    assemblies.Add(assembly);
+                }
+            }
+
+            return assemblies;
+        }
+
+        private static bool IsCandidateLibrary(RuntimeLibrary library, string assemblyName)
+        {
+            return library.Name == assemblyName
+                || library.Dependencies.Any(d => d.Name.StartsWith(assemblyName));
+        }
+    }
+#endif
+}

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

- Add a test to ensure that all value types in options classes are nullable.
    (The test only runs under .NET Core 1.1 and not .NET Framework because reflection works differently, but that's okay: this is a "wholesome" test that enforces a code constraint, not a typical test that verifies the library works as expected under all runtimes.)

- Actually make all value types in options classes nullable.
