### PR TITLE
Add XML comments on interfaces

### DIFF
--- a/src/Stripe.net/Entities/_interfaces/IBalanceTransactionSource.cs
+++ b/src/Stripe.net/Entities/_interfaces/IBalanceTransactionSource.cs
@@ -2,6 +2,42 @@ namespace Stripe
 {
     /// <summary>
     /// Resources that implement this interface can appear as sources in balance transactions.
+    /// <para>Possible concrete classes:</para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description><see cref="ApplicationFee" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="ApplicationFeeRefund" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Charge" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Dispute" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Issuing.Authorization" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Issuing.Transaction" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Payout" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Refund" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Topup" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Transfer" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="TransferReversal" /></description>
+    /// </item>
+    /// </list>
     /// </summary>
     public interface IBalanceTransactionSource : IStripeEntity, IHasId, IHasObject
     {

--- a/src/Stripe.net/Entities/_interfaces/IExternalAccount.cs
+++ b/src/Stripe.net/Entities/_interfaces/IExternalAccount.cs
@@ -3,6 +3,15 @@ namespace Stripe
     /// <summary>
     /// Resources that implement this interface can be used as external accounts, i.e. they can
     /// be attached to a Stripe account to receive payouts.
+    /// <para>Possible concrete classes:</para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description><see cref="BankAccount" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Card" /></description>
+    /// </item>
+    /// </list>
     /// </summary>
     public interface IExternalAccount : IStripeEntity, IHasId, IHasObject
     {

--- a/src/Stripe.net/Entities/_interfaces/IHasId.cs
+++ b/src/Stripe.net/Entities/_interfaces/IHasId.cs
@@ -7,6 +7,9 @@ namespace Stripe
     /// </summary>
     public interface IHasId
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         string Id { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/_interfaces/IHasMetadata.cs
+++ b/src/Stripe.net/Entities/_interfaces/IHasMetadata.cs
@@ -3,10 +3,15 @@ namespace Stripe
     using System.Collections.Generic;
 
     /// <summary>
-    /// Interface that identifies entities with a Metadata property of type <see cref="Dictionary{String, String}" />.
+    /// Interface that identifies entities with a Metadata property of type
+    /// <see cref="Dictionary{String, String}" />.
     /// </summary>
     public interface IHasMetadata
     {
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
         Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/_interfaces/IHasObject.cs
+++ b/src/Stripe.net/Entities/_interfaces/IHasObject.cs
@@ -7,6 +7,9 @@ namespace Stripe
     /// </summary>
     public interface IHasObject
     {
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
         string Object { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/_interfaces/IPaymentSource.cs
+++ b/src/Stripe.net/Entities/_interfaces/IPaymentSource.cs
@@ -1,7 +1,23 @@
 namespace Stripe
 {
     /// <summary>
-    /// Resources that implement this interface can be used to create charges.
+    /// Resources that implement this interface can be used as payment sources when creating
+    /// charges.
+    /// <para>Possible concrete classes:</para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description><see cref="Account" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="BankAccount" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Card" /></description>
+    /// </item>
+    /// <item>
+    /// <description><see cref="Source" /></description>
+    /// </item>
+    /// </list>
     /// </summary>
     public interface IPaymentSource : IStripeEntity, IHasId, IHasObject
     {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add XML comments on `IBalanceTransactionSource`, `IExternalAccount` and `IPaymentSource` to provide an explicit list of concrete classes that implement the interfaces, so users know which types they should test when receiving one of these interfaces.

Fixes #1369.
