### PR TITLE
Make internals visible to Newtonsoft.Json

### DIFF
--- a/src/Stripe.net/Properties/InternalsVisibleTo.cs
+++ b/src/Stripe.net/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Newtonsoft.Json")]
 [assembly: InternalsVisibleTo("StripeTests")]


### PR DESCRIPTION
r? @anelder-stripe @remi-stripe 
cc @stripe/api-libraries 

Make internals visible to Newtonsoft.Json, as suggested by @anelder-stripe in #971.

Unfortunately, I'm not sure if it's possible to write a test for this, but the change does make sense to me: `StripeDateTimeConverter` is declared as an `internal` class, but it needs to be instantiated by Newtonsoft.Json when deserializing.
