### PR TITLE
URL-encode dictionary keys

### DIFF
--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -181,7 +181,7 @@ namespace Stripe.Infrastructure.Middleware
 
             foreach (KeyValuePair<string, object> entry in dictionary)
             {
-                string key = entry.Key;
+                string key = WebUtility.UrlEncode(entry.Key);
                 object value = entry.Value;
 
                 string newPrefix = NewPrefix(key, keyPrefix);

--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -396,5 +396,21 @@ namespace StripeTests
             }
         }
         #endif
+
+        [Fact]
+        public void UrlEncodesKeysAndValues()
+        {
+            var obj = new TestOptions
+            {
+                    Dictionary = new Dictionary<string, object>
+                    {
+                        { "#", "42" },
+                        { "bar&baz", "+foo?" },
+                    },
+                    String = "[éàü]",
+            };
+            var url = this.service.ApplyAllParameters(obj, string.Empty, false);
+            Assert.Equal("?dictionary[%23]=42&dictionary[bar%26baz]=%2Bfoo%3F&string=%5B%C3%A9%C3%A0%C3%BC%5D", url);
+        }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries @karlr-stripe 

Ensures that dictionary keys (typically, metadata keys) are URL-encoded. Otherwise, if a metadata key contains a hash mark character `#`, the requestor interprets it as a fragment delimiter and doesn't send the character and the rest of the string to the server.

Fixes #1376.
