### PR TITLE
Use Mono for .NET Framework targets on UNIX systems

### DIFF
--- a/netfx.props
+++ b/netfx.props
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- When compiling .NET SDK 2.0 projects targeting .NET 4.x on Mono using 'dotnet build' you -->
+    <!-- have to teach MSBuild where the Mono copy of the reference asssemblies is -->
+    <TargetIsMono Condition="$(TargetFramework.StartsWith('net4')) and '$(OS)' == 'Unix'">true</TargetIsMono>
+
+    <!-- Look in the standard install locations -->
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono')">/Library/Frameworks/Mono.framework/Versions/Current/lib/mono</BaseFrameworkPathOverrideForMono>
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/usr/lib/mono')">/usr/lib/mono</BaseFrameworkPathOverrideForMono>
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/usr/local/lib/mono')">/usr/local/lib/mono</BaseFrameworkPathOverrideForMono>
+
+    <!-- If we found Mono reference assemblies, then use them -->
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net45'">$(BaseFrameworkPathOverrideForMono)/4.5-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net451'">$(BaseFrameworkPathOverrideForMono)/4.5.1-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net452'">$(BaseFrameworkPathOverrideForMono)/4.5.2-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net46'">$(BaseFrameworkPathOverrideForMono)/4.6-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net461'">$(BaseFrameworkPathOverrideForMono)/4.6.1-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net462'">$(BaseFrameworkPathOverrideForMono)/4.6.2-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net47'">$(BaseFrameworkPathOverrideForMono)/4.7-api/</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net471'">$(BaseFrameworkPathOverrideForMono)/4.7.1-api/</FrameworkPathOverride>
+    <EnableFrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != ''">true</EnableFrameworkPathOverride>
+
+    <!-- Add the Facades directory.  Not sure how else to do this. Necessary at least for .NET 4.5 -->
+    <AssemblySearchPaths Condition="'$(BaseFrameworkPathOverrideForMono)' != ''">$(FrameworkPathOverride)/Facades;$(AssemblySearchPaths)</AssemblySearchPaths>
+
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- When using 'dotnet build' to compile against Mono reference assemblies it seems necessary to add some explicit references to some facade DLLs  -->
+    <Reference Include="System.Runtime" Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND $(TargetFramework.StartsWith('net4'))" />
+    <Reference Include="System.IO" Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND $(TargetFramework.StartsWith('net4'))" />
+
+  </ItemGroup>
+</Project>

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
     <Description>Stripe.net is a sync/async .NET 4.5+ client, and a portable class library for the Stripe API.  (Official Library)</Description>

--- a/src/StripeTests/Properties.cs
+++ b/src/StripeTests/Properties.cs
@@ -1,1 +1,0 @@
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
@@ -6,6 +7,12 @@
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.3.0" />

--- a/src/StripeTests/xunit.runner.json
+++ b/src/StripeTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "appDomain": "denied",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

This PR lets us test .NET Framework targets (`net45` for the library / `net452` for the tests) on macOS, using Mono.

The `netfx.props` file containing the magic was copied from this project: https://github.com/fsprojects/FSharp.TypeProviders.SDK/blob/master/netfx.props.

I also had to create a configuration file for xUnit in order to set `appDomain` to `denied` in order to work around a Mono limitation (cf. https://github.com/xunit/xunit/issues/1357#issuecomment-314416426).

This should have no impact on Windows systems but it does let us build / pack / test on OS X without having to specify a target framework or manually editing `.csproj` files to remove targets \o/

```
❯ dotnet test src/StripeTests/StripeTests.csproj
Build started, please wait...
Build completed.

Test run for /Users/ob/workspace/dotnet/stripe-dotnet/src/StripeTests/bin/Debug/netcoreapp1.1/StripeTests.dll(.NETCoreApp,Version=v1.1)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 575. Passed: 575. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 5.8369 Seconds
Test run for /Users/ob/workspace/dotnet/stripe-dotnet/src/StripeTests/bin/Debug/netcoreapp2.1/StripeTests.dll(.NETCoreApp,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 576. Passed: 576. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 5.3234 Seconds
Test run for /Users/ob/workspace/dotnet/stripe-dotnet/src/StripeTests/bin/Debug/net452/StripeTests.dll(.NETFramework,Version=v4.5.2)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 574. Passed: 574. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 4.1456 Seconds

❯ dotnet pack -c Release src/Stripe.net
Microsoft (R) Build Engine version 15.9.20+g88f5fadfbe for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 42.22 ms for /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/Stripe.net.csproj.
  Stripe.net -> /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/bin/Release/net45/Stripe.net.dll
  Stripe.net -> /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/bin/Release/netstandard1.2/Stripe.net.dll
  Stripe.net -> /Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/bin/Release/netstandard2.0/Stripe.net.dll
  Successfully created package '/Users/ob/workspace/dotnet/stripe-dotnet/src/Stripe.net/bin/Release/Stripe.net.21.7.0.nupkg'.
```
