### PR TITLE
Use IHasObject interface instead of dynamic for data.object attribute of event objects

### DIFF
--- a/src/Stripe.net/Entities/Events/EventData.cs
+++ b/src/Stripe.net/Entities/Events/EventData.cs
@@ -1,11 +1,12 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class EventData : StripeEntity
     {
         [JsonProperty("object")]
-        public dynamic Object { get; set; }
+        public IHasObject Object { get; set; }
 
         [JsonProperty("previous_attributes")]
         public dynamic PreviousAttributes { get; set; }

--- a/src/Stripe.net/Entities/Orders/OrderItem.cs
+++ b/src/Stripe.net/Entities/Orders/OrderItem.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class OrderItem : StripeEntity
+    public class OrderItem : StripeEntity, IHasObject
     {
         [JsonProperty("object")]
         public string Object { get; set; }

--- a/src/Stripe.net/Infrastructure/JsonConverters/StripeObjectConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/StripeObjectConverter.cs
@@ -1,0 +1,72 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// This converter is used to deserialize attributes declared as `IHasObject` into concrete
+    /// model classes. In other words, this converter can deserialize any Stripe object based on
+    /// the value of the <c>object</c> attribute. This is useful when the type of the object has
+    /// to be determined at runtime, such as when decoding the <c>data.object</c> attribute of
+    /// event objects.
+    /// </summary>
+    internal class StripeObjectConverter : AbstractStripeObjectConverter<IHasObject>
+    {
+        protected override Dictionary<string, Func<string, IHasObject>> ObjectsToMapperFuncs
+            => new Dictionary<string, Func<string, IHasObject>>()
+        {
+            { "account", Mapper<Account>.MapFromJson },
+            { "apple_pay_domain", Mapper<ApplePayDomain>.MapFromJson },
+            { "application_fee", Mapper<ApplicationFee>.MapFromJson },
+            { "balance", Mapper<Balance>.MapFromJson },
+            { "balance_transaction", Mapper<BalanceTransaction>.MapFromJson },
+            { "bank_account", Mapper<BankAccount>.MapFromJson },
+            { "card", Mapper<Card>.MapFromJson },
+            { "charge", Mapper<Charge>.MapFromJson },
+            { "country_spec", Mapper<CountrySpec>.MapFromJson },
+            { "coupon", Mapper<Coupon>.MapFromJson },
+            { "customer", Mapper<Customer>.MapFromJson },
+            { "discount", Mapper<Discount>.MapFromJson },
+            { "dispute", Mapper<Dispute>.MapFromJson },
+            { "ephemeral_key", Mapper<EphemeralKey>.MapFromJson },
+            { "event", Mapper<Event>.MapFromJson },
+            { "exchange_rate", Mapper<ExchangeRate>.MapFromJson },
+            { "fee_refund", Mapper<ApplicationFeeRefund>.MapFromJson },
+            { "file", Mapper<File>.MapFromJson },
+            { "file_link", Mapper<FileLink>.MapFromJson },
+            { "invoice", Mapper<Invoice>.MapFromJson },
+            { "invoiceitem", Mapper<InvoiceItem>.MapFromJson },
+            { "issuing.authorization", Mapper<Issuing.Authorization>.MapFromJson },
+            { "issuing.cardholder", Mapper<Issuing.Cardholder>.MapFromJson },
+            { "issuing.card", Mapper<Issuing.Card>.MapFromJson },
+            { "issuing.dispute", Mapper<Issuing.Dispute>.MapFromJson },
+            { "issuing.transaction", Mapper<Issuing.Transaction>.MapFromJson },
+            { "login_link", Mapper<LoginLink>.MapFromJson },
+            { "order", Mapper<Order>.MapFromJson },
+            { "order_item", Mapper<OrderItem>.MapFromJson },
+            { "order_return", Mapper<OrderReturn>.MapFromJson },
+            { "payment_intent", Mapper<PaymentIntent>.MapFromJson },
+            { "payout", Mapper<Payout>.MapFromJson },
+            { "plan", Mapper<Plan>.MapFromJson },
+            { "product", Mapper<Product>.MapFromJson },
+            { "recipient", Mapper<Recipient>.MapFromJson },
+            { "refund", Mapper<Refund>.MapFromJson },
+            { "reporting.report_run", Mapper<Reporting.ReportRun>.MapFromJson },
+            { "reporting.report_type", Mapper<Reporting.ReportType>.MapFromJson },
+            { "scheduled_query_run", Mapper<Sigma.ScheduledQueryRun>.MapFromJson },
+            { "sku", Mapper<Sku>.MapFromJson },
+            { "source", Mapper<Source>.MapFromJson },
+            { "source_mandate_notification", Mapper<SourceMandateNotification>.MapFromJson },
+            { "source_transaction", Mapper<SourceTransaction>.MapFromJson },
+            { "subscription", Mapper<Subscription>.MapFromJson },
+            { "subscription_item", Mapper<SubscriptionItem>.MapFromJson },
+            { "three_d_secure", Mapper<ThreeDSecure>.MapFromJson },
+            { "token", Mapper<Token>.MapFromJson },
+            { "topup", Mapper<Topup>.MapFromJson },
+            { "transfer", Mapper<Transfer>.MapFromJson },
+            { "transfer_reversal", Mapper<TransferReversal>.MapFromJson },
+            { "usage_record", Mapper<UsageRecord>.MapFromJson },
+            { "usage_record_summary", Mapper<UsageRecordSummary>.MapFromJson },
+        };
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/Mapper.cs
+++ b/src/Stripe.net/Infrastructure/Public/Mapper.cs
@@ -14,6 +14,7 @@ namespace Stripe
             new DateTimeConverter(),
             new ExternalAccountConverter(),
             new PaymentSourceConverter(),
+            new StripeObjectConverter(),
         };
 
         public static List<T> MapCollectionFromJson(string json, string token = "data", StripeResponse stripeResponse = null)

--- a/src/StripeTests/Entities/Events/EventTest.cs
+++ b/src/StripeTests/Entities/Events/EventTest.cs
@@ -2,9 +2,6 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
-
-    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -19,6 +16,27 @@ namespace StripeTests
             Assert.IsType<Event>(evt);
             Assert.NotNull(evt.Id);
             Assert.Equal("event", evt.Object);
+
+            Assert.NotNull(evt.Data);
+            Assert.NotNull(evt.Data.Object);
+            Assert.IsType<Customer>(evt.Data.Object);
+        }
+
+        [Fact]
+        public void DeserializePreviousAttributes()
+        {
+            var json = GetResourceAsString("api_fixtures.events.customer_updated.json");
+            var evt = Mapper<Event>.MapFromJson(json);
+            Assert.NotNull(evt);
+            Assert.IsType<Event>(evt);
+            Assert.NotNull(evt.Id);
+            Assert.Equal("event", evt.Object);
+
+            Assert.NotNull(evt.Data);
+            Assert.NotNull(evt.Data.PreviousAttributes);
+            Assert.NotNull(evt.Data.PreviousAttributes.metadata);
+            Assert.NotNull(evt.Data.PreviousAttributes.metadata["foo"]);
+            Assert.Equal("bar", (string)evt.Data.PreviousAttributes.metadata["foo"]);
         }
     }
 }

--- a/src/StripeTests/Resources/api_fixtures/events/customer_updated.json
+++ b/src/StripeTests/Resources/api_fixtures/events/customer_updated.json
@@ -1,0 +1,80 @@
+{
+  "api_version": "2018-09-24",
+  "created": 1538742675,
+  "data": {
+    "object": {
+      "account_balance": 0,
+      "created": 1538742657,
+      "currency": null,
+      "default_source": "card_1DHsSLKCFFPkgtRh2n45D5HN",
+      "delinquent": false,
+      "description": "Test customer",
+      "discount": null,
+      "email": null,
+      "id": "cus_DjL8lObxrWj04W",
+      "invoice_prefix": "EF4DEC0",
+      "livemode": false,
+      "metadata": {
+        "foo": "baz"
+      },
+      "object": "customer",
+      "shipping": null,
+      "sources": {
+        "data": [
+          {
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_DjL8lObxrWj04W",
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 10,
+            "exp_year": 2019,
+            "fingerprint": "NrVafqTONZfbLkQK",
+            "funding": "credit",
+            "id": "card_1DHsSLKCFFPkgtRh2n45D5HN",
+            "last4": "4242",
+            "metadata": {},
+            "name": null,
+            "object": "card",
+            "tokenization_method": null
+          }
+        ],
+        "has_more": false,
+        "object": "list",
+        "total_count": 1,
+        "url": "/v1/customers/cus_DjL8lObxrWj04W/sources"
+      },
+      "subscriptions": {
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "total_count": 0,
+        "url": "/v1/customers/cus_DjL8lObxrWj04W/subscriptions"
+      },
+      "tax_info": null,
+      "tax_info_verification": null
+    },
+    "previous_attributes": {
+      "metadata": {
+        "foo": "bar"
+      }
+    }
+  },
+  "id": "evt_1DHsSdKCFFPkgtRhy4YMdffC",
+  "livemode": false,
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_w9JioK0o4mriXj",
+    "idempotency_key": "364f382e-9469-4dc3-b4d0-83c930ade869"
+  },
+  "type": "customer.updated"
+}

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries @fred-stripe 

This PR changes the declaration of the `Object` property in `EventData` to be an `IHasObject` instead of `dynamic`, and adds a new `StripeObjectConverter` that can instantiate any Stripe model class based on the value of the `object` attribute.

Replaces #1129.

Some notes:

- technically, not all objects can be found in events, so this could have been implemented by adding a new interface (`IEventDataObject`), tagging classes for resources that can be found in events with this interface, and adding a converter that only handles those resources. But this works just as well and means that the library won't have to be updated if we suddenly decide to add new event types for existing resources.

- I added a test for `PreviousAttributes` as well, mostly because I was curious how Newtonsoft.Json handled deserialization of `dynamic` properties. It's actually quite nifty: it gives you an object that lets you access all properties of the JSON via methods (`.metadata`) or indexes (`["foo"]`). Of course you don't have any type safety and have to cast manually, but we can't make any assumptions on the shape of `previous_attributes` so that seems reasonable. (To be clear, this is already how the library works today -- I just added a test.)
