### PR TITLE
Fix LGTM alerts

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -30,12 +30,12 @@ namespace Stripe
 
         internal static string GetApiKey()
         {
+#if NET45
             if (string.IsNullOrEmpty(apiKey))
             {
-#if NET45
                 apiKey = System.Configuration.ConfigurationManager.AppSettings["StripeApiKey"];
-#endif
             }
+#endif
 
             return apiKey;
         }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes a couple of code quality issues reported by LGTM.com.

This is very likely a no-op, as on non-`NET45` platforms, the compiler probably optimized away the useless `if` clause.