### PR TITLE
Add support for new methods on the Invoice resource

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -59,9 +59,6 @@ namespace Stripe
         }
         #endregion
 
-        [JsonProperty("closed")]
-        public bool? Closed { get; set; }
-
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
@@ -84,6 +81,22 @@ namespace Stripe
         [JsonProperty("date")]
         public DateTime? Date { get; set; }
 
+        #region Expandable DefaultSource
+        public string DefaultSourceId { get; set; }
+
+        [JsonIgnore]
+        public IPaymentSource DefaultSource { get; set; }
+
+        [JsonProperty("default_source")]
+        internal object InternalDefaultSource
+        {
+            set
+            {
+                StringOrObject<IPaymentSource>.Map(value, s => this.DefaultSourceId = s, o => this.DefaultSource = o);
+            }
+        }
+        #endregion
+
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -99,8 +112,8 @@ namespace Stripe
         [JsonProperty("ending_balance")]
         public long? EndingBalance { get; set; }
 
-        [JsonProperty("forgiven")]
-        public bool? Forgiven { get; set; }
+        [JsonProperty("finalized_at")]
+        public DateTime? FinalizedAt { get; set; }
 
         [JsonProperty("hosted_invoice_url")]
         public string HostedInvoiceUrl { get; set; }
@@ -143,6 +156,9 @@ namespace Stripe
 
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
 
         #region Expandable Subscription
         public string SubscriptionId { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -62,6 +62,22 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        #region Expandable DefaultSource
+        public string DefaultSourceId { get; set; }
+
+        [JsonIgnore]
+        public IPaymentSource DefaultSource { get; set; }
+
+        [JsonProperty("default_source")]
+        internal object InternalDefaultSource
+        {
+            set
+            {
+                StringOrObject<IPaymentSource>.Map(value, s => this.DefaultSourceId = s, o => this.DefaultSource = o);
+            }
+        }
+        #endregion
+
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
 

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public static class StripeConfiguration
     {
-        public static string StripeApiVersion = "2018-09-24";
+        public static string StripeApiVersion = "2018-11-08";
 
         private static string apiKey;
         private static string apiBase;

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -16,6 +16,9 @@ namespace Stripe
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
 
+        [JsonProperty("auto_advance")]
+        public bool? AutoAdvance { get; set; }
+
         /// <summary>
         /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
         /// this invoice using the default source attached to the customer. When sending an invoice,
@@ -37,6 +40,9 @@ namespace Stripe
         /// </summary>
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
+
+        [JsonProperty("default_source")]
+        public string DefaultSource { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceFinalizeOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceFinalizeOptions.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceFinalizeOptions : BaseOptions
+    {
+        [JsonProperty("auto_advance")]
+        public bool? AutoAdvance { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceMarkUncollectibleOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceMarkUncollectibleOptions.cs
@@ -1,0 +1,11 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceMarkUncollectibleOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceSendOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSendOptions.cs
@@ -1,0 +1,11 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceSendOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -39,6 +39,26 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
+        public virtual Invoice Delete(string invoiceId, RequestOptions requestOptions = null)
+        {
+            return this.DeleteEntity(invoiceId, null, requestOptions);
+        }
+
+        public virtual Task<Invoice> DeleteAsync(string invoiceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.DeleteEntityAsync(invoiceId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual Invoice FinalizeInvoice(string invoiceId, InvoiceFinalizeOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions);
+        }
+
+        public virtual Task<Invoice> FinalizeInvoiceAsync(string invoiceId, InvoiceFinalizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions, cancellationToken);
+        }
+
         public virtual Invoice Get(string invoiceId, RequestOptions requestOptions = null)
         {
             return this.GetEntity(invoiceId, null, requestOptions);
@@ -79,6 +99,16 @@ namespace Stripe
             return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true, cancellationToken);
         }
 
+        public virtual Invoice MarkUncollectible(string invoiceId, InvoiceMarkUncollectibleOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions);
+        }
+
+        public virtual Task<Invoice> MarkUncollectibleAsync(string invoiceId, InvoiceMarkUncollectibleOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions, cancellationToken);
+        }
+
         public virtual Invoice Pay(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null)
         {
             return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions);
@@ -87,6 +117,16 @@ namespace Stripe
         public virtual Task<Invoice> PayAsync(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions, cancellationToken);
+        }
+
+        public virtual Invoice SendInvoice(string invoiceId, InvoiceSendOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/send", options, requestOptions);
+        }
+
+        public virtual Task<Invoice> SendInvoiceAsync(string invoiceId, InvoiceSendOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/send", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Upcoming(UpcomingInvoiceOptions options, RequestOptions requestOptions = null)
@@ -107,6 +147,16 @@ namespace Stripe
         public virtual Task<Invoice> UpdateAsync(string invoiceId, InvoiceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.UpdateEntityAsync(invoiceId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual Invoice VoidInvoice(string invoiceId, InvoiceVoidOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/void", options, requestOptions);
+        }
+
+        public virtual Task<Invoice> VoidInvoiceAsync(string invoiceId, InvoiceVoidOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/void", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -10,8 +10,14 @@ namespace Stripe
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
 
+        [JsonProperty("auto_advance")]
+        public bool? AutoAdvance { get; set; }
+
         [JsonProperty("closed")]
         public bool? Closed { get; set; }
+
+        [JsonProperty("default_source")]
+        public string DefaultSource { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceVoidOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceVoidOptions.cs
@@ -1,0 +1,11 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceVoidOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -37,6 +37,9 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        [JsonProperty("default_source")]
+        public string DefaultSource { get; set; }
+
         /// <summary>
         /// A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.
         /// </summary>

--- a/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
+++ b/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
@@ -19,11 +19,12 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
+            // Do not test expanding `source` as it is not supported by stripe-mock
+            // and will be auto-expanded in a future API version.
             string[] expansions =
             {
               "application",
               "customer",
-              "source",
               "transfer_data.destination",
             };
 
@@ -39,10 +40,6 @@ namespace StripeTests
 
             Assert.NotNull(intent.Customer);
             Assert.Equal("customer", intent.Customer.Object);
-
-            Assert.NotNull(intent.Source);
-            Assert.IsType<Card>(intent.Source);
-            Assert.Equal("card", intent.Source.Object);
 
             Assert.NotNull(intent.TransferData);
             Assert.NotNull(intent.TransferData.Destination);

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -18,18 +18,22 @@ namespace StripeTests
         private InvoiceListOptions listOptions;
         private InvoiceListLineItemsOptions listLineItemsOptions;
         private UpcomingInvoiceOptions upcomingOptions;
+        private InvoiceFinalizeOptions finalizeOptions;
+        private InvoiceMarkUncollectibleOptions markUncollectibleOptions;
+        private InvoiceSendOptions sendOptions;
+        private InvoiceVoidOptions voidOptions;
 
         public InvoiceServiceTest()
         {
             this.service = new InvoiceService();
 
-            this.createOptions = new InvoiceCreateOptions()
+            this.createOptions = new InvoiceCreateOptions
             {
                 CustomerId = "cus_123",
                 TaxPercent = 12.5m,
             };
 
-            this.updateOptions = new InvoiceUpdateOptions()
+            this.updateOptions = new InvoiceUpdateOptions
             {
                 Metadata = new Dictionary<string, string>()
                 {
@@ -37,26 +41,42 @@ namespace StripeTests
                 },
             };
 
-            this.payOptions = new InvoicePayOptions()
+            this.payOptions = new InvoicePayOptions
             {
                 Forgive = true,
                 SourceId = "src_123",
             };
 
-            this.listOptions = new InvoiceListOptions()
+            this.listOptions = new InvoiceListOptions
             {
                 Limit = 1,
             };
 
-            this.listLineItemsOptions = new InvoiceListLineItemsOptions()
+            this.listLineItemsOptions = new InvoiceListLineItemsOptions
             {
                 Limit = 1,
             };
 
-            this.upcomingOptions = new UpcomingInvoiceOptions()
+            this.upcomingOptions = new UpcomingInvoiceOptions
             {
                 CustomerId = "cus_123",
                 SubscriptionId = "sub_123",
+            };
+
+            this.finalizeOptions = new InvoiceFinalizeOptions
+            {
+            };
+
+            this.markUncollectibleOptions = new InvoiceMarkUncollectibleOptions
+            {
+            };
+
+            this.sendOptions = new InvoiceSendOptions
+            {
+            };
+
+            this.voidOptions = new InvoiceVoidOptions
+            {
             };
         }
 
@@ -74,6 +94,42 @@ namespace StripeTests
         {
             var invoice = await this.service.CreateAsync(this.createOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public void Delete()
+        {
+            var invoice = this.service.Delete(InvoiceId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/invoices/in_123");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public async Task DeleteAsync()
+        {
+            var invoice = await this.service.DeleteAsync(InvoiceId);
+            this.AssertRequest(HttpMethod.Delete, "/v1/invoices/in_123");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public void FinalizeInvoice()
+        {
+            var invoice = this.service.FinalizeInvoice(InvoiceId, this.finalizeOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/finalize");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public async Task FinalizeInvoiceAsync()
+        {
+            var invoice = await this.service.FinalizeInvoiceAsync(InvoiceId, this.finalizeOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/finalize");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -163,6 +219,24 @@ namespace StripeTests
         }
 
         [Fact]
+        public void MarkUncollectible()
+        {
+            var invoice = this.service.MarkUncollectible(InvoiceId, this.markUncollectibleOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/mark_uncollectible");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public async Task MarkUncollectibleAsync()
+        {
+            var invoice = await this.service.MarkUncollectibleAsync(InvoiceId, this.markUncollectibleOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/mark_uncollectible");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
         public void Pay()
         {
             var invoice = this.service.Pay(InvoiceId, this.payOptions);
@@ -176,6 +250,24 @@ namespace StripeTests
         {
             var invoice = await this.service.PayAsync(InvoiceId, this.payOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/pay");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public void SendInvoice()
+        {
+            var invoice = this.service.SendInvoice(InvoiceId, this.sendOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/send");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public async Task SendInvoiceAsync()
+        {
+            var invoice = await this.service.SendInvoiceAsync(InvoiceId, this.sendOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/send");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
@@ -212,6 +304,24 @@ namespace StripeTests
         {
             var invoice = await this.service.UpdateAsync(InvoiceId, this.updateOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public void VoidInvoice()
+        {
+            var invoice = this.service.VoidInvoice(InvoiceId, this.voidOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/void");
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+
+        [Fact]
+        public async Task VoidInvoiceAsync()
+        {
+            var invoice = await this.service.VoidInvoiceAsync(InvoiceId, this.voidOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/void");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }


### PR DESCRIPTION
This is a breaking change as it will be linked to a new API version since we are removing some fields.

cc @stripe/api-libraries 

