### PR TITLE
Properly support shared customers for a specific source

### DIFF
--- a/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
@@ -10,7 +10,13 @@ namespace Stripe
         [JsonProperty("card")]
         public CreditCardOptions Card { get; set; }
 
+        [JsonProperty("card")]
+        public string CardId { get; set; }
+
         [JsonProperty("bank_account")]
         public BankAccountOptions BankAccount { get; set; }
+
+        [JsonProperty("bank_account")]
+        public string BankAccountId { get; set; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1346 which is a bug I just introduced because I removed the ability to pass `TokenId` in `StripeCreditCardOptions`. Ultimately, the old way was confusing and did not make a lot of sense. Now we explicitly can pass a specific card or bank account id in `TokenCreateOptions`.

r? @ob-stripe 
cc @anelder-stripe @stripe/api-libraries 