### PR TITLE
Disable optimizations in SecureCompare

### DIFF
--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -3,6 +3,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Security.Cryptography;
     using System.Text;
     using Newtonsoft.Json;
@@ -82,6 +83,7 @@ namespace Stripe
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         private static bool SecureCompare(string a, string b)
         {
             if (a.Length != b.Length)


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Prevents the compiler from optimizing `SecureCompare`, which could make it non-constant-time.

Cf. https://stackoverflow.com/a/20448922/5307473.
