### PR TITLE
Add `TrialPeriodDays` property to `PlanUpdateOptions`

### DIFF
--- a/src/Stripe.net/Services/Plans/PlanUpdateOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanUpdateOptions.cs
@@ -16,5 +16,8 @@ namespace Stripe
 
         [JsonProperty("product")]
         public string ProductId { get; set; }
+
+        [JsonProperty("trial_period_days")]
+        public long? TrialPeriodDays { get; set; }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add `TrialPeriodDays` property to `PlanUpdateOptions`.

Fixes #1365.
