### PR TITLE
Better URL handling in services

### DIFF
--- a/src/Stripe.net/Infrastructure/ParameterBuilder.cs
+++ b/src/Stripe.net/Infrastructure/ParameterBuilder.cs
@@ -10,6 +10,7 @@ namespace Stripe.Infrastructure
     internal static class ParameterBuilder
     {
         public static string ApplyAllParameters<T>(this Service<T> service, BaseOptions obj, string url, bool isListMethod = false)
+            where T : StripeEntity
         {
             // store the original url from the service call into requestString (e.g. https://api.stripe.com/v1/accounts/account_id)
             // before the stripe attributes get applied. all of the attributes that will get passed to stripe will be applied to this string,

--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -22,78 +22,78 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/accounts";
+
         public bool ExpandBusinessLogo { get; set; }
 
         public virtual Account Create(AccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/accounts", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Account> CreateAsync(AccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Account Delete(string accountId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/accounts/{accountId}", requestOptions);
+            return this.DeleteEntity(accountId, null, requestOptions);
         }
 
         public virtual Task<Account> DeleteAsync(string accountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/accounts/{accountId}", requestOptions, cancellationToken);
-        }
-
-        public virtual Account Get(RequestOptions requestOptions = null)
-        {
-            return this.Get(string.Empty, requestOptions);
+            return this.DeleteEntityAsync(accountId, null, requestOptions, cancellationToken);
         }
 
         public virtual Account Get(string accountId, RequestOptions requestOptions = null)
         {
-            var path = string.IsNullOrEmpty(accountId) ? $"{Urls.BaseUrl}/account" : $"{Urls.BaseUrl}/accounts/{accountId}";
-            return this.GetEntity(path, requestOptions);
-        }
-
-        public virtual Task<Account> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.GetAsync(string.Empty, requestOptions, cancellationToken);
+            return this.GetEntity(accountId, null, requestOptions);
         }
 
         public virtual Task<Account> GetAsync(string accountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var path = string.IsNullOrEmpty(accountId) ? $"{Urls.BaseUrl}/account" : $"{Urls.BaseUrl}/accounts/{accountId}";
-            return this.GetEntityAsync(path, requestOptions, cancellationToken);
+            return this.GetEntityAsync(accountId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual Account GetSelf(RequestOptions requestOptions = null)
+        {
+            return this.GetRequest<Account>($"{Urls.BaseUrl}/account", null, requestOptions);
+        }
+
+        public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetRequestAsync<Account>($"{Urls.BaseUrl}/account", null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/accounts", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Account>> ListAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/accounts", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Account Reject(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/accounts/{accountId}/reject", requestOptions, options);
+            return this.PostRequest<Account>($"{this.InstanceUrl(accountId)}/reject", options, requestOptions);
         }
 
         public virtual Task<Account> RejectAsync(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts/{accountId}/reject", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Account>($"{this.InstanceUrl(accountId)}/reject", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Update(string accountId, AccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/accounts/{accountId}", requestOptions, options);
+            return this.UpdateEntity(accountId, options, requestOptions);
         }
 
         public virtual Task<Account> UpdateAsync(string accountId, AccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts/{accountId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -21,44 +21,46 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/apple_pay/domains";
+
         public virtual ApplePayDomain Create(ApplePayDomainCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/apple_pay/domains", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> CreateAsync(ApplePayDomainCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/apple_pay/domains", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual ApplePayDomain Delete(string domainId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/apple_pay/domains/{domainId}", requestOptions);
+            return this.DeleteEntity(domainId, null, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> DeleteAsync(string domainId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/apple_pay/domains/{domainId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(domainId, null, requestOptions, cancellationToken);
         }
 
         public virtual ApplePayDomain Get(string domainId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/apple_pay/domains/{domainId}", requestOptions);
+            return this.GetEntity(domainId, null, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> GetAsync(string domainId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/apple_pay/domains/{domainId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(domainId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<ApplePayDomain> List(ApplePayDomainListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<ApplePayDomain> List(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/apple_pay/domains", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<ApplePayDomain>> ListAsync(ApplePayDomainListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<ApplePayDomain>> ListAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/apple_pay/domains", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class ApplicationFeeRefundService : Service<ApplicationFeeRefund>,
+    public class ApplicationFeeRefundService : ServiceNested<ApplicationFeeRefund>,
         INestedCreatable<ApplicationFeeRefund, ApplicationFeeRefundCreateOptions>,
         INestedListable<ApplicationFeeRefund, ApplicationFeeRefundListOptions>,
         INestedRetrievable<ApplicationFeeRefund>,
@@ -21,48 +21,50 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/application_fees/{PARENT_ID}/refunds";
+
         public bool ExpandBalanceTransaction { get; set; }
 
         public bool ExpandFee { get; set; }
 
-        public virtual ApplicationFeeRefund Create(string applicationFeeId, ApplicationFeeRefundCreateOptions createOptions = null, RequestOptions requestOptions = null)
+        public virtual ApplicationFeeRefund Create(string applicationFeeId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, createOptions);
+            return this.CreateNestedEntity(applicationFeeId, options, requestOptions);
         }
 
-        public virtual Task<ApplicationFeeRefund> CreateAsync(string applicationFeeId, ApplicationFeeRefundCreateOptions createOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplicationFeeRefund> CreateAsync(string applicationFeeId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, cancellationToken, createOptions);
+            return this.CreateNestedEntityAsync(applicationFeeId, options, requestOptions, cancellationToken);
         }
 
         public virtual ApplicationFeeRefund Get(string applicationFeeId, string refundId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions);
+            return this.GetNestedEntity(applicationFeeId, refundId, null, requestOptions);
         }
 
         public virtual Task<ApplicationFeeRefund> GetAsync(string applicationFeeId, string refundId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(applicationFeeId, refundId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<ApplicationFeeRefund> List(string applicationFeeId, ApplicationFeeRefundListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<ApplicationFeeRefund> List(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, listOptions);
+            return this.ListNestedEntities(applicationFeeId, options, requestOptions);
         }
 
-        public virtual Task<StripeList<ApplicationFeeRefund>> ListAsync(string applicationFeeId, ApplicationFeeRefundListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<ApplicationFeeRefund>> ListAsync(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds", requestOptions, cancellationToken, listOptions);
+            return this.ListNestedEntitiesAsync(applicationFeeId, options, requestOptions, cancellationToken);
         }
 
-        public virtual ApplicationFeeRefund Update(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions updateOptions, RequestOptions requestOptions = null)
+        public virtual ApplicationFeeRefund Update(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions, updateOptions);
+            return this.UpdateNestedEntity(applicationFeeId, refundId, options, requestOptions);
         }
 
-        public virtual Task<ApplicationFeeRefund> UpdateAsync(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplicationFeeRefund> UpdateAsync(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}/refunds/{refundId}", requestOptions, cancellationToken, updateOptions);
+            return this.UpdateNestedEntityAsync(applicationFeeId, refundId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -19,6 +19,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/application_fees";
+
         public bool ExpandAccount { get; set; }
 
         public bool ExpandApplication { get; set; }
@@ -31,22 +33,22 @@ namespace Stripe
 
         public virtual ApplicationFee Get(string applicationFeeId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/application_fees/{applicationFeeId}", requestOptions);
+            return this.GetEntity(applicationFeeId, null, requestOptions);
         }
 
         public virtual Task<ApplicationFee> GetAsync(string applicationFeeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/application_fees/{applicationFeeId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(applicationFeeId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplicationFee> List(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/application_fees", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<ApplicationFee>> ListAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/application_fees", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Balance/BalanceService.cs
+++ b/src/Stripe.net/Services/Balance/BalanceService.cs
@@ -9,8 +9,6 @@ namespace Stripe
     public class BalanceService : Service<Balance>,
         ISingletonRetrievable<Balance>
     {
-        private static string classUrl = Urls.BaseUrl + "/balance";
-
         public BalanceService()
             : base(null)
         {
@@ -21,14 +19,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/balance";
+
         public virtual Balance Get(RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/balance", requestOptions);
+            return this.GetRequest<Balance>(this.ClassUrl(), null, requestOptions);
         }
 
         public virtual Task<Balance> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/balance", requestOptions, cancellationToken);
+            return this.GetRequestAsync<Balance>(this.ClassUrl(), null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -10,8 +10,6 @@ namespace Stripe
         IListable<BalanceTransaction, BalanceTransactionListOptions>,
         IRetrievable<BalanceTransaction>
     {
-        private static string classUrl = Urls.BaseUrl + "/balance/history";
-
         public BalanceTransactionService()
             : base(null)
         {
@@ -22,26 +20,28 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/balance/history";
+
         public bool ExpandSource { get; set; }
 
         public virtual BalanceTransaction Get(string balanceTransactionId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{balanceTransactionId}", requestOptions);
+            return this.GetEntity(balanceTransactionId, null, requestOptions);
         }
 
         public virtual Task<BalanceTransaction> GetAsync(string balanceTransactionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{balanceTransactionId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(balanceTransactionId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<BalanceTransaction> List(BalanceTransactionListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<BalanceTransaction> List(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList(classUrl, requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<BalanceTransaction>> ListAsync(BalanceTransactionListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<BalanceTransaction>> ListAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync(classUrl, requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class BankAccountService : Service<BankAccount>,
+    public class BankAccountService : ServiceNested<BankAccount>,
         INestedCreatable<BankAccount, BankAccountCreateOptions>,
         INestedDeletable<BankAccount>,
         INestedListable<BankAccount, BankAccountListOptions>,
@@ -22,66 +22,68 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/customers/{PARENT_ID}/sources";
+
         public bool ExpandCustomer { get; set; }
 
         public virtual BankAccount Create(string customerId, BankAccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.CreateNestedEntity(customerId, options, requestOptions);
         }
 
         public virtual Task<BankAccount> CreateAsync(string customerId, BankAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Delete(string customerId, string bankAccountId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions);
+            return this.DeleteNestedEntity(customerId, bankAccountId, null, requestOptions);
         }
 
         public virtual Task<BankAccount> DeleteAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(customerId, bankAccountId, null, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Get(string customerId, string bankAccountId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions);
+            return this.GetNestedEntity(customerId, bankAccountId, null, requestOptions);
         }
 
         public virtual Task<BankAccount> GetAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(customerId, bankAccountId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<BankAccount> List(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.ListNestedEntities(customerId, options, requestOptions);
         }
 
         public virtual Task<StripeList<BankAccount>> ListAsync(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.ListNestedEntitiesAsync(customerId, options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Update(string customerId, string bankAccountId, BankAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, options);
+            return this.UpdateNestedEntity(customerId, bankAccountId, options, requestOptions);
         }
 
         public virtual Task<BankAccount> UpdateAsync(string customerId, string bankAccountId, BankAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken, options);
+            return this.UpdateNestedEntityAsync(customerId, bankAccountId, options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Verify(string customerId, string bankAccountId, BankAccountVerifyOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}/verify", requestOptions, options);
+            return this.PostRequest<BankAccount>($"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions);
         }
 
         public virtual Task<BankAccount> VerifyAsync(string customerId, string bankAccountId, BankAccountVerifyOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}/verify", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<BankAccount>($"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class CardService : Service<Card>,
+    public class CardService : ServiceNested<Card>,
         INestedCreatable<Card, CardCreateOptions>,
         INestedDeletable<Card>,
         INestedListable<Card, CardListOptions>,
@@ -23,58 +23,60 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/customers/{PARENT_ID}/sources";
+
         public bool ExpandCustomer { get; set; }
 
         public bool ExpandRecipient { get; set; }
 
         public virtual Card Create(string customerId, CardCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.CreateNestedEntity(customerId, options, requestOptions);
         }
 
         public virtual Task<Card> CreateAsync(string customerId, CardCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
-        public virtual Card Delete(string customerId, string bankAccountId, RequestOptions requestOptions = null)
+        public virtual Card Delete(string customerId, string cardId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions);
+            return this.DeleteNestedEntity(customerId, cardId, null, requestOptions);
         }
 
-        public virtual Task<Card> DeleteAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> DeleteAsync(string customerId, string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(customerId, cardId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Card Get(string customerId, string bankAccountId, RequestOptions requestOptions = null)
+        public virtual Card Get(string customerId, string cardId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions);
+            return this.GetNestedEntity(customerId, cardId, null, requestOptions);
         }
 
-        public virtual Task<Card> GetAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> GetAsync(string customerId, string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(customerId, cardId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(string customerId, CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.ListNestedEntities(customerId, options, requestOptions);
         }
 
         public virtual Task<StripeList<Card>> ListAsync(string customerId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.ListNestedEntitiesAsync(customerId, options, requestOptions, cancellationToken);
         }
 
-        public virtual Card Update(string customerId, string bankAccountId, CardUpdateOptions options, RequestOptions requestOptions = null)
+        public virtual Card Update(string customerId, string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, options);
+            return this.UpdateNestedEntity(customerId, cardId, options, requestOptions);
         }
 
-        public virtual Task<Card> UpdateAsync(string customerId, string bankAccountId, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> UpdateAsync(string customerId, string cardId, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{bankAccountId}", requestOptions, cancellationToken, options);
+            return this.UpdateNestedEntityAsync(customerId, cardId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -20,6 +20,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/charges";
+
         public bool ExpandApplication { get; set; }
 
         public bool ExpandApplicationFee { get; set; }
@@ -48,52 +50,52 @@ namespace Stripe
 
         public virtual Charge Capture(string chargeId, ChargeCaptureOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/charges/{chargeId}/capture", requestOptions, options);
+            return this.PostRequest<Charge>($"{this.InstanceUrl(chargeId)}/capture", options, requestOptions);
         }
 
         public virtual Task<Charge> CaptureAsync(string chargeId, ChargeCaptureOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/charges/{chargeId}/capture", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Charge>($"{this.InstanceUrl(chargeId)}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Create(ChargeCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/charges", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Charge> CreateAsync(ChargeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/charges", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Get(string chargeId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/charges/{chargeId}", requestOptions);
+            return this.GetEntity(chargeId, null, requestOptions);
         }
 
         public virtual Task<Charge> GetAsync(string chargeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/charges/{chargeId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(chargeId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Charge> List(ChargeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/charges", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Charge>> ListAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/charges", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Update(string chargeId, ChargeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/charges/{chargeId}", requestOptions, options);
+            return this.UpdateEntity(chargeId, options, requestOptions);
         }
 
         public virtual Task<Charge> UpdateAsync(string chargeId, ChargeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/charges/{chargeId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(chargeId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -19,24 +19,26 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/country_specs";
+
         public virtual CountrySpec Get(string country, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/country_specs/{country}", requestOptions);
+            return this.GetEntity(country, null, requestOptions);
         }
 
         public virtual Task<CountrySpec> GetAsync(string country, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/country_specs/{country}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(country, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CountrySpec> List(CountrySpecListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/country_specs", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<CountrySpec>> ListAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/country_specs", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -23,54 +23,56 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/coupons";
+
         public virtual Coupon Create(CouponCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/coupons", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Coupon> CreateAsync(CouponCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/coupons", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Delete(string couponId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions);
+            return this.DeleteEntity(couponId, null, requestOptions);
         }
 
         public virtual Task<Coupon> DeleteAsync(string couponId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(couponId, null, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Get(string couponId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions);
+            return this.GetEntity(couponId, null, requestOptions);
         }
 
         public virtual Task<Coupon> GetAsync(string couponId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(couponId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Coupon> List(CouponListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/coupons", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Coupon>> ListAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/coupons", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Update(string couponId, CouponUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions, options);
+            return this.UpdateEntity(couponId, options, requestOptions);
         }
 
         public virtual Task<Coupon> UpdateAsync(string couponId, CouponUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/coupons/{couponId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(couponId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -23,58 +23,60 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/customers";
+
         public bool ExpandDefaultSource { get; set; }
 
         public bool ExpandDefaultCustomerBankAccount { get; set; }
 
         public virtual Customer Create(CustomerCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Customer> CreateAsync(CustomerCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Delete(string customerId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/customers/{customerId}", requestOptions);
+            return this.DeleteEntity(customerId, null, requestOptions);
         }
 
         public virtual Task<Customer> DeleteAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/customers/{customerId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(customerId, null, requestOptions, cancellationToken);
         }
 
         public virtual Customer Get(string customerId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/customers/{customerId}", requestOptions);
+            return this.GetEntity(customerId, null, requestOptions);
         }
 
         public virtual Task<Customer> GetAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/customers/{customerId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(customerId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Customer> List(CustomerListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/customers", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Customer>> ListAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/customers", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Update(string customerId, CustomerUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}", requestOptions, options);
+            return this.UpdateEntity(customerId, options, requestOptions);
         }
 
         public virtual Task<Customer> UpdateAsync(string customerId, CustomerUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Discounts/DiscountService.cs
+++ b/src/Stripe.net/Services/Discounts/DiscountService.cs
@@ -16,24 +16,26 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => null;
+
         public virtual Discount DeleteCustomerDiscount(string customerId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/customers/{customerId}/discount", requestOptions);
+            return this.DeleteRequest<Discount>($"{Urls.BaseUrl}/customers/{customerId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteCustomerDiscountAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/discount", requestOptions, cancellationToken);
+            return this.DeleteRequestAsync<Discount>($"{Urls.BaseUrl}/customers/{customerId}/discount", null, requestOptions, cancellationToken);
         }
 
         public virtual Discount DeleteSubscriptionDiscount(string subscriptionId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/subscriptions/{subscriptionId}/discount", requestOptions);
+            return this.DeleteRequest<Discount>($"{Urls.BaseUrl}/subscriptions/{subscriptionId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteSubscriptionDiscountAsync(string subscriptionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/subscriptions/{subscriptionId}/discount", requestOptions, cancellationToken);
+            return this.DeleteRequestAsync<Discount>($"{Urls.BaseUrl}/subscriptions/{subscriptionId}/discount", null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -21,46 +21,48 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/disputes";
+
         public bool ExpandCharge { get; set; }
 
         public virtual Dispute Close(string disputeId, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/disputes/{disputeId}/close", requestOptions);
+            return this.PostRequest<Dispute>($"{this.InstanceUrl(disputeId)}/close", null, requestOptions);
         }
 
         public virtual Task<Dispute> CloseAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/disputes/{disputeId}/close", requestOptions, cancellationToken);
+            return this.PostRequestAsync<Dispute>($"{this.InstanceUrl(disputeId)}/close", null, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Get(string disputeId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/disputes/{disputeId}", requestOptions);
+            return this.GetEntity(disputeId, null, requestOptions);
         }
 
         public virtual Task<Dispute> GetAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/disputes/{disputeId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(disputeId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Dispute> List(DisputeListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/disputes", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/disputes", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Dispute Update(string disputeId, DisputeUpdateOptions updateOptions, RequestOptions requestOptions = null)
+        public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/disputes/{disputeId}", requestOptions, updateOptions);
+            return this.UpdateEntity(disputeId, options, requestOptions);
         }
 
-        public virtual Task<Dispute> UpdateAsync(string disputeId, DisputeUpdateOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Dispute> UpdateAsync(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/disputes/{disputeId}", requestOptions, cancellationToken, updateOptions);
+            return this.UpdateEntityAsync(disputeId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -19,6 +19,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/ephemeral_keys";
+
         public virtual EphemeralKey Create(EphemeralKeyCreateOptions options, RequestOptions requestOptions = null)
         {
             if (options.StripeVersion == null)
@@ -31,7 +33,7 @@ namespace Stripe
             requestOptions = requestOptions ?? new RequestOptions();
             requestOptions.StripeVersion = options.StripeVersion;
 
-            return this.Post($"{Urls.BaseUrl}/ephemeral_keys", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<EphemeralKey> CreateAsync(EphemeralKeyCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -41,17 +43,17 @@ namespace Stripe
             requestOptions = requestOptions ?? new RequestOptions();
             requestOptions.StripeVersion = options.StripeVersion;
 
-            return this.PostAsync($"{Urls.BaseUrl}/ephemeral_keys", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual EphemeralKey Delete(string keyId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/ephemeral_keys/{keyId}", requestOptions);
+            return this.DeleteEntity(keyId, null, requestOptions);
         }
 
         public virtual Task<EphemeralKey> DeleteAsync(string keyId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/ephemeral_keys/{keyId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(keyId, null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -19,24 +19,26 @@ namespace Stripe
         {
         }
 
-        public virtual Event Get(string country, RequestOptions requestOptions = null)
+        public override string BasePath => "/events";
+
+        public virtual Event Get(string eventId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/events/{country}", requestOptions);
+            return this.GetEntity(eventId, null, requestOptions);
         }
 
-        public virtual Task<Event> GetAsync(string country, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Event> GetAsync(string eventId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/events/{country}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(eventId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Event> List(EventListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/events", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Event>> ListAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/events", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
@@ -19,24 +19,26 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/exchange_rates";
+
         public virtual ExchangeRate Get(string currency, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/exchange_rates/{currency}", requestOptions);
+            return this.GetEntity(currency, null, requestOptions);
         }
 
         public virtual Task<ExchangeRate> GetAsync(string currency, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/exchange_rates/{currency}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(currency, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ExchangeRate> List(ExchangeRateListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/exchange_rates", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<ExchangeRate>> ListAsync(ExchangeRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/exchange_rates", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class ExternalAccountService : Service<ExternalAccount>,
+    public class ExternalAccountService : ServiceNested<ExternalAccount>,
         INestedCreatable<ExternalAccount, ExternalAccountCreateOptions>,
         INestedDeletable<ExternalAccount>,
         INestedListable<ExternalAccount, ExternalAccountListOptions>,
@@ -22,54 +22,56 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/accounts/{PARENT_ID}/external_accounts";
+
         public virtual ExternalAccount Create(string accountId, ExternalAccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts", requestOptions, options);
+            return this.CreateNestedEntity(accountId, options, requestOptions);
         }
 
         public virtual Task<ExternalAccount> CreateAsync(string accountId, ExternalAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
         public virtual ExternalAccount Delete(string accountId, string externalAccountId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions);
+            return this.DeleteNestedEntity(accountId, externalAccountId, null, requestOptions);
         }
 
         public virtual Task<ExternalAccount> DeleteAsync(string accountId, string externalAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(accountId, externalAccountId, null, requestOptions, cancellationToken);
         }
 
         public virtual ExternalAccount Get(string accountId, string externalAccountId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions);
-        }
-
-        public virtual StripeList<ExternalAccount> List(string accountId, ExternalAccountListOptions listOptions = null, RequestOptions requestOptions = null)
-        {
-            return this.GetEntityList($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts", requestOptions, listOptions);
-        }
-
-        public virtual Task<StripeList<ExternalAccount>> ListAsync(string accountId, ExternalAccountListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts", requestOptions, cancellationToken, listOptions);
-        }
-
-        public virtual ExternalAccount Update(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
-        {
-            return this.Post($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions, options);
-        }
-
-        public virtual Task<ExternalAccount> UpdateAsync(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions, cancellationToken, options);
+            return this.GetNestedEntity(accountId, externalAccountId, null, requestOptions);
         }
 
         public virtual Task<ExternalAccount> GetAsync(string accountId, string externalAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/accounts/{accountId}/external_accounts/{externalAccountId}", requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(accountId, externalAccountId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<ExternalAccount> List(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntities(accountId, options, requestOptions);
+        }
+
+        public virtual Task<StripeList<ExternalAccount>> ListAsync(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListNestedEntitiesAsync(accountId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual ExternalAccount Update(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateNestedEntity(accountId, externalAccountId, options, requestOptions);
+        }
+
+        public virtual Task<ExternalAccount> UpdateAsync(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.UpdateNestedEntityAsync(accountId, externalAccountId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -12,8 +12,6 @@ namespace Stripe
         IRetrievable<FileLink>,
         IUpdatable<FileLink, FileLinkUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/file_links";
-
         public FileLinkService()
             : base(null)
         {
@@ -24,44 +22,46 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/file_links";
+
         public virtual FileLink Create(FileLinkCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<FileLink> CreateAsync(FileLinkCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual FileLink Get(string fileLinkId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{fileLinkId}", requestOptions);
+            return this.GetEntity(fileLinkId, null, requestOptions);
         }
 
         public virtual Task<FileLink> GetAsync(string fileLinkId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{fileLinkId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(fileLinkId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<FileLink> List(FileLinkListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<FileLink>> ListAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual FileLink Update(string fileLinkId, FileLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{fileLinkId}", requestOptions, options);
+            return this.UpdateEntity(fileLinkId, options, requestOptions);
         }
 
         public virtual Task<FileLink> UpdateAsync(string fileLinkId, FileLinkUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{fileLinkId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(fileLinkId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -11,8 +11,6 @@ namespace Stripe
         IListable<File, FileListOptions>,
         IRetrievable<File>
     {
-        private static string classPath = "/files";
-
         public FileService()
             : base(null)
         {
@@ -23,11 +21,13 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/files";
+
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
             return Mapper<File>.MapFromJson(
                 Requestor.PostFile(
-                    $"{Urls.BaseFilesUrl}{classPath}",
+                    this.ClassUrl(Urls.BaseFilesUrl),
                     options.File,
                     options.Purpose,
                     this.SetupRequestOptions(requestOptions)));
@@ -37,7 +37,7 @@ namespace Stripe
         {
             return Mapper<File>.MapFromJson(
                 await Requestor.PostFileAsync(
-                    $"{Urls.BaseFilesUrl}{classPath}",
+                    this.ClassUrl(Urls.BaseFilesUrl),
                     options.File,
                     options.Purpose,
                     this.SetupRequestOptions(requestOptions),
@@ -46,22 +46,22 @@ namespace Stripe
 
         public virtual File Get(string fileId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}{classPath}/{fileId}", requestOptions);
+            return this.GetEntity(fileId, null, requestOptions);
         }
 
         public virtual Task<File> GetAsync(string fileId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}{classPath}/{fileId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(fileId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<File> List(FileListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<File> List(FileListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}{classPath}", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<File>> ListAsync(FileListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<File>> ListAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}{classPath}", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -22,6 +22,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/invoiceitems";
+
         public bool ExpandCustomer { get; set; }
 
         public bool ExpandInvoice { get; set; }
@@ -30,52 +32,52 @@ namespace Stripe
 
         public virtual InvoiceLineItem Create(InvoiceItemCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/invoiceitems", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<InvoiceLineItem> CreateAsync(InvoiceItemCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/invoiceitems", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceLineItem Delete(string invoiceitemId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions);
+            return this.DeleteEntity(invoiceitemId, null, requestOptions);
         }
 
         public virtual Task<InvoiceLineItem> DeleteAsync(string invoiceitemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(invoiceitemId, null, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceLineItem Get(string invoiceitemId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions);
+            return this.GetEntity(invoiceitemId, null, requestOptions);
         }
 
         public virtual Task<InvoiceLineItem> GetAsync(string invoiceitemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(invoiceitemId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InvoiceLineItem> List(InvoiceItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/invoiceitems", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/invoiceitems", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceLineItem Update(string invoiceitemId, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions, options);
+            return this.UpdateEntity(invoiceitemId, options, requestOptions);
         }
 
         public virtual Task<InvoiceLineItem> UpdateAsync(string invoiceitemId, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/invoiceitems/{invoiceitemId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(invoiceitemId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -11,8 +11,6 @@ namespace Stripe
         IRetrievable<Invoice>,
         IUpdatable<Invoice, InvoiceUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/invoices";
-
         public InvoiceService()
             : base(null)
         {
@@ -23,6 +21,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/invoices";
+
         public bool ExpandCharge { get; set; }
 
         public bool ExpandCustomer { get; set; }
@@ -31,82 +31,82 @@ namespace Stripe
 
         public virtual Invoice Create(InvoiceCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Invoice> CreateAsync(InvoiceCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Get(string invoiceId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{invoiceId}", requestOptions);
+            return this.GetEntity(invoiceId, null, requestOptions);
         }
 
         public virtual Task<Invoice> GetAsync(string invoiceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{invoiceId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(invoiceId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Invoice> List(InvoiceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Invoice>> ListAsync(InvoiceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{classUrl}/{invoiceId}/lines", listOptions, requestOptions);
+            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
         }
 
-        public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string invoiceId, InvoiceListLineItemsOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{classUrl}/{invoiceId}/lines", listOptions, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{classUrl}/upcoming/lines", listOptions, requestOptions);
+            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
         }
 
-        public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{classUrl}/upcoming/lines", listOptions, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Pay(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{invoiceId}/pay", requestOptions, options);
+            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions);
         }
 
         public virtual Task<Invoice> PayAsync(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{invoiceId}/pay", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Upcoming(UpcomingInvoiceOptions options, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/upcoming", requestOptions, options);
+            return this.GetRequest<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions);
         }
 
         public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/upcoming", requestOptions, cancellationToken, options);
+            return this.GetRequestAsync<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Update(string invoiceId, InvoiceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{invoiceId}", requestOptions, options);
+            return this.UpdateEntity(invoiceId, options, requestOptions);
         }
 
         public virtual Task<Invoice> UpdateAsync(string invoiceId, InvoiceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{invoiceId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(invoiceId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -11,8 +11,6 @@ namespace Stripe.Issuing
         IRetrievable<Authorization>,
         IUpdatable<Authorization, AuthorizationUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/issuing/authorizations";
-
         public AuthorizationService()
             : base(null)
         {
@@ -23,54 +21,56 @@ namespace Stripe.Issuing
         {
         }
 
+        public override string BasePath => "/issuing/authorizations";
+
         public virtual Authorization Approve(string authorizationId, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{authorizationId}/approve", requestOptions, options);
+            return this.PostRequest<Authorization>($"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions);
         }
 
         public virtual Task<Authorization> ApproveAsync(string authorizationId, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{authorizationId}/approve", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Authorization>($"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Decline(string authorizationId, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{authorizationId}/decline", requestOptions, options);
+            return this.PostRequest<Authorization>($"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions);
         }
 
         public virtual Task<Authorization> DeclineAsync(string authorizationId, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{authorizationId}/decline", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Authorization>($"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Get(string authorizationId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{authorizationId}", requestOptions);
+            return this.GetEntity(authorizationId, null, requestOptions);
         }
 
         public virtual Task<Authorization> GetAsync(string authorizationId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{authorizationId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(authorizationId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Authorization> List(AuthorizationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Authorization>> ListAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Update(string authorizationId, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{authorizationId}", requestOptions, options);
+            return this.UpdateEntity(authorizationId, options, requestOptions);
         }
 
         public virtual Task<Authorization> UpdateAsync(string authorizationId, AuthorizationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{authorizationId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(authorizationId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -12,8 +12,6 @@ namespace Stripe.Issuing
         IRetrievable<Cardholder>,
         IUpdatable<Cardholder, CardholderUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/issuing/cardholders";
-
         public CardholderService()
             : base(null)
         {
@@ -24,44 +22,46 @@ namespace Stripe.Issuing
         {
         }
 
+        public override string BasePath => "/issuing/cardholders";
+
         public virtual Cardholder Create(CardholderCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Cardholder> CreateAsync(CardholderCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Cardholder Get(string cardholderId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{cardholderId}", requestOptions);
+            return this.GetEntity(cardholderId, null, requestOptions);
         }
 
         public virtual Task<Cardholder> GetAsync(string cardholderId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{cardholderId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(cardholderId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Cardholder> List(CardholderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Cardholder>> ListAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Cardholder Update(string cardholderId, CardholderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{cardholderId}", requestOptions, options);
+            return this.UpdateEntity(cardholderId, options, requestOptions);
         }
 
         public virtual Task<Cardholder> UpdateAsync(string cardholderId, CardholderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{cardholderId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(cardholderId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -12,8 +12,6 @@ namespace Stripe.Issuing
         IRetrievable<Card>,
         IUpdatable<Card, CardUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/issuing/cards";
-
         public CardService()
             : base(null)
         {
@@ -24,54 +22,56 @@ namespace Stripe.Issuing
         {
         }
 
+        public override string BasePath => "/issuing/cards";
+
         public virtual Card Create(CardCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Card> CreateAsync(CardCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual CardDetails Details(string cardId, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<CardDetails>($"{classUrl}/{cardId}/details", null, requestOptions);
+            return this.GetRequest<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions);
         }
 
         public virtual Task<CardDetails> DetailsAsync(string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<CardDetails>($"{classUrl}/{cardId}/details", null, requestOptions, cancellationToken);
+            return this.GetRequestAsync<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, cancellationToken);
         }
 
         public virtual Card Get(string cardId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{cardId}", requestOptions);
+            return this.GetEntity(cardId, null, requestOptions);
         }
 
         public virtual Task<Card> GetAsync(string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{cardId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(cardId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Card>> ListAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Card Update(string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{cardId}", requestOptions, options);
+            return this.UpdateEntity(cardId, options, requestOptions);
         }
 
         public virtual Task<Card> UpdateAsync(string cardId, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{cardId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(cardId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -12,8 +12,6 @@ namespace Stripe.Issuing
         IRetrievable<Dispute>,
         IUpdatable<Dispute, DisputeUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/issuing/disputes";
-
         public DisputeService()
             : base(null)
         {
@@ -24,44 +22,46 @@ namespace Stripe.Issuing
         {
         }
 
+        public override string BasePath => "/issuing/disputes";
+
         public virtual Dispute Create(DisputeCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Dispute> CreateAsync(DisputeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Get(string disputeId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{disputeId}", requestOptions);
+            return this.GetEntity(disputeId, null, requestOptions);
         }
 
         public virtual Task<Dispute> GetAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{disputeId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(disputeId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{disputeId}", requestOptions, options);
+            return this.UpdateEntity(disputeId, options, requestOptions);
         }
 
         public virtual Task<Dispute> UpdateAsync(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{disputeId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(disputeId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -11,8 +11,6 @@ namespace Stripe.Issuing
         IRetrievable<Transaction>,
         IUpdatable<Transaction, TransactionUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/issuing/transactions";
-
         public TransactionService()
             : base(null)
         {
@@ -23,34 +21,36 @@ namespace Stripe.Issuing
         {
         }
 
+        public override string BasePath => "/issuing/transactions";
+
         public virtual Transaction Get(string transactionId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{transactionId}", requestOptions);
+            return this.GetEntity(transactionId, null, requestOptions);
         }
 
         public virtual Task<Transaction> GetAsync(string transactionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{transactionId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(transactionId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transaction> List(TransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Transaction>> ListAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Transaction Update(string transactionId, TransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{transactionId}", requestOptions, options);
+            return this.UpdateEntity(transactionId, options, requestOptions);
         }
 
         public virtual Task<Transaction> UpdateAsync(string transactionId, TransactionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{transactionId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(transactionId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/LoginLink/LoginLinkService.cs
+++ b/src/Stripe.net/Services/LoginLink/LoginLinkService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class LoginLinkService : Service<LoginLink>,
+    public class LoginLinkService : ServiceNested<LoginLink>,
         INestedCreatable<LoginLink, LoginLinkCreateOptions>
     {
         public LoginLinkService()
@@ -18,14 +18,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/accounts/{PARENT_ID}/login_links";
+
         public virtual LoginLink Create(string accountId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/accounts/{accountId}/login_links", requestOptions, options);
+            return this.CreateNestedEntity(accountId, options, requestOptions);
         }
 
         public virtual Task<LoginLink> CreateAsync(string accountId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/accounts/{accountId}/login_links", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -17,14 +17,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => null;
+
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseConnectUrl}/oauth/token", requestOptions, options);
+            return this.PostRequest<OAuthToken>($"{Urls.BaseConnectUrl}/oauth/token", options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseConnectUrl}/oauth/token", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<OAuthToken>($"{Urls.BaseConnectUrl}/oauth/token", options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(string clientId, string stripeUserId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -21,58 +21,60 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/orders";
+
         public bool ExpandCharge { get; set; }
 
         public bool ExpandCustomer { get; set; }
 
         public virtual Order Create(OrderCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/orders", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Order> CreateAsync(OrderCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/orders", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Order Get(string orderId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/orders/{orderId}", requestOptions);
+            return this.GetEntity(orderId, null, requestOptions);
         }
 
         public virtual Task<Order> GetAsync(string orderId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/orders/{orderId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(orderId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Order> List(OrderListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Order> List(OrderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/orders", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Order>> ListAsync(OrderListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Order>> ListAsync(OrderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/orders", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Order Pay(string orderId, OrderPayOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/orders/{orderId}/pay", requestOptions, options);
+            return this.PostRequest<Order>($"{this.InstanceUrl(orderId)}/pay", options, requestOptions);
         }
 
         public virtual Task<Order> PayAsync(string orderId, OrderPayOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/orders/{orderId}/pay", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Order>($"{this.InstanceUrl(orderId)}/pay", options, requestOptions, cancellationToken);
         }
 
         public virtual Order Update(string orderId, OrderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/orders/{orderId}", requestOptions, options);
+            return this.UpdateEntity(orderId, options, requestOptions);
         }
 
         public virtual Task<Order> UpdateAsync(string orderId, OrderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/orders/{orderId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(orderId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -21,6 +21,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/payment_intents";
+
         public bool ExpandApplication { get; set; }
 
         public bool ExpandCustomer { get; set; }
@@ -29,72 +31,72 @@ namespace Stripe
 
         public virtual PaymentIntent Cancel(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/cancel", requestOptions, options);
+            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CancelAsync(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/cancel", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Capture(string paymentIntentId, PaymentIntentCaptureOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/capture", requestOptions, options);
+            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CaptureAsync(string paymentIntentId, PaymentIntentCaptureOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/capture", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Confirm(string paymentIntentId, PaymentIntentConfirmOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/confirm", requestOptions, options);
+            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> ConfirmAsync(string paymentIntentId, PaymentIntentConfirmOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}/confirm", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Create(PaymentIntentCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payment_intents", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CreateAsync(PaymentIntentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payment_intents", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Get(string paymentIntentId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}", requestOptions);
+            return this.GetEntity(paymentIntentId, null, requestOptions);
         }
 
         public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(paymentIntentId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<PaymentIntent> List(PaymentIntentListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<PaymentIntent> List(PaymentIntentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/payment_intents", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<PaymentIntent>> ListAsync(PaymentIntentListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<PaymentIntent>> ListAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/payment_intents", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Update(string paymentIntentId, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}", requestOptions, options);
+            return this.UpdateEntity(paymentIntentId, options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> UpdateAsync(string paymentIntentId, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payment_intents/{paymentIntentId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(paymentIntentId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -21,6 +21,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/payouts";
+
         public bool ExpandBalanceTransaction { get; set; }
 
         public bool ExpandDestination { get; set; }
@@ -29,52 +31,52 @@ namespace Stripe
 
         public virtual Payout Cancel(string payoutId, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payouts/{payoutId}/cancel", requestOptions);
+            return this.PostRequest<Payout>($"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions);
         }
 
         public virtual Task<Payout> CancelAsync(string payoutId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payouts/{payoutId}/cancel", requestOptions, cancellationToken);
+            return this.PostRequestAsync<Payout>($"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions, cancellationToken);
         }
 
         public virtual Payout Create(PayoutCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payouts", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Payout> CreateAsync(PayoutCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payouts", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Get(string payoutId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions);
+            return this.GetEntity(payoutId, null, requestOptions);
         }
 
         public virtual Task<Payout> GetAsync(string payoutId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(payoutId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Payout> List(PayoutListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Payout> List(PayoutListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/payouts", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Payout>> ListAsync(PayoutListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Payout>> ListAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/payouts", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Update(string payoutId, PayoutUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions, options);
+            return this.UpdateEntity(payoutId, options, requestOptions);
         }
 
         public virtual Task<Payout> UpdateAsync(string payoutId, PayoutUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/payouts/{payoutId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(payoutId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -23,56 +23,58 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/plans";
+
         public bool ExpandProduct { get; set; }
 
         public virtual Plan Create(PlanCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/plans", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Plan> CreateAsync(PlanCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/plans", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Delete(string planId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/plans/{planId}", requestOptions);
+            return this.DeleteEntity(planId, null, requestOptions);
         }
 
         public virtual Task<Plan> DeleteAsync(string planId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/plans/{planId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(planId, null, requestOptions, cancellationToken);
         }
 
         public virtual Plan Get(string planId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/plans/{planId}", requestOptions);
+            return this.GetEntity(planId, null, requestOptions);
         }
 
         public virtual Task<Plan> GetAsync(string planId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/plans/{planId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(planId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Plan> List(PlanListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/plans", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Plan>> ListAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/plans", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Update(string planId, PlanUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/plans/{planId}", requestOptions, options);
+            return this.UpdateEntity(planId, options, requestOptions);
         }
 
         public virtual Task<Plan> UpdateAsync(string planId, PlanUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/plans/{planId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(planId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -23,54 +23,56 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/products";
+
         public virtual Product Create(ProductCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/products", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Product> CreateAsync(ProductCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/products", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Product Delete(string productId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions);
+            return this.DeleteEntity(productId, null, requestOptions);
         }
 
         public virtual Task<Product> DeleteAsync(string productId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(productId, null, requestOptions, cancellationToken);
         }
 
         public virtual Product Get(string productId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions);
+            return this.GetEntity(productId, null, requestOptions);
         }
 
         public virtual Task<Product> GetAsync(string productId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(productId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Product> List(ProductListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Product> List(ProductListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/products", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Product>> ListAsync(ProductListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Product>> ListAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/products", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Product Update(string productId, ProductUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, options);
+            return this.UpdateEntity(productId, options, requestOptions);
         }
 
         public virtual Task<Product> UpdateAsync(string productId, ProductUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/products/{WebUtility.UrlEncode(productId)}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(productId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -12,8 +12,6 @@ namespace Stripe
         IRetrievable<Refund>,
         IUpdatable<Refund, RefundUpdateOptions>
     {
-        private static string classUrl = Urls.BaseUrl + "/refunds";
-
         public RefundService()
             : base(null)
         {
@@ -24,6 +22,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/refunds";
+
         public bool ExpandBalanceTransaction { get; set; }
 
         public bool ExpandCharge { get; set; }
@@ -32,42 +32,42 @@ namespace Stripe
 
         public virtual Refund Create(RefundCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Refund> CreateAsync(RefundCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Refund Get(string refundId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{refundId}", requestOptions);
+            return this.GetEntity(refundId, null, requestOptions);
         }
 
         public virtual Task<Refund> GetAsync(string refundId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{refundId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(refundId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Refund> List(RefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Refund>> ListAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Refund Update(string refundId, RefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}/{refundId}", requestOptions, options);
+            return this.UpdateEntity(refundId, options, requestOptions);
         }
 
         public virtual Task<Refund> UpdateAsync(string refundId, RefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}/{refundId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(refundId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -11,8 +11,6 @@ namespace Stripe.Reporting
         IListable<ReportRun, ReportRunListOptions>,
         IRetrievable<ReportRun>
     {
-        private static string classUrl = Urls.BaseUrl + "/reporting/report_runs";
-
         public ReportRunService()
             : base(null)
         {
@@ -23,34 +21,36 @@ namespace Stripe.Reporting
         {
         }
 
+        public override string BasePath => "/reporting/report_runs";
+
         public virtual ReportRun Create(ReportRunCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{classUrl}", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<ReportRun> CreateAsync(ReportRunCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual ReportRun Get(string reportRunId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{reportRunId}", requestOptions);
+            return this.GetEntity(reportRunId, null, requestOptions);
         }
 
         public virtual Task<ReportRun> GetAsync(string reportRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{reportRunId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(reportRunId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportRun> List(ReportRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<ReportRun>> ListAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -10,8 +10,6 @@ namespace Stripe.Reporting
         IListable<ReportType, ReportTypeListOptions>,
         IRetrievable<ReportType>
     {
-        private static string classUrl = Urls.BaseUrl + "/reporting/report_types";
-
         public ReportTypeService()
             : base(null)
         {
@@ -22,24 +20,26 @@ namespace Stripe.Reporting
         {
         }
 
+        public override string BasePath => "/reporting/report_types";
+
         public virtual ReportType Get(string reportTypeId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{reportTypeId}", requestOptions);
+            return this.GetEntity(reportTypeId, null, requestOptions);
         }
 
         public virtual Task<ReportType> GetAsync(string reportTypeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{reportTypeId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(reportTypeId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportType> List(ReportTypeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{classUrl}", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<ReportType>> ListAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{classUrl}", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Service.cs
+++ b/src/Stripe.net/Services/Service.cs
@@ -1,11 +1,14 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+
     using Stripe.Infrastructure;
 
     public abstract class Service<EntityReturned>
+        where EntityReturned : StripeEntity
     {
         protected Service()
         {
@@ -18,44 +21,56 @@ namespace Stripe
 
         public string ApiKey { get; set; }
 
-        public virtual EntityReturned DeleteEntity(string url, RequestOptions requestOptions, BaseOptions options = null)
+        public abstract string BasePath { get; }
+
+        protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
-            return this.DeleteRequest<EntityReturned>(url, options, requestOptions);
+            return this.PostRequest<EntityReturned>(this.ClassUrl(), options, requestOptions);
         }
 
-        public Task<EntityReturned> DeleteEntityAsync(string url, RequestOptions requestOptions, CancellationToken cancellationToken, BaseOptions options = null)
+        protected Task<EntityReturned> CreateEntityAsync(BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.DeleteRequestAsync<EntityReturned>(url, options, requestOptions, cancellationToken);
+            return this.PostRequestAsync<EntityReturned>(this.ClassUrl(), options, requestOptions, cancellationToken);
         }
 
-        public EntityReturned GetEntity(string url, RequestOptions requestOptions, BaseOptions options = null)
+        protected EntityReturned DeleteEntity(string id, BaseOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<EntityReturned>(url, options, requestOptions);
+            return this.DeleteRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
         }
 
-        public Task<EntityReturned> GetEntityAsync(string url, RequestOptions requestOptions, CancellationToken cancellationToken, BaseOptions options = null)
+        protected Task<EntityReturned> DeleteEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<EntityReturned>(url, options, requestOptions, cancellationToken);
+            return this.DeleteRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
         }
 
-        public StripeList<EntityReturned> GetEntityList(string url, RequestOptions requestOptions, BaseOptions options = null)
+        protected EntityReturned GetEntity(string id, BaseOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<StripeList<EntityReturned>>(url, options, requestOptions);
+            return this.GetRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
         }
 
-        public Task<StripeList<EntityReturned>> GetEntityListAsync(string url, RequestOptions requestOptions, CancellationToken cancellationToken, BaseOptions options = null)
+        protected Task<EntityReturned> GetEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<StripeList<EntityReturned>>(url, options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
         }
 
-        public EntityReturned Post(string url, RequestOptions requestOptions, BaseOptions options = null)
+        protected StripeList<EntityReturned> ListEntities(ListOptions options, RequestOptions requestOptions)
         {
-            return this.PostRequest<EntityReturned>(url, options, requestOptions);
+            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions);
         }
 
-        public Task<EntityReturned> PostAsync(string url, RequestOptions requestOptions, CancellationToken cancellationToken, BaseOptions options = null)
+        protected Task<StripeList<EntityReturned>> ListEntitiesAsync(ListOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.PostRequestAsync<EntityReturned>(url, options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, cancellationToken);
+        }
+
+        protected EntityReturned UpdateEntity(string id, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.PostRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
+        }
+
+        protected Task<EntityReturned> UpdateEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.PostRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
         }
 
         protected T DeleteRequest<T>(string url, BaseOptions options, RequestOptions requestOptions)
@@ -122,6 +137,17 @@ namespace Stripe
             }
 
             return requestOptions;
+        }
+
+        protected virtual string ClassUrl(string baseUrl = null)
+        {
+            baseUrl = baseUrl ?? StripeConfiguration.GetApiBase();
+            return $"{baseUrl}{this.BasePath}";
+        }
+
+        protected virtual string InstanceUrl(string id, string baseUrl = null)
+        {
+            return $"{this.ClassUrl(baseUrl)}/{WebUtility.UrlEncode(id)}";
         }
     }
 }

--- a/src/Stripe.net/Services/ServiceNested.cs
+++ b/src/Stripe.net/Services/ServiceNested.cs
@@ -1,0 +1,84 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Stripe.Infrastructure;
+
+    public abstract class ServiceNested<EntityReturned> : Service<EntityReturned>
+        where EntityReturned : StripeEntity
+    {
+        protected ServiceNested()
+            : base(null)
+        {
+        }
+
+        protected ServiceNested(string apiKey)
+            : base(apiKey)
+        {
+        }
+
+        protected EntityReturned CreateNestedEntity(string parentId, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.PostRequest<EntityReturned>(this.ClassUrl(parentId), options, requestOptions);
+        }
+
+        protected Task<EntityReturned> CreateNestedEntityAsync(string parentId, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.PostRequestAsync<EntityReturned>(this.ClassUrl(parentId), options, requestOptions, cancellationToken);
+        }
+
+        protected EntityReturned DeleteNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.DeleteRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+        }
+
+        protected Task<EntityReturned> DeleteNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.DeleteRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+        }
+
+        protected EntityReturned GetNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.GetRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+        }
+
+        protected Task<EntityReturned> GetNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+        }
+
+        protected StripeList<EntityReturned> ListNestedEntities(string parentId, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions);
+        }
+
+        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(string parentId, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, cancellationToken);
+        }
+
+        protected EntityReturned UpdateNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        {
+            return this.PostRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+        }
+
+        protected Task<EntityReturned> UpdateNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return this.PostRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+        }
+
+        protected virtual string ClassUrl(string parentId, string baseUrl = null)
+        {
+            baseUrl = baseUrl ?? StripeConfiguration.GetApiBase();
+            return $"{baseUrl}{this.BasePath.Replace("{PARENT_ID}", parentId)}";
+        }
+
+        protected virtual string InstanceUrl(string parentId, string id, string baseUrl = null)
+        {
+            return $"{this.ClassUrl(parentId, baseUrl)}/{WebUtility.UrlEncode(id)}";
+        }
+    }
+}

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -8,8 +8,6 @@ namespace Stripe.Sigma
         IListable<ScheduledQueryRun, ScheduledQueryRunListOptions>,
         IRetrievable<ScheduledQueryRun>
     {
-        private static string classUrl = Urls.BaseUrl + "/sigma/scheduled_query_runs";
-
         public ScheduledQueryRunService()
             : base(null)
         {
@@ -20,24 +18,26 @@ namespace Stripe.Sigma
         {
         }
 
+        public override string BasePath => "/sigma/scheduled_query_runs";
+
         public virtual ScheduledQueryRun Get(string queryRunId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{classUrl}/{queryRunId}", requestOptions);
+            return this.GetEntity(queryRunId, null, requestOptions);
         }
 
         public virtual Task<ScheduledQueryRun> GetAsync(string queryRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{classUrl}/{queryRunId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(queryRunId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList(classUrl, requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync(classUrl, requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -23,56 +23,58 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/skus";
+
         public bool ExpandProduct { get; set; }
 
         public virtual Sku Create(SkuCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/skus", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Sku> CreateAsync(SkuCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/skus", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Sku Delete(string skuId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions);
+            return this.DeleteEntity(skuId, null, requestOptions);
         }
 
         public virtual Task<Sku> DeleteAsync(string skuId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(skuId, null, requestOptions, cancellationToken);
         }
 
         public virtual Sku Get(string skuId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions);
+            return this.GetEntity(skuId, null, requestOptions);
         }
 
         public virtual Task<Sku> GetAsync(string skuId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(skuId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Sku> List(SkuListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Sku> List(SkuListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/skus", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Sku>> ListAsync(SkuListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Sku>> ListAsync(SkuListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/skus", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Sku Update(string skuId, SkuUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, options);
+            return this.UpdateEntity(skuId, options, requestOptions);
         }
 
         public virtual Task<Sku> UpdateAsync(string skuId, SkuUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/skus/{WebUtility.UrlEncode(skuId)}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(skuId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class SourceTransactionService : Service<SourceTransaction>,
+    public class SourceTransactionService : ServiceNested<SourceTransaction>,
         INestedListable<SourceTransaction, SourceTransactionsListOptions>
     {
         public SourceTransactionService()
@@ -17,14 +17,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/sources/{PARENT_ID}/source_transactions";
+
         public virtual StripeList<SourceTransaction> List(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/sources/{sourceId}/source_transactions", requestOptions, options);
+            return this.ListNestedEntities(sourceId, options, requestOptions);
         }
 
         public virtual Task<StripeList<SourceTransaction>> ListAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/sources/{sourceId}/source_transactions", requestOptions, cancellationToken, options);
+            return this.ListNestedEntitiesAsync(sourceId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -20,64 +20,66 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/sources";
+
         public virtual Source Attach(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.PostRequest<Source>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<Source> AttachAsync(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.PostRequestAsync<Source>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Create(SourceCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/sources", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Source> CreateAsync(SourceCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/sources", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Source Detach(string customerId, string sourceId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}", requestOptions);
+            return this.DeleteRequest<Source>($"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}", null, requestOptions);
         }
 
         public virtual Task<Source> DetachAsync(string customerId, string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}", requestOptions, cancellationToken);
+            return this.DeleteRequestAsync<Source>($"{Urls.BaseUrl}/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
         }
 
         public virtual Source Get(string sourceId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions);
+            return this.GetEntity(sourceId, null, requestOptions);
         }
 
         public virtual Task<Source> GetAsync(string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(sourceId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, options);
+            return this.GetRequest<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/customers/{customerId}/sources", requestOptions, cancellationToken, options);
+            return this.GetRequestAsync<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Update(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, options);
+            return this.UpdateEntity(sourceId, options, requestOptions);
         }
 
         public virtual Task<Source> UpdateAsync(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/sources/{sourceId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(sourceId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -22,54 +22,56 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/subscription_items";
+
         public virtual SubscriptionItem Create(SubscriptionItemCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/subscription_items", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> CreateAsync(SubscriptionItemCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/subscription_items", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Delete(string subscriptionItemId, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions);
+            return this.DeleteEntity(subscriptionItemId, null, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> DeleteAsync(string subscriptionItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(subscriptionItemId, null, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Get(string subscriptionItemId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions);
+            return this.GetEntity(subscriptionItemId, null, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> GetAsync(string subscriptionItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(subscriptionItemId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionItem> List(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/subscription_items", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<SubscriptionItem>> ListAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/subscription_items", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Update(string subscriptionItemId, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions, options);
+            return this.UpdateEntity(subscriptionItemId, options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> UpdateAsync(string subscriptionItemId, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(subscriptionItemId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -22,56 +22,58 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/subscriptions";
+
         public bool ExpandCustomer { get; set; }
 
         public virtual Subscription Cancel(string subscriptionId, SubscriptionCancelOptions options, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions, options);
+            return this.DeleteEntity(subscriptionId, options, requestOptions);
         }
 
         public virtual Task<Subscription> CancelAsync(string subscriptionId, SubscriptionCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions, cancellationToken, options);
+            return this.DeleteEntityAsync(subscriptionId, options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Create(SubscriptionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/subscriptions", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Subscription> CreateAsync(SubscriptionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/subscriptions", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Get(string subscriptionId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions);
+            return this.GetEntity(subscriptionId, null, requestOptions);
         }
 
         public virtual Task<Subscription> GetAsync(string subscriptionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(subscriptionId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Subscription> List(SubscriptionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/subscriptions", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Subscription>> ListAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/subscriptions", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Update(string subscriptionId, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions, options);
+            return this.UpdateEntity(subscriptionId, options, requestOptions);
         }
 
         public virtual Task<Subscription> UpdateAsync(string subscriptionId, SubscriptionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/subscriptions/{subscriptionId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(subscriptionId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureService.cs
+++ b/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureService.cs
@@ -19,14 +19,16 @@ namespace Stripe
         {
         }
 
-        public virtual ThreeDSecure Create(ThreeDSecureCreateOptions createOptions, RequestOptions requestOptions = null)
+        public override string BasePath => "/3d_secure";
+
+        public virtual ThreeDSecure Create(ThreeDSecureCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/3d_secure", requestOptions, createOptions);
+            return this.CreateEntity(options, requestOptions);
         }
 
-        public virtual Task<ThreeDSecure> CreateAsync(ThreeDSecureCreateOptions createOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ThreeDSecure> CreateAsync(ThreeDSecureCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/3d_secure", requestOptions, cancellationToken, createOptions);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -18,24 +18,26 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/tokens";
+
         public virtual Token Create(TokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/tokens", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Token> CreateAsync(TokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/tokens", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Token Get(string tokenId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/tokens/{tokenId}", requestOptions);
+            return this.GetEntity(tokenId, null, requestOptions);
         }
 
         public virtual Task<Token> GetAsync(string tokenId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/tokens/{tokenId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(tokenId, null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -10,10 +10,17 @@ namespace Stripe
         IRetrievable<Topup>,
         IUpdatable<Topup, TopupUpdateOptions>
     {
+        public TopupService()
+            : base(null)
+        {
+        }
+
         public TopupService(string apiKey = null)
             : base(apiKey)
         {
         }
+
+        public override string BasePath => "/topups";
 
         public bool ExpandBalanceTransaction { get; set; }
 
@@ -21,52 +28,52 @@ namespace Stripe
 
         public virtual Topup Cancel(string topupId, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/topups/{topupId}/cancel", requestOptions);
+            return this.PostRequest<Topup>($"{this.InstanceUrl(topupId)}/cancel", null, requestOptions);
         }
 
         public virtual Task<Topup> CancelAsync(string topupId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/topups/{topupId}/cancel", requestOptions, cancellationToken);
+            return this.PostRequestAsync<Topup>($"{this.InstanceUrl(topupId)}/cancel", null, requestOptions, cancellationToken);
         }
 
         public virtual Topup Create(TopupCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/topups", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Topup> CreateAsync(TopupCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/topups", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Topup Get(string topupId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/topups/{topupId}", requestOptions);
+            return this.GetEntity(topupId, null, requestOptions);
         }
 
         public virtual Task<Topup> GetAsync(string topupId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/topups/{topupId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(topupId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Topup> List(TopupListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/topups", requestOptions, options);
+            return this.ListEntities(options, requestOptions);
         }
 
         public virtual Task<StripeList<Topup>> ListAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/topups", requestOptions, cancellationToken, options);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Topup Update(string topupId, TopupUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/topups/{topupId}", requestOptions, options);
+            return this.UpdateEntity(topupId, options, requestOptions);
         }
 
         public virtual Task<Topup> UpdateAsync(string topupId, TopupUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/topups/{topupId}", requestOptions, cancellationToken);
+            return this.UpdateEntityAsync(topupId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class TransferReversalService : Service<TransferReversal>,
+    public class TransferReversalService : ServiceNested<TransferReversal>,
         INestedCreatable<TransferReversal, TransferReversalCreateOptions>,
         INestedListable<TransferReversal, TransferReversalListOptions>,
         INestedRetrievable<TransferReversal>,
@@ -21,48 +21,50 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/transfers/{PARENT_ID}/reversals";
+
         public bool ExpandBalanceTransaction { get; set; }
 
         public bool ExpandTransfer { get; set; }
 
         public virtual TransferReversal Create(string transferId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, options);
+            return this.CreateNestedEntity(transferId, options, requestOptions);
         }
 
         public virtual Task<TransferReversal> CreateAsync(string transferId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(transferId, options, requestOptions, cancellationToken);
         }
 
         public virtual TransferReversal Get(string transferId, string reversalId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions);
+            return this.GetNestedEntity(transferId, reversalId, null, requestOptions);
         }
 
         public virtual Task<TransferReversal> GetAsync(string transferId, string reversalId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(transferId, reversalId, null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TransferReversal> List(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, options);
+            return this.ListNestedEntities(transferId, options, requestOptions);
         }
 
         public virtual Task<StripeList<TransferReversal>> ListAsync(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals", requestOptions, cancellationToken, options);
+            return this.ListNestedEntitiesAsync(transferId, options, requestOptions, cancellationToken);
         }
 
         public virtual TransferReversal Update(string transferId,  string reversalId, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions, options);
+            return this.UpdateNestedEntity(transferId, reversalId, options, requestOptions);
         }
 
         public virtual Task<TransferReversal> UpdateAsync(string transferId,  string reversalId, TransferReversalUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/transfers/{transferId}/reversals/{reversalId}", requestOptions, cancellationToken, options);
+            return this.UpdateNestedEntityAsync(transferId, reversalId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -21,6 +21,8 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/transfers";
+
         public bool ExpandBalanceTransaction { get; set; }
 
         public bool ExpandDestination { get; set; }
@@ -31,42 +33,42 @@ namespace Stripe
 
         public virtual Transfer Create(TransferCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/transfers", requestOptions, options);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<Transfer> CreateAsync(TransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/transfers", requestOptions, cancellationToken, options);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Transfer Get(string payoutId, RequestOptions requestOptions = null)
+        public virtual Transfer Get(string transferId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity($"{Urls.BaseUrl}/transfers/{payoutId}", requestOptions);
+            return this.GetEntity(transferId, null, requestOptions);
         }
 
-        public virtual Task<Transfer> GetAsync(string payoutId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Transfer> GetAsync(string transferId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync($"{Urls.BaseUrl}/transfers/{payoutId}", requestOptions, cancellationToken);
+            return this.GetEntityAsync(transferId, null, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Transfer> List(TransferListOptions listOptions = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Transfer> List(TransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/transfers", requestOptions, listOptions);
+            return this.ListEntities(options, requestOptions);
         }
 
-        public virtual Task<StripeList<Transfer>> ListAsync(TransferListOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<Transfer>> ListAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/transfers", requestOptions, cancellationToken, listOptions);
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual Transfer Update(string transferId, TransferUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/transfers/{transferId}", requestOptions, options);
+            return this.UpdateEntity(transferId, options, requestOptions);
         }
 
         public virtual Task<Transfer> UpdateAsync(string transferId, TransferUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/transfers/{transferId}", requestOptions, cancellationToken, options);
+            return this.UpdateEntityAsync(transferId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class UsageRecordSummaryService : Service<UsageRecordSummary>,
+    public class UsageRecordSummaryService : ServiceNested<UsageRecordSummary>,
         INestedListable<UsageRecordSummary, UsageRecordSummaryListOptions>
     {
         public UsageRecordSummaryService()
@@ -18,14 +18,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/subscription_items/{PARENT_ID}/usage_record_summaries";
+
         public virtual StripeList<UsageRecordSummary> List(string subscriptionItemId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntityList($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}/usage_record_summaries", requestOptions, options);
+            return this.ListNestedEntities(subscriptionItemId, options, requestOptions);
         }
 
         public virtual Task<StripeList<UsageRecordSummary>> ListAsync(string subscriptionItemId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityListAsync($"{Urls.BaseUrl}/subscription_items/{subscriptionItemId}/usage_record_summaries", requestOptions, cancellationToken, options);
+            return this.ListNestedEntitiesAsync(subscriptionItemId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
-    public class UsageRecordService : Service<UsageRecord>,
+    public class UsageRecordService : ServiceNested<UsageRecord>,
         ICreatable<UsageRecord, UsageRecordCreateOptions>
     {
         public UsageRecordService()
@@ -18,14 +18,16 @@ namespace Stripe
         {
         }
 
+        public override string BasePath => "/subscription_items/{PARENT_ID}/usage_records";
+
         public virtual UsageRecord Create(UsageRecordCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Post($"{Urls.BaseUrl}/subscription_items/{options.SubscriptionItem}/usage_records", requestOptions, options);
+            return this.CreateNestedEntity(options.SubscriptionItem, options, requestOptions);
         }
 
         public virtual Task<UsageRecord> CreateAsync(UsageRecordCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostAsync($"{Urls.BaseUrl}/subscription_items/{options.SubscriptionItem}/usage_records", requestOptions, cancellationToken, options);
+            return this.CreateNestedEntityAsync(options.SubscriptionItem, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IListable.cs
+++ b/src/Stripe.net/Services/_interfaces/IListable.cs
@@ -5,7 +5,7 @@ namespace Stripe
 
     public interface IListable<T, O>
         where T : StripeEntity
-        where O : BaseOptions
+        where O : ListOptions
     {
         StripeList<T> List(O listOptions = null, RequestOptions requestOptions = null);
 

--- a/src/Stripe.net/Services/_interfaces/INestedListable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedListable.cs
@@ -5,7 +5,7 @@ namespace Stripe
 
     public interface INestedListable<T, O>
         where T : StripeEntity
-        where O : BaseOptions
+        where O : ListOptions
     {
         StripeList<T> List(string parentId, O listOptions = null, RequestOptions requestOptions = null);
 

--- a/src/StripeTests/Infrastructure/TestData/TestService.cs
+++ b/src/StripeTests/Infrastructure/TestData/TestService.cs
@@ -9,6 +9,8 @@ namespace StripeTests.Infrastructure.TestData
         {
         }
 
+        public override string BasePath => "/charges";
+
         public bool ExpandSimple { get; set; }
 
         public bool ExpandMultiWordProperty { get; set; }

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -142,9 +142,18 @@ namespace StripeTests
         }
 
         [Fact]
-        public void GetWithNoId()
+        public void GetSelf()
         {
-            var account = this.service.Get();
+            var account = this.service.GetSelf();
+            this.AssertRequest(HttpMethod.Get, "/v1/account");
+            Assert.NotNull(account);
+            Assert.Equal("account", account.Object);
+        }
+
+        [Fact]
+        public async Task GetSelfAsync()
+        {
+            var account = await this.service.GetSelfAsync();
             this.AssertRequest(HttpMethod.Get, "/v1/account");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);


### PR DESCRIPTION
Move URL creation in `Service` as much as possible, so that concrete services don't need to create their own URLs in every method.

Most services will only need to declare their `ObjectName`, then use the new parent methods for CRUD + list requests, or call `this.ClassUrl()` / `this.InstanceUrl(id)` as appropriate.

Some services will need to override `ClassUrl` if their object name doesn't cleanly map to the URL.

I'm not sure yet how to handle services for nested resources -- maybe another parent class `ServiceNested` with more helper methods, similar to these ones but with an additional argument for the parent resource's ID.

ptal @remi-stripe 
