### PR TITLE
Add support for `type` when listing Products

### DIFF
--- a/src/Stripe.net/Services/Products/ProductListOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductListOptions.cs
@@ -13,6 +13,9 @@ namespace Stripe
         [JsonProperty("shippable")]
         public bool? Shippable { get; set; }
 
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
         [JsonProperty("url")]
         public string Url { get; set; }
     }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1392

r? @ob-stripe 
cc @stripe/api-libraries 