### PR TITLE
Fix warning in .NET Framework specific code

### DIFF
--- a/src/Stripe.net/Infrastructure/Client.cs
+++ b/src/Stripe.net/Infrastructure/Client.cs
@@ -31,6 +31,30 @@ namespace Stripe.Infrastructure
             this.RequestMessage.Headers.Add("X-Stripe-Client-User-Agent", this.GetClientUserAgentString());
         }
 
+#if NET45
+        private static string GetMonoVersion()
+        {
+            Type monoRuntimeType = typeof(object).Assembly.GetType("Mono.Runtime");
+
+            if (monoRuntimeType != null)
+            {
+                MethodInfo getDisplayNameMethod = monoRuntimeType.GetMethod(
+                    "GetDisplayName",
+                    BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding,
+                    null,
+                    Type.EmptyTypes,
+                    null);
+
+                if (getDisplayNameMethod != null)
+                {
+                    return (string)getDisplayNameMethod.Invoke(null, null);
+                }
+            }
+
+            return null;
+        }
+#endif
+
         private string GetClientUserAgentString()
         {
             var values = new Dictionary<string, string>
@@ -45,7 +69,8 @@ namespace Stripe.Infrastructure
             values.Add("os_version", Environment.OSVersion.ToString());
 
             string monoVersion = Client.GetMonoVersion();
-            if (monoVersion != null) {
+            if (monoVersion != null)
+            {
                 values.Add("mono_version", monoVersion);
             }
 #else
@@ -55,20 +80,5 @@ namespace Stripe.Infrastructure
 
             return JsonConvert.SerializeObject(values, Formatting.None);
         }
-
-#if NET45
-        private static string GetMonoVersion()
-        {
-            Type monoRuntimeType;
-            MethodInfo getDisplayNameMethod;
-            if ((monoRuntimeType = typeof(object).Assembly.GetType("Mono.Runtime")) != null &&
-                (getDisplayNameMethod = monoRuntimeType.GetMethod("GetDisplayName",
-                BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding, null,
-                        Type.EmptyTypes, null)) != null) {
-                return (string)getDisplayNameMethod.Invoke(null, null);
-            }
-            return null;
-        }
-#endif
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

We had some remaining warnings in .NET Framework-specific code. This fixes them

I tweaked the logic of the `GetMonoVersion()` method to make the code easier to read, but it should work just the same.