### PR TITLE
Make ObjectsToTypes dictionary immutable

### DIFF
--- a/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
@@ -2,6 +2,7 @@ namespace Stripe.Infrastructure
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Reflection;
 
     internal static class StripeTypeRegistry
@@ -10,7 +11,7 @@ namespace Stripe.Infrastructure
         /// Dictionary mapping the values contained in the `object` key of JSON payloads returned
         /// by Stripe's API to concrete types of model classes.
         /// </summary>
-        public static readonly Dictionary<string, Type> ObjectsToTypes = new Dictionary<string, Type>
+        public static readonly ImmutableDictionary<string, Type> ObjectsToTypes = new Dictionary<string, Type>
         {
             { "account", typeof(Account) },
             { "apple_pay_domain", typeof(ApplePayDomain) },
@@ -75,7 +76,7 @@ namespace Stripe.Infrastructure
             { "usage_record", typeof(UsageRecord) },
             { "usage_record_summary", typeof(UsageRecordSummary) },
             { "webhook_endpoint", typeof(WebhookEndpoint) },
-        };
+        }.ToImmutableDictionary();
 
         /// <summary>
         /// Returns the concrete type to use, given a potential type and the value of the `object`

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -43,6 +43,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Make `StripeTypeRegistry.ObjectsToTypes` dictionary immutable.

There's no reason to change anything in this dictionary at runtime, so this provides a little additional safety.