### PR TITLE
Replace public fields with properties

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public static class StripeConfiguration
     {
-        public static string StripeApiVersion = "2018-11-08";
+        private static string stripeApiVersion = "2018-11-08";
 
         private static string apiKey;
         private static string apiBase;
@@ -17,6 +17,12 @@ namespace Stripe
         static StripeConfiguration()
         {
             StripeNetVersion = new AssemblyName(typeof(Requestor).GetTypeInfo().Assembly.FullName).Version.ToString(3);
+        }
+
+        public static string StripeApiVersion
+        {
+            get { return stripeApiVersion; }
+            set { stripeApiVersion = value; }
         }
 
         public static string StripeNetVersion { get; }

--- a/src/Stripe.net/Services/BaseOptions.cs
+++ b/src/Stripe.net/Services/BaseOptions.cs
@@ -4,8 +4,20 @@ namespace Stripe
 
     public class BaseOptions : INestedOptions
     {
-        public Dictionary<string, string> ExtraParams = new Dictionary<string, string>();
-        public List<string> Expand = new List<string>();
+        private Dictionary<string, string> extraParams = new Dictionary<string, string>();
+        private List<string> expand = new List<string>();
+
+        public Dictionary<string, string> ExtraParams
+        {
+            get { return this.extraParams; }
+            set { this.extraParams = value; }
+        }
+
+        public List<string> Expand
+        {
+            get { return this.expand; }
+            set { this.expand = value; }
+        }
 
         public void AddExtraParam(string key, string value)
         {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Replace public fields by private fields encapsulated by public properties.

> Public fields in public classes do not respect the encapsulation principle and has three main disadvantages:
> 
> Additional behavior such as validation cannot be added.
> The internal representation is exposed, and cannot be changed afterwards.
> Member values are subject to change from anywhere in the code and may not meet the programmer's assumptions.
> By using private fields and public properties (set and get), unauthorized modifications are prevented. Properties also benefit from additional protection (security) features such as Link Demands.
> 
> Note that due to optimizations on simple properties, public fields provide only very little performance gain.

