### PR TITLE
Create coverage report and upload to coveralls.io

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ version: 19.9.2.{build}
 image: Visual Studio 2017
 
 environment:
-  STRIPE_TEST_SK: sk_test_eBgAzVoEpJKfYjD9nf2YoyMM
+  COVERALLS_REPO_TOKEN:
+    secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `BaseStripeTest.cs` as well.
   STRIPE_MOCK_VERSION: 0.33.0
 
@@ -27,6 +28,7 @@ install:
       }
       $app = Start-Process -FilePath "stripe-mock\stripe-mock.exe" -NoNewWindow -PassThru
       Write-Host ("stripe-mock running, Id = $($app.Id)`n") -ForegroundColor Green
+  - dotnet tool install coveralls.net --version 1.0.0 --tool-path tools
 
 before_build:
   - ps: Write-Host $("`n               HOST INFORMATION               `n") -BackgroundColor DarkCyan
@@ -48,8 +50,13 @@ after_build:
   - dotnet pack -c Release src\Stripe.net
 
 test_script:
-  - ps: Write-Host $("`n               RUNNING THE NEW XUNIT + STRIPE-MOCK TESTS               `n") -BackgroundColor DarkCyan
+  - ps: Write-Host $("`n               RUNNING TESTS               `n") -BackgroundColor DarkCyan
   - dotnet test src\StripeTests\StripeTests.csproj
+
+after_test:
+  - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
+  - dotnet test -c Debug -f netcoreapp2.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+  - .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.opencover.xml --useRelativePaths
 
 artifacts:
   - path: '**\*.nupkg'

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# Stripe.net [![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet) [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
+# Stripe.net
+[![Build status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet) [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
 The official Stripe library, supporting .NET Standard 1.2+, .NET Core 1.0+, and .NET Framework 4.5+
 

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.10.0" />


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

This PR uses [coverlet](https://github.com/tonerdo/coverlet) to compute a coverage report and [coveralls.net](https://github.com/csMACnz/coveralls.net) to upload the report to coveralls.io.

Results can be viewed here: https://coveralls.io/github/stripe/stripe-dotnet

I had to add a new target framework `.netcoreapp2.1` in the `StripeTests` project because coverlet won't run with `.netcoreapp1.1`, but I think it's not a bad thing to test the library against more versions anyway.
