### PR TITLE
Make object instances in tests readonly

### DIFF
--- a/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
+++ b/src/StripeTests/Infrastructure/ParameterBuilderTest.cs
@@ -13,7 +13,7 @@ namespace StripeTests
 
     public class ParameterBuilderTest : BaseStripeTest
     {
-        private TestService service;
+        private readonly TestService service;
 
         public ParameterBuilderTest()
         {

--- a/src/StripeTests/Infrastructure/StripeResponseTest.cs
+++ b/src/StripeTests/Infrastructure/StripeResponseTest.cs
@@ -6,7 +6,7 @@ namespace StripeTests
 
     public class StripeResponseTest : BaseStripeTest
     {
-        private StripeList<Charge> charges;
+        private readonly StripeList<Charge> charges;
 
         public StripeResponseTest()
         {

--- a/src/StripeTests/Services/Accounts/AccountCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountCreateOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class AccountCreateOptionsTest : BaseStripeTest
     {
-        private AccountService service;
+        private readonly AccountService service;
 
         public AccountCreateOptionsTest()
         {

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -11,11 +11,11 @@ namespace StripeTests
     {
         private const string AccountId = "acct_123";
 
-        private AccountService service;
-        private AccountCreateOptions createOptions;
-        private AccountUpdateOptions updateOptions;
-        private AccountListOptions listOptions;
-        private AccountRejectOptions rejectOptions;
+        private readonly AccountService service;
+        private readonly AccountCreateOptions createOptions;
+        private readonly AccountUpdateOptions updateOptions;
+        private readonly AccountListOptions listOptions;
+        private readonly AccountRejectOptions rejectOptions;
 
         public AccountServiceTest()
         {

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -11,9 +11,9 @@ namespace StripeTests
     {
         private const string DomainId = "apwc_123";
 
-        private ApplePayDomainService service;
-        private ApplePayDomainCreateOptions createOptions;
-        private ApplePayDomainListOptions listOptions;
+        private readonly ApplePayDomainService service;
+        private readonly ApplePayDomainCreateOptions createOptions;
+        private readonly ApplePayDomainListOptions listOptions;
 
         public ApplePayDomainServiceTest()
         {

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests
         private const string ApplicationFeeId = "fee_123";
         private const string ApplicationFeeRefundId = "fr_123";
 
-        private ApplicationFeeRefundService service;
-        private ApplicationFeeRefundCreateOptions createOptions;
-        private ApplicationFeeRefundUpdateOptions updateOptions;
-        private ApplicationFeeRefundListOptions listOptions;
+        private readonly ApplicationFeeRefundService service;
+        private readonly ApplicationFeeRefundCreateOptions createOptions;
+        private readonly ApplicationFeeRefundUpdateOptions updateOptions;
+        private readonly ApplicationFeeRefundListOptions listOptions;
 
         public ApplicationFeeRefundServiceTest()
         {

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string ApplicationFeeId = "fee_123";
 
-        private ApplicationFeeService service;
-        private ApplicationFeeListOptions listOptions;
+        private readonly ApplicationFeeService service;
+        private readonly ApplicationFeeListOptions listOptions;
 
         public ApplicationFeeServiceTest()
         {

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -9,7 +9,7 @@ namespace StripeTests
 
     public class BalanceServiceTest : BaseStripeTest
     {
-        private BalanceService service;
+        private readonly BalanceService service;
 
         public BalanceServiceTest()
         {

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string BalanceTransactionId = "txn_123";
 
-        private BalanceTransactionService service;
-        private BalanceTransactionListOptions listOptions;
+        private readonly BalanceTransactionService service;
+        private readonly BalanceTransactionListOptions listOptions;
 
         public BalanceTransactionServiceTest()
         {

--- a/src/StripeTests/Services/BankAccounts/BankAccountListOptionsTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountListOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class BankAccountListOptionsTest : BaseStripeTest
     {
-        private BankAccountService service;
+        private readonly BankAccountService service;
 
         public BankAccountListOptionsTest()
         {

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -12,11 +12,11 @@ namespace StripeTests
         private const string CustomerId = "cus_123";
         private const string BankAccountId = "ba_123";
 
-        private BankAccountService service;
-        private BankAccountCreateOptions createOptions;
-        private BankAccountUpdateOptions updateOptions;
-        private BankAccountListOptions listOptions;
-        private BankAccountVerifyOptions verifyOptions;
+        private readonly BankAccountService service;
+        private readonly BankAccountCreateOptions createOptions;
+        private readonly BankAccountUpdateOptions updateOptions;
+        private readonly BankAccountListOptions listOptions;
+        private readonly BankAccountVerifyOptions verifyOptions;
 
         public BankAccountServiceTest()
         {

--- a/src/StripeTests/Services/Cards/CardListOptionsTest.cs
+++ b/src/StripeTests/Services/Cards/CardListOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class CardListOptionsTest : BaseStripeTest
     {
-        private CardService service;
+        private readonly CardService service;
 
         public CardListOptionsTest()
         {

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -16,10 +16,10 @@ namespace StripeTests
         private const string CardId = "card_123";
         private const string CustomerId = "cus_123";
 
-        private CardService service;
-        private CardCreateOptions createOptions;
-        private CardUpdateOptions updateOptions;
-        private CardListOptions listOptions;
+        private readonly CardService service;
+        private readonly CardCreateOptions createOptions;
+        private readonly CardUpdateOptions updateOptions;
+        private readonly CardListOptions listOptions;
 
         public CardServiceTest()
         {

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -11,11 +11,11 @@ namespace StripeTests
     {
         private const string ChargeId = "ch_123";
 
-        private ChargeService service;
-        private ChargeCaptureOptions captureOptions;
-        private ChargeCreateOptions createOptions;
-        private ChargeUpdateOptions updateOptions;
-        private ChargeListOptions listOptions;
+        private readonly ChargeService service;
+        private readonly ChargeCaptureOptions captureOptions;
+        private readonly ChargeCreateOptions createOptions;
+        private readonly ChargeUpdateOptions updateOptions;
+        private readonly ChargeListOptions listOptions;
 
         public ChargeServiceTest()
         {

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string CountrySpecId = "US";
 
-        private CountrySpecService service;
-        private CountrySpecListOptions listOptions;
+        private readonly CountrySpecService service;
+        private readonly CountrySpecListOptions listOptions;
 
         public CountrySpecServiceTest()
         {

--- a/src/StripeTests/Services/Coupons/CouponCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponCreateOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class CouponCreateOptionsTest : BaseStripeTest
     {
-        private CouponService service;
+        private readonly CouponService service;
 
         public CouponCreateOptionsTest()
         {

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string CouponId = "co_123";
 
-        private CouponService service;
-        private CouponCreateOptions createOptions;
-        private CouponUpdateOptions updateOptions;
-        private CouponListOptions listOptions;
+        private readonly CouponService service;
+        private readonly CouponCreateOptions createOptions;
+        private readonly CouponUpdateOptions updateOptions;
+        private readonly CouponListOptions listOptions;
 
         public CouponServiceTest()
         {

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string CustomerId = "cus_123";
 
-        private CustomerService service;
-        private CustomerCreateOptions createOptions;
-        private CustomerUpdateOptions updateOptions;
-        private CustomerListOptions listOptions;
+        private readonly CustomerService service;
+        private readonly CustomerCreateOptions createOptions;
+        private readonly CustomerUpdateOptions updateOptions;
+        private readonly CustomerListOptions listOptions;
 
         public CustomerServiceTest()
         {

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -9,7 +9,7 @@ namespace StripeTests
 
     public class DiscountServiceTest : BaseStripeTest
     {
-        private DiscountService service;
+        private readonly DiscountService service;
 
         public DiscountServiceTest()
         {

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -11,9 +11,9 @@ namespace StripeTests
     {
         private const string DisputeId = "dp_123";
 
-        private DisputeService service;
-        private DisputeUpdateOptions updateOptions;
-        private DisputeListOptions listOptions;
+        private readonly DisputeService service;
+        private readonly DisputeUpdateOptions updateOptions;
+        private readonly DisputeListOptions listOptions;
 
         public DisputeServiceTest()
         {

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string EphemeralKeyId = "ephkey_123";
 
-        private EphemeralKeyService service;
-        private EphemeralKeyCreateOptions createOptions;
+        private readonly EphemeralKeyService service;
+        private readonly EphemeralKeyCreateOptions createOptions;
 
         public EphemeralKeyServiceTest()
         {

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string EventId = "evt_123";
 
-        private EventService service;
-        private EventListOptions listOptions;
+        private readonly EventService service;
+        private readonly EventListOptions listOptions;
 
         public EventServiceTest()
         {

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -5,10 +5,10 @@ namespace StripeTests
 
     public class EventUtilityTest : BaseStripeTest
     {
-        private long eventTimestamp;
-        private string signature;
-        private string json;
-        private string secret;
+        private readonly long eventTimestamp;
+        private readonly string signature;
+        private readonly string json;
+        private readonly string secret;
 
         public EventUtilityTest()
         {

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -9,8 +9,8 @@ namespace StripeTests
 
     public class ExchangeRateServiceTest : BaseStripeTest
     {
-        private ExchangeRateService service;
-        private ExchangeRateListOptions listOptions;
+        private readonly ExchangeRateService service;
+        private readonly ExchangeRateListOptions listOptions;
 
         public ExchangeRateServiceTest()
         {

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests
         private const string AccountId = "acct_123";
         private const string ExternalAccountId = "ba_123";
 
-        private ExternalAccountService service;
-        private ExternalAccountCreateOptions createOptions;
-        private ExternalAccountUpdateOptions updateOptions;
-        private ExternalAccountListOptions listOptions;
+        private readonly ExternalAccountService service;
+        private readonly ExternalAccountCreateOptions createOptions;
+        private readonly ExternalAccountUpdateOptions updateOptions;
+        private readonly ExternalAccountListOptions listOptions;
 
         public ExternalAccountServiceTest()
         {

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string FileLinkId = "link_123";
 
-        private FileLinkService service;
-        private FileLinkCreateOptions createOptions;
-        private FileLinkUpdateOptions updateOptions;
-        private FileLinkListOptions listOptions;
+        private readonly FileLinkService service;
+        private readonly FileLinkCreateOptions createOptions;
+        private readonly FileLinkUpdateOptions updateOptions;
+        private readonly FileLinkListOptions listOptions;
 
         public FileLinkServiceTest()
         {

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -15,9 +15,9 @@ namespace StripeTests
         private const string FileId = "file_123";
         private const string FileName = "StripeTests.Resources.file_upload_logo.png";
 
-        private FileService service;
-        private FileCreateOptions createOptions;
-        private FileListOptions listOptions;
+        private readonly FileService service;
+        private readonly FileCreateOptions createOptions;
+        private readonly FileListOptions listOptions;
 
         public FileServiceTest()
         {

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string InvoiceItemId = "ii_123";
 
-        private InvoiceItemService service;
-        private InvoiceItemCreateOptions createOptions;
-        private InvoiceItemUpdateOptions updateOptions;
-        private InvoiceItemListOptions listOptions;
+        private readonly InvoiceItemService service;
+        private readonly InvoiceItemCreateOptions createOptions;
+        private readonly InvoiceItemUpdateOptions updateOptions;
+        private readonly InvoiceItemListOptions listOptions;
 
         public InvoiceItemServiceTest()
         {

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -11,18 +11,18 @@ namespace StripeTests
     {
         private const string InvoiceId = "in_123";
 
-        private InvoiceService service;
-        private InvoiceCreateOptions createOptions;
-        private InvoiceUpdateOptions updateOptions;
-        private InvoicePayOptions payOptions;
-        private InvoiceListOptions listOptions;
-        private InvoiceListLineItemsOptions listLineItemsOptions;
-        private UpcomingInvoiceOptions upcomingOptions;
-        private UpcomingInvoiceListLineItemsOptions upcomingListLineItemsOptions;
-        private InvoiceFinalizeOptions finalizeOptions;
-        private InvoiceMarkUncollectibleOptions markUncollectibleOptions;
-        private InvoiceSendOptions sendOptions;
-        private InvoiceVoidOptions voidOptions;
+        private readonly InvoiceService service;
+        private readonly InvoiceCreateOptions createOptions;
+        private readonly InvoiceUpdateOptions updateOptions;
+        private readonly InvoicePayOptions payOptions;
+        private readonly InvoiceListOptions listOptions;
+        private readonly InvoiceListLineItemsOptions listLineItemsOptions;
+        private readonly UpcomingInvoiceOptions upcomingOptions;
+        private readonly UpcomingInvoiceListLineItemsOptions upcomingListLineItemsOptions;
+        private readonly InvoiceFinalizeOptions finalizeOptions;
+        private readonly InvoiceMarkUncollectibleOptions markUncollectibleOptions;
+        private readonly InvoiceSendOptions sendOptions;
+        private readonly InvoiceVoidOptions voidOptions;
 
         public InvoiceServiceTest()
         {

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -11,9 +11,9 @@ namespace StripeTests.Issuing
     {
         private const string AuthorizationId = "iauth_123";
 
-        private AuthorizationService service;
-        private AuthorizationUpdateOptions updateOptions;
-        private AuthorizationListOptions listOptions;
+        private readonly AuthorizationService service;
+        private readonly AuthorizationUpdateOptions updateOptions;
+        private readonly AuthorizationListOptions listOptions;
 
         public AuthorizationServiceTest()
         {

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests.Issuing
     {
         private const string CardholderId = "ich_123";
 
-        private CardholderService service;
-        private CardholderCreateOptions createOptions;
-        private CardholderUpdateOptions updateOptions;
-        private CardholderListOptions listOptions;
+        private readonly CardholderService service;
+        private readonly CardholderCreateOptions createOptions;
+        private readonly CardholderUpdateOptions updateOptions;
+        private readonly CardholderListOptions listOptions;
 
         public CardholderServiceTest()
         {

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests.Issuing
     {
         private const string CardId = "ic_123";
 
-        private CardService service;
-        private CardCreateOptions createOptions;
-        private CardUpdateOptions updateOptions;
-        private CardListOptions listOptions;
+        private readonly CardService service;
+        private readonly CardCreateOptions createOptions;
+        private readonly CardUpdateOptions updateOptions;
+        private readonly CardListOptions listOptions;
 
         public IssuingCardServiceTest()
         {

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests.Issuing
     {
         private const string DisputeId = "idp_123";
 
-        private DisputeService service;
-        private DisputeCreateOptions createOptions;
-        private DisputeUpdateOptions updateOptions;
-        private DisputeListOptions listOptions;
+        private readonly DisputeService service;
+        private readonly DisputeCreateOptions createOptions;
+        private readonly DisputeUpdateOptions updateOptions;
+        private readonly DisputeListOptions listOptions;
 
         public IssuingDisputeServiceTest()
         {

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -11,9 +11,9 @@ namespace StripeTests.Issuing
     {
         private const string TransactionId = "ipi_123";
 
-        private TransactionService service;
-        private TransactionUpdateOptions updateOptions;
-        private TransactionListOptions listOptions;
+        private readonly TransactionService service;
+        private readonly TransactionUpdateOptions updateOptions;
+        private readonly TransactionListOptions listOptions;
 
         public TransactionServiceTest()
         {

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string AccountId = "acct_123";
 
-        private LoginLinkService service;
-        private LoginLinkCreateOptions createOptions;
+        private readonly LoginLinkService service;
+        private readonly LoginLinkCreateOptions createOptions;
 
         public LoginLinkServiceTest()
         {

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -11,11 +11,11 @@ namespace StripeTests
     {
         private const string OrderId = "or_123";
 
-        private OrderService service;
-        private OrderCreateOptions createOptions;
-        private OrderUpdateOptions updateOptions;
-        private OrderPayOptions payOptions;
-        private OrderListOptions listOptions;
+        private readonly OrderService service;
+        private readonly OrderCreateOptions createOptions;
+        private readonly OrderUpdateOptions updateOptions;
+        private readonly OrderPayOptions payOptions;
+        private readonly OrderListOptions listOptions;
 
         public OrderServiceTest()
         {

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -11,13 +11,13 @@ namespace StripeTests
     {
         private const string PaymentIntentId = "pi_123";
 
-        private PaymentIntentService service;
-        private PaymentIntentCancelOptions cancelOptions;
-        private PaymentIntentCaptureOptions captureOptions;
-        private PaymentIntentConfirmOptions confirmOptions;
-        private PaymentIntentCreateOptions createOptions;
-        private PaymentIntentListOptions listOptions;
-        private PaymentIntentUpdateOptions updateOptions;
+        private readonly PaymentIntentService service;
+        private readonly PaymentIntentCancelOptions cancelOptions;
+        private readonly PaymentIntentCaptureOptions captureOptions;
+        private readonly PaymentIntentConfirmOptions confirmOptions;
+        private readonly PaymentIntentCreateOptions createOptions;
+        private readonly PaymentIntentListOptions listOptions;
+        private readonly PaymentIntentUpdateOptions updateOptions;
 
         public PaymentIntentServiceTest()
         {

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string PayoutId = "po_123";
 
-        private PayoutService service;
-        private PayoutCreateOptions createOptions;
-        private PayoutUpdateOptions updateOptions;
-        private PayoutListOptions listOptions;
+        private readonly PayoutService service;
+        private readonly PayoutCreateOptions createOptions;
+        private readonly PayoutUpdateOptions updateOptions;
+        private readonly PayoutListOptions listOptions;
 
         public PayoutServiceTest()
         {

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests
         private const string AccountId = "acct_123";
         private const string PersonId = "person_123";
 
-        private PersonService service;
-        private PersonCreateOptions createOptions;
-        private PersonUpdateOptions updateOptions;
-        private PersonListOptions listOptions;
+        private readonly PersonService service;
+        private readonly PersonCreateOptions createOptions;
+        private readonly PersonUpdateOptions updateOptions;
+        private readonly PersonListOptions listOptions;
 
         public PersonServiceTest()
         {

--- a/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class PlanCreateOptionsTest : BaseStripeTest
     {
-        private PlanService service;
+        private readonly PlanService service;
 
         public PlanCreateOptionsTest()
         {

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string PlanId = "plan_123";
 
-        private PlanService service;
-        private PlanCreateOptions createOptions;
-        private PlanUpdateOptions updateOptions;
-        private PlanListOptions listOptions;
+        private readonly PlanService service;
+        private readonly PlanCreateOptions createOptions;
+        private readonly PlanUpdateOptions updateOptions;
+        private readonly PlanListOptions listOptions;
 
         public PlanServiceTest()
         {

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string ProductId = "prod_123";
 
-        private ProductService service;
-        private ProductCreateOptions createOptions;
-        private ProductUpdateOptions updateOptions;
-        private ProductListOptions listOptions;
+        private readonly ProductService service;
+        private readonly ProductCreateOptions createOptions;
+        private readonly ProductUpdateOptions updateOptions;
+        private readonly ProductListOptions listOptions;
 
         public ProductServiceTest()
         {

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -12,9 +12,9 @@ namespace StripeTests.Radar
     {
         private const string ValueListItemId = "rsli_123";
 
-        private ValueListItemService service;
-        private ValueListItemCreateOptions createOptions;
-        private ValueListItemListOptions listOptions;
+        private readonly ValueListItemService service;
+        private readonly ValueListItemCreateOptions createOptions;
+        private readonly ValueListItemListOptions listOptions;
 
         public ValueListItemServiceTest()
         {

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests.Radar
     {
         private const string ValueListId = "rsl_123";
 
-        private ValueListService service;
-        private ValueListCreateOptions createOptions;
-        private ValueListUpdateOptions updateOptions;
-        private ValueListListOptions listOptions;
+        private readonly ValueListService service;
+        private readonly ValueListCreateOptions createOptions;
+        private readonly ValueListUpdateOptions updateOptions;
+        private readonly ValueListListOptions listOptions;
 
         public ValueListServiceTest()
         {

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string RefundId = "re_123";
 
-        private RefundService service;
-        private RefundCreateOptions createOptions;
-        private RefundUpdateOptions updateOptions;
-        private RefundListOptions listOptions;
+        private readonly RefundService service;
+        private readonly RefundCreateOptions createOptions;
+        private readonly RefundUpdateOptions updateOptions;
+        private readonly RefundListOptions listOptions;
 
         public RefundServiceTest()
         {

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -12,9 +12,9 @@ namespace StripeTests.Reporting
     {
         private const string ReportRunId = "frr_123";
 
-        private ReportRunService service;
-        private ReportRunCreateOptions createOptions;
-        private ReportRunListOptions listOptions;
+        private readonly ReportRunService service;
+        private readonly ReportRunCreateOptions createOptions;
+        private readonly ReportRunListOptions listOptions;
 
         public ReportRunServiceTest()
         {

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -12,8 +12,8 @@ namespace StripeTests.Reporting
     {
         private const string ReportTypeId = "activity.summary.1";
 
-        private ReportTypeService service;
-        private ReportTypeListOptions listOptions;
+        private readonly ReportTypeService service;
+        private readonly ReportTypeListOptions listOptions;
 
         public ReportTypeServiceTest()
         {

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -12,9 +12,9 @@ namespace StripeTests
     {
         private const string ReviewId = "prv_123";
 
-        private ReviewService service;
-        private ReviewApproveOptions approveOptions;
-        private ReviewListOptions listOptions;
+        private readonly ReviewService service;
+        private readonly ReviewApproveOptions approveOptions;
+        private readonly ReviewListOptions listOptions;
 
         public ReviewServiceTest()
         {

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -11,8 +11,8 @@ namespace StripeTests
     {
         private const string ScheduledQueryId = "sqr_123";
 
-        private ScheduledQueryRunService service;
-        private ScheduledQueryRunListOptions listOptions;
+        private readonly ScheduledQueryRunService service;
+        private readonly ScheduledQueryRunListOptions listOptions;
 
         public ScheduledQueryRunServiceTest()
         {

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string SkuId = "sku_123";
 
-        private SkuService service;
-        private SkuCreateOptions createOptions;
-        private SkuUpdateOptions updateOptions;
-        private SkuListOptions listOptions;
+        private readonly SkuService service;
+        private readonly SkuCreateOptions createOptions;
+        private readonly SkuUpdateOptions updateOptions;
+        private readonly SkuListOptions listOptions;
 
         public SkuServiceTest()
         {

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -12,8 +12,8 @@ namespace StripeTests
     {
         private const string SourceId = "src_123";
 
-        private SourceTransactionService service;
-        private SourceTransactionsListOptions listOptions;
+        private readonly SourceTransactionService service;
+        private readonly SourceTransactionsListOptions listOptions;
 
         public SourceTransactionServiceTest()
         {

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -13,12 +13,12 @@ namespace StripeTests
         private const string CustomerId = "cus_123";
         private const string SourceId = "src_123";
 
-        private SourceService service;
-        private SourceAttachOptions attachOptions;
-        private SourceCreateOptions createOptions;
-        private SourceListOptions listOptions;
-        private SourceUpdateOptions updateOptions;
-        private SourceVerifyOptions verifyOptions;
+        private readonly SourceService service;
+        private readonly SourceAttachOptions attachOptions;
+        private readonly SourceCreateOptions createOptions;
+        private readonly SourceListOptions listOptions;
+        private readonly SourceUpdateOptions updateOptions;
+        private readonly SourceVerifyOptions verifyOptions;
 
         public SourceServiceTest()
         {

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string SubscriptionItemId = "si_123";
 
-        private SubscriptionItemService service;
-        private SubscriptionItemCreateOptions createOptions;
-        private SubscriptionItemUpdateOptions updateOptions;
-        private SubscriptionItemListOptions listOptions;
+        private readonly SubscriptionItemService service;
+        private readonly SubscriptionItemCreateOptions createOptions;
+        private readonly SubscriptionItemUpdateOptions updateOptions;
+        private readonly SubscriptionItemListOptions listOptions;
 
         public SubscriptionItemServiceTest()
         {

--- a/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
@@ -10,7 +10,7 @@ namespace StripeTests
 
     public class SubscriptionCreateOptionsTest : BaseStripeTest
     {
-        private SubscriptionService service;
+        private readonly SubscriptionService service;
 
         public SubscriptionCreateOptionsTest()
         {

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -11,11 +11,11 @@ namespace StripeTests
     {
         private const string SubscriptionId = "sub_123";
 
-        private SubscriptionService service;
-        private SubscriptionCancelOptions cancelOptions;
-        private SubscriptionCreateOptions createOptions;
-        private SubscriptionUpdateOptions updateOptions;
-        private SubscriptionListOptions listOptions;
+        private readonly SubscriptionService service;
+        private readonly SubscriptionCancelOptions cancelOptions;
+        private readonly SubscriptionCreateOptions createOptions;
+        private readonly SubscriptionUpdateOptions updateOptions;
+        private readonly SubscriptionListOptions listOptions;
 
         public SubscriptionServiceTest()
         {

--- a/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
@@ -10,8 +10,8 @@ namespace StripeTests.Terminal
 
     public class ConnectionTokenServiceTest : BaseStripeTest
     {
-        private ConnectionTokenService service;
-        private ConnectionTokenCreateOptions createOptions;
+        private readonly ConnectionTokenService service;
+        private readonly ConnectionTokenCreateOptions createOptions;
 
         public ConnectionTokenServiceTest()
         {

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -13,10 +13,10 @@ namespace StripeTests.Terminal
     {
         private const string LocationId = "loc_123";
 
-        private LocationService service;
-        private LocationCreateOptions createOptions;
-        private LocationListOptions listOptions;
-        private LocationUpdateOptions updateOptions;
+        private readonly LocationService service;
+        private readonly LocationCreateOptions createOptions;
+        private readonly LocationListOptions listOptions;
+        private readonly LocationUpdateOptions updateOptions;
 
         public LocationServiceTest()
         {

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests.Terminal
     {
         private const string ReaderId = "ds_123";
 
-        private ReaderService service;
-        private ReaderCreateOptions createOptions;
-        private ReaderListOptions listOptions;
-        private ReaderUpdateOptions updateOptions;
+        private readonly ReaderService service;
+        private readonly ReaderCreateOptions createOptions;
+        private readonly ReaderListOptions listOptions;
+        private readonly ReaderUpdateOptions updateOptions;
 
         public ReaderServiceTest()
         {

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -9,8 +9,8 @@ namespace StripeTests
 
     public class ThreeDSecureServiceTest : BaseStripeTest
     {
-        private ThreeDSecureService service;
-        private ThreeDSecureCreateOptions createOptions;
+        private readonly ThreeDSecureService service;
+        private readonly ThreeDSecureCreateOptions createOptions;
 
         public ThreeDSecureServiceTest()
         {

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -12,8 +12,8 @@ namespace StripeTests
     {
         private const string TokenId = "tok_123";
 
-        private TokenService service;
-        private TokenCreateOptions createOptions;
+        private readonly TokenService service;
+        private readonly TokenCreateOptions createOptions;
 
         public TokenServiceTest()
         {

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string TopupId = "tu_123";
 
-        private TopupService service;
-        private TopupCreateOptions createOptions;
-        private TopupUpdateOptions updateOptions;
-        private TopupListOptions listOptions;
+        private readonly TopupService service;
+        private readonly TopupCreateOptions createOptions;
+        private readonly TopupUpdateOptions updateOptions;
+        private readonly TopupListOptions listOptions;
 
         public TopupServiceTest()
         {

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -12,10 +12,10 @@ namespace StripeTests
         private const string TransferId = "tr_123";
         private const string TransferReversalId = "trr_123";
 
-        private TransferReversalService service;
-        private TransferReversalCreateOptions createOptions;
-        private TransferReversalUpdateOptions updateOptions;
-        private TransferReversalListOptions listOptions;
+        private readonly TransferReversalService service;
+        private readonly TransferReversalCreateOptions createOptions;
+        private readonly TransferReversalUpdateOptions updateOptions;
+        private readonly TransferReversalListOptions listOptions;
 
         public TransferReversalServiceTest()
         {

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string TransferId = "tr_123";
 
-        private TransferService service;
-        private TransferCreateOptions createOptions;
-        private TransferUpdateOptions updateOptions;
-        private TransferListOptions listOptions;
+        private readonly TransferService service;
+        private readonly TransferCreateOptions createOptions;
+        private readonly TransferUpdateOptions updateOptions;
+        private readonly TransferListOptions listOptions;
 
         public TransferServiceTest()
         {

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -10,8 +10,8 @@ namespace StripeTests
 
     public class UsageRecordSummaryServiceTest : BaseStripeTest
     {
-        private UsageRecordSummaryService service;
-        private UsageRecordSummaryListOptions listOptions;
+        private readonly UsageRecordSummaryService service;
+        private readonly UsageRecordSummaryListOptions listOptions;
 
         public UsageRecordSummaryServiceTest()
         {

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -10,8 +10,8 @@ namespace StripeTests
 
     public class UsageRecordServiceTest : BaseStripeTest
     {
-        private UsageRecordService service;
-        private UsageRecordCreateOptions createOptions;
+        private readonly UsageRecordService service;
+        private readonly UsageRecordCreateOptions createOptions;
 
         public UsageRecordServiceTest()
         {

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -11,10 +11,10 @@ namespace StripeTests
     {
         private const string WebhookEndpointId = "we_123";
 
-        private WebhookEndpointService service;
-        private WebhookEndpointCreateOptions createOptions;
-        private WebhookEndpointUpdateOptions updateOptions;
-        private WebhookEndpointListOptions listOptions;
+        private readonly WebhookEndpointService service;
+        private readonly WebhookEndpointCreateOptions createOptions;
+        private readonly WebhookEndpointUpdateOptions updateOptions;
+        private readonly WebhookEndpointListOptions listOptions;
 
         public WebhookEndpointServiceTest()
         {


### PR DESCRIPTION
It's good practice to declare fields that are only assigned in constuctors as `readonly`.