### PR TITLE
Add some missing tests

### DIFF
--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -1,0 +1,50 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class SourceTransactionServiceTest : BaseStripeTest
+    {
+        private const string SourceId = "src_123";
+
+        private SourceTransactionService service;
+        private SourceTransactionsListOptions listOptions;
+
+        public SourceTransactionServiceTest()
+        {
+            this.service = new SourceTransactionService();
+
+            this.listOptions = new SourceTransactionsListOptions()
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void List()
+        {
+            var sources = this.service.List(SourceId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123/source_transactions");
+            Assert.NotNull(sources);
+            Assert.Equal("list", sources.Object);
+            Assert.Single(sources.Data);
+            Assert.Equal("source_transaction", sources.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var sources = await this.service.ListAsync(SourceId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123/source_transactions");
+            Assert.NotNull(sources);
+            Assert.Equal("list", sources.Object);
+            Assert.Single(sources.Data);
+            Assert.Equal("source_transaction", sources.Data[0].Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -14,6 +14,7 @@ namespace StripeTests
         private const string SourceId = "src_123";
 
         private SourceService service;
+        private SourceAttachOptions attachOptions;
         private SourceCreateOptions createOptions;
         private SourceUpdateOptions updateOptions;
         private SourceListOptions listOptions;
@@ -21,6 +22,11 @@ namespace StripeTests
         public SourceServiceTest()
         {
             this.service = new SourceService();
+
+            this.attachOptions = new SourceAttachOptions
+            {
+                Source = SourceId,
+            };
 
             this.createOptions = new SourceCreateOptions
             {
@@ -70,6 +76,28 @@ namespace StripeTests
             {
                 Limit = 1,
             };
+        }
+
+        [Fact]
+        public void Attach()
+        {
+            var source = this.service.Attach(CustomerId, this.attachOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
+            Assert.NotNull(source);
+
+            // We can't test the object returned as stripe-mock returns an Account
+            // Assert.Equal("source", source.Object);
+        }
+
+        [Fact]
+        public async Task AttachAsync()
+        {
+            var source = await this.service.AttachAsync(CustomerId, this.attachOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/customers/cus_123/sources");
+            Assert.NotNull(source);
+
+            // We can't test the object returned as stripe-mock returns an Account
+            // Assert.Equal("source", source.Object);
         }
 
         [Fact]


### PR DESCRIPTION
cc @stripe/api-libraries 

Add tests for `SourceTransactionService` and `Source.Attach`.

Also simplify the `NullableValueTypes` wholesome test.