### PR TITLE
Add unit_label and active fields for creating/updating Products

### DIFF
--- a/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
@@ -5,17 +5,20 @@ namespace Stripe
 
     public class PlanProductCreateOptions : INestedOptions
     {
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }
 
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("unit_label")]
         public string UnitLabel { get; set; }

--- a/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
@@ -16,5 +16,8 @@ namespace Stripe
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("unit_label")]
+        public string UnitLabel { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Products/ProductSharedOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductSharedOptions.cs
@@ -72,6 +72,12 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// A label that represents units of this product, such as seat(s), in Stripe and on customers’ receipts and invoices.
+        /// </summary>
+        [JsonProperty("unit_label")]
+        public string UnitLabel { get; set; }
+
+        /// <summary>
         /// A URL of a publicly-accessible webpage for this product.
         /// </summary>
         [JsonProperty("url")]


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Attempts to fix #1363. It's quite likely I haven't understood the PlanProductCreateOptions versus ProductSharedOptions distinction though, so let me know if I should do this in a different way.