### PR TITLE
Fix handling of Expand* properties in list requests

### DIFF
--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -58,12 +58,12 @@ namespace Stripe
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Account>($"{Urls.BaseUrl}/account", null, requestOptions);
+            return this.GetRequest<Account>($"{Urls.BaseUrl}/account", null, requestOptions, false);
         }
 
         public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Account>($"{Urls.BaseUrl}/account", null, requestOptions, cancellationToken);
+            return this.GetRequestAsync<Account>($"{Urls.BaseUrl}/account", null, requestOptions, false, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Balance/BalanceService.cs
+++ b/src/Stripe.net/Services/Balance/BalanceService.cs
@@ -23,12 +23,12 @@ namespace Stripe
 
         public virtual Balance Get(RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Balance>(this.ClassUrl(), null, requestOptions);
+            return this.GetRequest<Balance>(this.ClassUrl(), null, requestOptions, false);
         }
 
         public virtual Task<Balance> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Balance>(this.ClassUrl(), null, requestOptions, cancellationToken);
+            return this.GetRequestAsync<Balance>(this.ClassUrl(), null, requestOptions, false, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -27,7 +27,7 @@ namespace Stripe
 
         public bool ExpandDefaultSource { get; set; }
 
-        public bool ExpandDefaultCustomerBankAccount { get; set; }
+        public bool ExpandDefaultCustomerBankAccount { get; set; } // TODO: remove in next major version
 
         public virtual Customer Create(CustomerCreateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -61,22 +61,22 @@ namespace Stripe
 
         public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
+            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true, cancellationToken);
         }
 
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
+            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true, cancellationToken);
         }
 
         public virtual Invoice Pay(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null)
@@ -91,12 +91,12 @@ namespace Stripe
 
         public virtual Invoice Upcoming(UpcomingInvoiceOptions options, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions);
+            return this.GetRequest<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, false);
         }
 
         public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, false, cancellationToken);
         }
 
         public virtual Invoice Update(string invoiceId, InvoiceUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -36,12 +36,12 @@ namespace Stripe.Issuing
 
         public virtual CardDetails Details(string cardId, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions);
+            return this.GetRequest<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, false);
         }
 
         public virtual Task<CardDetails> DetailsAsync(string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, cancellationToken);
+            return this.GetRequestAsync<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, false, cancellationToken);
         }
 
         public virtual Card Get(string cardId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Service.cs
+++ b/src/Stripe.net/Services/Service.cs
@@ -45,22 +45,22 @@ namespace Stripe
 
         protected EntityReturned GetEntity(string id, BaseOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
+            return this.GetRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions, false);
         }
 
         protected Task<EntityReturned> GetEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, false, cancellationToken);
         }
 
         protected StripeList<EntityReturned> ListEntities(ListOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions);
+            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, true);
         }
 
         protected Task<StripeList<EntityReturned>> ListEntitiesAsync(ListOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, true, cancellationToken);
         }
 
         protected EntityReturned UpdateEntity(string id, BaseOptions options, RequestOptions requestOptions)
@@ -90,19 +90,19 @@ namespace Stripe
                     cancellationToken).ConfigureAwait(false));
         }
 
-        protected T GetRequest<T>(string url, BaseOptions options, RequestOptions requestOptions)
+        protected T GetRequest<T>(string url, BaseOptions options, RequestOptions requestOptions, bool isListMethod)
         {
             return Mapper<T>.MapFromJson(
                 Requestor.GetString(
-                    this.ApplyAllParameters(options, url),
+                    this.ApplyAllParameters(options, url, isListMethod),
                     this.SetupRequestOptions(requestOptions)));
         }
 
-        protected async Task<T> GetRequestAsync<T>(string url, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected async Task<T> GetRequestAsync<T>(string url, BaseOptions options, RequestOptions requestOptions, bool isListMethod, CancellationToken cancellationToken)
         {
             return Mapper<T>.MapFromJson(
                 await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(options, url),
+                    this.ApplyAllParameters(options, url, isListMethod),
                     this.SetupRequestOptions(requestOptions),
                     cancellationToken).ConfigureAwait(false));
         }

--- a/src/Stripe.net/Services/ServiceNested.cs
+++ b/src/Stripe.net/Services/ServiceNested.cs
@@ -42,22 +42,22 @@ namespace Stripe
 
         protected EntityReturned GetNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+            return this.GetRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, false);
         }
 
         protected Task<EntityReturned> GetNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, false, cancellationToken);
         }
 
         protected StripeList<EntityReturned> ListNestedEntities(string parentId, BaseOptions options, RequestOptions requestOptions)
         {
-            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions);
+            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true);
         }
 
         protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(string parentId, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true, cancellationToken);
         }
 
         protected EntityReturned UpdateNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -64,12 +64,12 @@ namespace Stripe
 
         public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions);
+            return this.GetRequest<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, true);
         }
 
         public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, cancellationToken);
+            return this.GetRequestAsync<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, true, cancellationToken);
         }
 
         public virtual Source Update(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -95,6 +95,7 @@ namespace StripeTests
         [Fact]
         public void List()
         {
+            this.service.ExpandDefaultSource = true;
             var customers = this.service.List(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/customers");
             Assert.NotNull(customers);
@@ -106,6 +107,7 @@ namespace StripeTests
         [Fact]
         public async Task ListAsync()
         {
+            this.service.ExpandDefaultSource = true;
             var customers = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/customers");
             Assert.NotNull(customers);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fix handling of `Expand*` properties in list requests. After #1308, we no longer passed the `isListMethod` value to `ApplyAllParameters`, which caused the `data.` prefix to not be prepended in list requests.

Fixes #1351.
