### PR TITLE
Fix artifacts path in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ after_test:
   - .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.opencover.xml --useRelativePaths
 
 artifacts:
-  - path: '**\*.nupkg'
+  - path: 'src\Stripe.net\bin\Release\*.nupkg'
 
 # these commands tell appveyor to open an RDP session for debugging
 #init:


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Just noticed that after merging #1318, the coveralls.net `.nupkg` file is included in the build artifacts (https://ci.appveyor.com/project/stripe/stripe-dotnet/build/19.9.2.1608#L352), so I think Appveyor would try to push it to Nuget in the next tagged version. This PR prevents that (https://ci.appveyor.com/project/stripe/stripe-dotnet/build/19.9.2.1618#L364).

