### PR TITLE
Verifying requests in tests

### DIFF
--- a/src/StripeTests/Properties.cs
+++ b/src/StripeTests/Properties.cs
@@ -1,0 +1,1 @@
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -92,6 +93,7 @@ namespace StripeTests
         public void Create()
         {
             var account = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -100,6 +102,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var account = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -108,6 +111,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(AccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/accounts/acct_123");
             Assert.NotNull(deleted);
         }
 
@@ -115,6 +119,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(AccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/accounts/acct_123");
             Assert.NotNull(deleted);
         }
 
@@ -122,6 +127,7 @@ namespace StripeTests
         public void Get()
         {
             var account = this.service.Get(AccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -130,6 +136,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var account = await this.service.GetAsync(AccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -138,6 +145,7 @@ namespace StripeTests
         public void GetWithNoId()
         {
             var account = this.service.Get();
+            this.AssertRequest(HttpMethod.Get, "/v1/account");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -146,6 +154,7 @@ namespace StripeTests
         public void List()
         {
             var accounts = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts");
             Assert.NotNull(accounts);
             Assert.Equal("list", accounts.Object);
             Assert.Single(accounts.Data);
@@ -156,6 +165,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var accounts = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts");
             Assert.NotNull(accounts);
             Assert.Equal("list", accounts.Object);
             Assert.Single(accounts.Data);
@@ -166,6 +176,7 @@ namespace StripeTests
         public void Reject()
         {
             var account = this.service.Reject(AccountId, this.rejectOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/reject");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -174,6 +185,7 @@ namespace StripeTests
         public async Task RejectAsync()
         {
             var account = await this.service.RejectAsync(AccountId, this.rejectOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/reject");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -182,6 +194,7 @@ namespace StripeTests
         public void Update()
         {
             var account = this.service.Update(AccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
@@ -190,6 +203,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var account = await this.service.UpdateAsync(AccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123");
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -33,6 +34,7 @@ namespace StripeTests
         public void Create()
         {
             var domain = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/apple_pay/domains");
             Assert.NotNull(domain);
             Assert.Equal("apple_pay_domain", domain.Object);
         }
@@ -41,6 +43,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var domain = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/apple_pay/domains");
             Assert.NotNull(domain);
             Assert.Equal("apple_pay_domain", domain.Object);
         }
@@ -49,6 +52,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(DomainId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/apple_pay/domains/apwc_123");
             Assert.NotNull(deleted);
         }
 
@@ -56,6 +60,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(DomainId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/apple_pay/domains/apwc_123");
             Assert.NotNull(deleted);
         }
 
@@ -63,6 +68,7 @@ namespace StripeTests
         public void Get()
         {
             var domain = this.service.Get(DomainId);
+            this.AssertRequest(HttpMethod.Get, "/v1/apple_pay/domains/apwc_123");
             Assert.NotNull(domain);
             Assert.Equal("apple_pay_domain", domain.Object);
         }
@@ -71,6 +77,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var domain = await this.service.GetAsync(DomainId);
+            this.AssertRequest(HttpMethod.Get, "/v1/apple_pay/domains/apwc_123");
             Assert.NotNull(domain);
             Assert.Equal("apple_pay_domain", domain.Object);
         }
@@ -79,6 +86,7 @@ namespace StripeTests
         public void List()
         {
             var domains = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/apple_pay/domains");
             Assert.NotNull(domains);
             Assert.Equal("list", domains.Object);
             Assert.Single(domains.Data);
@@ -89,6 +97,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var domains = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/apple_pay/domains");
             Assert.NotNull(domains);
             Assert.Equal("list", domains.Object);
             Assert.Single(domains.Data);

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -45,6 +46,7 @@ namespace StripeTests
             var applicationFeeRefund = this.service.Create(
                 ApplicationFeeId,
                 this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/application_fees/fee_123/refunds");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
@@ -55,6 +57,7 @@ namespace StripeTests
             var applicationFeeRefund = await this.service.CreateAsync(
                 ApplicationFeeId,
                 this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/application_fees/fee_123/refunds");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
@@ -63,6 +66,7 @@ namespace StripeTests
         public void Get()
         {
             var applicationFeeRefund = this.service.Get(ApplicationFeeId, ApplicationFeeRefundId);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123/refunds/fr_123");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
@@ -71,6 +75,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var applicationFeeRefund = await this.service.GetAsync(ApplicationFeeId, ApplicationFeeRefundId);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123/refunds/fr_123");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
@@ -79,6 +84,7 @@ namespace StripeTests
         public void List()
         {
             var applicationFeeRefunds = this.service.List(ApplicationFeeId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123/refunds");
             Assert.NotNull(applicationFeeRefunds);
             Assert.Equal("list", applicationFeeRefunds.Object);
             Assert.Single(applicationFeeRefunds.Data);
@@ -89,6 +95,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var applicationFeeRefunds = await this.service.ListAsync(ApplicationFeeId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123/refunds");
             Assert.NotNull(applicationFeeRefunds);
             Assert.Equal("list", applicationFeeRefunds.Object);
             Assert.Single(applicationFeeRefunds.Data);
@@ -102,6 +109,7 @@ namespace StripeTests
                 ApplicationFeeId,
                 ApplicationFeeRefundId,
                 this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/application_fees/fee_123/refunds/fr_123");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
@@ -113,6 +121,7 @@ namespace StripeTests
                 ApplicationFeeId,
                 ApplicationFeeRefundId,
                 this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/application_fees/fee_123/refunds/fr_123");
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Get()
         {
             var applicationFee = this.service.Get(ApplicationFeeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123");
             Assert.NotNull(applicationFee);
             Assert.Equal("application_fee", applicationFee.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var applicationFee = await this.service.GetAsync(ApplicationFeeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees/fee_123");
             Assert.NotNull(applicationFee);
             Assert.Equal("application_fee", applicationFee.Object);
         }
@@ -43,6 +46,7 @@ namespace StripeTests
         public void List()
         {
             var applicationFees = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees");
             Assert.NotNull(applicationFees);
             Assert.Equal("list", applicationFees.Object);
             Assert.Single(applicationFees.Data);
@@ -53,6 +57,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var applicationFees = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/application_fees");
             Assert.NotNull(applicationFees);
             Assert.Equal("list", applicationFees.Object);
             Assert.Single(applicationFees.Data);

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -19,6 +20,7 @@ namespace StripeTests
         public void Get()
         {
             var balance = this.service.Get();
+            this.AssertRequest(HttpMethod.Get, "/v1/balance");
             Assert.NotNull(balance);
             Assert.Equal("balance", balance.Object);
         }
@@ -27,6 +29,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var balance = await this.service.GetAsync();
+            this.AssertRequest(HttpMethod.Get, "/v1/balance");
             Assert.NotNull(balance);
             Assert.Equal("balance", balance.Object);
         }

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Get()
         {
             var balanceTransaction = this.service.Get(BalanceTransactionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/balance/history/txn_123");
             Assert.NotNull(balanceTransaction);
             Assert.Equal("balance_transaction", balanceTransaction.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var balanceTransaction = await this.service.GetAsync(BalanceTransactionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/balance/history/txn_123");
             Assert.NotNull(balanceTransaction);
             Assert.Equal("balance_transaction", balanceTransaction.Object);
         }
@@ -43,6 +46,7 @@ namespace StripeTests
         public void List()
         {
             var balanceTransactions = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/balance/history");
             Assert.NotNull(balanceTransactions);
             Assert.Equal("list", balanceTransactions.Object);
             Assert.Single(balanceTransactions.Data);
@@ -53,6 +57,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var balanceTransactions = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/balance/history");
             Assert.NotNull(balanceTransactions);
             Assert.Equal("list", balanceTransactions.Object);
             Assert.Single(balanceTransactions.Data);

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -65,6 +66,7 @@ namespace StripeTests
         public void Create()
         {
             var bankAccount = this.service.Create(CustomerId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
             Assert.NotNull(bankAccount);
             Assert.Equal("bank_account", bankAccount.Object);
         }
@@ -73,6 +75,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var bankAccount = await this.service.CreateAsync(CustomerId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
             Assert.NotNull(bankAccount);
             Assert.Equal("bank_account", bankAccount.Object);
         }
@@ -81,6 +84,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(CustomerId, BankAccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(deleted);
         }
 
@@ -88,6 +92,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(CustomerId, BankAccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(deleted);
         }
 
@@ -95,6 +100,7 @@ namespace StripeTests
         public void Get()
         {
             var bankAccount = this.service.Get(CustomerId, BankAccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(bankAccount);
             Assert.Equal("bank_account", bankAccount.Object);
         }
@@ -103,6 +109,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var bankAccount = await this.service.GetAsync(CustomerId, BankAccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(bankAccount);
             Assert.Equal("bank_account", bankAccount.Object);
         }
@@ -111,6 +118,7 @@ namespace StripeTests
         public void List()
         {
             var bankAccounts = this.service.List(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(bankAccounts);
             Assert.Equal("list", bankAccounts.Object);
             Assert.Single(bankAccounts.Data);
@@ -120,6 +128,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var bankAccounts = await this.service.ListAsync(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(bankAccounts);
             Assert.Equal("list", bankAccounts.Object);
             Assert.Single(bankAccounts.Data);
@@ -131,6 +140,7 @@ namespace StripeTests
         public void Update()
         {
             var bankAccount = this.service.Update(CustomerId, BankAccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(bankAccount);
         }
 
@@ -138,6 +148,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var bankAccount = await this.service.UpdateAsync(CustomerId, BankAccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/ba_123");
             Assert.NotNull(bankAccount);
         }
 
@@ -145,6 +156,7 @@ namespace StripeTests
         public void Verify()
         {
             var bankAccount = this.service.Verify(CustomerId, BankAccountId, this.verifyOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/ba_123/verify");
             Assert.NotNull(bankAccount);
         }
 
@@ -152,6 +164,7 @@ namespace StripeTests
         public async Task VerifyAsync()
         {
             var bankAccount = await this.service.VerifyAsync(CustomerId, BankAccountId, this.verifyOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/ba_123/verify");
             Assert.NotNull(bankAccount);
         }
     }

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -47,6 +48,7 @@ namespace StripeTests
         public void Create()
         {
             var card = this.service.Create(CustomerId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
             Assert.NotNull(card);
         }
 
@@ -54,6 +56,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var card = await this.service.CreateAsync(CustomerId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
             Assert.NotNull(card);
         }
 
@@ -61,6 +64,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(CustomerId, CardId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(deleted);
         }
 
@@ -68,6 +72,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(CustomerId, CardId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(deleted);
         }
 
@@ -75,6 +80,7 @@ namespace StripeTests
         public void Get()
         {
             var card = this.service.Get(CustomerId, CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(card);
         }
 
@@ -82,6 +88,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var card = await this.service.GetAsync(CustomerId, CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(card);
         }
 
@@ -89,6 +96,7 @@ namespace StripeTests
         public void List()
         {
             var cards = this.service.List(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(cards);
             Assert.Equal("list", cards.Object);
             Assert.Single(cards.Data);
@@ -98,6 +106,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var cards = await this.service.ListAsync(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(cards);
             Assert.Equal("list", cards.Object);
             Assert.Single(cards.Data);
@@ -107,6 +116,7 @@ namespace StripeTests
         public void Update()
         {
             var card = this.service.Update(CustomerId, CardId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(card);
             Assert.Equal("card", card.Object);
         }
@@ -115,6 +125,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var card = await this.service.UpdateAsync(CustomerId, CardId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources/card_123");
             Assert.NotNull(card);
             Assert.Equal("card", card.Object);
         }

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -50,6 +51,7 @@ namespace StripeTests
         public void Capture()
         {
             var charge = this.service.Capture(ChargeId, this.captureOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges/ch_123/capture");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -58,6 +60,7 @@ namespace StripeTests
         public async Task CaptureAsync()
         {
             var charge = await this.service.CaptureAsync(ChargeId, this.captureOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges/ch_123/capture");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -66,6 +69,7 @@ namespace StripeTests
         public void Create()
         {
             var charge = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -74,6 +78,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var charge = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -82,6 +87,7 @@ namespace StripeTests
         public void Get()
         {
             var charge = this.service.Get(ChargeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/charges/ch_123");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -90,6 +96,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var charge = await this.service.GetAsync(ChargeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/charges/ch_123");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -98,6 +105,7 @@ namespace StripeTests
         public void List()
         {
             var charges = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/charges");
             Assert.NotNull(charges);
             Assert.Equal("list", charges.Object);
             Assert.Single(charges.Data);
@@ -108,6 +116,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var charges = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/charges");
             Assert.NotNull(charges);
             Assert.Equal("list", charges.Object);
             Assert.Single(charges.Data);
@@ -118,6 +127,7 @@ namespace StripeTests
         public void Update()
         {
             var charge = this.service.Update(ChargeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges/ch_123");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
@@ -126,6 +136,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var charge = await this.service.UpdateAsync(ChargeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/charges/ch_123");
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Get()
         {
             var countrySpec = this.service.Get(CountrySpecId);
+            this.AssertRequest(HttpMethod.Get, "/v1/country_specs/US");
             Assert.NotNull(countrySpec);
             Assert.Equal("country_spec", countrySpec.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var countrySpec = await this.service.GetAsync(CountrySpecId);
+            this.AssertRequest(HttpMethod.Get, "/v1/country_specs/US");
             Assert.NotNull(countrySpec);
             Assert.Equal("country_spec", countrySpec.Object);
         }
@@ -43,6 +46,7 @@ namespace StripeTests
         public void List()
         {
             var countrySpecs = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/country_specs");
             Assert.NotNull(countrySpecs);
             Assert.Equal("list", countrySpecs.Object);
             Assert.Single(countrySpecs.Data);
@@ -53,6 +57,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var countrySpecs = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/country_specs");
             Assert.NotNull(countrySpecs);
             Assert.Equal("list", countrySpecs.Object);
             Assert.Single(countrySpecs.Data);

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var coupon = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/coupons");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var coupon = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/coupons");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(CouponId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/coupons/co_123");
             Assert.NotNull(deleted);
         }
 
@@ -66,6 +70,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(CouponId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/coupons/co_123");
             Assert.NotNull(deleted);
         }
 
@@ -73,6 +78,7 @@ namespace StripeTests
         public void Get()
         {
             var coupon = this.service.Get(CouponId);
+            this.AssertRequest(HttpMethod.Get, "/v1/coupons/co_123");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
@@ -81,6 +87,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var coupon = await this.service.GetAsync(CouponId);
+            this.AssertRequest(HttpMethod.Get, "/v1/coupons/co_123");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
@@ -89,6 +96,7 @@ namespace StripeTests
         public void List()
         {
             var coupons = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/coupons");
             Assert.NotNull(coupons);
             Assert.Equal("list", coupons.Object);
             Assert.Single(coupons.Data);
@@ -99,6 +107,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var coupons = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/coupons");
             Assert.NotNull(coupons);
             Assert.Equal("list", coupons.Object);
             Assert.Single(coupons.Data);
@@ -109,6 +118,7 @@ namespace StripeTests
         public void Update()
         {
             var coupon = this.service.Update(CouponId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/coupons/co_123");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
@@ -117,6 +127,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var coupon = await this.service.UpdateAsync(CouponId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/coupons/co_123");
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -8,7 +9,7 @@ namespace StripeTests
 
     public class CustomerServiceTest : BaseStripeTest
     {
-        private const string CustomerId = "co_123";
+        private const string CustomerId = "cus_123";
 
         private CustomerService service;
         private CustomerCreateOptions createOptions;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var customer = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var customer = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(CustomerId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123");
             Assert.NotNull(deleted);
         }
 
@@ -66,6 +70,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(CustomerId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123");
             Assert.NotNull(deleted);
         }
 
@@ -73,6 +78,7 @@ namespace StripeTests
         public void Get()
         {
             var customer = this.service.Get(CustomerId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
@@ -81,6 +87,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var customer = await this.service.GetAsync(CustomerId);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
@@ -89,6 +96,7 @@ namespace StripeTests
         public void List()
         {
             var customers = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers");
             Assert.NotNull(customers);
             Assert.Equal("list", customers.Object);
             Assert.Single(customers.Data);
@@ -99,6 +107,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var customers = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers");
             Assert.NotNull(customers);
             Assert.Equal("list", customers.Object);
             Assert.Single(customers.Data);
@@ -109,6 +118,7 @@ namespace StripeTests
         public void Update()
         {
             var customer = this.service.Update(CustomerId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
@@ -117,6 +127,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var customer = await this.service.UpdateAsync(CustomerId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123");
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -19,6 +20,7 @@ namespace StripeTests
         public void DeleteCustomerDiscount()
         {
             var deleted = this.service.DeleteCustomerDiscount("cus_123");
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/discount");
             Assert.NotNull(deleted);
         }
 
@@ -26,6 +28,7 @@ namespace StripeTests
         public async Task DeleteCustomerDiscountAsync()
         {
             var deleted = await this.service.DeleteCustomerDiscountAsync("cus_123");
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/discount");
             Assert.NotNull(deleted);
         }
 
@@ -33,6 +36,7 @@ namespace StripeTests
         public void DeleteSubscriptionDiscount()
         {
             var deleted = this.service.DeleteSubscriptionDiscount("sub_123");
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscriptions/sub_123/discount");
             Assert.NotNull(deleted);
         }
 
@@ -40,6 +44,7 @@ namespace StripeTests
         public async Task DeleteSubscriptionDiscountAsync()
         {
             var deleted = await this.service.DeleteSubscriptionDiscountAsync("sub_123");
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscriptions/sub_123/discount");
             Assert.NotNull(deleted);
         }
     }

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -36,6 +37,7 @@ namespace StripeTests
         public void Close()
         {
             var dispute = this.service.Close(DisputeId);
+            this.AssertRequest(HttpMethod.Post, "/v1/disputes/dp_123/close");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
@@ -44,6 +46,7 @@ namespace StripeTests
         public async Task CloseAsync()
         {
             var dispute = await this.service.CloseAsync(DisputeId);
+            this.AssertRequest(HttpMethod.Post, "/v1/disputes/dp_123/close");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
@@ -52,6 +55,7 @@ namespace StripeTests
         public void Get()
         {
             var dispute = this.service.Get(DisputeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/disputes/dp_123");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
@@ -60,6 +64,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var dispute = await this.service.GetAsync(DisputeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/disputes/dp_123");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
@@ -68,6 +73,7 @@ namespace StripeTests
         public void List()
         {
             var disputes = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/disputes");
             Assert.NotNull(disputes);
             Assert.Equal("list", disputes.Object);
             Assert.Single(disputes.Data);
@@ -78,6 +84,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var disputes = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/disputes");
             Assert.NotNull(disputes);
             Assert.Equal("list", disputes.Object);
             Assert.Single(disputes.Data);
@@ -88,6 +95,7 @@ namespace StripeTests
         public void Update()
         {
             var dispute = this.service.Update(DisputeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/disputes/dp_123");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
@@ -96,6 +104,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var dispute = await this.service.UpdateAsync(DisputeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/disputes/dp_123");
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -28,6 +29,7 @@ namespace StripeTests
         public void Create()
         {
             var ephemeralKey = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/ephemeral_keys");
             Assert.NotNull(ephemeralKey);
             Assert.Equal("ephemeral_key", ephemeralKey.Object);
             Assert.NotNull(ephemeralKey.RawJson);
@@ -37,6 +39,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var ephemeralKey = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/ephemeral_keys");
             Assert.NotNull(ephemeralKey);
             Assert.Equal("ephemeral_key", ephemeralKey.Object);
         }
@@ -45,6 +48,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(EphemeralKeyId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/ephemeral_keys/ephkey_123");
             Assert.NotNull(deleted);
         }
 
@@ -52,6 +56,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(EphemeralKeyId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/ephemeral_keys/ephkey_123");
             Assert.NotNull(deleted);
         }
     }

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Get()
         {
             var evt = this.service.Get(EventId);
+            this.AssertRequest(HttpMethod.Get, "/v1/events/evt_123");
             Assert.NotNull(evt);
             Assert.Equal("event", evt.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var evt = await this.service.GetAsync(EventId);
+            this.AssertRequest(HttpMethod.Get, "/v1/events/evt_123");
             Assert.NotNull(evt);
             Assert.Equal("event", evt.Object);
         }
@@ -43,6 +46,7 @@ namespace StripeTests
         public void List()
         {
             var events = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/events");
             Assert.NotNull(events);
             Assert.Equal("list", events.Object);
             Assert.Single(events.Data);
@@ -53,6 +57,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var events = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/events");
             Assert.NotNull(events);
             Assert.Equal("list", events.Object);
             Assert.Single(events.Data);

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -25,6 +26,7 @@ namespace StripeTests
         public void Get()
         {
             var exchangeRate = this.service.Get("usd");
+            this.AssertRequest(HttpMethod.Get, "/v1/exchange_rates/usd");
             Assert.NotNull(exchangeRate);
             Assert.Equal("exchange_rate", exchangeRate.Object);
         }
@@ -33,6 +35,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var exchangeRate = await this.service.GetAsync("usd");
+            this.AssertRequest(HttpMethod.Get, "/v1/exchange_rates/usd");
             Assert.NotNull(exchangeRate);
             Assert.Equal("exchange_rate", exchangeRate.Object);
         }
@@ -41,6 +44,7 @@ namespace StripeTests
         public void List()
         {
             var exchangeRates = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/exchange_rates");
             Assert.NotNull(exchangeRates);
             Assert.Equal("list", exchangeRates.Object);
             Assert.Single(exchangeRates.Data);
@@ -51,6 +55,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var exchangeRates = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/exchange_rates");
             Assert.NotNull(exchangeRates);
             Assert.Equal("list", exchangeRates.Object);
             Assert.Single(exchangeRates.Data);

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -49,6 +50,7 @@ namespace StripeTests
         public void Create()
         {
             var externalAccount = this.service.Create(AccountId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/external_accounts");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);
@@ -59,6 +61,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var externalAccount = await this.service.CreateAsync(AccountId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/external_accounts");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);
@@ -69,6 +72,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(AccountId, ExternalAccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(deleted);
         }
 
@@ -76,6 +80,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(AccountId, ExternalAccountId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(deleted);
         }
 
@@ -83,6 +88,7 @@ namespace StripeTests
         public void Get()
         {
             var externalAccount = this.service.Get(AccountId, ExternalAccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);
@@ -93,6 +99,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var externalAccount = await this.service.GetAsync(AccountId, ExternalAccountId);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);
@@ -105,6 +112,7 @@ namespace StripeTests
         public void List()
         {
             var externalAccounts = this.service.List(AccountId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/external_accounts");
             Assert.NotNull(externalAccounts);
             Assert.Equal("list", externalAccounts.Object);
             Assert.Single(externalAccounts.Data);
@@ -114,6 +122,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var externalAccounts = await this.service.ListAsync(AccountId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/external_accounts");
             Assert.NotNull(externalAccounts);
             Assert.Equal("list", externalAccounts.Object);
             Assert.Single(externalAccounts.Data);
@@ -123,6 +132,7 @@ namespace StripeTests
         public void Update()
         {
             var externalAccount = this.service.Update(AccountId, ExternalAccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);
@@ -133,6 +143,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var externalAccount = await this.service.UpdateAsync(AccountId, ExternalAccountId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/external_accounts/ba_123");
             Assert.NotNull(externalAccount);
             Assert.Equal(ExternalAccountType.BankAccount, externalAccount.Type);
             Assert.NotNull(externalAccount.BankAccount);

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var fileLink = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/file_links");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var fileLink = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/file_links");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Get()
         {
             var fileLink = this.service.Get(FileLinkId);
+            this.AssertRequest(HttpMethod.Get, "/v1/file_links/link_123");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }
@@ -67,6 +71,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var fileLink = await this.service.GetAsync(FileLinkId);
+            this.AssertRequest(HttpMethod.Get, "/v1/file_links/link_123");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }
@@ -75,6 +80,7 @@ namespace StripeTests
         public void List()
         {
             var fileLinks = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/file_links");
             Assert.NotNull(fileLinks);
             Assert.Equal("list", fileLinks.Object);
             Assert.Single(fileLinks.Data);
@@ -85,6 +91,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var fileLinks = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/file_links");
             Assert.NotNull(fileLinks);
             Assert.Equal("list", fileLinks.Object);
             Assert.Single(fileLinks.Data);
@@ -95,6 +102,7 @@ namespace StripeTests
         public void Update()
         {
             var fileLink = this.service.Update(FileLinkId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/file_links/link_123");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }
@@ -103,6 +111,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var fileLink = await this.service.UpdateAsync(FileLinkId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/file_links/link_123");
             Assert.NotNull(fileLink);
             Assert.Equal("file_link", fileLink.Object);
         }

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -3,6 +3,7 @@ namespace StripeTests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net.Http;
     using System.Reflection;
     using System.Threading.Tasks;
 
@@ -38,6 +39,7 @@ namespace StripeTests
         public void Create()
         {
             var file = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/files");
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }
@@ -46,6 +48,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var file = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/files");
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }
@@ -54,6 +57,7 @@ namespace StripeTests
         public void Get()
         {
             var file = this.service.Get(FileId);
+            this.AssertRequest(HttpMethod.Get, "/v1/files/file_123");
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }
@@ -62,6 +66,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var file = await this.service.GetAsync(FileId);
+            this.AssertRequest(HttpMethod.Get, "/v1/files/file_123");
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }
@@ -70,6 +75,7 @@ namespace StripeTests
         public void List()
         {
             var files = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/files");
             Assert.NotNull(files);
             Assert.Equal("list", files.Object);
             Assert.Single(files.Data);
@@ -80,6 +86,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var files = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/files");
             Assert.NotNull(files);
             Assert.Equal("list", files.Object);
             Assert.Single(files.Data);

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -8,7 +9,7 @@ namespace StripeTests
 
     public class InvoiceItemServiceTest : BaseStripeTest
     {
-        private const string InvoiceItemId = "co_123";
+        private const string InvoiceItemId = "ii_123";
 
         private InvoiceItemService service;
         private InvoiceItemCreateOptions createOptions;
@@ -44,6 +45,7 @@ namespace StripeTests
         public void Create()
         {
             var invoiceItem = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoiceitems");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
@@ -52,6 +54,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var invoiceItem = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoiceitems");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
@@ -60,6 +63,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(InvoiceItemId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/invoiceitems/ii_123");
             Assert.NotNull(deleted);
         }
 
@@ -67,6 +71,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(InvoiceItemId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/invoiceitems/ii_123");
             Assert.NotNull(deleted);
         }
 
@@ -74,6 +79,7 @@ namespace StripeTests
         public void Get()
         {
             var invoiceItem = this.service.Get(InvoiceItemId);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoiceitems/ii_123");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
@@ -82,6 +88,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var invoiceItem = await this.service.GetAsync(InvoiceItemId);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoiceitems/ii_123");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
@@ -90,6 +97,7 @@ namespace StripeTests
         public void List()
         {
             var invoiceItems = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoiceitems");
             Assert.NotNull(invoiceItems);
             Assert.Equal("list", invoiceItems.Object);
             Assert.Single(invoiceItems.Data);
@@ -100,6 +108,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var invoiceItems = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoiceitems");
             Assert.NotNull(invoiceItems);
             Assert.Equal("list", invoiceItems.Object);
             Assert.Single(invoiceItems.Data);
@@ -110,6 +119,7 @@ namespace StripeTests
         public void Update()
         {
             var invoiceItem = this.service.Update(InvoiceItemId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoiceitems/ii_123");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
@@ -118,6 +128,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var invoiceItem = await this.service.UpdateAsync(InvoiceItemId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoiceitems/ii_123");
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -63,6 +64,7 @@ namespace StripeTests
         public void Create()
         {
             var invoice = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -71,6 +73,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var invoice = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -79,6 +82,7 @@ namespace StripeTests
         public void Get()
         {
             var invoice = this.service.Get(InvoiceId);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -87,6 +91,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var invoice = await this.service.GetAsync(InvoiceId);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -95,6 +100,7 @@ namespace StripeTests
         public void List()
         {
             var invoices = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -105,6 +111,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var invoices = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -115,6 +122,7 @@ namespace StripeTests
         public void ListLineItems()
         {
             var invoices = this.service.ListLineItems(InvoiceId, this.listLineItemsOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -125,6 +133,7 @@ namespace StripeTests
         public async Task ListLineItemsAsync()
         {
             var invoices = await this.service.ListLineItemsAsync(InvoiceId, this.listLineItemsOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -135,6 +144,7 @@ namespace StripeTests
         public void ListUpcomingLineItems()
         {
             var invoices = this.service.ListUpcomingLineItems(this.upcomingOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -145,6 +155,7 @@ namespace StripeTests
         public async Task ListUpcomingLineItemsAsync()
         {
             var invoices = await this.service.ListUpcomingLineItemsAsync(this.upcomingOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
             Assert.Single(invoices.Data);
@@ -155,6 +166,7 @@ namespace StripeTests
         public void Pay()
         {
             var invoice = this.service.Pay(InvoiceId, this.payOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/pay");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -163,6 +175,7 @@ namespace StripeTests
         public async Task PayAsync()
         {
             var invoice = await this.service.PayAsync(InvoiceId, this.payOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/pay");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -171,6 +184,7 @@ namespace StripeTests
         public void Upcoming()
         {
             var invoice = this.service.Upcoming(this.upcomingOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -179,6 +193,7 @@ namespace StripeTests
         public async Task UpcomingAsync()
         {
             var invoice = await this.service.UpcomingAsync(this.upcomingOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -187,6 +202,7 @@ namespace StripeTests
         public void Update()
         {
             var invoice = this.service.Update(InvoiceId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -195,6 +211,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var invoice = await this.service.UpdateAsync(InvoiceId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Issuing;
@@ -36,6 +37,7 @@ namespace StripeTests.Issuing
         public void Approve()
         {
             var authorization = this.service.Approve(AuthorizationId);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123/approve");
             Assert.NotNull(authorization);
         }
 
@@ -43,6 +45,7 @@ namespace StripeTests.Issuing
         public async Task ApproveAsync()
         {
             var authorization = await this.service.ApproveAsync(AuthorizationId);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123/approve");
             Assert.NotNull(authorization);
         }
 
@@ -50,6 +53,7 @@ namespace StripeTests.Issuing
         public void Decline()
         {
             var authorization = this.service.Decline(AuthorizationId);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123/decline");
             Assert.NotNull(authorization);
         }
 
@@ -57,6 +61,7 @@ namespace StripeTests.Issuing
         public async Task DeclineAsync()
         {
             var authorization = await this.service.DeclineAsync(AuthorizationId);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123/decline");
             Assert.NotNull(authorization);
         }
 
@@ -64,6 +69,7 @@ namespace StripeTests.Issuing
         public void Get()
         {
             var authorization = this.service.Get(AuthorizationId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/authorizations/iauth_123");
             Assert.NotNull(authorization);
         }
 
@@ -71,6 +77,7 @@ namespace StripeTests.Issuing
         public async Task GetAsync()
         {
             var authorization = await this.service.GetAsync(AuthorizationId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/authorizations/iauth_123");
             Assert.NotNull(authorization);
         }
 
@@ -78,6 +85,7 @@ namespace StripeTests.Issuing
         public void List()
         {
             var authorizations = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/authorizations");
             Assert.NotNull(authorizations);
         }
 
@@ -85,6 +93,7 @@ namespace StripeTests.Issuing
         public async Task ListAsync()
         {
             var authorizations = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/authorizations");
             Assert.NotNull(authorizations);
         }
 
@@ -92,6 +101,7 @@ namespace StripeTests.Issuing
         public void Update()
         {
             var authorization = this.service.Update(AuthorizationId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123");
             Assert.NotNull(authorization);
         }
 
@@ -99,6 +109,7 @@ namespace StripeTests.Issuing
         public async Task UpdateAsync()
         {
             var authorization = await this.service.UpdateAsync(AuthorizationId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/authorizations/iauth_123");
             Assert.NotNull(authorization);
         }
     }

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -56,6 +57,7 @@ namespace StripeTests.Issuing
         public void Create()
         {
             var cardholder = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cardholders");
             Assert.NotNull(cardholder);
         }
 
@@ -63,6 +65,7 @@ namespace StripeTests.Issuing
         public async Task CreateAsync()
         {
             var cardholder = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cardholders");
             Assert.NotNull(cardholder);
         }
 
@@ -70,6 +73,7 @@ namespace StripeTests.Issuing
         public void Get()
         {
             var cardholder = this.service.Get(CardholderId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cardholders/ich_123");
             Assert.NotNull(cardholder);
         }
 
@@ -77,6 +81,7 @@ namespace StripeTests.Issuing
         public async Task GetAsync()
         {
             var cardholder = await this.service.GetAsync(CardholderId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cardholders/ich_123");
             Assert.NotNull(cardholder);
         }
 
@@ -84,6 +89,7 @@ namespace StripeTests.Issuing
         public void List()
         {
             var cardholders = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cardholders");
             Assert.NotNull(cardholders);
         }
 
@@ -91,6 +97,7 @@ namespace StripeTests.Issuing
         public async Task ListAsync()
         {
             var cardholders = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cardholders");
             Assert.NotNull(cardholders);
         }
 
@@ -98,6 +105,7 @@ namespace StripeTests.Issuing
         public void Update()
         {
             var cardholder = this.service.Update(CardholderId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cardholders/ich_123");
             Assert.NotNull(cardholder);
         }
 
@@ -105,6 +113,7 @@ namespace StripeTests.Issuing
         public async Task UpdateAsync()
         {
             var cardholder = await this.service.UpdateAsync(CardholderId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cardholders/ich_123");
             Assert.NotNull(cardholder);
         }
     }

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Issuing;
@@ -43,6 +44,7 @@ namespace StripeTests.Issuing
         public void Create()
         {
             var card = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cards");
             Assert.NotNull(card);
         }
 
@@ -50,6 +52,7 @@ namespace StripeTests.Issuing
         public async Task CreateAsync()
         {
             var card = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cards");
             Assert.NotNull(card);
         }
 
@@ -57,6 +60,7 @@ namespace StripeTests.Issuing
         public void Details()
         {
             var cardDetails = this.service.Details(CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards/ic_123/details");
             Assert.NotNull(cardDetails);
         }
 
@@ -64,6 +68,7 @@ namespace StripeTests.Issuing
         public async Task DetailsAsync()
         {
             var cardDetails = await this.service.DetailsAsync(CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards/ic_123/details");
             Assert.NotNull(cardDetails);
         }
 
@@ -71,6 +76,7 @@ namespace StripeTests.Issuing
         public void Get()
         {
             var card = this.service.Get(CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards/ic_123");
             Assert.NotNull(card);
         }
 
@@ -78,6 +84,7 @@ namespace StripeTests.Issuing
         public async Task GetAsync()
         {
             var card = await this.service.GetAsync(CardId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards/ic_123");
             Assert.NotNull(card);
         }
 
@@ -85,6 +92,7 @@ namespace StripeTests.Issuing
         public void List()
         {
             var cards = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards");
             Assert.NotNull(cards);
         }
 
@@ -92,6 +100,7 @@ namespace StripeTests.Issuing
         public async Task ListAsync()
         {
             var cards = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards");
             Assert.NotNull(cards);
         }
 
@@ -99,6 +108,7 @@ namespace StripeTests.Issuing
         public void Update()
         {
             var card = this.service.Update(CardId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cards/ic_123");
             Assert.NotNull(card);
         }
 
@@ -106,6 +116,7 @@ namespace StripeTests.Issuing
         public async Task UpdateAsync()
         {
             var card = await this.service.UpdateAsync(CardId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/cards/ic_123");
             Assert.NotNull(card);
         }
     }

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Issuing;
@@ -51,6 +52,7 @@ namespace StripeTests.Issuing
         public void Create()
         {
             var dispute = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes");
             Assert.NotNull(dispute);
         }
 
@@ -58,6 +60,7 @@ namespace StripeTests.Issuing
         public async Task CreateAsync()
         {
             var dispute = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes");
             Assert.NotNull(dispute);
         }
 
@@ -65,6 +68,7 @@ namespace StripeTests.Issuing
         public void Get()
         {
             var dispute = this.service.Get(DisputeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/disputes/idp_123");
             Assert.NotNull(dispute);
         }
 
@@ -72,6 +76,7 @@ namespace StripeTests.Issuing
         public async Task GetAsync()
         {
             var dispute = await this.service.GetAsync(DisputeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/disputes/idp_123");
             Assert.NotNull(dispute);
         }
 
@@ -79,6 +84,7 @@ namespace StripeTests.Issuing
         public void List()
         {
             var disputes = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/disputes");
             Assert.NotNull(disputes);
         }
 
@@ -86,6 +92,7 @@ namespace StripeTests.Issuing
         public async Task ListAsync()
         {
             var disputes = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/disputes");
             Assert.NotNull(disputes);
         }
 
@@ -93,6 +100,7 @@ namespace StripeTests.Issuing
         public void Update()
         {
             var dispute = this.service.Update(DisputeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes/idp_123");
             Assert.NotNull(dispute);
         }
 
@@ -100,6 +108,7 @@ namespace StripeTests.Issuing
         public async Task UpdateAsync()
         {
             var dispute = await this.service.UpdateAsync(DisputeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes/idp_123");
             Assert.NotNull(dispute);
         }
     }

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Issuing;
@@ -36,6 +37,7 @@ namespace StripeTests.Issuing
         public void Get()
         {
             var transaction = this.service.Get(TransactionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/transactions/ipi_123");
             Assert.NotNull(transaction);
         }
 
@@ -43,6 +45,7 @@ namespace StripeTests.Issuing
         public async Task GetAsync()
         {
             var transaction = await this.service.GetAsync(TransactionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/transactions/ipi_123");
             Assert.NotNull(transaction);
         }
 
@@ -50,6 +53,7 @@ namespace StripeTests.Issuing
         public void List()
         {
             var transactions = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/transactions");
             Assert.NotNull(transactions);
         }
 
@@ -57,6 +61,7 @@ namespace StripeTests.Issuing
         public async Task ListAsync()
         {
             var transactions = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/issuing/transactions");
             Assert.NotNull(transactions);
         }
 
@@ -64,6 +69,7 @@ namespace StripeTests.Issuing
         public void Update()
         {
             var transaction = this.service.Update(TransactionId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/transactions/ipi_123");
             Assert.NotNull(transaction);
         }
 
@@ -71,6 +77,7 @@ namespace StripeTests.Issuing
         public async Task UpdateAsync()
         {
             var transaction = await this.service.UpdateAsync(TransactionId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/transactions/ipi_123");
             Assert.NotNull(transaction);
         }
     }

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Create()
         {
             var loginLink = this.service.Create(AccountId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/login_links");
             Assert.NotNull(loginLink);
             Assert.Equal("login_link", loginLink.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var loginLink = await this.service.CreateAsync(AccountId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/accounts/acct_123/login_links");
             Assert.NotNull(loginLink);
             Assert.Equal("login_link", loginLink.Object);
         }

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -56,6 +57,7 @@ namespace StripeTests
         public void Create()
         {
             var order = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -64,6 +66,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var order = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -72,6 +75,7 @@ namespace StripeTests
         public void Get()
         {
             var order = this.service.Get(OrderId);
+            this.AssertRequest(HttpMethod.Get, "/v1/orders/or_123");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -80,6 +84,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var order = await this.service.GetAsync(OrderId);
+            this.AssertRequest(HttpMethod.Get, "/v1/orders/or_123");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -88,6 +93,7 @@ namespace StripeTests
         public void List()
         {
             var orders = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/orders");
             Assert.NotNull(orders);
             Assert.Equal("list", orders.Object);
             Assert.Single(orders.Data);
@@ -98,6 +104,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var orders = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/orders");
             Assert.NotNull(orders);
             Assert.Equal("list", orders.Object);
             Assert.Single(orders.Data);
@@ -108,6 +115,7 @@ namespace StripeTests
         public void Pay()
         {
             var order = this.service.Pay(OrderId, this.payOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123/pay");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -116,6 +124,7 @@ namespace StripeTests
         public async Task PayAsync()
         {
             var order = await this.service.PayAsync(OrderId, this.payOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123/pay");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -124,6 +133,7 @@ namespace StripeTests
         public void Update()
         {
             var order = this.service.Update(OrderId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
@@ -132,6 +142,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var order = await this.service.UpdateAsync(OrderId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -69,6 +70,7 @@ namespace StripeTests
         public void Cancel()
         {
             var intent = this.service.Cancel(PaymentIntentId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/cancel");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -77,6 +79,7 @@ namespace StripeTests
         public async Task CancelAsync()
         {
             var intent = await this.service.CancelAsync(PaymentIntentId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/cancel");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -85,6 +88,7 @@ namespace StripeTests
         public void Capture()
         {
             var intent = this.service.Capture(PaymentIntentId, this.captureOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/capture");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -93,6 +97,7 @@ namespace StripeTests
         public async Task CaptureAsync()
         {
             var intent = await this.service.CaptureAsync(PaymentIntentId, this.captureOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/capture");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -101,6 +106,7 @@ namespace StripeTests
         public void Confirm()
         {
             var intent = this.service.Confirm(PaymentIntentId, this.confirmOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/confirm");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -109,6 +115,7 @@ namespace StripeTests
         public async Task ConfirmAsync()
         {
             var intent = await this.service.ConfirmAsync(PaymentIntentId, this.confirmOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123/confirm");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -117,6 +124,7 @@ namespace StripeTests
         public void Create()
         {
             var intent = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -125,6 +133,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var intent = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -133,6 +142,7 @@ namespace StripeTests
         public void Get()
         {
             var intent = this.service.Get(PaymentIntentId);
+            this.AssertRequest(HttpMethod.Get, "/v1/payment_intents/pi_123");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -141,6 +151,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var intent = await this.service.GetAsync(PaymentIntentId);
+            this.AssertRequest(HttpMethod.Get, "/v1/payment_intents/pi_123");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -149,6 +160,7 @@ namespace StripeTests
         public void List()
         {
             var intents = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/payment_intents");
             Assert.NotNull(intents);
             Assert.Equal("list", intents.Object);
             Assert.Single(intents.Data);
@@ -159,6 +171,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var intents = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/payment_intents");
             Assert.NotNull(intents);
             Assert.Equal("list", intents.Object);
             Assert.Single(intents.Data);
@@ -169,6 +182,7 @@ namespace StripeTests
         public void Update()
         {
             var intent = this.service.Update(PaymentIntentId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
@@ -177,6 +191,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var intent = await this.service.UpdateAsync(PaymentIntentId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payment_intents/pi_123");
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var payout = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var payout = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Cancel()
         {
             var payout = this.service.Cancel(PayoutId);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts/po_123/cancel");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -67,6 +71,7 @@ namespace StripeTests
         public async Task CancelAsync()
         {
             var payout = await this.service.CancelAsync(PayoutId);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts/po_123/cancel");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -75,6 +80,7 @@ namespace StripeTests
         public void Get()
         {
             var payout = this.service.Get(PayoutId);
+            this.AssertRequest(HttpMethod.Get, "/v1/payouts/po_123");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -83,6 +89,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var payout = await this.service.GetAsync(PayoutId);
+            this.AssertRequest(HttpMethod.Get, "/v1/payouts/po_123");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -91,6 +98,7 @@ namespace StripeTests
         public void List()
         {
             var payouts = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/payouts");
             Assert.NotNull(payouts);
             Assert.Equal("list", payouts.Object);
             Assert.Single(payouts.Data);
@@ -101,6 +109,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var payouts = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/payouts");
             Assert.NotNull(payouts);
             Assert.Equal("list", payouts.Object);
             Assert.Single(payouts.Data);
@@ -111,6 +120,7 @@ namespace StripeTests
         public void Update()
         {
             var payout = this.service.Update(PayoutId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts/po_123");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
@@ -119,6 +129,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var payout = await this.service.UpdateAsync(PayoutId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/payouts/po_123");
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -49,6 +50,7 @@ namespace StripeTests
         public void Create()
         {
             var plan = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
@@ -57,6 +59,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var plan = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
@@ -65,6 +68,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(PlanId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/plans/plan_123");
             Assert.NotNull(deleted);
         }
 
@@ -72,6 +76,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(PlanId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/plans/plan_123");
             Assert.NotNull(deleted);
         }
 
@@ -79,6 +84,7 @@ namespace StripeTests
         public void Get()
         {
             var plan = this.service.Get(PlanId);
+            this.AssertRequest(HttpMethod.Get, "/v1/plans/plan_123");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
@@ -87,6 +93,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var plan = await this.service.GetAsync(PlanId);
+            this.AssertRequest(HttpMethod.Get, "/v1/plans/plan_123");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
@@ -95,6 +102,7 @@ namespace StripeTests
         public void List()
         {
             var plans = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/plans");
             Assert.NotNull(plans);
             Assert.Equal("list", plans.Object);
             Assert.Single(plans.Data);
@@ -105,6 +113,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var plans = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/plans");
             Assert.NotNull(plans);
             Assert.Equal("list", plans.Object);
             Assert.Single(plans.Data);
@@ -115,6 +124,7 @@ namespace StripeTests
         public void Update()
         {
             var plan = this.service.Update(PlanId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans/plan_123");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
@@ -123,6 +133,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var plan = await this.service.UpdateAsync(PlanId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans/plan_123");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -55,6 +56,7 @@ namespace StripeTests
         public void Create()
         {
             var product = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/products");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
@@ -63,6 +65,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var product = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/products");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
@@ -71,6 +74,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(ProductId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/products/prod_123");
             Assert.NotNull(deleted);
         }
 
@@ -78,6 +82,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(ProductId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/products/prod_123");
             Assert.NotNull(deleted);
         }
 
@@ -85,6 +90,7 @@ namespace StripeTests
         public void Get()
         {
             var product = this.service.Get(ProductId);
+            this.AssertRequest(HttpMethod.Get, "/v1/products/prod_123");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
@@ -93,6 +99,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var product = await this.service.GetAsync(ProductId);
+            this.AssertRequest(HttpMethod.Get, "/v1/products/prod_123");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
@@ -101,6 +108,7 @@ namespace StripeTests
         public void List()
         {
             var products = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/products");
             Assert.NotNull(products);
             Assert.Equal("list", products.Object);
             Assert.Single(products.Data);
@@ -111,6 +119,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var products = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/products");
             Assert.NotNull(products);
             Assert.Equal("list", products.Object);
             Assert.Single(products.Data);
@@ -121,6 +130,7 @@ namespace StripeTests
         public void Update()
         {
             var product = this.service.Update(ProductId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/products/prod_123");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
@@ -129,6 +139,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var product = await this.service.UpdateAsync(ProductId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/products/prod_123");
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var refund = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/refunds");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var refund = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/refunds");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Get()
         {
             var refund = this.service.Get(RefundId);
+            this.AssertRequest(HttpMethod.Get, "/v1/refunds/re_123");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -67,6 +71,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var refund = await this.service.GetAsync(RefundId);
+            this.AssertRequest(HttpMethod.Get, "/v1/refunds/re_123");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -75,6 +80,7 @@ namespace StripeTests
         public void List()
         {
             var refunds = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/refunds");
             Assert.NotNull(refunds);
             Assert.Equal("list", refunds.Object);
             Assert.Single(refunds.Data);
@@ -85,6 +91,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var refunds = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/refunds");
             Assert.NotNull(refunds);
             Assert.Equal("list", refunds.Object);
             Assert.Single(refunds.Data);
@@ -95,6 +102,7 @@ namespace StripeTests
         public void Update()
         {
             var refund = this.service.Update(RefundId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/refunds/re_123");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
@@ -103,6 +111,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var refund = await this.service.UpdateAsync(RefundId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/refunds/re_123");
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests.Reporting
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Reporting;
@@ -38,6 +39,7 @@ namespace StripeTests.Reporting
         public void Create()
         {
             var reportRun = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/reporting/report_runs");
             Assert.NotNull(reportRun);
         }
 
@@ -45,6 +47,7 @@ namespace StripeTests.Reporting
         public async Task CreateAsync()
         {
             var reportRun = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/reporting/report_runs");
             Assert.NotNull(reportRun);
         }
 
@@ -52,6 +55,7 @@ namespace StripeTests.Reporting
         public void Get()
         {
             var reportRun = this.service.Get(ReportRunId);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_runs/frr_123");
             Assert.NotNull(reportRun);
         }
 
@@ -59,6 +63,7 @@ namespace StripeTests.Reporting
         public async Task GetAsync()
         {
             var reportRun = await this.service.GetAsync(ReportRunId);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_runs/frr_123");
             Assert.NotNull(reportRun);
         }
 
@@ -66,6 +71,7 @@ namespace StripeTests.Reporting
         public void List()
         {
             var reportRuns = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_runs");
             Assert.NotNull(reportRuns);
         }
 
@@ -73,6 +79,7 @@ namespace StripeTests.Reporting
         public async Task ListAsync()
         {
             var reportRuns = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_runs");
             Assert.NotNull(reportRuns);
         }
     }

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests.Reporting
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Reporting;
@@ -27,6 +28,7 @@ namespace StripeTests.Reporting
         public void Get()
         {
             var reportType = this.service.Get(ReportTypeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types/activity.summary.1");
             Assert.NotNull(reportType);
         }
 
@@ -34,6 +36,7 @@ namespace StripeTests.Reporting
         public async Task GetAsync()
         {
             var reportType = await this.service.GetAsync(ReportTypeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types/activity.summary.1");
             Assert.NotNull(reportType);
         }
 
@@ -41,6 +44,7 @@ namespace StripeTests.Reporting
         public void List()
         {
             var reportTypes = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types");
             Assert.NotNull(reportTypes);
         }
 
@@ -48,6 +52,7 @@ namespace StripeTests.Reporting
         public async Task ListAsync()
         {
             var reportTypes = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types");
             Assert.NotNull(reportTypes);
         }
     }

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe.Sigma;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Get()
         {
             var run = this.service.Get(ScheduledQueryId);
+            this.AssertRequest(HttpMethod.Get, "/v1/sigma/scheduled_query_runs/sqr_123");
             Assert.NotNull(run);
             Assert.Equal("scheduled_query_run", run.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var run = await this.service.GetAsync(ScheduledQueryId);
+            this.AssertRequest(HttpMethod.Get, "/v1/sigma/scheduled_query_runs/sqr_123");
             Assert.NotNull(run);
             Assert.Equal("scheduled_query_run", run.Object);
         }
@@ -43,6 +46,7 @@ namespace StripeTests
         public void List()
         {
             var runs = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/sigma/scheduled_query_runs");
             Assert.NotNull(runs);
             Assert.Equal("list", runs.Object);
             Assert.Single(runs.Data);
@@ -53,6 +57,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var runs = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/sigma/scheduled_query_runs");
             Assert.NotNull(runs);
             Assert.Equal("list", runs.Object);
             Assert.Single(runs.Data);

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -8,7 +9,7 @@ namespace StripeTests
 
     public class SkuServiceTest : BaseStripeTest
     {
-        private const string SkuId = "prod_123";
+        private const string SkuId = "sku_123";
 
         private SkuService service;
         private SkuCreateOptions createOptions;
@@ -61,6 +62,7 @@ namespace StripeTests
         public void Create()
         {
             var sku = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/skus");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
@@ -69,6 +71,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var sku = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/skus");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
@@ -77,6 +80,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(SkuId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/skus/sku_123");
             Assert.NotNull(deleted);
         }
 
@@ -84,6 +88,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(SkuId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/skus/sku_123");
             Assert.NotNull(deleted);
         }
 
@@ -91,6 +96,7 @@ namespace StripeTests
         public void Get()
         {
             var sku = this.service.Get(SkuId);
+            this.AssertRequest(HttpMethod.Get, "/v1/skus/sku_123");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
@@ -99,6 +105,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var sku = await this.service.GetAsync(SkuId);
+            this.AssertRequest(HttpMethod.Get, "/v1/skus/sku_123");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
@@ -107,6 +114,7 @@ namespace StripeTests
         public void List()
         {
             var skus = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/skus");
             Assert.NotNull(skus);
             Assert.Equal("list", skus.Object);
             Assert.Single(skus.Data);
@@ -117,6 +125,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var skus = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/skus");
             Assert.NotNull(skus);
             Assert.Equal("list", skus.Object);
             Assert.Single(skus.Data);
@@ -127,6 +136,7 @@ namespace StripeTests
         public void Update()
         {
             var sku = this.service.Update(SkuId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/skus/sku_123");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
@@ -135,6 +145,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var sku = await this.service.UpdateAsync(SkuId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/skus/sku_123");
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -75,6 +76,7 @@ namespace StripeTests
         public void Create()
         {
             var source = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/sources");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -83,6 +85,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var source = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/sources");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -91,6 +94,7 @@ namespace StripeTests
         public void Detach()
         {
             var source = this.service.Detach(CustomerId, SourceId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -99,6 +103,7 @@ namespace StripeTests
         public async Task DetachAsync()
         {
             var source = await this.service.DetachAsync(CustomerId, SourceId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/customers/cus_123/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -107,6 +112,7 @@ namespace StripeTests
         public void Get()
         {
             var source = this.service.Get(SourceId);
+            this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -115,6 +121,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var source = await this.service.GetAsync(SourceId);
+            this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -123,6 +130,7 @@ namespace StripeTests
         public void List()
         {
             var sources = this.service.List(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(sources);
             Assert.Equal("list", sources.Object);
             Assert.Single(sources.Data);
@@ -133,6 +141,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var sources = await this.service.ListAsync(CustomerId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/customers/cus_123/sources");
             Assert.NotNull(sources);
             Assert.Equal("list", sources.Object);
             Assert.Single(sources.Data);
@@ -143,6 +152,7 @@ namespace StripeTests
         public void Update()
         {
             var source = this.service.Update(SourceId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }
@@ -151,6 +161,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var source = await this.service.UpdateAsync(SourceId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/sources/src_123");
             Assert.NotNull(source);
             Assert.Equal("source", source.Object);
         }

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -45,6 +46,7 @@ namespace StripeTests
         public void Create()
         {
             var subscriptionItem = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
@@ -53,6 +55,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var subscriptionItem = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
@@ -61,6 +64,7 @@ namespace StripeTests
         public void Delete()
         {
             var deleted = this.service.Delete(SubscriptionItemId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscription_items/si_123");
             Assert.NotNull(deleted);
         }
 
@@ -68,6 +72,7 @@ namespace StripeTests
         public async Task DeleteAsync()
         {
             var deleted = await this.service.DeleteAsync(SubscriptionItemId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscription_items/si_123");
             Assert.NotNull(deleted);
         }
 
@@ -75,6 +80,7 @@ namespace StripeTests
         public void Get()
         {
             var subscriptionItem = this.service.Get(SubscriptionItemId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
@@ -83,6 +89,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var subscriptionItem = await this.service.GetAsync(SubscriptionItemId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
@@ -91,6 +98,7 @@ namespace StripeTests
         public void List()
         {
             var subscriptionItems = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items");
             Assert.NotNull(subscriptionItems);
             Assert.Equal("list", subscriptionItems.Object);
             Assert.Single(subscriptionItems.Data);
@@ -101,6 +109,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var subscriptionItems = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items");
             Assert.NotNull(subscriptionItems);
             Assert.Equal("list", subscriptionItems.Object);
             Assert.Single(subscriptionItems.Data);
@@ -111,6 +120,7 @@ namespace StripeTests
         public void Update()
         {
             var subscriptionItem = this.service.Update(SubscriptionItemId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items/si_123");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
@@ -119,6 +129,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var subscriptionItem = await this.service.UpdateAsync(SubscriptionItemId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items/si_123");
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -60,6 +61,7 @@ namespace StripeTests
         public void Cancel()
         {
             var subscription = this.service.Cancel(SubscriptionId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -68,6 +70,7 @@ namespace StripeTests
         public async Task CancelAsync()
         {
             var subscription = await this.service.CancelAsync(SubscriptionId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Delete, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -76,6 +79,7 @@ namespace StripeTests
         public void Create()
         {
             var subscription = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscriptions");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -84,6 +88,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var subscription = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscriptions");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -92,6 +97,7 @@ namespace StripeTests
         public void Get()
         {
             var subscription = this.service.Get(SubscriptionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -100,6 +106,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var subscription = await this.service.GetAsync(SubscriptionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -108,6 +115,7 @@ namespace StripeTests
         public void List()
         {
             var subscriptions = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscriptions");
             Assert.NotNull(subscriptions);
             Assert.Equal("list", subscriptions.Object);
             Assert.Single(subscriptions.Data);
@@ -118,6 +126,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var subscriptions = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscriptions");
             Assert.NotNull(subscriptions);
             Assert.Equal("list", subscriptions.Object);
             Assert.Single(subscriptions.Data);
@@ -128,6 +137,7 @@ namespace StripeTests
         public void Update()
         {
             var subscription = this.service.Update(SubscriptionId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
@@ -136,6 +146,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var subscription = await this.service.UpdateAsync(SubscriptionId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscriptions/sub_123");
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -27,6 +28,7 @@ namespace StripeTests
         public void Create()
         {
             var threeDSecure = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/3d_secure");
             Assert.NotNull(threeDSecure);
             Assert.Equal("three_d_secure", threeDSecure.Object);
         }
@@ -35,6 +37,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var threeDSecure = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/3d_secure");
             Assert.NotNull(threeDSecure);
             Assert.Equal("three_d_secure", threeDSecure.Object);
         }

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -41,6 +42,7 @@ namespace StripeTests
         public void Create()
         {
             var token = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tokens");
             Assert.NotNull(token);
             Assert.Equal("token", token.Object);
         }
@@ -49,6 +51,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var token = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tokens");
             Assert.NotNull(token);
             Assert.Equal("token", token.Object);
         }
@@ -57,6 +60,7 @@ namespace StripeTests
         public void Get()
         {
             var token = this.service.Get(TokenId);
+            this.AssertRequest(HttpMethod.Get, "/v1/tokens/tok_123");
             Assert.NotNull(token);
             Assert.Equal("token", token.Object);
         }
@@ -65,6 +69,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var token = await this.service.GetAsync(TokenId);
+            this.AssertRequest(HttpMethod.Get, "/v1/tokens/tok_123");
             Assert.NotNull(token);
             Assert.Equal("token", token.Object);
         }

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -8,7 +9,7 @@ namespace StripeTests
 
     public class TopupServiceTest : BaseStripeTest
     {
-        private const string TopupId = "po_123";
+        private const string TopupId = "tu_123";
 
         private TopupService service;
         private TopupCreateOptions createOptions;
@@ -44,6 +45,7 @@ namespace StripeTests
         public void Cancel()
         {
             var topup = this.service.Cancel(TopupId);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups/tu_123/cancel");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -52,6 +54,7 @@ namespace StripeTests
         public async Task CancelAsync()
         {
             var topup = await this.service.CancelAsync(TopupId);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups/tu_123/cancel");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -60,6 +63,7 @@ namespace StripeTests
         public void Create()
         {
             var topup = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -68,6 +72,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var topup = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -76,6 +81,7 @@ namespace StripeTests
         public void Get()
         {
             var topup = this.service.Get(TopupId);
+            this.AssertRequest(HttpMethod.Get, "/v1/topups/tu_123");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -84,6 +90,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var topup = await this.service.GetAsync(TopupId);
+            this.AssertRequest(HttpMethod.Get, "/v1/topups/tu_123");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -92,6 +99,7 @@ namespace StripeTests
         public void List()
         {
             var topups = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/topups");
             Assert.NotNull(topups);
             Assert.Equal("list", topups.Object);
             Assert.Single(topups.Data);
@@ -102,6 +110,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var topups = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/topups");
             Assert.NotNull(topups);
             Assert.Equal("list", topups.Object);
             Assert.Single(topups.Data);
@@ -112,6 +121,7 @@ namespace StripeTests
         public void Update()
         {
             var topup = this.service.Update(TopupId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups/tu_123");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
@@ -120,6 +130,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var topup = await this.service.UpdateAsync(TopupId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/topups/tu_123");
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -43,6 +44,7 @@ namespace StripeTests
         public void Create()
         {
             var transferReversal = this.service.Create(TransferId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123/reversals");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
@@ -51,6 +53,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var transferReversal = await this.service.CreateAsync(TransferId, this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123/reversals");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
@@ -59,6 +62,7 @@ namespace StripeTests
         public void Get()
         {
             var transferReversal = this.service.Get(TransferId, TransferReversalId);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals/trr_123");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
@@ -67,6 +71,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var transferReversal = await this.service.GetAsync(TransferId, TransferReversalId);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals/trr_123");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
@@ -75,6 +80,7 @@ namespace StripeTests
         public void List()
         {
             var transfers = this.service.List(TransferId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals");
             Assert.NotNull(transfers);
             Assert.Equal("list", transfers.Object);
             Assert.Single(transfers.Data);
@@ -85,6 +91,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var transfers = await this.service.ListAsync(TransferId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals");
             Assert.NotNull(transfers);
             Assert.Equal("list", transfers.Object);
             Assert.Single(transfers.Data);
@@ -95,6 +102,7 @@ namespace StripeTests
         public void Update()
         {
             var transferReversal = this.service.Update(TransferId, TransferReversalId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123/reversals/trr_123");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
@@ -103,6 +111,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var transferReversal = await this.service.UpdateAsync(TransferId, TransferReversalId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123/reversals/trr_123");
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -44,6 +45,7 @@ namespace StripeTests
         public void Create()
         {
             var transfer = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
@@ -52,6 +54,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var transfer = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
@@ -60,6 +63,7 @@ namespace StripeTests
         public void Get()
         {
             var transfer = this.service.Get(TransferId);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
@@ -68,6 +72,7 @@ namespace StripeTests
         public async Task GetAsync()
         {
             var transfer = await this.service.GetAsync(TransferId);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
@@ -76,6 +81,7 @@ namespace StripeTests
         public void List()
         {
             var transfers = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers");
             Assert.NotNull(transfers);
             Assert.Equal("list", transfers.Object);
             Assert.Single(transfers.Data);
@@ -86,6 +92,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var transfers = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/transfers");
             Assert.NotNull(transfers);
             Assert.Equal("list", transfers.Object);
             Assert.Single(transfers.Data);
@@ -96,6 +103,7 @@ namespace StripeTests
         public void Update()
         {
             var transfer = this.service.Update(TransferId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
@@ -104,6 +112,7 @@ namespace StripeTests
         public async Task UpdateAsync()
         {
             var transfer = await this.service.UpdateAsync(TransferId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/transfers/tr_123");
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -16,13 +17,17 @@ namespace StripeTests
         {
             this.service = new UsageRecordSummaryService();
 
-            this.listOptions = new UsageRecordSummaryListOptions();
+            this.listOptions = new UsageRecordSummaryListOptions()
+            {
+                Limit = 1,
+            };
         }
 
         [Fact]
         public void List()
         {
             var summaries = this.service.List("si_123", this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123/usage_record_summaries");
             Assert.NotNull(summaries);
             Assert.Equal("list", summaries.Object);
             Assert.Single(summaries.Data);
@@ -33,6 +38,7 @@ namespace StripeTests
         public async Task ListAsync()
         {
             var summaries = await this.service.ListAsync("si_123", this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123/usage_record_summaries");
             Assert.NotNull(summaries);
             Assert.Equal("list", summaries.Object);
             Assert.Single(summaries.Data);

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
 
     using Stripe;
@@ -28,6 +29,7 @@ namespace StripeTests
         public void Create()
         {
             var plan = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items/si_123/usage_records");
             Assert.NotNull(plan);
             Assert.Equal("usage_record", plan.Object);
         }
@@ -36,6 +38,7 @@ namespace StripeTests
         public async Task CreateAsync()
         {
             var plan = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_items/si_123/usage_records");
             Assert.NotNull(plan);
             Assert.Equal("usage_record", plan.Object);
         }

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add support for verifying requests in tests.

Some notes:

- I had to disable parallel test execution. I suspect the mock object breaks thread-safety in some way. The test suite is fast now that we use stripe-mock so this isn't a huge deal.

- Right now, we can only check the HTTP method and path -- the body is stored in an object that is GC'd by the time `AssertRequest` is called. This is probably solvable by replacing the default mock by a more complex object that would store the body.
