### PR TITLE
Fix JSON serialization of Stripe objects

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -19,6 +19,7 @@ namespace Stripe
         /// (ID of a <see cref="File"/>) A logo for this account (at least 128px x 128px).
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string BusinessLogoId { get; set; }
 
         /// <summary>
@@ -30,6 +31,11 @@ namespace Stripe
         [JsonProperty("business_logo")]
         internal object InternalBusinessLogo
         {
+            get
+            {
+                return this.BusinessLogo ?? (object)this.BusinessLogoId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.BusinessLogoId = s, o => this.BusinessLogo = o);

--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -74,7 +74,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("details_submitted")]

--- a/src/Stripe.net/Entities/Accounts/LegalEntityVerification.cs
+++ b/src/Stripe.net/Entities/Accounts/LegalEntityVerification.cs
@@ -18,6 +18,7 @@ namespace Stripe
         /// document, either a passport or local ID card.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string DocumentId { get; set; }
 
         /// <summary>
@@ -30,6 +31,11 @@ namespace Stripe
         [JsonProperty("document")]
         internal object InternalDocument
         {
+            get
+            {
+                return this.Document ?? (object)this.DocumentId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.DocumentId = s, o => this.Document = o);
@@ -44,6 +50,7 @@ namespace Stripe
         /// document, either a passport or local ID card.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string DocumentBackId { get; set; }
 
         /// <summary>
@@ -56,6 +63,11 @@ namespace Stripe
         [JsonProperty("document_back")]
         internal object InternalDocumentBack
         {
+            get
+            {
+                return this.DocumentBack ?? (object)this.DocumentBackId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.DocumentBackId = s, o => this.DocumentBack = o);

--- a/src/Stripe.net/Entities/ApplePayDomains/ApplePayDomain.cs
+++ b/src/Stripe.net/Entities/ApplePayDomains/ApplePayDomain.cs
@@ -19,7 +19,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("domain_name")]

--- a/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -25,6 +26,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -40,6 +46,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Fee
+        [JsonIgnore]
         public string FeeId { get; set; }
 
         [JsonIgnore]
@@ -48,6 +55,11 @@ namespace Stripe
         [JsonProperty("fee")]
         internal object InternalFee
         {
+            get
+            {
+                return this.Fee ?? (object)this.FeeId;
+            }
+
             set
             {
                 StringOrObject<ApplicationFee>.Map(value, s => this.FeeId = s, o => this.Fee = o);

--- a/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
+++ b/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+        [JsonIgnore]
         public string AccountId { get; set; }
 
         [JsonIgnore]
@@ -21,6 +22,11 @@ namespace Stripe
         [JsonProperty("account")]
         internal object InternalAccount
         {
+            get
+            {
+                return this.Account ?? (object)this.AccountId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.AccountId = s, o => this.Account = o);
@@ -35,6 +41,7 @@ namespace Stripe
         public long AmountRefunded { get; set; }
 
         #region Expandable Application
+        [JsonIgnore]
         public string ApplicationId { get; set; }
 
         [JsonIgnore]
@@ -43,6 +50,11 @@ namespace Stripe
         [JsonProperty("application")]
         internal object InternalApplication
         {
+            get
+            {
+                return this.Application ?? (object)this.ApplicationId;
+            }
+
             set
             {
                 StringOrObject<Application>.Map(value, s => this.ApplicationId = s, o => this.Application = o);
@@ -51,6 +63,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -59,6 +72,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -67,6 +85,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Charge
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -75,6 +94,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);
@@ -93,6 +117,7 @@ namespace Stripe
         public bool Livemode { get; set; }
 
         #region Expandable Originating Transaction
+        [JsonIgnore]
         public string OriginatingTransactionId { get; set; }
 
         [JsonIgnore]
@@ -101,6 +126,11 @@ namespace Stripe
         [JsonProperty("originating_transaction")]
         internal object InternalOriginatingTransaction
         {
+            get
+            {
+                return this.OriginatingTransaction ?? (object)this.OriginatingTransactionId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.OriginatingTransactionId = s, o => this.OriginatingTransaction = o);

--- a/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
+++ b/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
@@ -43,6 +43,7 @@ namespace Stripe
         public long Net { get; set; }
 
         #region Expandable Source
+        [JsonIgnore]
         public string SourceId { get; set; }
 
         [JsonIgnore]
@@ -51,6 +52,11 @@ namespace Stripe
         [JsonProperty("source")]
         internal object InternalSource
         {
+            get
+            {
+                return this.Source ?? (object)this.SourceId;
+            }
+
             set
             {
                 StringOrObject<IBalanceTransactionSource>.Map(value, s => this.SourceId = s, o => this.Source = o);

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -78,7 +78,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("fingerprint")]

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -14,6 +14,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+        [JsonIgnore]
         public string AccountId { get; set; }
 
         [JsonIgnore]
@@ -22,6 +23,11 @@ namespace Stripe
         [JsonProperty("account")]
         internal object InternalAccount
         {
+            get
+            {
+                return this.Account ?? (object)this.AccountId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.AccountId = s, o => this.Account = o);
@@ -45,6 +51,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -53,6 +60,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+        [JsonIgnore]
         public string AccountId { get; set; }
 
         [JsonIgnore]
@@ -21,6 +22,11 @@ namespace Stripe
         [JsonProperty("account")]
         internal object InternalAccount
         {
+            get
+            {
+                return this.Account ?? (object)this.AccountId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.AccountId = s, o => this.Account = o);
@@ -65,6 +71,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -73,6 +80,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -117,6 +129,7 @@ namespace Stripe
         public string Name { get; set; }
 
         #region Expandable Recipient
+        [JsonIgnore]
         public string RecipientId { get; set; }
 
         [JsonIgnore]
@@ -125,6 +138,11 @@ namespace Stripe
         [JsonProperty("recipient")]
         internal object InternalRecipient
         {
+            get
+            {
+                return this.Recipient ?? (object)this.RecipientId;
+            }
+
             set
             {
                 StringOrObject<Recipient>.Map(value, s => this.RecipientId = s, o => this.Recipient = o);

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -101,7 +101,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("dynamic_last4")]

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -26,6 +26,7 @@ namespace Stripe
         public long AmountRefunded { get; set; }
 
         #region Expandable Application
+        [JsonIgnore]
         public string ApplicationId { get; set; }
 
         [JsonIgnore]
@@ -34,6 +35,11 @@ namespace Stripe
         [JsonProperty("application")]
         internal object InternalApplication
         {
+            get
+            {
+                return this.Application ?? (object)this.ApplicationId;
+            }
+
             set
             {
                 StringOrObject<Application>.Map(value, s => this.ApplicationId = s, o => this.Application = o);
@@ -42,6 +48,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Application Fee
+        [JsonIgnore]
         public string ApplicationFeeId { get; set; }
 
         /// <summary>
@@ -53,6 +60,11 @@ namespace Stripe
         [JsonProperty("application_fee")]
         internal object InternalApplicationFee
         {
+            get
+            {
+                return this.ApplicationFee ?? (object)this.ApplicationFeeId;
+            }
+
             set
             {
                 StringOrObject<ApplicationFee>.Map(value, s => this.ApplicationFeeId = s, o => this.ApplicationFee = o);
@@ -65,6 +77,7 @@ namespace Stripe
         /// <summary>
         /// ID of the balance transaction that describes the impact of this charge on your account balance (not including refunds or disputes).
         /// </summary>
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -73,6 +86,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -101,6 +119,7 @@ namespace Stripe
         /// <summary>
         /// ID of the customer this charge is for if one exists.
         /// </summary>
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -109,6 +128,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -120,6 +144,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+        [JsonIgnore]
         public string DestinationId { get; set; }
 
         /// <summary>
@@ -131,6 +156,11 @@ namespace Stripe
         [JsonProperty("destination")]
         internal object InternalDestination
         {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.DestinationId = s, o => this.Destination = o);
@@ -139,6 +169,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Dispute
+        [JsonIgnore]
         public string DisputeId { get; set; }
 
         /// <summary>
@@ -150,6 +181,11 @@ namespace Stripe
         [JsonProperty("dispute")]
         internal object InternalDispute
         {
+            get
+            {
+                return this.Dispute ?? (object)this.DisputeId;
+            }
+
             set
             {
                 StringOrObject<Dispute>.Map(value, s => this.DisputeId = s, o => this.Dispute = o);
@@ -180,6 +216,7 @@ namespace Stripe
         /// <summary>
         /// ID of the invoice this charge is for if one exists.
         /// </summary>
+        [JsonIgnore]
         public string InvoiceId { get; set; }
 
         [JsonIgnore]
@@ -188,6 +225,11 @@ namespace Stripe
         [JsonProperty("invoice")]
         internal object InternalInvoice
         {
+            get
+            {
+                return this.Invoice ?? (object)this.InvoiceId;
+            }
+
             set
             {
                 StringOrObject<Invoice>.Map(value, s => this.InvoiceId = s, o => this.Invoice = o);
@@ -210,6 +252,7 @@ namespace Stripe
         /// The account (if any) the charge was made on behalf of without triggering an automatic transfer. See the Connect documentation for details.
         /// <para>To populate the OnBehalfOf entity, you need to set ExpandOnBehalfOf to true on your service before invoking a service method.</para>
         /// </summary>
+        [JsonIgnore]
         public string OnBehalfOfId { get; set; }
 
         [JsonIgnore]
@@ -218,6 +261,11 @@ namespace Stripe
         [JsonProperty("on_behalf_of")]
         internal object InternalOnBehalfOf
         {
+            get
+            {
+                return this.OnBehalfOf ?? (object)this.OnBehalfOfId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.OnBehalfOfId = s, o => this.OnBehalfOf = o);
@@ -230,6 +278,7 @@ namespace Stripe
         /// <summary>
         /// ID of the order this charge is for if one exists.
         /// </summary>
+        [JsonIgnore]
         public string OrderId { get; set; }
 
         [JsonIgnore]
@@ -238,6 +287,11 @@ namespace Stripe
         [JsonProperty("order")]
         internal object InternalOrder
         {
+            get
+            {
+                return this.Order ?? (object)this.OrderId;
+            }
+
             set
             {
                 StringOrObject<Order>.Map(value, s => this.OrderId = s, o => this.Order = o);
@@ -269,6 +323,7 @@ namespace Stripe
         /// <summary>
         /// ID of the payment intent this charge is for if one exists.
         /// </summary>
+        [JsonIgnore]
         public string PaymentIntentId { get; set; }
 
         [JsonIgnore]
@@ -277,6 +332,11 @@ namespace Stripe
         [JsonProperty("payment_intent")]
         internal object InternalPaymentIntent
         {
+            get
+            {
+                return this.PaymentIntent ?? (object)this.PaymentIntentId;
+            }
+
             set
             {
                 StringOrObject<PaymentIntent>.Map(value, s => this.PaymentIntentId = s, o => this.PaymentIntent = o);
@@ -313,6 +373,7 @@ namespace Stripe
         /// <summary>
         /// ID of the review associated with this charge if one exists.
         /// </summary>
+        [JsonIgnore]
         public string ReviewId { get; set; }
 
         [JsonIgnore]
@@ -321,6 +382,11 @@ namespace Stripe
         [JsonProperty("review")]
         internal object InternalReview
         {
+            get
+            {
+                return this.Review ?? (object)this.ReviewId;
+            }
+
             set
             {
                 StringOrObject<Review>.Map(value, s => this.ReviewId = s, o => this.Review = o);
@@ -346,6 +412,7 @@ namespace Stripe
         /// <summary>
         /// The transfer ID which created this charge. Only present if the charge came from another Stripe account. See the Connect documentation for details.
         /// </summary>
+        [JsonIgnore]
         public string SourceTransferId { get; set; }
 
         [JsonIgnore]
@@ -354,6 +421,11 @@ namespace Stripe
         [JsonProperty("source_transfer")]
         internal object InternalSourceTransfer
         {
+            get
+            {
+                return this.SourceTransfer ?? (object)this.SourceTransferId;
+            }
+
             set
             {
                 StringOrObject<Transfer>.Map(value, s => this.SourceTransferId = s, o => this.SourceTransfer = o);
@@ -378,6 +450,7 @@ namespace Stripe
         /// <summary>
         /// ID of the transfer to the destination account (only applicable if the charge was created using the destination parameter).
         /// </summary>
+        [JsonIgnore]
         public string TransferId { get; set; }
 
         [JsonIgnore]
@@ -386,6 +459,11 @@ namespace Stripe
         [JsonProperty("transfer")]
         internal object InternalTransfer
         {
+            get
+            {
+                return this.Transfer ?? (object)this.TransferId;
+            }
+
             set
             {
                 StringOrObject<Transfer>.Map(value, s => this.TransferId = s, o => this.Transfer = o);

--- a/src/Stripe.net/Entities/Charges/Outcome.cs
+++ b/src/Stripe.net/Entities/Charges/Outcome.cs
@@ -34,14 +34,20 @@ namespace Stripe
         /// <summary>
         /// The ID of the Radar rule that matched the payment, if applicable.
         /// </summary>
+        [JsonIgnore]
         public string RuleId { get; set; }
 
         [JsonIgnore]
         public OutcomeRule Rule { get; set; }
 
         [JsonProperty("rule")]
-        internal object InternalOutcomeRule
+        internal object InternalRule
         {
+            get
+            {
+                return this.Rule ?? (object)this.RuleId;
+            }
+
             set
             {
                 StringOrObject<OutcomeRule>.Map(value, s => this.RuleId = s, o => this.Rule = o);

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -26,7 +26,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("duration")]

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -65,7 +65,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -43,6 +43,11 @@ namespace Stripe
         [JsonProperty("default_source")]
         internal object InternalDefaultSource
         {
+            get
+            {
+                return this.DefaultSource ?? (object)this.DefaultSourceId;
+            }
+
             set
             {
                 StringOrObject<IPaymentSource>.Map(value, s => this.DefaultSourceId = s, o => this.DefaultSource = o);

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -37,7 +37,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("end")]

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public Coupon Coupon { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -21,6 +22,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -43,6 +49,7 @@ namespace Stripe
         public DateTime? Start { get; set; }
 
         #region Expandable Subscription
+        [JsonIgnore]
         public string SubscriptionId { get; set; }
 
         [JsonIgnore]
@@ -51,6 +58,11 @@ namespace Stripe
         [JsonProperty("subscription")]
         internal object InternalSubscription
         {
+            get
+            {
+                return this.Subscription ?? (object)this.SubscriptionId;
+            }
+
             set
             {
                 StringOrObject<Subscription>.Map(value, s => this.SubscriptionId = s, o => this.Subscription = o);

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public List<BalanceTransaction> BalanceTransactions { get; set; }
 
         #region Expandable Charge
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -28,6 +29,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);

--- a/src/Stripe.net/Entities/Disputes/Evidence.cs
+++ b/src/Stripe.net/Entities/Disputes/Evidence.cs
@@ -18,6 +18,7 @@ namespace Stripe
         /// customer.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string CancellationPolicyId { get; set; }
 
         /// <summary>
@@ -29,6 +30,11 @@ namespace Stripe
         [JsonProperty("cancellation_policy")]
         internal object InternalCancellationPolicy
         {
+            get
+            {
+                return this.CancellationPolicy ?? (object)this.CancellationPolicyId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.CancellationPolicyId = s, o => this.CancellationPolicy = o);
@@ -51,6 +57,7 @@ namespace Stripe
         /// service.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string CustomerCommunicationId { get; set; }
 
         /// <summary>
@@ -64,6 +71,11 @@ namespace Stripe
         [JsonProperty("customer_communication")]
         internal object InternalCustomerCommunication
         {
+            get
+            {
+                return this.CustomerCommunication ?? (object)this.CustomerCommunicationId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.CustomerCommunicationId = s, o => this.CustomerCommunication = o);
@@ -87,6 +99,7 @@ namespace Stripe
         /// signature.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string CustomerSignatureId { get; set; }
 
         /// <summary>
@@ -98,6 +111,11 @@ namespace Stripe
         [JsonProperty("customer_signature")]
         internal object InternalCustomerSignature
         {
+            get
+            {
+                return this.CustomerSignature ?? (object)this.CustomerSignatureId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.CustomerSignatureId = s, o => this.CustomerSignature = o);
@@ -114,6 +132,7 @@ namespace Stripe
         /// payments are separate.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string DuplicateChargeDocumentationId { get; set; }
 
         /// <summary>
@@ -127,6 +146,11 @@ namespace Stripe
         [JsonProperty("duplicate_charge_documentation")]
         internal object InternalDuplicateChargeDocumentation
         {
+            get
+            {
+                return this.DuplicateChargeDocumentation ?? (object)this.DuplicateChargeDocumentationId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.DuplicateChargeDocumentationId = s, o => this.DuplicateChargeDocumentation = o);
@@ -150,6 +174,7 @@ namespace Stripe
         /// of the charge.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string ReceiptId { get; set; }
 
         /// <summary>
@@ -161,6 +186,11 @@ namespace Stripe
         [JsonProperty("receipt")]
         internal object InternalReceipt
         {
+            get
+            {
+                return this.Receipt ?? (object)this.ReceiptId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.ReceiptId = s, o => this.Receipt = o);
@@ -174,6 +204,7 @@ namespace Stripe
         /// (ID of a <see cref="File"/>) Your refund policy, as shown to the customer.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string RefundPolicyId { get; set; }
 
         /// <summary>
@@ -185,6 +216,11 @@ namespace Stripe
         [JsonProperty("refund_policy")]
         internal object InternalRefundPolicy
         {
+            get
+            {
+                return this.RefundPolicy ?? (object)this.RefundPolicyId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.RefundPolicyId = s, o => this.RefundPolicy = o);
@@ -209,6 +245,7 @@ namespace Stripe
         /// of written agreement.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string ServiceDocumentationId { get; set; }
 
         /// <summary>
@@ -222,6 +259,11 @@ namespace Stripe
         [JsonProperty("service_documentation")]
         internal object InternalServiceDocumentation
         {
+            get
+            {
+                return this.ServiceDocumentation ?? (object)this.ServiceDocumentationId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.ServiceDocumentationId = s, o => this.ServiceDocumentation = o);
@@ -247,6 +289,7 @@ namespace Stripe
         /// shipping address, if possible.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string ShippingDocumentationId { get; set; }
 
         /// <summary>
@@ -261,6 +304,11 @@ namespace Stripe
         [JsonProperty("shipping_documentation")]
         internal object InternalShippingDocumentation
         {
+            get
+            {
+                return this.ShippingDocumentation ?? (object)this.ShippingDocumentationId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.ShippingDocumentationId = s, o => this.ShippingDocumentation = o);
@@ -277,6 +325,7 @@ namespace Stripe
         /// (ID of a <see cref="File"/>) Any additional evidence or statements.
         /// <para>Expandable.</para>
         /// </summary>
+        [JsonIgnore]
         public string UncategorizedFileId { get; set; }
 
         /// <summary>
@@ -288,6 +337,11 @@ namespace Stripe
         [JsonProperty("uncategorized_file")]
         internal object InternalUncategorizedFile
         {
+            get
+            {
+                return this.UncategorizedFile ?? (object)this.UncategorizedFileId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.UncategorizedFileId = s, o => this.UncategorizedFile = o);

--- a/src/Stripe.net/Entities/EphemeralKeys/EphemeralKey.cs
+++ b/src/Stripe.net/Entities/EphemeralKeys/EphemeralKey.cs
@@ -32,7 +32,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("expires")]

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -45,6 +45,7 @@ namespace Stripe
         /// <summary>
         /// ID of the file object this link points to.
         /// </summary>
+        [JsonIgnore]
         public string FileId { get; set; }
 
         /// <summary>
@@ -56,6 +57,11 @@ namespace Stripe
         [JsonProperty("file")]
         internal object InternalFile
         {
+            get
+            {
+                return this.File ?? (object)this.FileId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.FileId = s, o => this.File = o);

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -28,6 +29,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -52,6 +58,7 @@ namespace Stripe
         public bool Discountable { get; set; }
 
         #region Expandable Invoice
+        [JsonIgnore]
         public string InvoiceId { get; set; }
 
         [JsonIgnore]
@@ -60,6 +67,11 @@ namespace Stripe
         [JsonProperty("invoice")]
         internal object InternalInvoice
         {
+            get
+            {
+                return this.Invoice ?? (object)this.InvoiceId;
+            }
+
             set
             {
                 StringOrObject<Invoice>.Map(value, s => this.InvoiceId = s, o => this.Invoice = o);
@@ -86,6 +98,7 @@ namespace Stripe
         public long? Quantity { get; set; }
 
         #region Expandable Subscription
+        [JsonIgnore]
         public string SubscriptionId { get; set; }
 
         [JsonIgnore]
@@ -94,6 +107,11 @@ namespace Stripe
         [JsonProperty("subscription")]
         internal object InternalSubscription
         {
+            get
+            {
+                return this.Subscription ?? (object)this.SubscriptionId;
+            }
+
             set
             {
                 StringOrObject<Subscription>.Map(value, s => this.SubscriptionId = s, o => this.Subscription = o);

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -48,7 +48,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("description")]

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -44,6 +44,7 @@ namespace Stripe
         public string BillingReason { get; set; }
 
         #region Expandable Charge
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -52,6 +53,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);
@@ -63,6 +69,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -71,6 +78,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -83,6 +95,7 @@ namespace Stripe
         public DateTime? Date { get; set; }
 
         #region Expandable DefaultSource
+        [JsonIgnore]
         public string DefaultSourceId { get; set; }
 
         [JsonIgnore]
@@ -91,6 +104,11 @@ namespace Stripe
         [JsonProperty("default_source")]
         internal object InternalDefaultSource
         {
+            get
+            {
+                return this.DefaultSource ?? (object)this.DefaultSourceId;
+            }
+
             set
             {
                 StringOrObject<IPaymentSource>.Map(value, s => this.DefaultSourceId = s, o => this.DefaultSource = o);
@@ -167,6 +185,7 @@ namespace Stripe
         public string Status { get; set; }
 
         #region Expandable Subscription
+        [JsonIgnore]
         public string SubscriptionId { get; set; }
 
         [JsonIgnore]
@@ -175,6 +194,11 @@ namespace Stripe
         [JsonProperty("subscription")]
         internal object InternalSubscription
         {
+            get
+            {
+                return this.Subscription ?? (object)this.SubscriptionId;
+            }
+
             set
             {
                 StringOrObject<Subscription>.Map(value, s => this.SubscriptionId = s, o => this.Subscription = o);

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -32,6 +32,7 @@ namespace Stripe.Issuing
         public Card Card { get; set; }
 
         #region Expandable Cardholder
+        [JsonIgnore]
         public string CardholderId { get; set; }
 
         [JsonIgnore]
@@ -40,6 +41,11 @@ namespace Stripe.Issuing
         [JsonProperty("cardholder")]
         internal object InternalCardholder
         {
+            get
+            {
+                return this.Cardholder ?? (object)this.CardholderId;
+            }
+
             set
             {
                 StringOrObject<Cardholder>.Map(value, s => this.CardholderId = s, o => this.Cardholder = o);

--- a/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
@@ -11,6 +11,7 @@ namespace Stripe.Issuing
         public string Object { get; set; }
 
         #region Expandable Card
+        [JsonIgnore]
         public string CardId { get; set; }
 
         [JsonIgnore]
@@ -19,6 +20,11 @@ namespace Stripe.Issuing
         [JsonProperty("card")]
         internal object InternalCard
         {
+            get
+            {
+                return this.Card ?? (object)this.CardId;
+            }
+
             set
             {
                 StringOrObject<Card>.Map(value, s => this.CardId = s, o => this.Card = o);

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -36,6 +36,7 @@ namespace Stripe.Issuing
         public string Status { get; set; }
 
         #region Expandable Transaction
+        [JsonIgnore]
         public string TransactionId { get; set; }
 
         [JsonIgnore]
@@ -44,6 +45,11 @@ namespace Stripe.Issuing
         [JsonProperty("transaction")]
         internal object InternalTransaction
         {
+            get
+            {
+                return this.Transaction ?? (object)this.TransactionId;
+            }
+
             set
             {
                 StringOrObject<Transaction>.Map(value, s => this.TransactionId = s, o => this.Transaction = o);

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
@@ -9,6 +9,7 @@ namespace Stripe.Issuing
         public string DisputeExplanation { get; set; }
 
         #region Expandable UncategorizedFile
+        [JsonIgnore]
         public string UncategorizedFileId { get; set; }
 
         [JsonIgnore]
@@ -17,6 +18,11 @@ namespace Stripe.Issuing
         [JsonProperty("uncategorized_file")]
         internal object InternalUncategorizedFile
         {
+            get
+            {
+                return this.UncategorizedFile ?? (object)this.UncategorizedFileId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.UncategorizedFileId = s, o => this.UncategorizedFile = o);

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
@@ -9,6 +9,7 @@ namespace Stripe.Issuing
         public string DisputeExplanation { get; set; }
 
         #region Expandable UncategorizedFile
+        [JsonIgnore]
         public string UncategorizedFileId { get; set; }
 
         [JsonIgnore]
@@ -17,6 +18,11 @@ namespace Stripe.Issuing
         [JsonProperty("uncategorized_file")]
         internal object InternalUncategorizedFile
         {
+            get
+            {
+                return this.UncategorizedFile ?? (object)this.UncategorizedFileId;
+            }
+
             set
             {
                 StringOrObject<File>.Map(value, s => this.UncategorizedFileId = s, o => this.UncategorizedFile = o);

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -14,6 +14,7 @@ namespace Stripe.Issuing
         public string Object { get; set; }
 
         #region Expandable Authorization
+        [JsonIgnore]
         public string AuthorizationId { get; set; }
 
         [JsonIgnore]
@@ -22,6 +23,11 @@ namespace Stripe.Issuing
         [JsonProperty("authorization")]
         internal object InternalAuthorization
         {
+            get
+            {
+                return this.Authorization ?? (object)this.AuthorizationId;
+            }
+
             set
             {
                 StringOrObject<Authorization>.Map(value, s => this.AuthorizationId = s, o => this.Authorization = o);
@@ -30,6 +36,7 @@ namespace Stripe.Issuing
         #endregion
 
         #region Expandable BalanceTransaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -38,6 +45,11 @@ namespace Stripe.Issuing
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -46,6 +58,7 @@ namespace Stripe.Issuing
         #endregion
 
         #region Expandable Card
+        [JsonIgnore]
         public string CardId { get; set; }
 
         [JsonIgnore]
@@ -54,6 +67,11 @@ namespace Stripe.Issuing
         [JsonProperty("card")]
         internal object InternalCard
         {
+            get
+            {
+                return this.Card ?? (object)this.CardId;
+            }
+
             set
             {
                 StringOrObject<Card>.Map(value, s => this.CardId = s, o => this.Card = o);
@@ -62,6 +80,7 @@ namespace Stripe.Issuing
         #endregion
 
         #region Expandable Cardholder
+        [JsonIgnore]
         public string CardholderId { get; set; }
 
         [JsonIgnore]
@@ -70,6 +89,11 @@ namespace Stripe.Issuing
         [JsonProperty("cardholder")]
         internal object InternalCardholder
         {
+            get
+            {
+                return this.Cardholder ?? (object)this.CardholderId;
+            }
+
             set
             {
                 StringOrObject<Cardholder>.Map(value, s => this.CardholderId = s, o => this.Cardholder = o);
@@ -85,6 +109,7 @@ namespace Stripe.Issuing
         public string Currency { get; set; }
 
         #region Expandable Dispute
+        [JsonIgnore]
         public string DisputeId { get; set; }
 
         [JsonIgnore]
@@ -93,6 +118,11 @@ namespace Stripe.Issuing
         [JsonProperty("dispute")]
         internal object InternalDispute
         {
+            get
+            {
+                return this.Dispute ?? (object)this.DisputeId;
+            }
+
             set
             {
                 StringOrObject<Dispute>.Map(value, s => this.DisputeId = s, o => this.Dispute = o);

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -37,6 +37,7 @@ namespace Stripe
         /// <para>The ID of the payment used to pay for the order. Present if the order status is paid, fulfilled, or refunded.</para>
         /// <para>Expandable</para>
         /// </summary>
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -45,6 +46,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);
@@ -78,6 +84,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -44,6 +44,7 @@ namespace Stripe
         /// <para>The order that this return includes items from.</para>
         /// <para>Expandable</para>
         /// </summary>
+        [JsonIgnore]
         public string OrderId { get; set; }
 
         [JsonIgnore]
@@ -52,6 +53,11 @@ namespace Stripe
         [JsonProperty("order")]
         internal object InternalOrder
         {
+            get
+            {
+                return this.Order ?? (object)this.OrderId;
+            }
+
             set
             {
                 StringOrObject<Order>.Map(value, s => this.OrderId = s, o => this.Order = o);
@@ -73,6 +79,11 @@ namespace Stripe
         [JsonProperty("refund")]
         internal object InternalRefund
         {
+            get
+            {
+                return this.Refund ?? (object)this.RefundId;
+            }
+
             set
             {
                 StringOrObject<Refund>.Map(value, s => this.RefundId = s, o => this.Refund = o);

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -26,6 +26,7 @@ namespace Stripe
         public long? AmountReceived { get; set; }
 
         #region Expandable Application
+        [JsonIgnore]
         public string ApplicationId { get; set; }
 
         [JsonIgnore]
@@ -34,6 +35,11 @@ namespace Stripe
         [JsonProperty("application")]
         internal object InternalApplication
         {
+            get
+            {
+                return this.Application ?? (object)this.ApplicationId;
+            }
+
             set
             {
                 StringOrObject<Application>.Map(value, s => this.ApplicationId = s, o => this.Application = o);
@@ -71,6 +77,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -79,6 +86,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -102,6 +114,7 @@ namespace Stripe
         public PaymentIntentSourceAction NextSourceAction { get; set; }
 
         #region Expandable OnBehalfOf (Account)
+        [JsonIgnore]
         public string OnBehalfOfId { get; set; }
 
         [JsonIgnore]
@@ -110,6 +123,11 @@ namespace Stripe
         [JsonProperty("on_behalf_of")]
         internal object InternalOnBehalfOf
         {
+            get
+            {
+                return this.OnBehalfOf ?? (object)this.OnBehalfOfId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.OnBehalfOfId = s, o => this.OnBehalfOf = o);
@@ -121,6 +139,7 @@ namespace Stripe
         public string ReceiptEmail { get; set; }
 
         #region Expandable Review
+        [JsonIgnore]
         public string ReviewId { get; set; }
 
         [JsonIgnore]
@@ -129,6 +148,11 @@ namespace Stripe
         [JsonProperty("review")]
         internal object InternalReview
         {
+            get
+            {
+                return this.Review ?? (object)this.ReviewId;
+            }
+
             set
             {
                 StringOrObject<Review>.Map(value, s => this.ReviewId = s, o => this.Review = o);
@@ -140,6 +164,7 @@ namespace Stripe
         public Shipping Shipping { get; set; }
 
         #region Expandable Source
+        [JsonIgnore]
         public string SourceId { get; set; }
 
         [JsonIgnore]
@@ -148,6 +173,11 @@ namespace Stripe
         [JsonProperty("source")]
         internal object InternalSource
         {
+            get
+            {
+                return this.Source ?? (object)this.SourceId;
+            }
+
             set
             {
                 StringOrObject<IPaymentSource>.Map(value, s => this.SourceId = s, o => this.Source = o);

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
@@ -9,6 +9,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         #region Expandable Destination (Account)
+        [JsonIgnore]
         public string DestinationId { get; set; }
 
         [JsonIgnore]
@@ -17,6 +18,11 @@ namespace Stripe
         [JsonProperty("destination")]
         internal object InternalDestination
         {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.DestinationId = s, o => this.Destination = o);

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -24,6 +24,7 @@ namespace Stripe
         public bool Automatic { get; set; }
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -32,6 +33,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -50,6 +56,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+        [JsonIgnore]
         public string DestinationId { get; set; }
 
         [JsonIgnore]
@@ -58,6 +65,11 @@ namespace Stripe
         [JsonProperty("destination")]
         internal object InternalDestination
         {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
             set
             {
                 StringOrObject<IExternalAccount>.Map(value, s => this.DestinationId = s, o => this.Destination = o);
@@ -78,6 +90,11 @@ namespace Stripe
         [JsonProperty("failure_balance_transaction")]
         internal object InternalFailureBalanceTransaction
         {
+            get
+            {
+                return this.FailureBalanceTransaction ?? (object)this.FailureBalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.FailureBalanceTransactionId = s, o => this.FailureBalanceTransaction = o);

--- a/src/Stripe.net/Entities/Persons/Person.cs
+++ b/src/Stripe.net/Entities/Persons/Person.cs
@@ -29,7 +29,7 @@ namespace Stripe
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("dob")]

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -35,7 +35,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("interval")]

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -59,6 +59,7 @@ namespace Stripe
         /// ID of the product linked to this plan
         /// <para>You can expand the Product by setting the ExpandProduct property on the service to true</para>
         /// </summary>
+        [JsonIgnore]
         public string ProductId { get; set; }
 
         [JsonIgnore]
@@ -67,6 +68,11 @@ namespace Stripe
         [JsonProperty("product")]
         internal object InternalProduct
         {
+            get
+            {
+                return this.Product ?? (object)this.ProductId;
+            }
+
             set
             {
                 StringOrObject<Product>.Map(value, s => this.ProductId = s, o => this.Product = o);

--- a/src/Stripe.net/Entities/Products/Product.cs
+++ b/src/Stripe.net/Entities/Products/Product.cs
@@ -47,7 +47,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -24,6 +24,7 @@ namespace Stripe
         public DateTime Created { get; set; }
 
         #region Expandable Default Card
+        [JsonIgnore]
         public string DefaultCardId { get; set; }
 
         [JsonIgnore]
@@ -32,6 +33,11 @@ namespace Stripe
         [JsonProperty("default_card")]
         internal object InternalDefaultCard
         {
+            get
+            {
+                return this.DefaultCard ?? (object)this.DefaultCardId;
+            }
+
             set
             {
                 StringOrObject<Card>.Map(value, s => this.DefaultCardId = s, o => this.DefaultCard = o);

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -25,6 +26,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -33,6 +39,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Charge
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -41,6 +48,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);
@@ -59,6 +71,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Failure Balance Transaction
+        [JsonIgnore]
         public string FailureBalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -67,6 +80,11 @@ namespace Stripe
         [JsonProperty("failure_balance_transaction")]
         internal object InternalFailureBalanceTransaction
         {
+            get
+            {
+                return this.FailureBalanceTransaction ?? (object)this.FailureBalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.FailureBalanceTransactionId = s, o => this.FailureBalanceTransaction = o);
@@ -87,6 +105,7 @@ namespace Stripe
         public string ReceiptNumber { get; set; }
 
         #region Expandable Source Transfer Reversal
+        [JsonIgnore]
         public string SourceTransferReversalId { get; set; }
 
         [JsonIgnore]
@@ -95,6 +114,11 @@ namespace Stripe
         [JsonProperty("source_transfer_reversal")]
         internal object InternalSourceTransferReversal
         {
+            get
+            {
+                return this.SourceTransferReversal ?? (object)this.SourceTransferReversalId;
+            }
+
             set
             {
                 StringOrObject<TransferReversal>.Map(value, s => this.SourceTransferReversalId = s, o => this.SourceTransferReversal = o);
@@ -106,6 +130,7 @@ namespace Stripe
         public string Status { get; set; }
 
         #region Expandable  Transfer Reversal
+        [JsonIgnore]
         public string TransferReversalId { get; set; }
 
         [JsonIgnore]
@@ -114,6 +139,11 @@ namespace Stripe
         [JsonProperty("transfer_reversal")]
         internal object InternalTransferReversal
         {
+            get
+            {
+                return this.TransferReversal ?? (object)this.TransferReversalId;
+            }
+
             set
             {
                 StringOrObject<TransferReversal>.Map(value, s => this.TransferReversalId = s, o => this.TransferReversal = o);

--- a/src/Stripe.net/Entities/Reviews/Review.cs
+++ b/src/Stripe.net/Entities/Reviews/Review.cs
@@ -14,6 +14,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Charge
+        [JsonIgnore]
         public string ChargeId { get; set; }
 
         [JsonIgnore]
@@ -22,6 +23,11 @@ namespace Stripe
         [JsonProperty("charge")]
         internal object InternalCharge
         {
+            get
+            {
+                return this.Charge ?? (object)this.ChargeId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.ChargeId = s, o => this.Charge = o);
@@ -40,6 +46,7 @@ namespace Stripe
         public bool Open { get; set; }
 
         #region Expandable PaymentIntent
+        [JsonIgnore]
         public string PaymentIntentId { get; set; }
 
         [JsonIgnore]
@@ -48,6 +55,11 @@ namespace Stripe
         [JsonProperty("payment_intent")]
         internal object InternalPaymentIntent
         {
+            get
+            {
+                return this.PaymentIntent ?? (object)this.PaymentIntentId;
+            }
+
             set
             {
                 StringOrObject<PaymentIntent>.Map(value, s => this.PaymentIntentId = s, o => this.PaymentIntent = o);

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -41,7 +41,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -85,6 +85,7 @@ namespace Stripe
         /// <summary>
         /// The ID of the product this SKU is associated with. The product must be currently active.
         /// </summary>
+        [JsonIgnore]
         public string ProductId { get; set; }
 
         [JsonIgnore]
@@ -93,6 +94,11 @@ namespace Stripe
         [JsonProperty("product")]
         internal object InternalProduct
         {
+            get
+            {
+                return this.Product ?? (object)this.ProductId;
+            }
+
             set
             {
                 StringOrObject<Product>.Map(value, s => this.ProductId = s, o => this.Product = o);

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
@@ -20,7 +20,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("metadata")]

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -46,6 +46,7 @@ namespace Stripe
         public DateTime? CurrentPeriodStart { get; set; }
 
         #region Expandable Customer
+        [JsonIgnore]
         public string CustomerId { get; set; }
 
         [JsonIgnore]
@@ -54,6 +55,11 @@ namespace Stripe
         [JsonProperty("customer")]
         internal object InternalCustomer
         {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
             set
             {
                 StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
@@ -68,6 +74,7 @@ namespace Stripe
         public long? DaysUntilDue { get; set; }
 
         #region Expandable DefaultSource
+        [JsonIgnore]
         public string DefaultSourceId { get; set; }
 
         [JsonIgnore]
@@ -76,6 +83,11 @@ namespace Stripe
         [JsonProperty("default_source")]
         internal object InternalDefaultSource
         {
+            get
+            {
+                return this.DefaultSource ?? (object)this.DefaultSourceId;
+            }
+
             set
             {
                 StringOrObject<IPaymentSource>.Map(value, s => this.DefaultSourceId = s, o => this.DefaultSource = o);

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -32,6 +32,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);

--- a/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
+++ b/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
@@ -17,6 +17,7 @@ namespace Stripe
         public long Amount { get; set; }
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -25,6 +26,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -43,6 +49,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         #region Expandable Transfer
+        [JsonIgnore]
         public string TransferId { get; set; }
 
         [JsonIgnore]
@@ -51,6 +58,11 @@ namespace Stripe
         [JsonProperty("transfer")]
         internal object InternalTransfer
         {
+            get
+            {
+                return this.Transfer ?? (object)this.TransferId;
+            }
+
             set
             {
                 StringOrObject<Transfer>.Map(value, s => this.TransferId = s, o => this.Transfer = o);

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public long AmountReversed { get; set; }
 
         #region Expandable Balance Transaction
+        [JsonIgnore]
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -28,6 +29,11 @@ namespace Stripe
         [JsonProperty("balance_transaction")]
         internal object InternalBalanceTransaction
         {
+            get
+            {
+                return this.BalanceTransaction ?? (object)this.BalanceTransactionId;
+            }
+
             set
             {
                 StringOrObject<BalanceTransaction>.Map(value, s => this.BalanceTransactionId = s, o => this.BalanceTransaction = o);
@@ -46,6 +52,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+        [JsonIgnore]
         public string DestinationId { get; set; }
 
         [JsonIgnore]
@@ -54,6 +61,11 @@ namespace Stripe
         [JsonProperty("destination")]
         internal object InternalDestination
         {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
             set
             {
                 StringOrObject<Account>.Map(value, s => this.DestinationId = s, o => this.Destination = o);
@@ -62,6 +74,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Destination Payment
+        [JsonIgnore]
         public string DestinationPaymentId { get; set; }
 
         [JsonIgnore]
@@ -70,6 +83,11 @@ namespace Stripe
         [JsonProperty("destination_payment")]
         internal object InternalDestinationPayment
         {
+            get
+            {
+                return this.DestinationPayment ?? (object)this.DestinationPaymentId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.DestinationPaymentId = s, o => this.DestinationPayment = o);
@@ -90,6 +108,7 @@ namespace Stripe
         public bool Reversed { get; set; }
 
         #region Expandable Source Transaction
+        [JsonIgnore]
         public string SourceTransactionId { get; set; }
 
         [JsonIgnore]
@@ -98,6 +117,11 @@ namespace Stripe
         [JsonProperty("source_transaction")]
         internal object InternalSourceTransaction
         {
+            get
+            {
+                return this.SourceTransaction ?? (object)this.SourceTransactionId;
+            }
+
             set
             {
                 StringOrObject<Charge>.Map(value, s => this.SourceTransactionId = s, o => this.SourceTransaction = o);

--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -23,7 +23,7 @@ namespace Stripe
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
-        [JsonProperty("deleted")]
+        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("enabled_events")]

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -6,6 +6,7 @@ namespace Stripe
 
     public abstract class StripeEntity : IStripeEntity
     {
+        [JsonIgnore]
         public StripeResponse StripeResponse { get; set; }
 
         /// <summary>Reports a Stripe object as a string.</summary>

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -1,7 +1,46 @@
 namespace Stripe
 {
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using Newtonsoft.Json;
+
     public abstract class StripeEntity : IStripeEntity
     {
         public StripeResponse StripeResponse { get; set; }
+
+        /// <summary>Reports a Stripe object as a string.</summary>
+        /// <returns>
+        /// A string representing the Stripe object, including its JSON serialization.
+        /// </returns>
+        /// <seealso cref="ToJson"/>
+        public override string ToString()
+        {
+            return string.Format(
+                "<{0}@{1} id={2}> JSON: {3}",
+                this.GetType().FullName,
+                RuntimeHelpers.GetHashCode(this),
+                this.GetIdString(),
+                this.ToJson());
+        }
+
+        /// <summary>Serializes the Stripe object as a JSON string.</summary>
+        /// <returns>An indented JSON string represensation of the object.</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        private object GetIdString()
+        {
+            foreach (var property in this.GetType().GetTypeInfo().DeclaredProperties)
+            {
+                if (property.Name == "Id")
+                {
+                    return property.GetValue(this);
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/StripeTests/Infrastructure/ExpandableSerializationTest.cs
+++ b/src/StripeTests/Infrastructure/ExpandableSerializationTest.cs
@@ -1,0 +1,87 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class ExpandableSerializationTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeNotExpanded()
+        {
+            var obj = new TestTopLevelObject
+            {
+                NestedId = "id_not_expanded",
+                Nested = null,
+            };
+
+            var expected = "{\n  \"nested\": \"id_not_expanded\"\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        [Fact]
+        public void SerializeExpanded()
+        {
+            var nested = new TestNestedObject
+            {
+                Id = "id_expanded",
+                Bar = 42,
+            };
+            var obj = new TestTopLevelObject
+            {
+                NestedId = nested.Id,
+                Nested = nested,
+            };
+
+            var expected =
+                "{\n  \"nested\": {\n    \"id\": \"id_expanded\",\n    \"bar\": 42\n  }\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        [Fact]
+        public void SerializeNull()
+        {
+            var obj = new TestTopLevelObject
+            {
+                NestedId = null,
+                Nested = null,
+            };
+
+            var expected = "{\n  \"nested\": null\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        private class TestNestedObject : StripeEntity, IHasId
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("bar")]
+            public int Bar { get; set; }
+        }
+
+        private class TestTopLevelObject : StripeEntity
+        {
+            [JsonIgnore]
+            public string NestedId { get; set; }
+
+            [JsonIgnore]
+            public TestNestedObject Nested { get; set; }
+
+            [JsonProperty("nested")]
+            internal object InternalNested
+            {
+                get
+                {
+                    return this.Nested ?? (object)this.NestedId;
+                }
+
+                set
+                {
+                    StringOrObject<TestNestedObject>.Map(value, s => this.NestedId = s, o => this.Nested = o);
+                }
+            }
+        }
+    }
+}

--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -1,0 +1,74 @@
+#if NETCOREAPP
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class DontSerializeNullDeletedAttrs
+    {
+        private const string AssertionMessage =
+            "Found at least one invalid Deleted property. Make sure that the property " +
+            "has a JsonPropertyAttribute and that NullValueHandling is set to Ignore.";
+
+        [Fact]
+        public void Check()
+        {
+            List<string> results = new List<string>();
+
+            // Get all StripeEntity subclasses
+            var type = typeof(StripeEntity);
+            var assembly = type.GetTypeInfo().Assembly;
+            var entityClasses = assembly.DefinedTypes
+                .Where(t => t.IsClass && t.IsSubclassOf(type))
+                .Select(t => t.AsType());
+
+            foreach (Type entityClass in entityClasses)
+            {
+                foreach (PropertyInfo property in entityClass.GetProperties())
+                {
+                    if (property.Name != "Deleted")
+                    {
+                        continue;
+                    }
+
+                    // Check that property has a JsonPropertyAttribute
+                    var attribute = property.GetCustomAttribute<JsonPropertyAttribute>();
+                    if (attribute == null)
+                    {
+                        continue;
+                    }
+
+                    // Check that NullValueHanding is set to Ignore
+                    if (attribute.NullValueHandling == NullValueHandling.Ignore)
+                    {
+                        continue;
+                    }
+
+                    results.Add($"{entityClass.Name}.{property.Name}");
+                }
+            }
+
+            if (results.Any())
+            {
+                // Sort results alphabetically
+                results = results.OrderBy(i => i).ToList();
+
+                // Display our own error message (because Assert.Empty truncates the results)
+                Console.WriteLine("Found invalid Deleted properties:");
+                foreach (string item in results)
+                {
+                    Console.WriteLine($"- {item}");
+                }
+
+                // Actually fail test
+                Assert.True(false, AssertionMessage);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

- Adds `ToString` and `ToJson` methods to `StripeEntity`
- Exclude `StripeResponse` from JSON serialization
- Fix serialization of expandable attributes
- Don't serialize `deleted` attribute when it's `null`
- Add a test for serialization of expandable fields

I realize that the new getters for expandable fields add a lot of boilerplate. In the future, I'll probably replace the `object` declarations with an `ExpandableField<>` generic class and a custom serializer/deserializer, similar to what we do in Java, but for now this does the job.
