### PR TITLE
Specify culture for string operations

### DIFF
--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -372,7 +372,7 @@ namespace Stripe.Infrastructure.Middleware
             }
             else
             {
-                int i = key.IndexOf("[");
+                int i = key.IndexOf("[", StringComparison.Ordinal);
                 if (i == -1)
                 {
                     return $"{keyPrefix}[{key}]";

--- a/src/Stripe.net/Infrastructure/MimeTypes.cs
+++ b/src/Stripe.net/Infrastructure/MimeTypes.cs
@@ -6,7 +6,7 @@ namespace Stripe.Infrastructure
     {
         public static string GetMimeType(string fileName)
         {
-            switch (Path.GetExtension(fileName.ToLower()))
+            switch (Path.GetExtension(fileName.ToLowerInvariant()))
             {
                 case ".jpeg":
                 case ".jpg":

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -78,7 +78,7 @@ namespace Stripe
             using (var cryptographer = new HMACSHA256(secretBytes))
             {
                 var hash = cryptographer.ComputeHash(payloadBytes);
-                return BitConverter.ToString(hash).Replace("-", string.Empty).ToLower();
+                return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
             }
         }
 

--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -381,7 +381,7 @@ namespace StripeTests
                 Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
 
                 var dec = 123.45m;
-                Assert.Equal("123,45", dec.ToString());
+                Assert.Equal("123,45", dec.ToString(CultureInfo.CurrentCulture));
 
                 var obj = new TestOptions
                 {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

It's good practice to specify an explicit culture when dealing with string operations to get consistent results (as otherwise the system's default culture will be used).
