### PR TITLE
Move SerializerSettings to StripeConfiguration

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/Mapper.cs
+++ b/src/Stripe.net/Infrastructure/Public/Mapper.cs
@@ -9,8 +9,6 @@ namespace Stripe
 
     public static class Mapper<T>
     {
-        public static JsonSerializerSettings SerializerSettings = InitSerializerSettings();
-
         public static List<T> MapCollectionFromJson(string json, string token = "data", StripeResponse stripeResponse = null)
         {
             var jObject = JObject.Parse(json);
@@ -32,7 +30,7 @@ namespace Stripe
         {
             var jsonToParse = string.IsNullOrEmpty(parentToken) ? json : JObject.Parse(json).SelectToken(parentToken).ToString();
 
-            var result = JsonConvert.DeserializeObject<T>(jsonToParse, SerializerSettings);
+            var result = JsonConvert.DeserializeObject<T>(jsonToParse, StripeConfiguration.SerializerSettings);
 
             // if necessary, we might need to apply the stripe response to nested properties for StripeList<T>
             ApplyStripeResponse(json, stripeResponse, result);
@@ -61,18 +59,6 @@ namespace Stripe
             }
 
             stripeResponse.ObjectJson = json;
-        }
-
-        private static JsonSerializerSettings InitSerializerSettings()
-        {
-            return new JsonSerializerSettings
-            {
-                Converters = new List<JsonConverter>
-                {
-                    new StripeObjectConverter(),
-                },
-                DateParseHandling = DateParseHandling.None,
-            };
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -1,8 +1,10 @@
 namespace Stripe
 {
     using System;
+    using System.Collections.Generic;
     using System.Net.Http;
     using System.Reflection;
+    using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
     public static class StripeConfiguration
@@ -13,6 +15,7 @@ namespace Stripe
         private static string apiBase;
         private static string connectBase;
         private static string filesBase;
+        private static JsonSerializerSettings serializerSettings = DefaultSerializerSettings();
 
         static StripeConfiguration()
         {
@@ -23,6 +26,20 @@ namespace Stripe
         {
             get { return stripeApiVersion; }
             set { stripeApiVersion = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the settings used for deserializing JSON objects returned by Stripe's API.
+        /// It is highly recommended you do not change these settings, as doing so can produce
+        /// unexpected results. If you do change these settings, make sure that
+        /// <see cref="Stripe.Infrastructure.StripeObjectConverter"/> is among the converters,
+        /// otherwise the library will no longer be able to deserialize polymorphic resources
+        /// represented by interfaces (e.g. <see cref="IPaymentSource"/>).
+        /// </summary>
+        public static JsonSerializerSettings SerializerSettings
+        {
+            get { return serializerSettings; }
+            set { serializerSettings = value; }
         }
 
         public static string StripeNetVersion { get; }
@@ -94,6 +111,22 @@ namespace Stripe
         public static void SetFilesBase(string baseUrl)
         {
             filesBase = baseUrl;
+        }
+
+        /// <summary>
+        /// Returns a new instance of <see cref="Newtonsoft.Json.JsonSerializerSettings"/> with
+        /// the default settings used by Stripe.net.
+        /// <summary>
+        public static JsonSerializerSettings DefaultSerializerSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter>
+                {
+                    new StripeObjectConverter(),
+                },
+                DateParseHandling = DateParseHandling.None,
+            };
         }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Move `SerializerSettings` to `StripeConfiguration`.

The reason for this is that `Mapper<>` is a generic class, and static properties on generic classes are not shared (e.g. `Mapper<Charge>.SerializerSettings` and `Mapper<Customer>.SerializerSettings` are two different instances).

Also, since the intent is to let users retrieve or change the settings, `StripeConfiguration` is a better place anyway.

I also added a XML comment warning users about changing these settings.