### PR TITLE
Enable SourceLink

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,8 @@ build:
 
 build_script:
   - ps: Write-Host $("`n               BUILDING EVERYTHING               `n") -BackgroundColor DarkCyan
-  - dotnet build -c Release src\Stripe.net
-  - dotnet build -c Debug src\Stripe.net
+  - dotnet build src\Stripe.net -c Release /p:ContinuousIntegrationBuild=true
+  - dotnet build src\Stripe.net -c Debug
   - dotnet build src\StripeTests -c Debug
 
 after_build:

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -13,13 +13,14 @@
     <PackageIconUrl>http://i.imgur.com/UuBwQ33.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/stripe/stripe-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/stripe/stripe-dotnet/master/LICENSE</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/stripe/stripe-dotnet</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.2' ">$(PackageTargetFallback);netcoreapp1.0</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.2' ">1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <!--
@@ -38,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

[SourceLink](https://github.com/dotnet/sourcelink/) is a cool new feature that provides developers with seamless access to sources of the libraries they're using.

It's still technically in beta, but it was enabled in the latest version of Json.Net. This PR is based on the one for Json.Net (https://github.com/JamesNK/Newtonsoft.Json/pull/1746), as well as this blog post: http://blog.ctaggart.com/2018/06/newtonsoftjson-enabling-source-link.html.

I installed the `sourcelink` tool locally and checked that things work (I had to disable the `net45` target to test the `.nupkg` build since it's not available on macOS):
```
❯ dotnet build -c Release src/Stripe.net /p:TargetFramework=netstandard1.2
...
Build succeeded.

❯ ~/.dotnet/tools/sourcelink test src/Stripe.net/bin/Release/netstandard1.2/Stripe.net.pdb
sourcelink test passed: src/Stripe.net/bin/Release/netstandard1.2/Stripe.net.pdb

❯ ~/.dotnet/tools/sourcelink print-json src/Stripe.net/bin/Release/netstandard1.2/Stripe.net.pdb
{"documents":{"/Users/ob/workspace/dotnet/stripe-dotnet/*":"https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/*"}}

❯ ~/.dotnet/tools/sourcelink print-urls src/Stripe.net/bin/Release/netstandard1.2/Stripe.net.pdb
14a26cd990d39597d80a4f4d326f4a39e81895dd sha1 csharp /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/Constants/AccountType.cs
https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/src/Stripe.net/Constants/AccountType.cs
...
9a62488763be5efdd8b1efb3a55f723cb858ba1b sha1 csharp /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
36ff84774aa05fee5ee89563390f7f18b80df39c sha1 csharp /var/folders/fr/1d9bfhg17x58gdqyvg_ymcm40000gn/T/.NETStandard,Version=v1.2.AssemblyAttributes.cs
embedded

❯ dotnet build -c Release src/Stripe.net /p:TargetFramework=netstandard2.0
...
Build succeeded.

❯ ~/.dotnet/tools/sourcelink test src/Stripe.net/bin/Release/netstandard2.0/Stripe.net.pdb
sourcelink test passed: src/Stripe.net/bin/Release/netstandard2.0/Stripe.net.pdb

❯ ~/.dotnet/tools/sourcelink print-json src/Stripe.net/bin/Release/netstandard2.0/Stripe.net.pdb
{"documents":{"/Users/ob/workspace/dotnet/stripe-dotnet/*":"https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/*"}}

❯ ~/.dotnet/tools/sourcelink print-urls src/Stripe.net/bin/Release/netstandard2.0/Stripe.net.pdb
14a26cd990d39597d80a4f4d326f4a39e81895dd sha1 csharp /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/Constants/AccountType.cs
https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/src/Stripe.net/Constants/AccountType.cs
...
9a62488763be5efdd8b1efb3a55f723cb858ba1b sha1 csharp /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
https://raw.githubusercontent.com/stripe/stripe-dotnet/5ea88a73bfa2ddf0527f84bc8785dbebbd4f00ef/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
78caba916da115f043ae57a8e2c14315a6a56ea2 sha1 csharp /var/folders/fr/1d9bfhg17x58gdqyvg_ymcm40000gn/T/.NETStandard,Version=v2.0.AssemblyAttributes.cs
embedded

❯ dotnet pack -c Release src/Stripe.net
...
  Successfully created package '/Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/bin/Release/Stripe.net.21.7.0.nupkg'.

❯ ~/.dotnet/tools/sourcelink test src/Stripe.net/bin/Release/Stripe.net.21.7.0.nupkg
sourcelink test passed: lib/netstandard1.2/Stripe.net.pdb
sourcelink test passed: lib/netstandard2.0/Stripe.net.pdb
