### PR TITLE
Add support for IHasMetadata back

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Account : StripeEntity, IHasId, IHasObject, IPaymentSource
+    public class Account : StripeEntity, IHasId, IHasMetadata, IHasObject, IPaymentSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class ApplicationFeeRefund : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class ApplicationFeeRefund : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class BankAccount : StripeEntity, IHasId, IHasObject, IExternalAccount, IPaymentSource
+    public class BankAccount : StripeEntity, IHasId, IHasMetadata, IHasObject, IExternalAccount, IPaymentSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Card : StripeEntity, IHasId, IHasObject, IExternalAccount, IPaymentSource
+    public class Card : StripeEntity, IHasId, IHasMetadata, IHasObject, IExternalAccount, IPaymentSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Charge : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Charge : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Coupon : StripeEntity, IHasId, IHasObject
+    public class Coupon : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Customer : StripeEntity, IHasId, IHasObject
+    public class Customer : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Dispute : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Dispute : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class FileLink : StripeEntity, IHasId, IHasObject
+    public class FileLink : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class InvoiceItem : StripeEntity, IHasId, IHasObject
+    public class InvoiceItem : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Invoice : StripeEntity, IHasId, IHasObject
+    public class Invoice : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class InvoiceLineItem : StripeEntity, IHasId, IHasObject
+    public class InvoiceLineItem : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -5,7 +5,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Authorization : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Authorization : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
@@ -5,7 +5,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Cardholder : StripeEntity, IHasId, IHasObject
+    public class Cardholder : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -5,7 +5,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Card : StripeEntity, IHasId, IHasObject
+    public class Card : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -5,7 +5,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Dispute : StripeEntity, IHasId, IHasObject
+    public class Dispute : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -5,7 +5,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Transaction : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Transaction : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Order : StripeEntity, IHasId, IHasObject
+    public class Order : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PaymentIntent : StripeEntity, IHasId, IHasObject
+    public class PaymentIntent : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Payout : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Payout : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Plan : StripeEntity, IHasId, IHasObject
+    public class Plan : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Products/Product.cs
+++ b/src/Stripe.net/Entities/Products/Product.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Product : StripeEntity, IHasId, IHasObject
+    public class Product : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Recipient : StripeEntity, IHasId, IHasObject
+    public class Recipient : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Recipients/RecipientActiveAccount.cs
+++ b/src/Stripe.net/Entities/Recipients/RecipientActiveAccount.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class RecipientActiveAccount : StripeEntity, IHasId, IHasObject
+    public class RecipientActiveAccount : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Refund : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Refund : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Sku : StripeEntity, IHasId, IHasObject
+    public class Sku : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Sources/Source.cs
+++ b/src/Stripe.net/Entities/Sources/Source.cs
@@ -7,7 +7,7 @@ namespace Stripe
     /// <summary>
     /// Source objects allow you to accept a variety of payment methods. They represent a customer's payment instrument and can be used with the Source API just like a card object: once chargeable, they can be charged, or attached to customers.
     /// </summary>
-    public class Source : StripeEntity, IHasId, IHasObject, IPaymentSource
+    public class Source : StripeEntity, IHasId, IHasMetadata, IHasObject, IPaymentSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class SubscriptionItem : StripeEntity, IHasId, IHasObject
+    public class SubscriptionItem : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Subscription : StripeEntity, IHasId, IHasObject
+    public class Subscription : StripeEntity, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Topup : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Topup : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
+++ b/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class TransferReversal : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class TransferReversal : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Transfer : StripeEntity, IHasId, IHasObject, IBalanceTransactionSource
+    public class Transfer : StripeEntity, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/_interfaces/IHasMetadata.cs
+++ b/src/Stripe.net/Entities/_interfaces/IHasMetadata.cs
@@ -1,0 +1,12 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Interface that identifies entities with a Metadata property of type <see cref="Dictionary{String, String}" />.
+    /// </summary>
+    public interface IHasMetadata
+    {
+        Dictionary<string, string> Metadata { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes an issue reported by @buvinghausen and adds back support for an interface for objects supporting `metadata`.

r? ob-stripe
cc @stripe/api-libraries 