### PR TITLE
Add support for auto-pagination

### DIFF
--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -239,9 +239,13 @@ namespace Stripe.Infrastructure
         {
             var result = new StripeResponse
             {
-                RequestId = response.Headers.Contains("Request-Id") ? response.Headers.GetValues("Request-Id").First() : "n/a",
-                RequestDate = Convert.ToDateTime(response.Headers.GetValues("Date").First(), CultureInfo.InvariantCulture),
-                ResponseJson = responseText
+                RequestId = response.Headers.Contains("Request-Id") ?
+                    response.Headers.GetValues("Request-Id").First() :
+                    "n/a",
+                RequestDate = response.Headers.Contains("Date") ?
+                    Convert.ToDateTime(response.Headers.GetValues("Date").First(), CultureInfo.InvariantCulture) :
+                    default(DateTime),
+                ResponseJson = responseText,
             };
 
             return result;

--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -76,6 +76,11 @@ namespace Stripe
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
+        public virtual IEnumerable<Account> ListAutoPaging(AccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
         public virtual Account Reject(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null)
         {
             return this.PostRequest<Account>($"{this.InstanceUrl(accountId)}/reject", options, requestOptions);

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ApplePayDomainService : Service<ApplePayDomain>,
         ICreatable<ApplePayDomain, ApplePayDomainCreateOptions>,
@@ -61,6 +60,11 @@ namespace Stripe
         public virtual Task<StripeList<ApplePayDomain>> ListAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ApplePayDomain> ListAutoPaging(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ApplicationFeeRefundService : ServiceNested<ApplicationFeeRefund>,
         INestedCreatable<ApplicationFeeRefund, ApplicationFeeRefundCreateOptions>,
@@ -55,6 +54,11 @@ namespace Stripe
         public virtual Task<StripeList<ApplicationFeeRefund>> ListAsync(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(applicationFeeId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ApplicationFeeRefund> ListAutoPaging(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(applicationFeeId, options, requestOptions);
         }
 
         public virtual ApplicationFeeRefund Update(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ApplicationFeeService : Service<ApplicationFee>,
         IListable<ApplicationFee, ApplicationFeeListOptions>,
@@ -49,6 +48,11 @@ namespace Stripe
         public virtual Task<StripeList<ApplicationFee>> ListAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ApplicationFee> ListAutoPaging(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class BalanceTransactionService : Service<BalanceTransaction>,
         IListable<BalanceTransaction, BalanceTransactionListOptions>,
@@ -42,6 +40,11 @@ namespace Stripe
         public virtual Task<StripeList<BalanceTransaction>> ListAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<BalanceTransaction> ListAutoPaging(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class BankAccountService : ServiceNested<BankAccount>,
         INestedCreatable<BankAccount, BankAccountCreateOptions>,
@@ -64,6 +63,11 @@ namespace Stripe
         public virtual Task<StripeList<BankAccount>> ListAsync(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(customerId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<BankAccount> ListAutoPaging(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(customerId, options, requestOptions);
         }
 
         public virtual BankAccount Update(string customerId, string bankAccountId, BankAccountUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CardService : ServiceNested<Card>,
         INestedCreatable<Card, CardCreateOptions>,
@@ -67,6 +65,11 @@ namespace Stripe
         public virtual Task<StripeList<Card>> ListAsync(string customerId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(customerId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Card> ListAutoPaging(string customerId, CardListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(customerId, options, requestOptions);
         }
 
         public virtual Card Update(string customerId, string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ChargeService : Service<Charge>,
         ICreatable<Charge, ChargeCreateOptions>,
@@ -86,6 +86,11 @@ namespace Stripe
         public virtual Task<StripeList<Charge>> ListAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Charge> ListAutoPaging(ChargeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Charge Update(string chargeId, ChargeUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CountrySpecService : Service<CountrySpec>,
         IListable<CountrySpec, CountrySpecListOptions>,
@@ -39,6 +38,11 @@ namespace Stripe
         public virtual Task<StripeList<CountrySpec>> ListAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<CountrySpec> ListAutoPaging(CountrySpecListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CouponService : Service<Coupon>,
         ICreatable<Coupon, CouponCreateOptions>,
@@ -63,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<Coupon>> ListAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Coupon> ListAutoPaging(CouponListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Coupon Update(string couponId, CouponUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CustomerService : Service<Customer>,
         ICreatable<Customer, CustomerCreateOptions>,
@@ -67,6 +65,11 @@ namespace Stripe
         public virtual Task<StripeList<Customer>> ListAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Customer> ListAutoPaging(CustomerListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Customer Update(string customerId, CustomerUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class DisputeService : Service<Dispute>,
         IListable<Dispute, DisputeListOptions>,
@@ -53,6 +51,11 @@ namespace Stripe
         public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Dispute> ListAutoPaging(DisputeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class EventService : Service<Event>,
         IListable<Event, EventListOptions>,
@@ -39,6 +38,11 @@ namespace Stripe
         public virtual Task<StripeList<Event>> ListAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ExchangeRateService : Service<ExchangeRate>,
         IListable<ExchangeRate, ExchangeRateListOptions>,
@@ -39,6 +38,11 @@ namespace Stripe
         public virtual Task<StripeList<ExchangeRate>> ListAsync(ExchangeRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ExchangeRate> ListAutoPaging(ExchangeRateListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -60,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<IExternalAccount>> ListAsync(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(accountId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<IExternalAccount> ListAutoPaging(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(accountId, options, requestOptions);
         }
 
         public virtual IExternalAccount Update(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class FileLinkService : Service<FileLink>,
         ICreatable<FileLink, FileLinkCreateOptions>,
@@ -52,6 +50,11 @@ namespace Stripe
         public virtual Task<StripeList<FileLink>> ListAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<FileLink> ListAutoPaging(FileLinkListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual FileLink Update(string fileLinkId, FileLinkUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
@@ -62,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<File>> ListAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<File> ListAutoPaging(FileListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class InvoiceItemService : Service<InvoiceItem>,
         ICreatable<InvoiceItem, InvoiceItemCreateOptions>,
@@ -68,6 +67,11 @@ namespace Stripe
         public virtual Task<StripeList<InvoiceItem>> ListAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<InvoiceItem> ListAutoPaging(InvoiceItemListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual InvoiceItem Update(string invoiceitemId, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class InvoiceService : Service<Invoice>,
         ICreatable<Invoice, InvoiceCreateOptions>,
@@ -79,6 +78,11 @@ namespace Stripe
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
         }
 
+        public virtual IEnumerable<Invoice> ListAutoPaging(InvoiceListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
         public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true);
@@ -89,6 +93,11 @@ namespace Stripe
             return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true, cancellationToken);
         }
 
+        public virtual IEnumerable<InvoiceLineItem> ListLineItemsAutoPaging(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
+        }
+
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true);
@@ -97,6 +106,11 @@ namespace Stripe
         public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true, cancellationToken);
+        }
+
+        public virtual IEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPaging(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
         }
 
         public virtual Invoice MarkUncollectible(string invoiceId, InvoiceMarkUncollectibleOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class AuthorizationService : Service<Authorization>,
         IListable<Authorization, AuthorizationListOptions>,
@@ -61,6 +59,11 @@ namespace Stripe.Issuing
         public virtual Task<StripeList<Authorization>> ListAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Authorization> ListAutoPaging(AuthorizationListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Authorization Update(string authorizationId, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CardholderService : Service<Cardholder>,
         ICreatable<Cardholder, CardholderCreateOptions>,
@@ -52,6 +50,11 @@ namespace Stripe.Issuing
         public virtual Task<StripeList<Cardholder>> ListAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Cardholder> ListAutoPaging(CardholderListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Cardholder Update(string cardholderId, CardholderUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class CardService : Service<Card>,
         ICreatable<Card, CardCreateOptions>,
@@ -62,6 +60,11 @@ namespace Stripe.Issuing
         public virtual Task<StripeList<Card>> ListAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Card> ListAutoPaging(CardListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Card Update(string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class DisputeService : Service<Dispute>,
         ICreatable<Dispute, DisputeCreateOptions>,
@@ -52,6 +50,11 @@ namespace Stripe.Issuing
         public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Dispute> ListAutoPaging(DisputeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class TransactionService : Service<Transaction>,
         IListable<Transaction, TransactionListOptions>,
@@ -41,6 +39,11 @@ namespace Stripe.Issuing
         public virtual Task<StripeList<Transaction>> ListAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Transaction> ListAutoPaging(TransactionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Transaction Update(string transactionId, TransactionUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class OrderService : Service<Order>,
         ICreatable<Order, OrderCreateOptions>,
@@ -55,6 +54,11 @@ namespace Stripe
         public virtual Task<StripeList<Order>> ListAsync(OrderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Order> ListAutoPaging(OrderListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Order Pay(string orderId, OrderPayOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class PaymentIntentService : Service<PaymentIntent>,
         ICreatable<PaymentIntent, PaymentIntentCreateOptions>,
@@ -97,6 +96,11 @@ namespace Stripe
         public virtual Task<StripeList<PaymentIntent>> ListAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<PaymentIntent> ListAutoPaging(PaymentIntentListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual PaymentIntent Update(string paymentIntentId, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class PayoutService : Service<Payout>,
         ICreatable<Payout, PayoutCreateOptions>,
@@ -67,6 +66,11 @@ namespace Stripe
         public virtual Task<StripeList<Payout>> ListAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Payout> ListAutoPaging(PayoutListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Payout Update(string payoutId, PayoutUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class PersonService : ServiceNested<Person>,
         INestedCreatable<Person, PersonCreateOptions>,
@@ -65,6 +64,11 @@ namespace Stripe
         public virtual Task<StripeList<Person>> ListAsync(string accountId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(accountId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Person> ListAutoPaging(string accountId, PersonListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(accountId, options, requestOptions);
         }
 
         public virtual Person Update(string accountId,  string personId, PersonUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class PlanService : Service<Plan>,
         ICreatable<Plan, PlanCreateOptions>,
@@ -65,6 +63,11 @@ namespace Stripe
         public virtual Task<StripeList<Plan>> ListAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Plan> ListAutoPaging(PlanListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Plan Update(string planId, PlanUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ProductService : Service<Product>,
         ICreatable<Product, ProductCreateOptions>,
@@ -63,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<Product>> ListAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Product> ListAutoPaging(ProductListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Product Update(string productId, ProductUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Radar
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ValueListItemService : Service<ValueListItem>,
         ICreatable<ValueListItem, ValueListItemCreateOptions>,
@@ -61,6 +59,11 @@ namespace Stripe.Radar
         public virtual Task<StripeList<ValueListItem>> ListAsync(ValueListItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ValueListItem> ListAutoPaging(ValueListItemListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Radar
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ValueListService : Service<ValueList>,
         ICreatable<ValueList, ValueListCreateOptions>,
@@ -61,6 +59,11 @@ namespace Stripe.Radar
         public virtual Task<StripeList<ValueList>> ListAsync(ValueListListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ValueList> ListAutoPaging(ValueListListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual ValueList Update(string valueListId, ValueListUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class RefundService : Service<Refund>,
         ICreatable<Refund, RefundCreateOptions>,
@@ -58,6 +56,11 @@ namespace Stripe
         public virtual Task<StripeList<Refund>> ListAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Refund> ListAutoPaging(RefundListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Refund Update(string refundId, RefundUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Reporting
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ReportRunService : Service<ReportRun>,
         ICreatable<ReportRun, ReportRunCreateOptions>,
@@ -51,6 +49,11 @@ namespace Stripe.Reporting
         public virtual Task<StripeList<ReportRun>> ListAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ReportRun> ListAutoPaging(ReportRunListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -1,10 +1,8 @@
 namespace Stripe.Reporting
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ReportTypeService : Service<ReportType>,
         IListable<ReportType, ReportTypeListOptions>,
@@ -40,6 +38,11 @@ namespace Stripe.Reporting
         public virtual Task<StripeList<ReportType>> ListAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ReportType> ListAutoPaging(ReportTypeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ReviewService : Service<Review>,
         IListable<Review, ReviewListOptions>,
@@ -50,6 +48,11 @@ namespace Stripe
         public virtual Task<StripeList<Review>> ListAsync(ReviewListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Review> ListAutoPaging(ReviewListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/ServiceNested.cs
+++ b/src/Stripe.net/Services/ServiceNested.cs
@@ -50,14 +50,19 @@ namespace Stripe
             return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, false, cancellationToken);
         }
 
-        protected StripeList<EntityReturned> ListNestedEntities(string parentId, BaseOptions options, RequestOptions requestOptions)
+        protected StripeList<EntityReturned> ListNestedEntities(string parentId, ListOptions options, RequestOptions requestOptions)
         {
             return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true);
         }
 
-        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(string parentId, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(string parentId, ListOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
         {
             return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true, cancellationToken);
+        }
+
+        protected IEnumerable<EntityReturned> ListNestedEntitiesAutoPaging(string parentId, ListOptions options, RequestOptions requestOptions)
+        {
+            return this.ListRequestAutoPaging<EntityReturned>(this.ClassUrl(parentId), options, requestOptions);
         }
 
         protected EntityReturned UpdateNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -1,8 +1,8 @@
 namespace Stripe.Sigma
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class ScheduledQueryRunService : Service<ScheduledQueryRun>,
         IListable<ScheduledQueryRun, ScheduledQueryRunListOptions>,
@@ -38,6 +38,11 @@ namespace Stripe.Sigma
         public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ScheduledQueryRun> ListAutoPaging(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SkuService : Service<Sku>,
         ICreatable<Sku, SkuCreateOptions>,
@@ -65,6 +63,11 @@ namespace Stripe
         public virtual Task<StripeList<Sku>> ListAsync(SkuListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Sku> ListAutoPaging(SkuListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Sku Update(string skuId, SkuUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SourceTransactionService : ServiceNested<SourceTransaction>,
         INestedListable<SourceTransaction, SourceTransactionsListOptions>
@@ -27,6 +27,11 @@ namespace Stripe
         public virtual Task<StripeList<SourceTransaction>> ListAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(sourceId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<SourceTransaction> ListAutoPaging(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(sourceId, options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
@@ -80,6 +81,11 @@ namespace Stripe
         public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetRequestAsync<StripeList<Source>>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions, true, cancellationToken);
+        }
+
+        public virtual IEnumerable<Source> ListAutoPaging(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<Source>($"{Urls.BaseUrl}/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Source Update(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SubscriptionItemService : Service<SubscriptionItem>,
         ICreatable<SubscriptionItem, SubscriptionItemCreateOptions>,
@@ -62,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<SubscriptionItem>> ListAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<SubscriptionItem> ListAutoPaging(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual SubscriptionItem Update(string subscriptionItemId, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SubscriptionService : Service<Subscription>,
         ICreatable<Subscription, SubscriptionCreateOptions>,
@@ -64,6 +62,11 @@ namespace Stripe
         public virtual Task<StripeList<Subscription>> ListAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Subscription> ListAutoPaging(SubscriptionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Subscription Update(string subscriptionId, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class TopupService : Service<Topup>,
         ICreatable<Topup, TopupCreateOptions>,
@@ -64,6 +64,11 @@ namespace Stripe
         public virtual Task<StripeList<Topup>> ListAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Topup> ListAutoPaging(TopupListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Topup Update(string topupId, TopupUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class TransferReversalService : ServiceNested<TransferReversal>,
         INestedCreatable<TransferReversal, TransferReversalCreateOptions>,
@@ -55,6 +54,11 @@ namespace Stripe
         public virtual Task<StripeList<TransferReversal>> ListAsync(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(transferId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<TransferReversal> ListAutoPaging(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(transferId, options, requestOptions);
         }
 
         public virtual TransferReversal Update(string transferId,  string reversalId, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class TransferService : Service<Transfer>,
         ICreatable<Transfer, TransferCreateOptions>,
@@ -59,6 +58,11 @@ namespace Stripe
         public virtual Task<StripeList<Transfer>> ListAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Transfer> ListAutoPaging(TransferListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual Transfer Update(string transferId, TransferUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class UsageRecordSummaryService : ServiceNested<UsageRecordSummary>,
         INestedListable<UsageRecordSummary, UsageRecordSummaryListOptions>
@@ -28,6 +27,11 @@ namespace Stripe
         public virtual Task<StripeList<UsageRecordSummary>> ListAsync(string subscriptionItemId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListNestedEntitiesAsync(subscriptionItemId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<UsageRecordSummary> ListAutoPaging(string subscriptionItemId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(subscriptionItemId, options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -1,10 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class WebhookEndpointService : Service<WebhookEndpoint>,
         ICreatable<WebhookEndpoint, WebhookEndpointCreateOptions>,
@@ -63,6 +61,11 @@ namespace Stripe
         public virtual Task<StripeList<WebhookEndpoint>> ListAsync(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<WebhookEndpoint> ListAutoPaging(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
         public virtual WebhookEndpoint Update(string endpointId, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/_interfaces/IDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/IDeletable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface IDeletable<T>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
     {
         T Delete(string id, RequestOptions requestOptions = null);
 

--- a/src/Stripe.net/Services/_interfaces/IListable.cs
+++ b/src/Stripe.net/Services/_interfaces/IListable.cs
@@ -1,14 +1,17 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
     public interface IListable<T, O>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
         where O : ListOptions
     {
         StripeList<T> List(O listOptions = null, RequestOptions requestOptions = null);
 
         Task<StripeList<T>> ListAsync(O listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        IEnumerable<T> ListAutoPaging(O listOptions = null, RequestOptions requestOptions = null);
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface INestedDeletable<T>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
     {
         T Delete(string parentId, string id, RequestOptions requestOptions = null);
 

--- a/src/Stripe.net/Services/_interfaces/INestedListable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedListable.cs
@@ -1,14 +1,17 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
     public interface INestedListable<T, O>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
         where O : ListOptions
     {
         StripeList<T> List(string parentId, O listOptions = null, RequestOptions requestOptions = null);
 
         Task<StripeList<T>> ListAsync(string parentId, O listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        IEnumerable<T> ListAutoPaging(string parentId, O listOptions = null, RequestOptions requestOptions = null);
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface INestedRetrievable<T>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
     {
         T Get(string parentId, string id, RequestOptions requestOptions = null);
 

--- a/src/Stripe.net/Services/_interfaces/INestedUpdatable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedUpdatable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface INestedUpdatable<T, O>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
         where O : BaseOptions
     {
         T Update(string parentId, string id, O updateOptions, RequestOptions requestOptions = null);

--- a/src/Stripe.net/Services/_interfaces/IRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/IRetrievable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface IRetrievable<T>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
     {
         T Get(string id, RequestOptions requestOptions = null);
 

--- a/src/Stripe.net/Services/_interfaces/IUpdatable.cs
+++ b/src/Stripe.net/Services/_interfaces/IUpdatable.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public interface IUpdatable<T, O>
-        where T : IStripeEntity
+        where T : IStripeEntity, IHasId
         where O : BaseOptions
     {
         T Update(string id, O updateOptions, RequestOptions requestOptions = null);

--- a/src/StripeTests/MockHttpClientFixture.cs
+++ b/src/StripeTests/MockHttpClientFixture.cs
@@ -9,20 +9,20 @@ namespace StripeTests
 
     public class MockHttpClientFixture : IDisposable
     {
-        private readonly Mock<HttpClientHandler> mockHandler;
-
         private readonly HttpMessageHandler origHandler;
 
         public MockHttpClientFixture()
         {
-            this.mockHandler = new Mock<HttpClientHandler>
+            this.MockHandler = new Mock<HttpClientHandler>
             {
                 CallBase = true
             };
 
             this.origHandler = StripeConfiguration.HttpMessageHandler;
-            StripeConfiguration.HttpMessageHandler = this.mockHandler.Object;
+            StripeConfiguration.HttpMessageHandler = this.MockHandler.Object;
         }
+
+        public Mock<HttpClientHandler> MockHandler { get; }
 
         public void Dispose()
         {
@@ -30,11 +30,11 @@ namespace StripeTests
         }
 
         /// <summary>
-        /// Resets all invocations recorded for the mock client.
+        /// Resets the mock's state.
         /// </summary>
         public void Reset()
         {
-            this.mockHandler.Invocations.Clear();
+            this.MockHandler.Reset();
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace StripeTests
         /// </summary>
         public void AssertRequest(HttpMethod method, string path)
         {
-            this.mockHandler.Protected().Verify(
+            this.MockHandler.Protected().Verify(
                 "SendAsync",
                 Times.Once(),
                 ItExpr.Is<HttpRequestMessage>(m =>

--- a/src/StripeTests/Resources/pageable_models/0.json
+++ b/src/StripeTests/Resources/pageable_models/0.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "id": "pm_123",
+      "object": "pageablemodel"
+    },
+    {
+      "id": "pm_124",
+      "object": "pageablemodel"
+    }
+  ],
+  "has_more": true,
+  "object": "list",
+  "url": "/v1/pageable_models"
+}

--- a/src/StripeTests/Resources/pageable_models/1.json
+++ b/src/StripeTests/Resources/pageable_models/1.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "id": "pm_125",
+      "object": "pageablemodel"
+    },
+    {
+      "id": "pm_126",
+      "object": "pageablemodel"
+    }
+  ],
+  "has_more": true,
+  "object": "list",
+  "url": "/v1/pageable_models"
+}

--- a/src/StripeTests/Resources/pageable_models/2.json
+++ b/src/StripeTests/Resources/pageable_models/2.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "id": "pm_127",
+      "object": "pageablemodel"
+    }
+  ],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/pageable_models"
+}

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -180,6 +181,14 @@ namespace StripeTests
             Assert.Equal("list", accounts.Object);
             Assert.Single(accounts.Data);
             Assert.Equal("account", accounts.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var accounts = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(accounts);
+            Assert.Equal("account", accounts[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -103,6 +103,14 @@ namespace StripeTests
             Assert.Equal("list", domains.Object);
             Assert.Single(domains.Data);
             Assert.Equal("apple_pay_domain", domains.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var domains = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(domains);
+            Assert.Equal("apple_pay_domain", domains[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -101,6 +102,14 @@ namespace StripeTests
             Assert.Equal("list", applicationFeeRefunds.Object);
             Assert.Single(applicationFeeRefunds.Data);
             Assert.Equal("fee_refund", applicationFeeRefunds.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var applicationFeeRefunds = this.service.ListAutoPaging(ApplicationFeeId, this.listOptions).ToList();
+            Assert.NotNull(applicationFeeRefunds);
+            Assert.Equal("fee_refund", applicationFeeRefunds[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +63,14 @@ namespace StripeTests
             Assert.Equal("list", applicationFees.Object);
             Assert.Single(applicationFees.Data);
             Assert.Equal("application_fee", applicationFees.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var applicationFees = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(applicationFees);
+            Assert.Equal("application_fee", applicationFees[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -1,0 +1,110 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using Moq.Protected;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class AutoPagingTest : BaseStripeTest
+    {
+        public AutoPagingTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.0.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK);
+            response3.Content = new StringContent(GetResourceAsString("pageable_models.2.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Returns(Task.FromResult(response3))
+                .Throws(new Exception("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService();
+            var options = new ListOptions()
+            {
+                Limit = 2,
+            };
+            var models = service.ListAutoPaging(options).ToList();
+
+            // Check results
+            Assert.Equal(5, models.Count);
+            Assert.Equal("pm_123", models[0].Id);
+            Assert.Equal("pm_124", models[1].Id);
+            Assert.Equal("pm_125", models[2].Id);
+            Assert.Equal("pm_126", models[3].Id);
+            Assert.Equal("pm_127", models[4].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_126"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        public class PageableModel : StripeEntity, IHasId
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+        }
+
+        public class PageableService : Service<PageableModel>
+        {
+            public override string BasePath => "/pageablemodels";
+
+            public IEnumerable<PageableModel> ListAutoPaging(ListOptions options)
+            {
+                return this.ListEntitiesAutoPaging(options, null);
+            }
+        }
+    }
+}

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +63,14 @@ namespace StripeTests
             Assert.Equal("list", balanceTransactions.Object);
             Assert.Single(balanceTransactions.Data);
             Assert.Equal("balance_transaction", balanceTransactions.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var balanceTransactions = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(balanceTransactions);
+            Assert.Equal("balance_transaction", balanceTransactions[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -129,6 +130,13 @@ namespace StripeTests
             Assert.NotNull(bankAccounts);
             Assert.Equal("list", bankAccounts.Object);
             Assert.Single(bankAccounts.Data);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var bankAccounts = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
+            Assert.NotNull(bankAccounts);
         }
 
         // stripe-mock does not return a bank account object on update today so we do not test

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -111,6 +112,13 @@ namespace StripeTests
             Assert.NotNull(cards);
             Assert.Equal("list", cards.Object);
             Assert.Single(cards.Data);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var cards = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
+            Assert.NotNull(cards);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -122,6 +123,14 @@ namespace StripeTests
             Assert.Equal("list", charges.Object);
             Assert.Single(charges.Data);
             Assert.Equal("charge", charges.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var charges = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(charges);
+            Assert.Equal("charge", charges[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +63,14 @@ namespace StripeTests
             Assert.Equal("list", countrySpecs.Object);
             Assert.Single(countrySpecs.Data);
             Assert.Equal("country_spec", countrySpecs.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var countrySpecs = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(countrySpecs);
+            Assert.Equal("country_spec", countrySpecs[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -113,6 +114,14 @@ namespace StripeTests
             Assert.Equal("list", coupons.Object);
             Assert.Single(coupons.Data);
             Assert.Equal("coupon", coupons.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var coupons = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(coupons);
+            Assert.Equal("coupon", coupons[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -115,6 +116,15 @@ namespace StripeTests
             Assert.Equal("list", customers.Object);
             Assert.Single(customers.Data);
             Assert.Equal("customer", customers.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            this.service.ExpandDefaultSource = true;
+            var customers = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(customers);
+            Assert.Equal("customer", customers[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -90,6 +91,14 @@ namespace StripeTests
             Assert.Equal("list", disputes.Object);
             Assert.Single(disputes.Data);
             Assert.Equal("dispute", disputes.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var disputes = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(disputes);
+            Assert.Equal("dispute", disputes[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +63,14 @@ namespace StripeTests
             Assert.Equal("list", events.Object);
             Assert.Single(events.Data);
             Assert.Equal("event", events.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var events = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(events);
+            Assert.Equal("event", events[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -61,6 +61,14 @@ namespace StripeTests
             Assert.Equal("list", exchangeRates.Object);
             Assert.Single(exchangeRates.Data);
             Assert.Equal("exchange_rate", exchangeRates.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var exchangeRates = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(exchangeRates);
+            Assert.Equal("exchange_rate", exchangeRates[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -123,6 +124,13 @@ namespace StripeTests
             Assert.NotNull(externalAccounts);
             Assert.Equal("list", externalAccounts.Object);
             Assert.Single(externalAccounts.Data);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var externalAccounts = this.service.ListAutoPaging(AccountId, this.listOptions).ToList();
+            Assert.NotNull(externalAccounts);
         }
 
         [Fact]

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -97,6 +98,14 @@ namespace StripeTests
             Assert.Equal("list", fileLinks.Object);
             Assert.Single(fileLinks.Data);
             Assert.Equal("file_link", fileLinks.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var domains = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(domains);
+            Assert.Equal("file_link", domains[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -1,8 +1,6 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
+    using System.Linq;
     using System.Net.Http;
     using System.Reflection;
     using System.Threading.Tasks;
@@ -92,6 +90,14 @@ namespace StripeTests
             Assert.Equal("list", files.Object);
             Assert.Single(files.Data);
             Assert.Equal("file", files.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var files = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(files);
+            Assert.Equal("file", files[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -114,6 +115,14 @@ namespace StripeTests
             Assert.Equal("list", invoiceItems.Object);
             Assert.Single(invoiceItems.Data);
             Assert.Equal("invoiceitem", invoiceItems.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var invoiceItems = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(invoiceItems);
+            Assert.Equal("invoiceitem", invoiceItems[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -184,47 +185,71 @@ namespace StripeTests
         }
 
         [Fact]
+        public void ListAutoPaging()
+        {
+            var invoices = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(invoices);
+            Assert.Equal("invoice", invoices[0].Object);
+        }
+
+        [Fact]
         public void ListLineItems()
         {
-            var invoices = this.service.ListLineItems(InvoiceId, this.listLineItemsOptions);
+            var lineItems = this.service.ListLineItems(InvoiceId, this.listLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123/lines");
-            Assert.NotNull(invoices);
-            Assert.Equal("list", invoices.Object);
-            Assert.Single(invoices.Data);
-            Assert.Equal("line_item", invoices.Data[0].Object);
+            Assert.NotNull(lineItems);
+            Assert.Equal("list", lineItems.Object);
+            Assert.Single(lineItems.Data);
+            Assert.Equal("line_item", lineItems.Data[0].Object);
         }
 
         [Fact]
         public async Task ListLineItemsAsync()
         {
-            var invoices = await this.service.ListLineItemsAsync(InvoiceId, this.listLineItemsOptions);
+            var lineItems = await this.service.ListLineItemsAsync(InvoiceId, this.listLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/in_123/lines");
-            Assert.NotNull(invoices);
-            Assert.Equal("list", invoices.Object);
-            Assert.Single(invoices.Data);
-            Assert.Equal("line_item", invoices.Data[0].Object);
+            Assert.NotNull(lineItems);
+            Assert.Equal("list", lineItems.Object);
+            Assert.Single(lineItems.Data);
+            Assert.Equal("line_item", lineItems.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListLineItemsAutoPaging()
+        {
+            var lineItems = this.service.ListLineItemsAutoPaging(InvoiceId, this.listLineItemsOptions).ToList();
+            Assert.NotNull(lineItems);
+            Assert.Equal("line_item", lineItems[0].Object);
         }
 
         [Fact]
         public void ListUpcomingLineItems()
         {
-            var invoices = this.service.ListUpcomingLineItems(this.upcomingListLineItemsOptions);
+            var lineItems = this.service.ListUpcomingLineItems(this.upcomingListLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
-            Assert.NotNull(invoices);
-            Assert.Equal("list", invoices.Object);
-            Assert.Single(invoices.Data);
-            Assert.Equal("line_item", invoices.Data[0].Object);
+            Assert.NotNull(lineItems);
+            Assert.Equal("list", lineItems.Object);
+            Assert.Single(lineItems.Data);
+            Assert.Equal("line_item", lineItems.Data[0].Object);
         }
 
         [Fact]
         public async Task ListUpcomingLineItemsAsync()
         {
-            var invoices = await this.service.ListUpcomingLineItemsAsync(this.upcomingListLineItemsOptions);
+            var lineItems = await this.service.ListUpcomingLineItemsAsync(this.upcomingListLineItemsOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/invoices/upcoming/lines");
-            Assert.NotNull(invoices);
-            Assert.Equal("list", invoices.Object);
-            Assert.Single(invoices.Data);
-            Assert.Equal("line_item", invoices.Data[0].Object);
+            Assert.NotNull(lineItems);
+            Assert.Equal("list", lineItems.Object);
+            Assert.Single(lineItems.Data);
+            Assert.Equal("line_item", lineItems.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListUpcomingLineItemsAutoPaging()
+        {
+            var lineItems = this.service.ListUpcomingLineItemsAutoPaging(this.upcomingListLineItemsOptions).ToList();
+            Assert.NotNull(lineItems);
+            Assert.Equal("line_item", lineItems[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -95,6 +96,13 @@ namespace StripeTests.Issuing
         {
             var authorizations = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/issuing/authorizations");
+            Assert.NotNull(authorizations);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var authorizations = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(authorizations);
         }
 

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -99,6 +100,13 @@ namespace StripeTests.Issuing
         {
             var cardholders = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/issuing/cardholders");
+            Assert.NotNull(cardholders);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var cardholders = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(cardholders);
         }
 

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -106,6 +107,13 @@ namespace StripeTests.Issuing
         {
             var cards = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/issuing/cards");
+            Assert.NotNull(cards);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var cards = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(cards);
         }
 

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -94,6 +95,13 @@ namespace StripeTests.Issuing
         {
             var disputes = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/issuing/disputes");
+            Assert.NotNull(disputes);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var disputes = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(disputes);
         }
 

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Issuing
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +64,13 @@ namespace StripeTests.Issuing
         {
             var transactions = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/issuing/transactions");
+            Assert.NotNull(transactions);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var transactions = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(transactions);
         }
 

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -110,6 +111,14 @@ namespace StripeTests
             Assert.Equal("list", orders.Object);
             Assert.Single(orders.Data);
             Assert.Equal("order", orders.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var orders = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(orders);
+            Assert.Equal("order", orders[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -190,6 +191,14 @@ namespace StripeTests
             Assert.Equal("list", intents.Object);
             Assert.Single(intents.Data);
             Assert.Equal("payment_intent", intents.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(intents);
+            Assert.Equal("payment_intent", intents[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -115,6 +116,14 @@ namespace StripeTests
             Assert.Equal("list", payouts.Object);
             Assert.Single(payouts.Data);
             Assert.Equal("payout", payouts.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var payouts = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(payouts);
+            Assert.Equal("payout", payouts[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -111,23 +111,31 @@ namespace StripeTests
         [Fact]
         public void List()
         {
-            var transfers = this.service.List(AccountId, this.listOptions);
+            var persons = this.service.List(AccountId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/persons");
-            Assert.NotNull(transfers);
-            Assert.Equal("list", transfers.Object);
-            Assert.Single(transfers.Data);
-            Assert.Equal("person", transfers.Data[0].Object);
+            Assert.NotNull(persons);
+            Assert.Equal("list", persons.Object);
+            Assert.Single(persons.Data);
+            Assert.Equal("person", persons.Data[0].Object);
         }
 
         [Fact]
         public async Task ListAsync()
         {
-            var transfers = await this.service.ListAsync(AccountId, this.listOptions);
+            var persons = await this.service.ListAsync(AccountId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/accounts/acct_123/persons");
-            Assert.NotNull(transfers);
-            Assert.Equal("list", transfers.Object);
-            Assert.Single(transfers.Data);
-            Assert.Equal("person", transfers.Data[0].Object);
+            Assert.NotNull(persons);
+            Assert.Equal("list", persons.Object);
+            Assert.Single(persons.Data);
+            Assert.Equal("person", persons.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var persons = this.service.ListAutoPaging(AccountId, this.listOptions).ToList();
+            Assert.NotNull(persons);
+            Assert.Equal("person", persons[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -119,6 +120,14 @@ namespace StripeTests
             Assert.Equal("list", plans.Object);
             Assert.Single(plans.Data);
             Assert.Equal("plan", plans.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var plans = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(plans);
+            Assert.Equal("plan", plans[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -125,6 +126,14 @@ namespace StripeTests
             Assert.Equal("list", products.Object);
             Assert.Single(products.Data);
             Assert.Equal("product", products.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var products = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(products);
+            Assert.Equal("product", products[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -1,7 +1,6 @@
 namespace StripeTests.Radar
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -106,6 +105,14 @@ namespace StripeTests.Radar
             Assert.Equal("list", valueListItems.Object);
             Assert.Single(valueListItems.Data);
             Assert.Equal("radar.value_list_item", valueListItems.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var valueListItems = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(valueListItems);
+            Assert.Equal("radar.value_list_item", valueListItems[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -1,7 +1,7 @@
 namespace StripeTests.Radar
 {
-    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -116,6 +116,14 @@ namespace StripeTests.Radar
             Assert.Equal("list", valueLists.Object);
             Assert.Single(valueLists.Data);
             Assert.Equal("radar.value_list", valueLists.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var valueLists = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(valueLists);
+            Assert.Equal("radar.value_list", valueLists[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -97,6 +98,14 @@ namespace StripeTests
             Assert.Equal("list", refunds.Object);
             Assert.Single(refunds.Data);
             Assert.Equal("refund", refunds.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var refunds = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(refunds);
+            Assert.Equal("refund", refunds[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -1,7 +1,7 @@
 namespace StripeTests.Reporting
 {
     using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -81,6 +81,13 @@ namespace StripeTests.Reporting
         {
             var reportRuns = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_runs");
+            Assert.NotNull(reportRuns);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var reportRuns = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(reportRuns);
         }
     }

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -1,7 +1,6 @@
 namespace StripeTests.Reporting
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -54,6 +53,13 @@ namespace StripeTests.Reporting
         {
             var reportTypes = await this.service.ListAsync(this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types");
+            Assert.NotNull(reportTypes);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var reportTypes = this.service.ListAutoPaging(this.listOptions).ToList();
             Assert.NotNull(reportTypes);
         }
     }

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -1,7 +1,6 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -86,6 +85,14 @@ namespace StripeTests
             Assert.Equal("list", reviews.Object);
             Assert.Single(reviews.Data);
             Assert.Equal("review", reviews.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var reviews = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(reviews);
+            Assert.Equal("review", reviews[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -1,6 +1,6 @@
 namespace StripeTests
 {
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -63,6 +63,14 @@ namespace StripeTests
             Assert.Equal("list", runs.Object);
             Assert.Single(runs.Data);
             Assert.Equal("scheduled_query_run", runs.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var runs = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(runs);
+            Assert.Equal("scheduled_query_run", runs[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -131,6 +132,14 @@ namespace StripeTests
             Assert.Equal("list", skus.Object);
             Assert.Single(skus.Data);
             Assert.Equal("sku", skus.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var skus = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(skus);
+            Assert.Equal("sku", skus[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -1,7 +1,6 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -29,23 +28,31 @@ namespace StripeTests
         [Fact]
         public void List()
         {
-            var sources = this.service.List(SourceId, this.listOptions);
+            var sourceTransactions = this.service.List(SourceId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123/source_transactions");
-            Assert.NotNull(sources);
-            Assert.Equal("list", sources.Object);
-            Assert.Single(sources.Data);
-            Assert.Equal("source_transaction", sources.Data[0].Object);
+            Assert.NotNull(sourceTransactions);
+            Assert.Equal("list", sourceTransactions.Object);
+            Assert.Single(sourceTransactions.Data);
+            Assert.Equal("source_transaction", sourceTransactions.Data[0].Object);
         }
 
         [Fact]
         public async Task ListAsync()
         {
-            var sources = await this.service.ListAsync(SourceId, this.listOptions);
+            var sourceTransactions = await this.service.ListAsync(SourceId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/sources/src_123/source_transactions");
-            Assert.NotNull(sources);
-            Assert.Equal("list", sources.Object);
-            Assert.Single(sources.Data);
-            Assert.Equal("source_transaction", sources.Data[0].Object);
+            Assert.NotNull(sourceTransactions);
+            Assert.Equal("list", sourceTransactions.Object);
+            Assert.Single(sourceTransactions.Data);
+            Assert.Equal("source_transaction", sourceTransactions.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var sourceTransactions = this.service.ListAutoPaging(SourceId, this.listOptions).ToList();
+            Assert.NotNull(sourceTransactions);
+            Assert.Equal("source_transaction", sourceTransactions[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -202,6 +203,13 @@ namespace StripeTests
 
             // We can't test the object returned as stripe-mock returns an Account
             // Assert.Equal("source", sources.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var sources = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
+            Assert.NotNull(sources);
         }
 
         [Fact]

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -115,6 +116,14 @@ namespace StripeTests
             Assert.Equal("list", subscriptionItems.Object);
             Assert.Single(subscriptionItems.Data);
             Assert.Equal("subscription_item", subscriptionItems.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var subscriptionItems = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(subscriptionItems);
+            Assert.Equal("subscription_item", subscriptionItems[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -134,6 +135,14 @@ namespace StripeTests
             Assert.Equal("list", subscriptions.Object);
             Assert.Single(subscriptions.Data);
             Assert.Equal("subscription", subscriptions.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var subscriptions = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(subscriptions);
+            Assert.Equal("subscription", subscriptions[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -116,6 +117,14 @@ namespace StripeTests
             Assert.Equal("list", topups.Object);
             Assert.Single(topups.Data);
             Assert.Equal("topup", topups.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var topups = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(topups);
+            Assert.Equal("topup", topups[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -80,23 +81,31 @@ namespace StripeTests
         [Fact]
         public void List()
         {
-            var transfers = this.service.List(TransferId, this.listOptions);
+            var transferReversals = this.service.List(TransferId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals");
-            Assert.NotNull(transfers);
-            Assert.Equal("list", transfers.Object);
-            Assert.Single(transfers.Data);
-            Assert.Equal("transfer_reversal", transfers.Data[0].Object);
+            Assert.NotNull(transferReversals);
+            Assert.Equal("list", transferReversals.Object);
+            Assert.Single(transferReversals.Data);
+            Assert.Equal("transfer_reversal", transferReversals.Data[0].Object);
         }
 
         [Fact]
         public async Task ListAsync()
         {
-            var transfers = await this.service.ListAsync(TransferId, this.listOptions);
+            var transferReversals = await this.service.ListAsync(TransferId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/transfers/tr_123/reversals");
-            Assert.NotNull(transfers);
-            Assert.Equal("list", transfers.Object);
-            Assert.Single(transfers.Data);
-            Assert.Equal("transfer_reversal", transfers.Data[0].Object);
+            Assert.NotNull(transferReversals);
+            Assert.Equal("list", transferReversals.Object);
+            Assert.Single(transferReversals.Data);
+            Assert.Equal("transfer_reversal", transferReversals.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var transferReversals = this.service.ListAutoPaging(TransferId, this.listOptions).ToList();
+            Assert.NotNull(transferReversals);
+            Assert.Equal("transfer_reversal", transferReversals[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -98,6 +99,14 @@ namespace StripeTests
             Assert.Equal("list", transfers.Object);
             Assert.Single(transfers.Data);
             Assert.Equal("transfer", transfers.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var transfers = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(transfers);
+            Assert.Equal("transfer", transfers[0].Object);
         }
 
         [Fact]

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -1,7 +1,6 @@
 namespace StripeTests
 {
-    using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -10,6 +9,7 @@ namespace StripeTests
 
     public class UsageRecordSummaryServiceTest : BaseStripeTest
     {
+        private const string SubscriptionItemId = "si_123";
         private readonly UsageRecordSummaryService service;
         private readonly UsageRecordSummaryListOptions listOptions;
 
@@ -27,7 +27,7 @@ namespace StripeTests
         [Fact]
         public void List()
         {
-            var summaries = this.service.List("si_123", this.listOptions);
+            var summaries = this.service.List(SubscriptionItemId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123/usage_record_summaries");
             Assert.NotNull(summaries);
             Assert.Equal("list", summaries.Object);
@@ -38,12 +38,20 @@ namespace StripeTests
         [Fact]
         public async Task ListAsync()
         {
-            var summaries = await this.service.ListAsync("si_123", this.listOptions);
+            var summaries = await this.service.ListAsync(SubscriptionItemId, this.listOptions);
             this.AssertRequest(HttpMethod.Get, "/v1/subscription_items/si_123/usage_record_summaries");
             Assert.NotNull(summaries);
             Assert.Equal("list", summaries.Object);
             Assert.Single(summaries.Data);
             Assert.Equal("usage_record_summary", summaries.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var summaries = this.service.ListAutoPaging(SubscriptionItemId, this.listOptions).ToList();
+            Assert.NotNull(summaries);
+            Assert.Equal("usage_record_summary", summaries[0].Object);
         }
     }
 }

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -116,6 +117,14 @@ namespace StripeTests
             Assert.Equal("list", endpoints.Object);
             Assert.Single(endpoints.Data);
             Assert.Equal("webhook_endpoint", endpoints.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var endpoints = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(endpoints);
+            Assert.Equal("webhook_endpoint", endpoints[0].Object);
         }
 
         [Fact]


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Adds support for auto-pagination.

Example usages:

```c#
var service = new BalanceTransactionService();
var listOptions = new BalanceTransactionListOptions
{
  Created = new DateRangeOptions
  {
    GreatherThanOrEqual = DateTime.Parse("2018-11-01T00:00:00Z"),
    LessThan = DateTime.Parse("2018-12-01T00:00:00Z"),
  },
  Limit = 100,
};

foreach (var balanceTransaction in service.ListAutoPaging(listOptions))
{
  // Do something with balanceTransaction
}
```

```c#
var service = new InvoiceService();
var lineItems = service.ListLineItemsAutoPaging("in_123").ToList();
```

The second example uses the LINQ method [`ToList()`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tolist?view=netframework-4.7.2) to directly convert the `IEnumerable<LineItem>` returned by `InvoiceService.ListLineItemsAutoPaging()` into a `List<LineItem>`.

Fixes #1038.
