### PR TITLE
Fix docs and move params to the shared class for Create and Update Subscription

### DIFF
--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -20,6 +20,12 @@ namespace Stripe
         public Billing? Billing { get; set; }
 
         /// <summary>
+        /// Boolean indicating whether this subscription should cancel at the end of the current period.
+        /// </summary>
+        [JsonProperty("cancel_at_period_end")]
+        public bool? CancelAtPeriodEnd { get; set; }
+
+        /// <summary>
         /// The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription.
         /// </summary>
         [JsonProperty("coupon")]

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -33,19 +33,13 @@ namespace Stripe
         #endregion
 
         /// <summary>
-        /// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with <see href="https://stripe.com/docs/api#upcoming_invoice">upcoming invoice</see> endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
-        /// </summary>
-        [JsonProperty("cancel_at_period_end")]
-        public bool? CancelAtPeriodEnd { get; set; }
-
-        /// <summary>
         /// List of subscription items, each with an attached plan.
         /// </summary>
         [JsonProperty("items")]
         public List<SubscriptionItemUpdateOption> Items { get; set; }
 
         /// <summary>
-        /// Boolean indicating whether this subscription should cancel at the end of the current period.
+        /// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with <see href="https://stripe.com/docs/api#upcoming_invoice">upcoming invoice</see> endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
         /// </summary>
         [JsonProperty("proration_date")]
         public DateTime? ProrationDate { get; set; }


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-dotnet/issues/1333 as the docs were inverted for 2 of the parameters. They are also moved to the shared class as those parameters are now supported on both Create and Update endpoints.

r? @ob-stripe 
cc @stripe/api-libraries 