### PR TITLE
Allow paging on upcoming invoice line items

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -89,12 +89,12 @@ namespace Stripe
             return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true, cancellationToken);
         }
 
-        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null)
+        public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true);
         }
 
-        public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true, cancellationToken);
         }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -1,0 +1,136 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class UpcomingInvoiceListLineItemsOptions : ListOptions
+    {
+        /// <summary>
+        /// The code of the coupon to apply. If <c>subscription</c> or <c>subscription_items</c> is
+        /// provided, the invoice returned will preview updating or creating a subscription with
+        /// that coupon. Otherwise, it will preview applying that coupon to the customer for the
+        /// next upcoming invoice from among the customer’s subscriptions. The invoice can be
+        /// previewed without a coupon by passing this value as an empty string.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string CouponId { get; set; }
+
+        /// <summary>
+        /// REQUIRED
+        /// </summary>
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// List of invoice items to add or update in the upcoming invoice preview.
+        /// </summary>
+        [JsonProperty("invoice_items")]
+        public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
+
+        #region SubscriptionBillingCycleAnchor
+
+        /// <summary>
+        /// For new subscriptions, a future timestamp to anchor the subscription’s
+        /// <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
+        /// This is used to determine the date of the first full invoice, and, for plans with
+        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.For
+        /// existing subscriptions, the value can only be set to <c>now</c> or <c>unchanged</c>.
+        /// </summary>
+        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
+
+        public bool SubscriptionBillingCycleAnchorNow { get; set; }
+
+        public bool SubscriptionBillingCycleAnchorUnchanged { get; set; }
+
+        [JsonProperty("subscription_billing_cycle_anchor")]
+        internal string SubscriptionBillingCycleAnchorInternal
+        {
+            get
+            {
+                if (this.SubscriptionBillingCycleAnchorNow)
+                {
+                    return "now";
+                }
+
+                if (this.SubscriptionBillingCycleAnchorUnchanged)
+                {
+                    return "unchanged";
+                }
+
+                return this.SubscriptionBillingCycleAnchor?.ConvertDateTimeToEpoch().ToString();
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Boolean indicating whether this subscription should cancel at the end of the current
+        /// period.
+        /// </summary>
+        [JsonProperty("subscription_cancel_at_period_end")]
+        public bool? SubscriptionCancelAtPeriodEnd { get; set; }
+
+        /// <summary>
+        /// The identifier of the subscription for which you’d like to retrieve the upcoming
+        /// invoice. If not provided, but a <c>subscription_items</c> is provided, you will preview
+        /// creating a subscription with those items. If neither <c>subscription</c> nor
+        /// <c>subscription_items</c> is provided, you will retrieve the next upcoming invoice from
+        /// among the customer’s subscriptions.
+        /// </summary>
+        [JsonProperty("subscription")]
+        public string SubscriptionId { get; set; }
+
+        /// <summary>
+        /// List of subscription items, each with an attached plan.
+        /// </summary>
+        [JsonProperty("subscription_items")]
+        public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
+
+        /// <summary>
+        /// If previewing an update to a subscription, this decides whether the preview will show
+        /// the result of applying prorations or not. If set, one of <c>subscription_items</c> or
+        /// <c>subscription</c>, and one of <c>subscription_items</c> or
+        /// <c>subscription_trial_end</c> are required.
+        /// </summary>
+        [JsonProperty("subscription_prorate")]
+        public bool? SubscriptionProrate { get; set; }
+
+        /// <summary>
+        /// If previewing an update to a subscription, and doing proration,
+        /// <c>subscription_proration_date</c> forces the proration to be calculated as though the
+        /// update was done at the specified time. The time given must be within the current
+        /// subscription period, and cannot be before the subscription was on its current plan. If
+        /// set, <c>subscription</c>, and one of <c>subscription_items</c>, or
+        /// <c>subscription_trial_end</c> are required. Also, <c>subscription_proration</c> cannot
+        /// be set to false.
+        /// </summary>
+        [JsonProperty("subscription_proration_date")]
+        public DateTime? SubscriptionProrationDate { get; set; }
+
+        /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// that tax percent. If set, one of <c>subscription_items</c> or
+        /// <c>subscription is required</c>.
+        /// </summary>
+        [JsonProperty("subscription_tax_percent")]
+        public decimal? SubscriptionTaxPercent { get; set; }
+
+        /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// that trial end. If set, one of <c>subscription_items</c> or <c>subscription</c> is
+        /// required.
+        /// </summary>
+        [JsonProperty("subscription_trial_end")]
+        public DateTime? SubscriptionTrialEnd { get; set; }
+
+        /// <summary>
+        /// Indicates if a plan’s <c>trial_period_days</c> should be applied to the subscription.
+        /// Setting <c>subscription_trial_end</c> per subscription is preferred, and this defaults
+        /// to <c>false</c>. Setting this flag to <c>true</c> together with
+        /// <c>subscription_trial_end</c> is not allowed.
+        /// </summary>
+        [JsonProperty("subscription_trial_from_plan")]
+        public bool? SubscriptionTrialFromPlan { get; set; }
+    }
+}

--- a/src/StripeTests/Entities/Reviews/ReviewTest.cs
+++ b/src/StripeTests/Entities/Reviews/ReviewTest.cs
@@ -1,10 +1,5 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
-    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -20,7 +15,6 @@ namespace StripeTests
             Assert.NotNull(review.Id);
             Assert.Equal("review", review.Object);
         }
-
 
         [Fact]
         public void DeserializeWithExpansions()

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -18,6 +18,7 @@ namespace StripeTests
         private InvoiceListOptions listOptions;
         private InvoiceListLineItemsOptions listLineItemsOptions;
         private UpcomingInvoiceOptions upcomingOptions;
+        private UpcomingInvoiceListLineItemsOptions upcomingListLineItemsOptions;
         private InvoiceFinalizeOptions finalizeOptions;
         private InvoiceMarkUncollectibleOptions markUncollectibleOptions;
         private InvoiceSendOptions sendOptions;
@@ -59,6 +60,13 @@ namespace StripeTests
 
             this.upcomingOptions = new UpcomingInvoiceOptions
             {
+                CustomerId = "cus_123",
+                SubscriptionId = "sub_123",
+            };
+
+            this.upcomingListLineItemsOptions = new UpcomingInvoiceListLineItemsOptions
+            {
+                Limit = 1,
                 CustomerId = "cus_123",
                 SubscriptionId = "sub_123",
             };
@@ -199,7 +207,7 @@ namespace StripeTests
         [Fact]
         public void ListUpcomingLineItems()
         {
-            var invoices = this.service.ListUpcomingLineItems(this.upcomingOptions);
+            var invoices = this.service.ListUpcomingLineItems(this.upcomingListLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);
@@ -210,7 +218,7 @@ namespace StripeTests
         [Fact]
         public async Task ListUpcomingLineItemsAsync()
         {
-            var invoices = await this.service.ListUpcomingLineItemsAsync(this.upcomingOptions);
+            var invoices = await this.service.ListUpcomingLineItemsAsync(this.upcomingListLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
             Assert.NotNull(invoices);
             Assert.Equal("list", invoices.Object);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Replace the existing `UpcomingInvoiceOptions` argument in `InvoiceService.ListUpcomingLineItems` by a new `UpcomingInvoiceListLineItemsOptions` class that accepts list parameters.

The new class is a clone of the existing `UpcomingInvoiceOptions` class, but it derives from `ListOptions` instead of `BaseOptions`. C# doesn't support multiple inheritance so there's some code duplication here.

This is a breaking change and will need to be released as a major version.

Fixes #1023 (finally!).