### PR TITLE
Add support for providing client_secret when retrieving sources and payment intents

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentGetOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentGetOptions.cs
@@ -1,0 +1,15 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class PaymentIntentGetOptions : BaseOptions
+    {
+        /// <summary>
+        /// The client secret of the PaymentIntent. Required if a publishable key is used to
+        /// retrieve the payment intent.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -71,12 +71,22 @@ namespace Stripe
 
         public virtual PaymentIntent Get(string paymentIntentId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(paymentIntentId, null, requestOptions);
+            return this.Get(paymentIntentId, null, requestOptions);
         }
 
         public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(paymentIntentId, null, requestOptions, cancellationToken);
+            return this.GetAsync(paymentIntentId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual PaymentIntent Get(string paymentIntentId, PaymentIntentGetOptions options, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(paymentIntentId, options, requestOptions);
+        }
+
+        public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, PaymentIntentGetOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetEntityAsync(paymentIntentId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentIntent> List(PaymentIntentListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Sources/SourceGetOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceGetOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SourceGetOptions : BaseOptions
+    {
+        /// <summary>
+        /// The client secret of the source. Required if a publishable key is used to retrieve the
+        /// source.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -54,12 +54,22 @@ namespace Stripe
 
         public virtual Source Get(string sourceId, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(sourceId, null, requestOptions);
+            return this.Get(sourceId, null, requestOptions);
         }
 
         public virtual Task<Source> GetAsync(string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(sourceId, null, requestOptions, cancellationToken);
+            return this.GetAsync(sourceId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual Source Get(string sourceId, SourceGetOptions options, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(sourceId, options, requestOptions);
+        }
+
+        public virtual Task<Source> GetAsync(string sourceId, SourceGetOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetEntityAsync(sourceId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -157,6 +157,19 @@ namespace StripeTests
         }
 
         [Fact]
+        public void GetWithClientSecret()
+        {
+            var options = new PaymentIntentGetOptions
+            {
+                ClientSecret = "pi_client_secret_123",
+            };
+            var intent = this.service.Get(PaymentIntentId, options);
+            this.AssertRequest(HttpMethod.Get, "/v1/payment_intents/pi_123");
+            Assert.NotNull(intent);
+            Assert.Equal("payment_intent", intent.Object);
+        }
+
+        [Fact]
         public void List()
         {
             var intents = this.service.List(this.listOptions);

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -159,6 +159,19 @@ namespace StripeTests
         }
 
         [Fact]
+        public void GetWithClientSecret()
+        {
+            var options = new SourceGetOptions
+            {
+                ClientSecret = "src_client_secret_123",
+            };
+            var source = this.service.Get(SourceId, options);
+            this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123");
+            Assert.NotNull(source);
+            Assert.Equal("source", source.Object);
+        }
+
+        [Fact]
         public void List()
         {
             var sources = this.service.List(CustomerId, this.listOptions);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add support for providing `client_secret` when retrieving sources and payment intents.

Fixes #1378.
