### PR TITLE
Fix some remaining StyleCop rules violations

### DIFF
--- a/src/Stripe.net/Enums/Billing.cs
+++ b/src/Stripe.net/Enums/Billing.cs
@@ -7,9 +7,17 @@ namespace Stripe
     [JsonConverter(typeof(StringEnumConverter))]
     public enum Billing
     {
+        /// <summary>
+        /// When charging automatically, Stripe will attempt to pay this invoice or subscription
+        /// using the default source attached to the customer.
+        /// </summary>
         [EnumMember(Value = "charge_automatically")]
         ChargeAutomatically,
 
+        /// <summary>
+        /// When sending an invoice, Stripe will email your customer an invoice with payment
+        /// instructions.
+        /// </summary>
         [EnumMember(Value = "send_invoice")]
         SendInvoice,
     }

--- a/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
+++ b/src/Stripe.net/Infrastructure/Middleware/RequestStringBuilder.cs
@@ -389,14 +389,15 @@ namespace Stripe.Infrastructure.Middleware
         /// </summary>
         internal sealed class Parameter
         {
-            public readonly string Key;
-            public readonly string Value;
-
             public Parameter(string key, string value)
             {
                 this.Key = key;
                 this.Value = value;
             }
+
+            public string Key { get; }
+
+            public string Value { get; }
         }
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -22,6 +22,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/_stylecop/StyleCopRules.ruleset
+++ b/src/_stylecop/StyleCopRules.ruleset
@@ -2,12 +2,6 @@
 <RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for Stripe.net" ToolsVersion="14.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!--
-      SA1401: FieldsMustBePrivate
-      This ones would introduce breaking changes
-    -->
-    <Rule Id="SA1401" Action="None" />
-
-    <!--
       Keep this rule disabled as it would force a header for each file
       and a copyright.
        - SA1633: FileMustHaveHeader
@@ -26,15 +20,11 @@
     <!--
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
       SA1600: ElementsMustBeDocumented
-      SA1601: PartialElementsMustBeDocumented
-      SA1602: EnumerationItemsMustBeDocumented
       SA1623: PropertySummaryDocumentationMustMatchAccessors
       Documentation related warnings. We should fix those in the future.
     -->
     <Rule Id="CS1591" Action="None" />
     <Rule Id="SA1600" Action="None" />
-    <Rule Id="SA1601" Action="None" />
-    <Rule Id="SA1602" Action="None" />
     <Rule Id="SA1623" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Also set `TreatWarningsAsErrors` to `true` on both projects to avoid introducing new warnings in the future.