### PR TITLE
Replace constants with static read-only properties

### DIFF
--- a/src/Stripe.net/Constants/AccountType.cs
+++ b/src/Stripe.net/Constants/AccountType.cs
@@ -2,7 +2,8 @@ namespace Stripe
 {
     public static class AccountType
     {
-        public const string Custom = "custom";
-        public const string Standard = "standard";
+        public static string Custom => "custom";
+
+        public static string Standard => "standard";
     }
 }

--- a/src/Stripe.net/Constants/BankAccountHolderType.cs
+++ b/src/Stripe.net/Constants/BankAccountHolderType.cs
@@ -2,7 +2,8 @@ namespace Stripe
 {
     public static class BankAccountHolderType
     {
-        public const string Individual = "individual";
-        public const string Company = "company";
+        public static string Individual => "individual";
+
+        public static string Company => "company";
     }
 }

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -7,481 +7,481 @@ namespace Stripe
         /// <summary>
         /// Occurs whenever an account status or property has changed.
         /// </summary>
-        public const string AccountUpdated = "account.updated";
+        public static string AccountUpdated => "account.updated";
 
         /// <summary>
         /// Occurs whenever a user deauthorizes an application. Sent to the related application only.
         /// </summary>
-        public const string AccountApplicationDeauthorized = "account.application.deauthorized";
+        public static string AccountApplicationDeauthorized => "account.application.deauthorized";
 
         /// <summary>
         /// Occurs whenever an external account is created.
         /// </summary>
-        public const string AccountExternalAccountCreated = "account.external_account.created";
+        public static string AccountExternalAccountCreated => "account.external_account.created";
 
         /// <summary>
         /// Occurs whenever an external account is deleted.
         /// </summary>
-        public const string AccountExternalAccountDeleted = "account.external_account.deleted";
+        public static string AccountExternalAccountDeleted => "account.external_account.deleted";
 
         /// <summary>
         /// Occurs whenever an external account is updated.
         /// </summary>
-        public const string AccountExternalAccountUpdated = "account.external_account.updated";
+        public static string AccountExternalAccountUpdated => "account.external_account.updated";
 
         /// <summary>
         /// Occurs whenever an application fee is created on a charge.
         /// </summary>
-        public const string ApplicationFeeCreated = "application_fee.created";
+        public static string ApplicationFeeCreated => "application_fee.created";
 
         /// <summary>
         /// Occurs whenever an application fee is refunded, whether from refunding a charge or from refunding the application fee directly, including partial refunds.
         /// </summary>
-        public const string ApplicationFeeRefunded = "application_fee.refunded";
+        public static string ApplicationFeeRefunded => "application_fee.refunded";
 
         /// <summary>
         /// Occurs whenever an application fee refund is updated.
         /// </summary>
-        public const string ApplicationFeeRefundUpdated = "application_fee.refund.updated";
+        public static string ApplicationFeeRefundUpdated => "application_fee.refund.updated";
 
         /// <summary>
         /// Occurs whenever your Stripe balance has been updated (e.g. when a charge collected is available to be paid out). By default, Stripe will automatically transfer any funds in your balance to your bank account on a daily basis.
         /// </summary>
-        public const string BalanceAvailable = "balance.available";
+        public static string BalanceAvailable => "balance.available";
 
         /// <summary>
         /// Occurs whenever a receiver has been created.
         /// </summary>
-        public const string BitcoinReceiverCreated = "bitcoin.receiver.created";
+        public static string BitcoinReceiverCreated => "bitcoin.receiver.created";
 
         /// <summary>
         /// Occurs whenever a receiver is filled (that is, when it has received enough bitcoin to process a payment of the same amount).
         /// </summary>
-        public const string BitcoinReceiverFilled = "bitcoin.receiver.filled";
+        public static string BitcoinReceiverFilled => "bitcoin.receiver.filled";
 
         /// <summary>
         /// Occurs whenever a receiver is updated.
         /// </summary>
-        public const string BitcoinReceiverUpdated = "bitcoin.receiver.updated";
+        public static string BitcoinReceiverUpdated => "bitcoin.receiver.updated";
 
         /// <summary>
         /// Occurs whenever bitcoin is pushed to a receiver.
         /// </summary>
-        public const string BitcoinReceiverTransactionUpdated = "bitcoin.receiver.transaction.created";
+        public static string BitcoinReceiverTransactionUpdated => "bitcoin.receiver.transaction.created";
 
         /// <summary>
         /// Occurs whenever a previously uncaptured charge is captured.
         /// </summary>
-        public const string ChargeCaptured = "charge.captured";
+        public static string ChargeCaptured => "charge.captured";
 
         /// <summary>
         /// Occurs whenever a previously uncaptured charge expires.
         /// </summary>
-        public const string ChargeExpired = "charge.expired";
+        public static string ChargeExpired => "charge.expired";
 
         /// <summary>
         /// Occurs whenever a failed charge attempt occurs.
         /// </summary>
-        public const string ChargeFailed = "charge.failed";
+        public static string ChargeFailed => "charge.failed";
 
         /// <summary>
         /// Occurs whenever a pending charge is created.
         /// </summary>
-        public const string ChargePending = "charge.pending";
+        public static string ChargePending => "charge.pending";
 
         /// <summary>
         /// Occurs whenever a refund is updated on selected payment methods.
         /// </summary>
-        public const string ChargeRefundUpdated = "charge.refund.updated";
+        public static string ChargeRefundUpdated => "charge.refund.updated";
 
         /// <summary>
         /// Occurs whenever a charge is refunded, including partial refunds.
         /// </summary>
-        public const string ChargeRefunded = "charge.refunded";
+        public static string ChargeRefunded => "charge.refunded";
 
         /// <summary>
         /// Occurs whenever a new charge is created and is successful.
         /// </summary>
-        public const string ChargeSucceeded = "charge.succeeded";
+        public static string ChargeSucceeded => "charge.succeeded";
 
         /// <summary>
         /// Occurs whenever a charge description or metadata is updated.
         /// </summary>
-        public const string ChargeUpdated = "charge.updated";
+        public static string ChargeUpdated => "charge.updated";
 
         /// <summary>
         /// Occurs when the dispute is closed and the dispute status changes to charge_refunded, lost, warning_closed, or won.
         /// </summary>
-        public const string ChargeDisputeClosed = "charge.dispute.closed";
+        public static string ChargeDisputeClosed => "charge.dispute.closed";
 
         /// <summary>
         /// Occurs whenever a customer disputes a charge with their bank (chargeback).
         /// </summary>
-        public const string ChargeDisputeCreated = "charge.dispute.created";
+        public static string ChargeDisputeCreated => "charge.dispute.created";
 
         /// <summary>
         /// Occurs when funds are reinstated to your account after a dispute is won.
         /// </summary>
-        public const string ChargeDisputeFundsReinstated = "charge.dispute.funds_reinstated";
+        public static string ChargeDisputeFundsReinstated => "charge.dispute.funds_reinstated";
 
         /// <summary>
         /// Occurs when funds are removed from your account due to a dispute.
         /// </summary>
-        public const string ChargeDisputeFundsWithdrawn = "charge.dispute.funds_withdrawn";
+        public static string ChargeDisputeFundsWithdrawn => "charge.dispute.funds_withdrawn";
 
         /// <summary>
         /// Occurs when the dispute is updated (usually with evidence).
         /// </summary>
-        public const string ChargeDisputeUpdated = "charge.dispute.updated";
+        public static string ChargeDisputeUpdated => "charge.dispute.updated";
 
         /// <summary>
         /// Occurs whenever a coupon is created.
         /// </summary>
-        public const string CouponCreated = "coupon.created";
+        public static string CouponCreated => "coupon.created";
 
         /// <summary>
         /// Occurs whenever a coupon is deleted.
         /// </summary>
-        public const string CouponDeleted = "coupon.deleted";
+        public static string CouponDeleted => "coupon.deleted";
 
         /// <summary>
         /// Occurs whenever a coupon is updated.
         /// </summary>
-        public const string CouponUpdated = "coupon.updated";
+        public static string CouponUpdated => "coupon.updated";
 
         /// <summary>
         /// Occurs whenever a new customer is created.
         /// </summary>
-        public const string CustomerCreated = "customer.created";
+        public static string CustomerCreated => "customer.created";
 
         /// <summary>
         /// Occurs whenever a customer is deleted.
         /// </summary>
-        public const string CustomerDeleted = "customer.deleted";
+        public static string CustomerDeleted => "customer.deleted";
 
         /// <summary>
         /// Occurs whenever any property of a customer changes.
         /// </summary>
-        public const string CustomerUpdated = "customer.updated";
+        public static string CustomerUpdated => "customer.updated";
 
         /// <summary>
         /// Occurs whenever a coupon is attached to a customer.
         /// </summary>
-        public const string CustomerDiscountCreated = "customer.discount.created";
+        public static string CustomerDiscountCreated => "customer.discount.created";
 
         /// <summary>
         /// Occurs whenever a customer's discount is removed.
         /// </summary>
-        public const string CustomerDiscountDeleted = "customer.discount.deleted";
+        public static string CustomerDiscountDeleted => "customer.discount.deleted";
 
         /// <summary>
         /// Occurs whenever a customer is switched from one coupon to another.
         /// </summary>
-        public const string CustomerDiscountUpdated = "customer.discount.updated";
+        public static string CustomerDiscountUpdated => "customer.discount.updated";
 
         /// <summary>
         /// Occurs whenever a new source is created for the customer.
         /// </summary>
-        public const string CustomerSourceCreated = "customer.source.created";
+        public static string CustomerSourceCreated => "customer.source.created";
 
         /// <summary>
         /// Occurs whenever a source is removed from a customer.
         /// </summary>
-        public const string CustomerSourceDeleted = "customer.source.deleted";
+        public static string CustomerSourceDeleted => "customer.source.deleted";
 
         /// <summary>
         /// Occurs whenever a source will expire at the end of the month.
         /// </summary>
-        public const string CustomerSourceExpiring = "customer.source.expiring";
+        public static string CustomerSourceExpiring => "customer.source.expiring";
 
         /// <summary>
         /// Occurs whenever a source's details are changed.
         /// </summary>
-        public const string CustomerSourceUpdated = "customer.source.updated";
+        public static string CustomerSourceUpdated => "customer.source.updated";
 
         /// <summary>
         /// Occurs whenever a customer with no subscription is signed up for a plan.
         /// </summary>
-        public const string CustomerSubscriptionCreated = "customer.subscription.created";
+        public static string CustomerSubscriptionCreated => "customer.subscription.created";
 
         /// <summary>
         /// Occurs whenever a customer ends their subscription.
         /// </summary>
-        public const string CustomerSubscriptionDeleted = "customer.subscription.deleted";
+        public static string CustomerSubscriptionDeleted => "customer.subscription.deleted";
 
         /// <summary>
         /// Occurs three days before the trial period of a subscription is scheduled to end.
         /// </summary>
-        public const string CustomerSubscriptionTrialWillEnd = "customer.subscription.trial_will_end";
+        public static string CustomerSubscriptionTrialWillEnd => "customer.subscription.trial_will_end";
 
         /// <summary>
         /// Occurs three days before the trial period of a subscription is scheduled to end.
         /// </summary>
-        public const string CustomerSubscriptionUpdated = "customer.subscription.updated";
+        public static string CustomerSubscriptionUpdated => "customer.subscription.updated";
 
         /// <summary>
         /// Occurs whenever a new invoice is created. If you are using webhooks, Stripe will wait one hour after they have all succeeded to attempt to pay the invoice; the only exception here is on the first invoice, which gets created and paid immediately when you subscribe a customer to a plan. If your webhooks do not all respond successfully, Stripe will continue retrying the webhooks every hour and will not attempt to pay the invoice. After 3 days, Stripe will attempt to pay the invoice regardless of whether or not your webhooks have succeeded.
         /// </summary>
-        public const string InvoiceCreated = "invoice.created";
+        public static string InvoiceCreated => "invoice.created";
 
         /// <summary>
         /// Occurs whenever an invoice attempts to be paid, and the payment fails. This can occur either due to a declined payment, or because the customer has no active card. A particular case of note is that if a customer with no active card reaches the end of its free trial, an invoice.payment_failed notification will occur.
         /// </summary>
-        public const string InvoicePaymentFailed = "invoice.payment_failed";
+        public static string InvoicePaymentFailed => "invoice.payment_failed";
 
         /// <summary>
         /// Occurs whenever an invoice attempts to be paid, and the payment succeeds.
         /// </summary>
-        public const string InvoicePaymentSucceeded = "invoice.payment_succeeded";
+        public static string InvoicePaymentSucceeded => "invoice.payment_succeeded";
 
         /// <summary>
         /// Occurs whenever an invoice email is sent out.
         /// </summary>
-        public const string InvoiceSent = "invoice.sent";
+        public static string InvoiceSent => "invoice.sent";
 
         /// <summary>
         /// Occurs X number of days before a subscription is scheduled to create an invoice that is charged automatically, where X is determined by your subscriptions settings.
         /// </summary>
-        public const string InvoiceUpcoming = "invoice.upcoming";
+        public static string InvoiceUpcoming => "invoice.upcoming";
 
         /// <summary>
         /// Occurs whenever an invoice changes (for example, the amount could change).
         /// </summary>
-        public const string InvoiceUpdated = "invoice.updated";
+        public static string InvoiceUpdated => "invoice.updated";
 
         /// <summary>
         /// Occurs whenever an invoice item is created.
         /// </summary>
-        public const string InvoiceItemCreated = "invoiceitem.created";
+        public static string InvoiceItemCreated => "invoiceitem.created";
 
         /// <summary>
         /// Occurs whenever an invoice item is deleted.
         /// </summary>
-        public const string InvoiceItemDeleted = "invoiceitem.deleted";
+        public static string InvoiceItemDeleted => "invoiceitem.deleted";
 
         /// <summary>
         /// Occurs whenever an invoice item is updated.
         /// </summary>
-        public const string InvoiceItemUpdated = "invoiceitem.updated";
+        public static string InvoiceItemUpdated => "invoiceitem.updated";
 
         /// <summary>
         /// Occurs whenever an issuing authorization is created.
         /// </summary>
-        public const string IssuingAuthorizationCreated = "issuing_authorization.created";
+        public static string IssuingAuthorizationCreated => "issuing_authorization.created";
 
         /// <summary>
         /// Occurs whenever an issuing authorization request is sent.
         /// </summary>
-        public const string IssuingAuthorizationRequest = "issuing_authorization.request";
+        public static string IssuingAuthorizationRequest => "issuing_authorization.request";
 
         /// <summary>
         /// Occurs whenever an issuing authorization is updated.
         /// </summary>
-        public const string IssuingAuthorizationUpdated = "issuing_authorization.updated";
+        public static string IssuingAuthorizationUpdated => "issuing_authorization.updated";
 
         /// <summary>
         /// Occurs whenever an issuing card is created.
         /// </summary>
-        public const string IssuingCardCreated = "issuing_card.created";
+        public static string IssuingCardCreated => "issuing_card.created";
 
         /// <summary>
         /// Occurs whenever an issuing card is updated.
         /// </summary>
-        public const string IssuingCardUpdated = "issuing_card.updated";
+        public static string IssuingCardUpdated => "issuing_card.updated";
 
         /// <summary>
         /// Occurs whenever an issuing cardholder is created.
         /// </summary>
-        public const string IssuingCardholderCreated = "issuing_cardholder.created";
+        public static string IssuingCardholderCreated => "issuing_cardholder.created";
 
         /// <summary>
         /// Occurs whenever an issuing cardholder is updated.
         /// </summary>
-        public const string IssuingCardholderUpdated = "issuing_cardholder.updated";
+        public static string IssuingCardholderUpdated => "issuing_cardholder.updated";
 
         /// <summary>
         /// Occurs whenever an issuing dispute is created.
         /// </summary>
-        public const string IssuingDisputeCreated = "issuing_dispute.created";
+        public static string IssuingDisputeCreated => "issuing_dispute.created";
 
         /// <summary>
         /// Occurs whenever an issuing dispute is updated.
         /// </summary>
-        public const string IssuingDisputeUpdated = "issuing_dispute.updated";
+        public static string IssuingDisputeUpdated => "issuing_dispute.updated";
 
         /// <summary>
         /// Occurs whenever an issuing transaction is created.
         /// </summary>
-        public const string IssuingTransactionCreated = "issuing_transaction.created";
+        public static string IssuingTransactionCreated => "issuing_transaction.created";
 
         /// <summary>
         /// Occurs whenever an issuing transaction is updated.
         /// </summary>
-        public const string IssuingTransactionUpdated = "issuing_transaction.updated";
+        public static string IssuingTransactionUpdated => "issuing_transaction.updated";
 
         /// <summary>
         /// Occurs whenever an order is created.
         /// </summary>
-        public const string OrderCreated = "order.created";
+        public static string OrderCreated => "order.created";
 
         /// <summary>
         /// Occurs whenever payment is attempted on an order, and the payment fails.
         /// </summary>
-        public const string OrderPaymentFailed = "order.payment_failed";
+        public static string OrderPaymentFailed => "order.payment_failed";
 
         /// <summary>
         /// Occurs whenever payment is attempted on an order, and the payment succeeds.
         /// </summary>
-        public const string OrderPaymentSucceeded = "order.payment_succeeded";
+        public static string OrderPaymentSucceeded => "order.payment_succeeded";
 
         /// <summary>
         /// Occurs whenever an order is updated.
         /// </summary>
-        public const string OrderUpdated = "order.updated";
+        public static string OrderUpdated => "order.updated";
 
         /// <summary>
         /// Occurs whenever an order return is created.
         /// </summary>
-        public const string OrderReturnCreated = "order_return.created";
+        public static string OrderReturnCreated => "order_return.created";
 
         /// <summary>
         /// Occurs whenever a payout is canceled.
         /// </summary>
-        public const string PayoutCanceled = "payout.canceled";
+        public static string PayoutCanceled => "payout.canceled";
 
         /// <summary>
         /// Occurs whenever a new payout is created.
         /// </summary>
-        public const string PayoutCreated = "payout.created";
+        public static string PayoutCreated => "payout.created";
 
         /// <summary>
         /// Occurs whenever Stripe attempts to send a payout and that transfer fails.
         /// </summary>
-        public const string PayoutFailed = "payout.failed";
+        public static string PayoutFailed => "payout.failed";
 
         /// <summary>
         /// Occurs whenever a payout is expected to be available in the destination bank account. If the payout failed, a payout.failed webhook will additionally be sent at a later time.
         /// </summary>
-        public const string PayoutPaid = "payout.paid";
+        public static string PayoutPaid => "payout.paid";
 
         /// <summary>
         /// Occurs whenever the metadata of a payout is updated.
         /// </summary>
-        public const string PayoutUpdated = "payout.updated";
+        public static string PayoutUpdated => "payout.updated";
 
         /// <summary>
         /// Occurs whenever a plan is created.
         /// </summary>
-        public const string PlanCreated = "plan.created";
+        public static string PlanCreated => "plan.created";
 
         /// <summary>
         /// Occurs whenever a plan is deleted.
         /// </summary>
-        public const string PlanDeleted = "plan.deleted";
+        public static string PlanDeleted => "plan.deleted";
 
         /// <summary>
         /// Occurs whenever a plan is updated.
         /// </summary>
-        public const string PlanUpdated = "plan.updated";
+        public static string PlanUpdated => "plan.updated";
 
         /// <summary>
         /// Occurs whenever a product is created.
         /// </summary>
-        public const string ProductCreated = "product.created";
+        public static string ProductCreated => "product.created";
 
         /// <summary>
         /// Occurs whenever a product is deleted.
         /// </summary>
-        public const string ProductDeleted = "product.deleted";
+        public static string ProductDeleted => "product.deleted";
 
         /// <summary>
         /// Occurs whenever a product is updated.
         /// </summary>
-        public const string ProductUpdated = "product.updated";
+        public static string ProductUpdated => "product.updated";
 
         /// <summary>
         /// Occurs whenever a recipient is created.
         /// </summary>
-        public const string RecipientCreated = "recipient.created";
+        public static string RecipientCreated => "recipient.created";
 
         /// <summary>
         /// Occurs whenever a recipient is deleted.
         /// </summary>
-        public const string RecipientDeleted = "recipient.deleted";
+        public static string RecipientDeleted => "recipient.deleted";
 
         /// <summary>
         /// Occurs whenever a recipient is updated.
         /// </summary>
-        public const string RecipientUpdated = "recipient.updated";
+        public static string RecipientUpdated => "recipient.updated";
 
         /// <summary>
         /// Occurs whenever a review is closed. The review's reason field will indicate why the review was closed (e.g. approved, refunded, refunded_as_fraud, disputed.
         /// </summary>
-        public const string ReviewClosed = "review.closed";
+        public static string ReviewClosed => "review.closed";
 
         /// <summary>
         /// Occurs whenever a review is opened.
         /// </summary>
-        public const string ReviewOpened = "review.opened";
+        public static string ReviewOpened => "review.opened";
 
         /// <summary>
         /// Occurs whenever a SKU is created.
         /// </summary>
-        public const string SkuCreated = "sku.created";
+        public static string SkuCreated => "sku.created";
 
         /// <summary>
         /// Occurs whenever a SKU is deleted.
         /// </summary>
-        public const string SkuDeleted = "sku.deleted";
+        public static string SkuDeleted => "sku.deleted";
 
         /// <summary>
         /// Occurs whenever a SKU is updated.
         /// </summary>
-        public const string SkuUpdated = "sku.updated";
+        public static string SkuUpdated => "sku.updated";
 
         /// <summary>
         /// Occurs whenever a source is canceled.
         /// </summary>
-        public const string SourceCanceled = "source.canceled";
+        public static string SourceCanceled => "source.canceled";
 
         /// <summary>
         /// Occurs whenever a source transitions to chargeable.
         /// </summary>
-        public const string SourceChargeable = "source.chargeable";
+        public static string SourceChargeable => "source.chargeable";
 
         /// <summary>
         /// Occurs whenever a source is failed.
         /// </summary>
-        public const string SourceFailed = "source.failed";
+        public static string SourceFailed => "source.failed";
 
         /// <summary>
         /// Occurs whenever a source transaction is created.
         /// </summary>
-        public const string SourceTransactionCreated = "source.transaction.created";
+        public static string SourceTransactionCreated => "source.transaction.created";
 
         /// <summary>
         /// Occurs whenever a source transaction is updated.
         /// </summary>
-        public const string SourceTransactionUpdated = "source.transaction.updated";
+        public static string SourceTransactionUpdated => "source.transaction.updated";
 
         /// <summary>
         /// Occurs whenever a new transfer is created.
         /// </summary>
-        public const string TransferCreated = "transfer.created";
+        public static string TransferCreated => "transfer.created";
 
         /// <summary>
         /// Occurs whenever a transfer is reversed, including partial reversals.
         /// </summary>
-        public const string TransferReversed = "transfer.reversed";
+        public static string TransferReversed => "transfer.reversed";
 
         /// <summary>
         /// Occurs whenever the description or metadata of a transfer is updated.
         /// </summary>
-        public const string TransferUpdated = "transfer.updated";
+        public static string TransferUpdated => "transfer.updated";
 
         /// <summary>
         /// May be sent by Stripe at any time to see if a provided webhook URL is working.
         /// </summary>
-        public const string Ping = "ping";
+        public static string Ping => "ping";
     }
 }

--- a/src/Stripe.net/Constants/FilePurpose.cs
+++ b/src/Stripe.net/Constants/FilePurpose.cs
@@ -2,12 +2,18 @@ namespace Stripe
 {
     public static class FilePurpose
     {
-        public const string BusinessLogo = "business_logo";
-        public const string DisputeEvidence = "dispute_evidence";
-        public const string IdentityDocument = "identity_document";
-        public const string IncorporationArticle = "incorporation_article";
-        public const string IncorporationDocument = "incorporation_document";
-        public const string PaymentProviderTransfer = "payment_provider_transfer";
-        public const string ProductFeed = "product_feed";
+        public static string BusinessLogo => "business_logo";
+
+        public static string DisputeEvidence => "dispute_evidence";
+
+        public static string IdentityDocument => "identity_document";
+
+        public static string IncorporationArticle => "incorporation_article";
+
+        public static string IncorporationDocument => "incorporation_document";
+
+        public static string PaymentProviderTransfer => "payment_provider_transfer";
+
+        public static string ProductFeed => "product_feed";
     }
 }

--- a/src/Stripe.net/Constants/PlanIntervals.cs
+++ b/src/Stripe.net/Constants/PlanIntervals.cs
@@ -2,9 +2,12 @@ namespace Stripe
 {
     public static class PlanIntervals
     {
-        public const string Day = "day";
-        public const string Week = "week";
-        public const string Month = "month";
-        public const string Year = "year";
+        public static string Day => "day";
+
+        public static string Week => "week";
+
+        public static string Month => "month";
+
+        public static string Year => "year";
     }
 }

--- a/src/Stripe.net/Constants/RefundReasons.cs
+++ b/src/Stripe.net/Constants/RefundReasons.cs
@@ -2,9 +2,12 @@ namespace Stripe
 {
     public static class RefundReasons
     {
-        public const string Unknown = null;
-        public const string Duplicate = "duplicate";
-        public const string Fraudulent = "fraudulent";
-        public const string RequestedByCustomer = "requested_by_customer";
+        public static string Unknown => null;
+
+        public static string Duplicate => "duplicate";
+
+        public static string Fraudulent => "fraudulent";
+
+        public static string RequestedByCustomer => "requested_by_customer";
     }
 }

--- a/src/Stripe.net/Constants/SourceFlow.cs
+++ b/src/Stripe.net/Constants/SourceFlow.cs
@@ -2,9 +2,12 @@ namespace Stripe
 {
     public static class SourceFlow
     {
-        public const string Redirect = "redirect";
-        public const string Receiver = "receiver";
-        public const string CodeVerification = "code_verification";
-        public const string None = "none";
+        public static string Redirect => "redirect";
+
+        public static string Receiver => "receiver";
+
+        public static string CodeVerification => "code_verification";
+
+        public static string None => "none";
     }
 }

--- a/src/Stripe.net/Constants/SourceType.cs
+++ b/src/Stripe.net/Constants/SourceType.cs
@@ -2,19 +2,32 @@ namespace Stripe
 {
     public static class SourceType
     {
-        public const string AchCreditTransfer = "ach_credit_transfer";
-        public const string AchDebit = "ach_debit";
-        public const string Alipay = "alipay";
-        public const string Bancontact = "bancontact";
-        public const string Bitcoin = "bitcoin";
-        public const string Card = "card";
-        public const string Eps = "eps";
-        public const string Giropay = "giropay";
-        public const string Ideal = "ideal";
-        public const string P24 = "p24";
-        public const string SepaCreditTransfer = "sepa_credit_transfer";
-        public const string SepaDebit = "sepa_debit";
-        public const string Sofort = "sofort";
-        public const string ThreeDSecure = "three_d_secure";
+        public static string AchCreditTransfer => "ach_credit_transfer";
+
+        public static string AchDebit => "ach_debit";
+
+        public static string Alipay => "alipay";
+
+        public static string Bancontact => "bancontact";
+
+        public static string Bitcoin => "bitcoin";
+
+        public static string Card => "card";
+
+        public static string Eps => "eps";
+
+        public static string Giropay => "giropay";
+
+        public static string Ideal => "ideal";
+
+        public static string P24 => "p24";
+
+        public static string SepaCreditTransfer => "sepa_credit_transfer";
+
+        public static string SepaDebit => "sepa_debit";
+
+        public static string Sofort => "sofort";
+
+        public static string ThreeDSecure => "three_d_secure";
     }
 }

--- a/src/Stripe.net/Constants/SourceUsage.cs
+++ b/src/Stripe.net/Constants/SourceUsage.cs
@@ -2,7 +2,8 @@ namespace Stripe
 {
     public static class SourceUsage
     {
-        public const string Reusable = "reusable";
-        public const string SingleUse = "single_use";
+        public static string Reusable => "reusable";
+
+        public static string SingleUse => "single_use";
     }
 }

--- a/src/Stripe.net/Constants/SubscriptionStatuses.cs
+++ b/src/Stripe.net/Constants/SubscriptionStatuses.cs
@@ -2,10 +2,14 @@ namespace Stripe
 {
     public static class SubscriptionStatuses
     {
-        public const string Trialing = "trialing";
-        public const string Active = "active";
-        public const string PastDue = "past_due";
-        public const string Canceled = "canceled";
-        public const string Unpaid = "unpaid";
+        public static string Trialing => "trialing";
+
+        public static string Active => "active";
+
+        public static string PastDue => "past_due";
+
+        public static string Canceled => "canceled";
+
+        public static string Unpaid => "unpaid";
     }
 }

--- a/src/Stripe.net/Constants/TransferFailureCodes.cs
+++ b/src/Stripe.net/Constants/TransferFailureCodes.cs
@@ -2,15 +2,24 @@ namespace Stripe
 {
     public static class TransferFailureCodes
     {
-        public const string InsufficientFunds = "insufficient_funds";
-        public const string AccountClosed = "account_closed";
-        public const string NoAccount = "no_account";
-        public const string InvalidAccountNumber = "invalid_account_number";
-        public const string DebitNotAuthorized = "debit_not_authorized";
-        public const string BankOwnershipChanged = "bank_ownership_changed";
-        public const string AccountFrozen = "account_frozen";
-        public const string CouldNotProcess = "could_not_process";
-        public const string BankAccountRestricted = "bank_account_restricted";
-        public const string InvalidCurrency = "invalid_currency";
+        public static string InsufficientFunds => "insufficient_funds";
+
+        public static string AccountClosed => "account_closed";
+
+        public static string NoAccount => "no_account";
+
+        public static string InvalidAccountNumber => "invalid_account_number";
+
+        public static string DebitNotAuthorized => "debit_not_authorized";
+
+        public static string BankOwnershipChanged => "bank_ownership_changed";
+
+        public static string AccountFrozen => "account_frozen";
+
+        public static string CouldNotProcess => "could_not_process";
+
+        public static string BankAccountRestricted => "bank_account_restricted";
+
+        public static string InvalidCurrency => "invalid_currency";
     }
 }

--- a/src/Stripe.net/Constants/TransferMethod.cs
+++ b/src/Stripe.net/Constants/TransferMethod.cs
@@ -5,11 +5,11 @@ namespace Stripe
         /// <summary>
         /// Standard is the default method.
         /// </summary>
-        public const string Standard = "standard";
+        public static string Standard => "standard";
 
         /// <summary>
         /// Only supported for transfers to debit cards.
         /// </summary>
-        public const string Instant = "instant";
+        public static string Instant => "instant";
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

It is considered bad practice to define public constants in C#. Static read-only properties should be used instead. Cf. [this SO answer](https://stackoverflow.com/a/755693/5307473).
