### PR TITLE
Fix `DateTime` deserialization

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -45,6 +45,7 @@ namespace Stripe
         public string Country { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("debit_negative_balances")]

--- a/src/Stripe.net/Entities/Accounts/AccountVerification.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountVerification.cs
@@ -10,6 +10,7 @@ namespace Stripe
         public string DisabledReason { get; set; }
 
         [JsonProperty("due_by")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? DueBy { get; set; }
 
         [JsonProperty("fields_needed")]

--- a/src/Stripe.net/Entities/Accounts/TermsOfServiceAcceptance.cs
+++ b/src/Stripe.net/Entities/Accounts/TermsOfServiceAcceptance.cs
@@ -7,6 +7,7 @@ namespace Stripe
     public class TermsOfServiceAcceptance : StripeEntity
     {
         [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Date { get; set; }
 
         [JsonProperty("ip")]

--- a/src/Stripe.net/Entities/ApplePayDomains/ApplePayDomain.cs
+++ b/src/Stripe.net/Entities/ApplePayDomains/ApplePayDomain.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
@@ -33,6 +33,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
+++ b/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
@@ -83,6 +83,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
+++ b/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
@@ -17,9 +17,11 @@ namespace Stripe
         public long Amount { get; set; }
 
         [JsonProperty("available_on")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime AvailableOn { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -87,6 +87,7 @@ namespace Stripe
         public bool? Captured { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Common/Review.cs
+++ b/src/Stripe.net/Entities/Common/Review.cs
@@ -29,6 +29,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("livemode")]

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long? AmountOff { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]
@@ -50,6 +51,7 @@ namespace Stripe
         public decimal? PercentOff { get; set; }
 
         [JsonProperty("redeem_by")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? RedeemBy { get; set; }
 
         [JsonProperty("times_redeemed")]

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public long AccountBalance { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -35,9 +35,11 @@ namespace Stripe
         public bool Deleted { get; set; }
 
         [JsonProperty("end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? End { get; set; }
 
         [JsonProperty("start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Start { get; set; }
 
         #region Expandable Subscription

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -36,6 +36,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Disputes/EvidenceDetails.cs
+++ b/src/Stripe.net/Entities/Disputes/EvidenceDetails.cs
@@ -7,6 +7,7 @@ namespace Stripe
     public class EvidenceDetails : StripeEntity
     {
         [JsonProperty("due_by")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? DueBy { get; set; }
 
         [JsonProperty("has_evidence")]

--- a/src/Stripe.net/Entities/EphemeralKeys/EphemeralKey.cs
+++ b/src/Stripe.net/Entities/EphemeralKeys/EphemeralKey.cs
@@ -26,6 +26,7 @@ namespace Stripe
         }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -35,6 +36,7 @@ namespace Stripe
         public bool Deleted { get; set; }
 
         [JsonProperty("expires")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Expires { get; set; }
 
         [JsonProperty("livemode")]

--- a/src/Stripe.net/Entities/Events/Event.cs
+++ b/src/Stripe.net/Entities/Events/Event.cs
@@ -19,6 +19,7 @@ namespace Stripe
         public string ApiVersion { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         [JsonProperty("data")]

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -17,6 +17,7 @@ namespace Stripe
         /// Time at which the object was created.
         /// </summary>
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -29,6 +30,7 @@ namespace Stripe
         /// Time at which the link expires.
         /// </summary>
         [JsonProperty("expires_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime ExpiresAt { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Files/File.cs
+++ b/src/Stripe.net/Entities/Files/File.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("filename")]

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -36,6 +36,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Date { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -79,6 +79,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Date { get; set; }
 
         #region Expandable DefaultSource
@@ -107,12 +108,14 @@ namespace Stripe
         /// The date on which payment for this invoice is due. This value will be null for invoices where billing=charge_automatically.
         /// </summary>
         [JsonProperty("due_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? DueDate { get; set; }
 
         [JsonProperty("ending_balance")]
         public long? EndingBalance { get; set; }
 
         [JsonProperty("finalized_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? FinalizedAt { get; set; }
 
         [JsonProperty("hosted_invoice_url")]
@@ -131,6 +134,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("next_payment_attempt")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? NextPaymentAttempt { get; set; }
 
         /// <summary>
@@ -143,9 +147,11 @@ namespace Stripe
         public bool Paid { get; set; }
 
         [JsonProperty("period_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime PeriodEnd { get; set; }
 
         [JsonProperty("period_start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime PeriodStart { get; set; }
 
         [JsonProperty("receipt_number")]
@@ -177,6 +183,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("subscription_proration_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime SubscriptionProrationDate { get; set; }
 
         [JsonProperty("subtotal")]
@@ -192,6 +199,7 @@ namespace Stripe
         public long Total { get; set; }
 
         [JsonProperty("webhooks_delivered_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? WebhooksDeliveredAt { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Date { get; set; }
 
         [JsonProperty("description")]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -48,6 +48,7 @@ namespace Stripe.Issuing
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("held_amount")]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/RequestHistory.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/RequestHistory.cs
@@ -16,6 +16,7 @@ namespace Stripe.Issuing
         public string AuthorizedCurrency { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("held_amount")]

--- a/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
@@ -17,6 +17,7 @@ namespace Stripe.Issuing
         public Billing Billing { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("email")]

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -26,6 +26,7 @@ namespace Stripe.Issuing
         public Cardholder Cardholder { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("exp_month")]

--- a/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
@@ -27,6 +27,7 @@ namespace Stripe.Issuing
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("cvc")]

--- a/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
@@ -13,6 +13,7 @@ namespace Stripe.Issuing
         public string Carrier { get; set; }
 
         [JsonProperty("eta")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Eta { get; set; }
 
         [JsonProperty("name")]

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -17,6 +17,7 @@ namespace Stripe.Issuing
         public long Amount { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -78,6 +78,7 @@ namespace Stripe.Issuing
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/LoginLinks/LoginLink.cs
+++ b/src/Stripe.net/Entities/LoginLinks/LoginLink.cs
@@ -10,6 +10,7 @@ namespace Stripe
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("url")]

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -56,6 +56,7 @@ namespace Stripe
         /// Time at which the object was created.
         /// </summary>
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -142,6 +143,7 @@ namespace Stripe
         public StatusTransitions StatusTransitions { get; set; }
 
         [JsonProperty("updated")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Updated { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Orders/StatusTransitions.cs
+++ b/src/Stripe.net/Entities/Orders/StatusTransitions.cs
@@ -7,15 +7,19 @@ namespace Stripe
     public class StatusTransitions : StripeEntity
     {
         [JsonProperty("canceled")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Canceled { get; set; }
 
         [JsonProperty("fulfiled")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Fulfiled { get; set; }
 
         [JsonProperty("paid")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Paid { get; set; }
 
         [JsonProperty("returned")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Returned { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -45,6 +45,7 @@ namespace Stripe
         public long? ApplicationFeeAmount { get; set; }
 
         [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CanceledAt { get; set; }
 
         [JsonProperty("cancellation_reason")]
@@ -63,6 +64,7 @@ namespace Stripe
         public string ConfirmationMethod { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         [JsonProperty("arrival_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime ArrivalDate { get; set; }
 
         [JsonProperty("automatic")]
@@ -39,6 +40,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Persons/Person.cs
+++ b/src/Stripe.net/Entities/Persons/Person.cs
@@ -26,6 +26,7 @@ namespace Stripe
         public AddressJapan AddressKanji { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("deleted")]

--- a/src/Stripe.net/Entities/Plans/Period.cs
+++ b/src/Stripe.net/Entities/Plans/Period.cs
@@ -7,9 +7,11 @@ namespace Stripe
     public class Period : StripeEntity
     {
         [JsonProperty("start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Start { get; set; }
 
         [JsonProperty("end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? End { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -26,6 +26,7 @@ namespace Stripe
         public string BillingScheme { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Products/Product.cs
+++ b/src/Stripe.net/Entities/Products/Product.cs
@@ -35,6 +35,7 @@ namespace Stripe
         /// Time at which the object was created.
         /// </summary>
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -110,6 +111,7 @@ namespace Stripe
         public string UnitLabel { get; set; }
 
         [JsonProperty("updated")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Updated { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public StripeList<Card> CardList { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         #region Expandable Default Card

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -49,6 +49,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Reporting/ReportRuns/Parameters.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/Parameters.cs
@@ -13,9 +13,11 @@ namespace Stripe.Reporting
         public string Currency { get; set; }
 
         [JsonProperty("interval_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime IntervalEnd { get; set; }
 
         [JsonProperty("interval_start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime IntervalStart { get; set; }
 
         [JsonProperty("payout")]

--- a/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
@@ -14,6 +14,7 @@ namespace Stripe.Reporting
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("error")]
@@ -35,6 +36,7 @@ namespace Stripe.Reporting
         public string Status { get; set; }
 
         [JsonProperty("succeeded_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime SucceededAt { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Reporting/ReportTypes/ReportType.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportTypes/ReportType.cs
@@ -14,15 +14,18 @@ namespace Stripe.Reporting
         public string Object { get; set; }
 
         [JsonProperty("data_available_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime DataAvailableEnd { get; set; }
 
         [JsonProperty("data_available_start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime DataAvailableStart { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }
 
         [JsonProperty("updated")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Updated { get; set; }
 
         [JsonProperty("version")]

--- a/src/Stripe.net/Entities/Sigma/ScheduledQueryRun.cs
+++ b/src/Stripe.net/Entities/Sigma/ScheduledQueryRun.cs
@@ -13,9 +13,11 @@ namespace Stripe.Sigma
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("data_load_time")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime DataLoadTime { get; set; }
 
         [JsonProperty("error")]
@@ -25,6 +27,7 @@ namespace Stripe.Sigma
         public File File { get; set; }
 
         [JsonProperty("result_available_until")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime ResultAvailableUntil { get; set; }
 
         [JsonProperty("sql")]

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -29,6 +29,7 @@ namespace Stripe
         /// Time at which the object was created.
         /// </summary>
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("updated")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Updated { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SourceMandateNotifications/SourceMandateNotification.cs
+++ b/src/Stripe.net/Entities/SourceMandateNotifications/SourceMandateNotification.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long? Amount { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("livemode")]

--- a/src/Stripe.net/Entities/SourceTransactions/SourceTransaction.cs
+++ b/src/Stripe.net/Entities/SourceTransactions/SourceTransaction.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long? Amount { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Sources/Source.cs
+++ b/src/Stripe.net/Entities/Sources/Source.cs
@@ -3,6 +3,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     /// <summary>
     /// Source objects allow you to accept a variety of payment methods. They represent a customer's payment instrument and can be used with the Source API just like a card object: once chargeable, they can be charged, or attached to customers.
@@ -34,6 +35,7 @@ namespace Stripe
         public SourceCodeVerification CodeVerification { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
@@ -14,6 +14,7 @@ namespace Stripe
         public string Object { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -23,21 +23,26 @@ namespace Stripe
         public Billing? Billing { get; set; }
 
         [JsonProperty("billing_cycle_anchor")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? BillingCycleAnchor { get; set; }
 
         [JsonProperty("cancel_at_period_end")]
         public bool CancelAtPeriodEnd { get; set; }
 
         [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CanceledAt { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         [JsonProperty("current_period_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CurrentPeriodEnd { get; set; }
 
         [JsonProperty("current_period_start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CurrentPeriodStart { get; set; }
 
         #region Expandable Customer
@@ -82,6 +87,7 @@ namespace Stripe
         public Discount Discount { get; set; }
 
         [JsonProperty("ended_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? EndedAt { get; set; }
 
         [JsonProperty("items")]
@@ -100,6 +106,7 @@ namespace Stripe
         public long? Quantity { get; set; }
 
         [JsonProperty("start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Start { get; set; }
 
         [JsonProperty("status")]
@@ -109,9 +116,11 @@ namespace Stripe
         public decimal? TaxPercent { get; set; }
 
         [JsonProperty("trial_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? TrialEnd { get; set; }
 
         [JsonProperty("trial_start")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? TrialStart { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/ThreeDSecure/ThreeDSecure.cs
+++ b/src/Stripe.net/Entities/ThreeDSecure/ThreeDSecure.cs
@@ -22,6 +22,7 @@ namespace Stripe
         public Card Card { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Tokens/Token.cs
+++ b/src/Stripe.net/Entities/Tokens/Token.cs
@@ -22,6 +22,7 @@ namespace Stripe
         public string ClientIp { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         [JsonProperty("livemode")]

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -40,6 +40,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         /// <summary>
@@ -52,6 +53,7 @@ namespace Stripe
         public string Description { get; set; }
 
         [JsonProperty("expected_availability_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? ExpectedAvailabilityDate { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
+++ b/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
@@ -33,6 +33,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -36,6 +36,7 @@ namespace Stripe
         #endregion
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("currency")]

--- a/src/Stripe.net/Entities/UsageRecords/UsageRecord.cs
+++ b/src/Stripe.net/Entities/UsageRecords/UsageRecord.cs
@@ -22,6 +22,7 @@ namespace Stripe
         public string SubscriptionItem { get; set; }
 
         [JsonProperty("timestamp")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Timestamp { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public bool Connect { get; set; }
 
         [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
         [JsonProperty("deleted")]

--- a/src/Stripe.net/Infrastructure/Public/Mapper.cs
+++ b/src/Stripe.net/Infrastructure/Public/Mapper.cs
@@ -12,7 +12,6 @@ namespace Stripe
         private static JsonConverter[] converters =
         {
             new BalanceTransactionSourceConverter(),
-            new DateTimeConverter(),
             new ExternalAccountConverter(),
             new PaymentSourceConverter(),
             new StripeObjectConverter(),

--- a/src/StripeTests/Entities/Accounts/AccountTest.cs
+++ b/src/StripeTests/Entities/Accounts/AccountTest.cs
@@ -1,10 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Text;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;

--- a/src/StripeTests/Entities/ApplePayDomains/ApplePayDomainTest.cs
+++ b/src/StripeTests/Entities/ApplePayDomains/ApplePayDomainTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/apple_pay/domains/apwc_123");
-            var domain = Mapper<ApplePayDomain>.MapFromJson(json);
+            var domain = JsonConvert.DeserializeObject<ApplePayDomain>(json);
             Assert.NotNull(domain);
             Assert.IsType<ApplePayDomain>(domain);
             Assert.NotNull(domain.Id);

--- a/src/StripeTests/Entities/ApplicationFeeRefunds/ApplicationFeeRefundTest.cs
+++ b/src/StripeTests/Entities/ApplicationFeeRefunds/ApplicationFeeRefundTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/application_fees/fee_123/refunds/fr_123");
-            var applicationFeeRefund = Mapper<ApplicationFeeRefund>.MapFromJson(json);
+            var applicationFeeRefund = JsonConvert.DeserializeObject<ApplicationFeeRefund>(json);
             Assert.NotNull(applicationFeeRefund);
             Assert.IsType<ApplicationFeeRefund>(applicationFeeRefund);
             Assert.NotNull(applicationFeeRefund.Id);

--- a/src/StripeTests/Entities/ApplicationFees/ApplicationFeeTest.cs
+++ b/src/StripeTests/Entities/ApplicationFees/ApplicationFeeTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/application_fees/fee_123");
-            var applicationFee = Mapper<ApplicationFee>.MapFromJson(json);
+            var applicationFee = JsonConvert.DeserializeObject<ApplicationFee>(json);
             Assert.NotNull(applicationFee);
             Assert.IsType<ApplicationFee>(applicationFee);
             Assert.NotNull(applicationFee.Id);
@@ -34,7 +30,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/application_fees/fee_123", expansions);
-            var applicationFee = Mapper<ApplicationFee>.MapFromJson(json);
+            var applicationFee = JsonConvert.DeserializeObject<ApplicationFee>(json);
             Assert.NotNull(applicationFee);
             Assert.IsType<ApplicationFee>(applicationFee);
             Assert.NotNull(applicationFee.Id);

--- a/src/StripeTests/Entities/Balance/BalanceTest.cs
+++ b/src/StripeTests/Entities/Balance/BalanceTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/balance");
-            var balance = Mapper<Balance>.MapFromJson(json);
+            var balance = JsonConvert.DeserializeObject<Balance>(json);
             Assert.NotNull(balance);
             Assert.IsType<Balance>(balance);
             Assert.Equal("balance", balance.Object);

--- a/src/StripeTests/Entities/BalanceTransactions/BalanceTransactionTest.cs
+++ b/src/StripeTests/Entities/BalanceTransactions/BalanceTransactionTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System;
+    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -10,7 +11,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/balance/history/txn_123");
-            var balanceTransaction = Mapper<BalanceTransaction>.MapFromJson(json);
+            var balanceTransaction = JsonConvert.DeserializeObject<BalanceTransaction>(json);
             Assert.NotNull(balanceTransaction);
             Assert.IsType<BalanceTransaction>(balanceTransaction);
             Assert.NotNull(balanceTransaction.Id);
@@ -23,7 +24,7 @@ namespace StripeTests
             // We test all balance transaction possible source types to ensure the deserializer
             // works as expectes.
             var json = GetResourceAsString("api_fixtures.balance_transaction_with_expansion.json");
-            var balanceTransactions = Mapper<StripeList<BalanceTransaction>>.MapFromJson(json);
+            var balanceTransactions = JsonConvert.DeserializeObject<StripeList<BalanceTransaction>>(json);
 
             Assert.NotNull(balanceTransactions);
             Assert.NotNull(balanceTransactions.Data);

--- a/src/StripeTests/Entities/BankAccounts/BankAccountTest.cs
+++ b/src/StripeTests/Entities/BankAccounts/BankAccountTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void DeserializeForAccount()
         {
             string json = GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
-            var bankAccount = Mapper<BankAccount>.MapFromJson(json);
+            var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);
             Assert.NotNull(bankAccount.Id);
@@ -25,7 +21,7 @@ namespace StripeTests
         public void DeserializeForCustomer()
         {
             string json = GetFixture("/v1/customers/cus_123/bank_accounts/ba_123");
-            var bankAccount = Mapper<BankAccount>.MapFromJson(json);
+            var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);
             Assert.NotNull(bankAccount.Id);
@@ -41,7 +37,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/customers/cus_123/bank_accounts/ba_123", expansions);
-            var bankAccount = Mapper<BankAccount>.MapFromJson(json);
+            var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);
             Assert.NotNull(bankAccount.Id);

--- a/src/StripeTests/Entities/Cards/CardTest.cs
+++ b/src/StripeTests/Entities/Cards/CardTest.cs
@@ -1,10 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Text;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -15,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/customers/cus_123/cards/card_123");
-            var card = Mapper<Card>.MapFromJson(json);
+            var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
             Assert.IsType<Card>(card);
             Assert.NotNull(card.Id);
@@ -32,7 +27,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/customers/cus_123/cards/card_123", expansions);
-            var card = Mapper<Card>.MapFromJson(json);
+            var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
             Assert.IsType<Card>(card);
             Assert.NotNull(card.Id);

--- a/src/StripeTests/Entities/Charges/ChargeTest.cs
+++ b/src/StripeTests/Entities/Charges/ChargeTest.cs
@@ -1,10 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
-    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 

--- a/src/StripeTests/Entities/CountrySpecs/CountrySpecTest.cs
+++ b/src/StripeTests/Entities/CountrySpecs/CountrySpecTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/country_specs/US");
-            var countrySpec = Mapper<CountrySpec>.MapFromJson(json);
+            var countrySpec = JsonConvert.DeserializeObject<CountrySpec>(json);
             Assert.NotNull(countrySpec);
             Assert.IsType<CountrySpec>(countrySpec);
             Assert.NotNull(countrySpec.Id);

--- a/src/StripeTests/Entities/Coupons/CouponTest.cs
+++ b/src/StripeTests/Entities/Coupons/CouponTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/coupons/co_123");
-            var coupon = Mapper<Coupon>.MapFromJson(json);
+            var coupon = JsonConvert.DeserializeObject<Coupon>(json);
             Assert.NotNull(coupon);
             Assert.IsType<Coupon>(coupon);
             Assert.NotNull(coupon.Id);

--- a/src/StripeTests/Entities/Discounts/DiscountTest.cs
+++ b/src/StripeTests/Entities/Discounts/DiscountTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.discount.json");
-            var discount = Mapper<Discount>.MapFromJson(json);
+            var discount = JsonConvert.DeserializeObject<Discount>(json);
 
             Assert.NotNull(discount);
             Assert.Equal("discount", discount.Object);

--- a/src/StripeTests/Entities/EphemeralKeys/EphemeralKeyTest.cs
+++ b/src/StripeTests/Entities/EphemeralKeys/EphemeralKeyTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.ephemeral_key.json");
-            var ephemeralKey = Mapper<EphemeralKey>.MapFromJson(json);
+            var ephemeralKey = JsonConvert.DeserializeObject<EphemeralKey>(json);
 
             Assert.NotNull(ephemeralKey);
             Assert.NotNull(ephemeralKey.Id);

--- a/src/StripeTests/Entities/Events/EventTest.cs
+++ b/src/StripeTests/Entities/Events/EventTest.cs
@@ -1,7 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
     using Stripe;
     using Xunit;
 

--- a/src/StripeTests/Entities/ExchangeRates/ExchangeRateTest.cs
+++ b/src/StripeTests/Entities/ExchangeRates/ExchangeRateTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/exchange_rates/usd");
-            var exchangeRate = Mapper<ExchangeRate>.MapFromJson(json);
+            var exchangeRate = JsonConvert.DeserializeObject<ExchangeRate>(json);
             Assert.NotNull(exchangeRate);
             Assert.IsType<ExchangeRate>(exchangeRate);
             Assert.NotNull(exchangeRate.Id);

--- a/src/StripeTests/Entities/FileLinks/FileLinkTest.cs
+++ b/src/StripeTests/Entities/FileLinks/FileLinkTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/file_links/link_123");
-            var fileLink = Mapper<FileLink>.MapFromJson(json);
+            var fileLink = JsonConvert.DeserializeObject<FileLink>(json);
             Assert.NotNull(fileLink);
             Assert.IsType<FileLink>(fileLink);
             Assert.NotNull(fileLink.Id);
@@ -30,7 +26,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/file_links/link_123", expansions);
-            var fileLink = Mapper<FileLink>.MapFromJson(json);
+            var fileLink = JsonConvert.DeserializeObject<FileLink>(json);
             Assert.NotNull(fileLink);
             Assert.IsType<FileLink>(fileLink);
             Assert.NotNull(fileLink.Id);

--- a/src/StripeTests/Entities/Files/FileTest.cs
+++ b/src/StripeTests/Entities/Files/FileTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/files/file_123");
-            var file = Mapper<File>.MapFromJson(json);
+            var file = JsonConvert.DeserializeObject<File>(json);
             Assert.NotNull(file);
             Assert.IsType<File>(file);
             Assert.NotNull(file.Id);

--- a/src/StripeTests/Entities/InvoiceItems/InvoiceItemTest.cs
+++ b/src/StripeTests/Entities/InvoiceItems/InvoiceItemTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/invoiceitems/ii_123");
-            var invoiceItem = Mapper<InvoiceItem>.MapFromJson(json);
+            var invoiceItem = JsonConvert.DeserializeObject<InvoiceItem>(json);
             Assert.NotNull(invoiceItem);
             Assert.IsType<InvoiceItem>(invoiceItem);
             Assert.NotNull(invoiceItem.Id);
@@ -32,7 +28,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/invoiceitems/ii_123", expansions);
-            var invoiceItem = Mapper<InvoiceItem>.MapFromJson(json);
+            var invoiceItem = JsonConvert.DeserializeObject<InvoiceItem>(json);
             Assert.NotNull(invoiceItem);
             Assert.IsType<InvoiceItem>(invoiceItem);
             Assert.NotNull(invoiceItem.Id);

--- a/src/StripeTests/Entities/Invoices/InvoiceLineItemTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceLineItemTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/invoices/in_123/lines");
-            var lineItems = Mapper<StripeList<InvoiceLineItem>>.MapFromJson(json);
+            var lineItems = JsonConvert.DeserializeObject<StripeList<InvoiceLineItem>>(json);
             Assert.NotNull(lineItems);
 
             InvoiceLineItem lineItem = lineItems.Data[0];

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/invoices/in_123");
-            var invoice = Mapper<Invoice>.MapFromJson(json);
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
             Assert.NotNull(invoice);
             Assert.IsType<Invoice>(invoice);
             Assert.NotNull(invoice.Id);
@@ -32,7 +28,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/invoices/in_123", expansions);
-            var invoice = Mapper<Invoice>.MapFromJson(json);
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
             Assert.NotNull(invoice);
             Assert.IsType<Invoice>(invoice);
             Assert.NotNull(invoice.Id);

--- a/src/StripeTests/Entities/Issuing/Authorizations/AuthorizationTest.cs
+++ b/src/StripeTests/Entities/Issuing/Authorizations/AuthorizationTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             string json = GetFixture("/v1/issuing/authorizations/iauth_123");
-            var authorization = Mapper<Authorization>.MapFromJson(json);
+            var authorization = JsonConvert.DeserializeObject<Authorization>(json);
             Assert.NotNull(authorization);
             Assert.IsType<Authorization>(authorization);
             Assert.NotNull(authorization.Id);
@@ -34,7 +29,7 @@ namespace StripeTests.Issuing
             };
 
             string json = GetFixture("/v1/issuing/authorizations/iauth_123", expansions);
-            var authorization = Mapper<Authorization>.MapFromJson(json);
+            var authorization = JsonConvert.DeserializeObject<Authorization>(json);
             Assert.NotNull(authorization);
             Assert.IsType<Authorization>(authorization);
             Assert.NotNull(authorization.Id);

--- a/src/StripeTests/Entities/Issuing/Cardholders/CardholderTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cardholders/CardholderTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             string json = GetFixture("/v1/issuing/cardholders/ich_123");
-            var cardholder = Mapper<Cardholder>.MapFromJson(json);
+            var cardholder = JsonConvert.DeserializeObject<Cardholder>(json);
             Assert.NotNull(cardholder);
             Assert.IsType<Cardholder>(cardholder);
             Assert.NotNull(cardholder.Id);

--- a/src/StripeTests/Entities/Issuing/Cards/CardDetailsTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cards/CardDetailsTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.issuing.card_details.json");
-            var cardDetails = Mapper<CardDetails>.MapFromJson(json);
+            var cardDetails = JsonConvert.DeserializeObject<CardDetails>(json);
             Assert.NotNull(cardDetails);
             Assert.IsType<CardDetails>(cardDetails);
             Assert.Equal("issuing.card_details", cardDetails.Object);

--- a/src/StripeTests/Entities/Issuing/Cards/CardTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cards/CardTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,9 +10,9 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             string json = GetFixture("/v1/issuing/cards/ic_123");
-            var card = Mapper<Stripe.Issuing.Card>.MapFromJson(json);
+            var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
-            Assert.IsType<Stripe.Issuing.Card>(card);
+            Assert.IsType<Card>(card);
             Assert.NotNull(card.Id);
             Assert.Equal("issuing.card", card.Object);
 

--- a/src/StripeTests/Entities/Issuing/Disputes/DisputeTest.cs
+++ b/src/StripeTests/Entities/Issuing/Disputes/DisputeTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,9 +10,9 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             string json = GetFixture("/v1/issuing/disputes/idp_123");
-            var dispute = Mapper<Stripe.Issuing.Dispute>.MapFromJson(json);
+            var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
-            Assert.IsType<Stripe.Issuing.Dispute>(dispute);
+            Assert.IsType<Dispute>(dispute);
             Assert.NotNull(dispute.Id);
             Assert.Equal("issuing.dispute", dispute.Object);
         }

--- a/src/StripeTests/Entities/Issuing/Transactions/TransactionTest.cs
+++ b/src/StripeTests/Entities/Issuing/Transactions/TransactionTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Issuing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Issuing;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Issuing
         public void Deserialize()
         {
             string json = GetFixture("/v1/issuing/transactions/ipi_123");
-            var transaction = Mapper<Transaction>.MapFromJson(json);
+            var transaction = JsonConvert.DeserializeObject<Transaction>(json);
             Assert.NotNull(transaction);
             Assert.IsType<Transaction>(transaction);
             Assert.NotNull(transaction.Id);

--- a/src/StripeTests/Entities/LoginLinks/LoginLinkTest.cs
+++ b/src/StripeTests/Entities/LoginLinks/LoginLinkTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.login_link.json");
-            var loginLink = Mapper<LoginLink>.MapFromJson(json);
+            var loginLink = JsonConvert.DeserializeObject<LoginLink>(json);
 
             Assert.NotNull(loginLink);
             Assert.Equal("login_link", loginLink.Object);

--- a/src/StripeTests/Entities/Orders/OrderTest.cs
+++ b/src/StripeTests/Entities/Orders/OrderTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/orders/or_123");
-            var order = Mapper<Order>.MapFromJson(json);
+            var order = JsonConvert.DeserializeObject<Order>(json);
             Assert.NotNull(order);
             Assert.IsType<Order>(order);
             Assert.NotNull(order.Id);
@@ -31,7 +27,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/orders/or_123", expansions);
-            var order = Mapper<Order>.MapFromJson(json);
+            var order = JsonConvert.DeserializeObject<Order>(json);
             Assert.NotNull(order);
             Assert.IsType<Order>(order);
             Assert.NotNull(order.Id);

--- a/src/StripeTests/Entities/Payouts/PayoutTest.cs
+++ b/src/StripeTests/Entities/Payouts/PayoutTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -9,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/payouts/po_123");
-            var payout = Mapper<Payout>.MapFromJson(json);
+            var payout = JsonConvert.DeserializeObject<Payout>(json);
             Assert.NotNull(payout);
             Assert.IsType<Payout>(payout);
             Assert.NotNull(payout.Id);
@@ -27,7 +28,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/payouts/po_123", expansions);
-            var payout = Mapper<Payout>.MapFromJson(json);
+            var payout = JsonConvert.DeserializeObject<Payout>(json);
             Assert.NotNull(payout);
             Assert.IsType<Payout>(payout);
             Assert.NotNull(payout.Id);

--- a/src/StripeTests/Entities/Persons/PersonTest.cs
+++ b/src/StripeTests/Entities/Persons/PersonTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/accounts/acct_123/persons/person_123");
-            var person = Mapper<Person>.MapFromJson(json);
+            var person = JsonConvert.DeserializeObject<Person>(json);
             Assert.NotNull(person);
             Assert.IsType<Person>(person);
             Assert.NotNull(person.Id);

--- a/src/StripeTests/Entities/Plans/PlanTest.cs
+++ b/src/StripeTests/Entities/Plans/PlanTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/plans/plan_123");
-            var plan = Mapper<Plan>.MapFromJson(json);
+            var plan = JsonConvert.DeserializeObject<Plan>(json);
             Assert.NotNull(plan);
             Assert.IsType<Plan>(plan);
             Assert.NotNull(plan.Id);
@@ -30,7 +26,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/plans/plan_123", expansions);
-            var plan = Mapper<Plan>.MapFromJson(json);
+            var plan = JsonConvert.DeserializeObject<Plan>(json);
             Assert.NotNull(plan);
             Assert.IsType<Plan>(plan);
             Assert.NotNull(plan.Id);

--- a/src/StripeTests/Entities/Products/ProductTest.cs
+++ b/src/StripeTests/Entities/Products/ProductTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/products/prod_123");
-            var product = Mapper<Product>.MapFromJson(json);
+            var product = JsonConvert.DeserializeObject<Product>(json);
             Assert.NotNull(product);
             Assert.IsType<Product>(product);
             Assert.NotNull(product.Id);

--- a/src/StripeTests/Entities/Refunds/RefundTest.cs
+++ b/src/StripeTests/Entities/Refunds/RefundTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/refunds/re_123");
-            var refund = Mapper<Refund>.MapFromJson(json);
+            var refund = JsonConvert.DeserializeObject<Refund>(json);
             Assert.NotNull(refund);
             Assert.IsType<Refund>(refund);
             Assert.NotNull(refund.Id);
@@ -32,7 +28,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/refunds/re_123", expansions);
-            var charge = Mapper<Refund>.MapFromJson(json);
+            var charge = JsonConvert.DeserializeObject<Refund>(json);
             Assert.NotNull(charge);
             Assert.IsType<Refund>(charge);
             Assert.NotNull(charge.Id);

--- a/src/StripeTests/Entities/Reporting/ReportRuns/ReportRunTest.cs
+++ b/src/StripeTests/Entities/Reporting/ReportRuns/ReportRunTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Reporting
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Reporting;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Reporting
         public void Deserialize()
         {
             string json = GetFixture("/v1/reporting/report_runs/frr_123");
-            var reportRun = Mapper<ReportRun>.MapFromJson(json);
+            var reportRun = JsonConvert.DeserializeObject<ReportRun>(json);
             Assert.NotNull(reportRun);
             Assert.IsType<ReportRun>(reportRun);
             Assert.NotNull(reportRun.Id);

--- a/src/StripeTests/Entities/Reporting/ReportTypes/ReportTypeTest.cs
+++ b/src/StripeTests/Entities/Reporting/ReportTypes/ReportTypeTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Reporting
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Reporting;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Reporting
         public void Deserialize()
         {
             string json = GetFixture("/v1/reporting/report_types/activity.summary.1");
-            var reportType = Mapper<ReportType>.MapFromJson(json);
+            var reportType = JsonConvert.DeserializeObject<ReportType>(json);
             Assert.NotNull(reportType);
             Assert.IsType<ReportType>(reportType);
             Assert.NotNull(reportType.Id);

--- a/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
+++ b/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Sigma
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Sigma;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Sigma
         public void Deserialize()
         {
             string json = GetFixture("/v1/sigma/scheduled_query_runs/sqr_123");
-            var run = Mapper<ScheduledQueryRun>.MapFromJson(json);
+            var run = JsonConvert.DeserializeObject<ScheduledQueryRun>(json);
             Assert.NotNull(run);
             Assert.IsType<ScheduledQueryRun>(run);
             Assert.NotNull(run.Id);

--- a/src/StripeTests/Entities/Skus/SkuTest.cs
+++ b/src/StripeTests/Entities/Skus/SkuTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/skus/sku_123");
-            var sku = Mapper<Sku>.MapFromJson(json);
+            var sku = JsonConvert.DeserializeObject<Sku>(json);
             Assert.NotNull(sku);
             Assert.IsType<Sku>(sku);
             Assert.NotNull(sku.Id);
@@ -30,7 +26,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/skus/sku_123", expansions);
-            var sku = Mapper<Sku>.MapFromJson(json);
+            var sku = JsonConvert.DeserializeObject<Sku>(json);
             Assert.NotNull(sku);
             Assert.IsType<Sku>(sku);
             Assert.NotNull(sku.Id);

--- a/src/StripeTests/Entities/SourceMandateNotifications/SourceMandateNotificationTest.cs
+++ b/src/StripeTests/Entities/SourceMandateNotifications/SourceMandateNotificationTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.source_mandate_notification.json");
-            var mandate = Mapper<SourceMandateNotification>.MapFromJson(json);
+            var mandate = JsonConvert.DeserializeObject<SourceMandateNotification>(json);
             Assert.NotNull(mandate);
             Assert.IsType<SourceMandateNotification>(mandate);
             Assert.NotNull(mandate.Id);

--- a/src/StripeTests/Entities/Sources/SourceTest.cs
+++ b/src/StripeTests/Entities/Sources/SourceTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/sources/src_123");
-            var source = Mapper<Source>.MapFromJson(json);
+            var source = JsonConvert.DeserializeObject<Source>(json);
             Assert.NotNull(source);
             Assert.IsType<Source>(source);
             Assert.NotNull(source.Id);

--- a/src/StripeTests/Entities/SubscriptionItems/SubscriptionItemTest.cs
+++ b/src/StripeTests/Entities/SubscriptionItems/SubscriptionItemTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/subscription_items/si_123");
-            var subscriptionItem = Mapper<SubscriptionItem>.MapFromJson(json);
+            var subscriptionItem = JsonConvert.DeserializeObject<SubscriptionItem>(json);
             Assert.NotNull(subscriptionItem);
             Assert.IsType<SubscriptionItem>(subscriptionItem);
             Assert.NotNull(subscriptionItem.Id);

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/subscriptions/sub_123");
-            var subscription = Mapper<Subscription>.MapFromJson(json);
+            var subscription = JsonConvert.DeserializeObject<Subscription>(json);
             Assert.NotNull(subscription);
             Assert.IsType<Subscription>(subscription);
             Assert.NotNull(subscription.Id);
@@ -30,7 +26,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/subscriptions/sub_123", expansions);
-            var subscription = Mapper<Subscription>.MapFromJson(json);
+            var subscription = JsonConvert.DeserializeObject<Subscription>(json);
             Assert.NotNull(subscription);
             Assert.IsType<Subscription>(subscription);
             Assert.NotNull(subscription.Id);

--- a/src/StripeTests/Entities/Terminal/ConnectionTokens/ConnectionTokenTest.cs
+++ b/src/StripeTests/Entities/Terminal/ConnectionTokens/ConnectionTokenTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Terminal
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Terminal;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Terminal
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.connection_token.json");
-            var connectionToken = Mapper<ConnectionToken>.MapFromJson(json);
+            var connectionToken = JsonConvert.DeserializeObject<ConnectionToken>(json);
             Assert.NotNull(connectionToken);
             Assert.IsType<ConnectionToken>(connectionToken);
             Assert.NotNull(connectionToken.Secret);

--- a/src/StripeTests/Entities/Terminal/Locations/LocationTest.cs
+++ b/src/StripeTests/Entities/Terminal/Locations/LocationTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Terminal
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Terminal;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Terminal
         public void Deserialize()
         {
             string json = GetFixture("/v1/terminal/locations/loc_123");
-            var location = Mapper<Location>.MapFromJson(json);
+            var location = JsonConvert.DeserializeObject<Location>(json);
             Assert.NotNull(location);
             Assert.IsType<Location>(location);
             Assert.NotNull(location.Id);

--- a/src/StripeTests/Entities/Terminal/Readers/ReaderTest.cs
+++ b/src/StripeTests/Entities/Terminal/Readers/ReaderTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Terminal
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Terminal;
     using Xunit;
 
@@ -15,7 +10,7 @@ namespace StripeTests.Terminal
         public void Deserialize()
         {
             string json = GetFixture("/v1/terminal/readers/ds_123");
-            var reader = Mapper<Reader>.MapFromJson(json);
+            var reader = JsonConvert.DeserializeObject<Reader>(json);
             Assert.NotNull(reader);
             Assert.IsType<Reader>(reader);
             Assert.NotNull(reader.Id);

--- a/src/StripeTests/Entities/ThreeDSecure/ThreeDSecureTest.cs
+++ b/src/StripeTests/Entities/ThreeDSecure/ThreeDSecureTest.cs
@@ -1,10 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Text;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -15,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/3d_secure/tdsrc_123");
-            var resource = Mapper<ThreeDSecure>.MapFromJson(json);
+            var resource = JsonConvert.DeserializeObject<ThreeDSecure>(json);
             Assert.NotNull(resource);
             Assert.IsType<ThreeDSecure>(resource);
             Assert.NotNull(resource.Id);

--- a/src/StripeTests/Entities/Tokens/TokenTest.cs
+++ b/src/StripeTests/Entities/Tokens/TokenTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/tokens/tok_123");
-            var token = Mapper<Token>.MapFromJson(json);
+            var token = JsonConvert.DeserializeObject<Token>(json);
             Assert.NotNull(token);
             Assert.IsType<Token>(token);
             Assert.NotNull(token.Id);

--- a/src/StripeTests/Entities/Topups/TopupTest.cs
+++ b/src/StripeTests/Entities/Topups/TopupTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/topups/tu_123");
-            var topup = Mapper<Topup>.MapFromJson(json);
+            var topup = JsonConvert.DeserializeObject<Topup>(json);
             Assert.NotNull(topup);
             Assert.IsType<Topup>(topup);
             Assert.NotNull(topup.Id);
@@ -31,7 +27,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/topups/tu_123", expansions);
-            var topup = Mapper<Topup>.MapFromJson(json);
+            var topup = JsonConvert.DeserializeObject<Topup>(json);
             Assert.NotNull(topup);
             Assert.IsType<Topup>(topup);
             Assert.NotNull(topup.Id);

--- a/src/StripeTests/Entities/TransferReversals/TransferReversalTest.cs
+++ b/src/StripeTests/Entities/TransferReversals/TransferReversalTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/transfers/tr_123/reversals/trr_123");
-            var transferReversal = Mapper<TransferReversal>.MapFromJson(json);
+            var transferReversal = JsonConvert.DeserializeObject<TransferReversal>(json);
             Assert.NotNull(transferReversal);
             Assert.IsType<TransferReversal>(transferReversal);
             Assert.NotNull(transferReversal.Id);
@@ -31,7 +27,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/transfers/tr_123/reversals/trr_123", expansions);
-            var transferReversal = Mapper<TransferReversal>.MapFromJson(json);
+            var transferReversal = JsonConvert.DeserializeObject<TransferReversal>(json);
             Assert.NotNull(transferReversal);
             Assert.IsType<TransferReversal>(transferReversal);
             Assert.NotNull(transferReversal.Id);

--- a/src/StripeTests/Entities/Transfers/TransferTest.cs
+++ b/src/StripeTests/Entities/Transfers/TransferTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/transfers/tr_123");
-            var transfer = Mapper<Transfer>.MapFromJson(json);
+            var transfer = JsonConvert.DeserializeObject<Transfer>(json);
             Assert.NotNull(transfer);
             Assert.IsType<Transfer>(transfer);
             Assert.NotNull(transfer.Id);
@@ -33,7 +29,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/transfers/tr_123", expansions);
-            var transfer = Mapper<Transfer>.MapFromJson(json);
+            var transfer = JsonConvert.DeserializeObject<Transfer>(json);
             Assert.NotNull(transfer);
             Assert.IsType<Transfer>(transfer);
             Assert.NotNull(transfer.Id);

--- a/src/StripeTests/Entities/UsageRecordSummaries/UsageRecordSummaryTest.cs
+++ b/src/StripeTests/Entities/UsageRecordSummaries/UsageRecordSummaryTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/subscription_items/si_123/usage_record_summaries");
-            var summaries = Mapper<StripeList<UsageRecordSummary>>.MapFromJson(json);
+            var summaries = JsonConvert.DeserializeObject<StripeList<UsageRecordSummary>>(json);
             Assert.NotNull(summaries);
 
             var summary = summaries.Data[0];

--- a/src/StripeTests/Entities/UsageRecords/UsageRecordTest.cs
+++ b/src/StripeTests/Entities/UsageRecords/UsageRecordTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             var json = GetResourceAsString("api_fixtures.usage_record.json");
-            var usageRecord = Mapper<UsageRecord>.MapFromJson(json);
+            var usageRecord = JsonConvert.DeserializeObject<UsageRecord>(json);
 
             Assert.NotNull(usageRecord);
             Assert.NotNull(usageRecord.Id);

--- a/src/StripeTests/Entities/WebhookEndpoints/WebhookEndpointTest.cs
+++ b/src/StripeTests/Entities/WebhookEndpoints/WebhookEndpointTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/webhook_endpoints/we_123");
-            var endpoint = Mapper<WebhookEndpoint>.MapFromJson(json);
+            var endpoint = JsonConvert.DeserializeObject<WebhookEndpoint>(json);
             Assert.NotNull(endpoint);
             Assert.IsType<WebhookEndpoint>(endpoint);
             Assert.NotNull(endpoint.Id);

--- a/src/StripeTests/Services/Discounts/DisputeTest.cs
+++ b/src/StripeTests/Services/Discounts/DisputeTest.cs
@@ -1,9 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -14,7 +10,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = GetFixture("/v1/disputes/dp_123");
-            var dispute = Mapper<Dispute>.MapFromJson(json);
+            var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
             Assert.IsType<Dispute>(dispute);
             Assert.NotNull(dispute.Id);
@@ -30,7 +26,7 @@ namespace StripeTests
             };
 
             string json = GetFixture("/v1/disputes/dp_123", expansions);
-            var dispute = Mapper<Dispute>.MapFromJson(json);
+            var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
             Assert.IsType<Dispute>(dispute);
             Assert.NotNull(dispute.Id);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Removes `DateTimeConverter` from the list of global converters and apply it directly to `DateTime` properties via the `JsonConverter` attribute.

Updates tests to use `JsonConvert.DeserializeObject<>` instead of `Mapper<>.MapFromJson` to deserialize objects wherever possible.
