### PR TITLE
Ignore culture when encoding parameters

### DIFF
--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -100,7 +100,7 @@ namespace Stripe.Infrastructure.Middleware
                 DateTime? dateTime = (DateTime)value;
                 if (dateTime.HasValue)
                 {
-                    flatParams.Add(new Parameter(keyPrefix, dateTime?.ConvertDateTimeToEpoch().ToString()));
+                    flatParams.Add(new Parameter(keyPrefix, dateTime?.ConvertDateTimeToEpoch().ToString(CultureInfo.InvariantCulture)));
                 }
             }
             else if (value == null)
@@ -111,7 +111,9 @@ namespace Stripe.Infrastructure.Middleware
             else
             {
                 flatParams = new List<Parameter>();
-                flatParams.Add(new Parameter(keyPrefix, value.ToString()));
+                flatParams.Add(new Parameter(
+                    keyPrefix,
+                    string.Format(CultureInfo.InvariantCulture, "{0}", value)));
             }
 
             return flatParams;

--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -2,6 +2,8 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
+    using System.Threading;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using Stripe;
@@ -359,5 +361,32 @@ namespace StripeTests
 
             Assert.Contains("Error converting value \"unknown_value\"", exception.Message);
         }
+
+        #if !NETCOREAPP1_1
+        [Fact]
+        public void IgnoresCulture()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+                var dec = 123.45m;
+                Assert.Equal("123,45", dec.ToString());
+
+                var obj = new TestOptions
+                {
+                        Decimal = dec,
+                };
+                var url = this.service.ApplyAllParameters(obj, string.Empty, false);
+                Assert.Equal("?decimal=123.45", url);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
+        }
+        #endif
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Ignore culture when encoding parameters, to ensure they're encoded like the API expects.

Fixes #1357.
