### PR TITLE
Add support for `created` param in some list options classes

### DIFF
--- a/src/Stripe.net/Services/Coupons/CouponListOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponListOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class CouponListOptions : ListOptions
+    public class CouponListOptions : ListOptionsWithCreated
     {
     }
 }

--- a/src/Stripe.net/Services/Products/ProductListOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductListOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class ProductListOptions : ListOptions
+    public class ProductListOptions : ListOptionsWithCreated
     {
         [JsonProperty("active")]
         public bool? Active { get; set; }

--- a/src/Stripe.net/Services/Refunds/RefundListOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundListOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class RefundListOptions : ListOptions
+    public class RefundListOptions : ListOptionsWithCreated
     {
         [JsonProperty("charge")]
         public string ChargeId { get; set; }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes #1382.
