### PR TITLE
Refactor test infrastructure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
-  # If you bump this, don't forget to bump `MinimumMockVersion` in `BaseStripeTest.cs` as well.
+  # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
   STRIPE_MOCK_VERSION: 0.39.0
 
 deploy:

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -1,56 +1,75 @@
 namespace StripeTests
 {
-    using System;
     using System.IO;
-    using System.Linq;
-    using System.Net;
     using System.Net.Http;
     using System.Reflection;
     using System.Text;
-    using System.Threading;
+    using Xunit;
 
-    using Moq;
-    using Moq.Protected;
-    using Stripe;
-
+    [Collection("stripe-mock tests")]
     public class BaseStripeTest
     {
-        /// <value>Minimum required version of stripe-mock</value>
-        /// <remarks>
-        /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in appveyor.yml as well.
-        /// </remarks>
-        private const string MockMinimumVersion = "0.39.0";
-
-        private static Mock<HttpClientHandler> mockHandler;
-
-        private static string port;
-
-        // Lazy initializer to ensure that initialization is run only once even when running tests
-        // in parallel.
-        private static Lazy<object> initializer = new Lazy<object>(InitStripeMock);
-
         public BaseStripeTest()
+            : this(null, null)
         {
-            // This triggers the lazy initialization. We don't actually care about the value of
-            // initialized (it will be null anyway), but simply writing `initializer.Value` is not
-            // a valid statement in C#.
-            var initialized = initializer.Value;
+        }
 
-            // Reset the mock before each test
-            mockHandler.Invocations.Clear();
+        public BaseStripeTest(StripeMockFixture stripeMockFixture)
+            : this(stripeMockFixture, null)
+        {
+        }
+
+        public BaseStripeTest(MockHttpClientFixture mockHttpClientFixture)
+            : this(null, mockHttpClientFixture)
+        {
+        }
+
+        public BaseStripeTest(StripeMockFixture stripeMockFixture, MockHttpClientFixture mockHttpClientFixture)
+        {
+            this.StripeMockFixture = stripeMockFixture;
+            this.MockHttpClientFixture = mockHttpClientFixture;
+
+            if (this.MockHttpClientFixture != null)
+            {
+                // Reset the mock before each test
+                this.MockHttpClientFixture.Reset();
+            }
+        }
+
+        protected MockHttpClientFixture MockHttpClientFixture { get; }
+
+        protected StripeMockFixture StripeMockFixture { get; }
+
+        /// <summary>
+        /// Gets a resource file and returns its contents in a string.
+        /// </summary>
+        /// <param name="path">Path to the resource file</param>
+        /// <returns>File contents</returns>
+        protected static string GetResourceAsString(string path)
+        {
+            var fullpath = "StripeTests.Resources." + path;
+            var contents = new StreamReader(
+                typeof(BaseStripeTest).GetTypeInfo().Assembly.GetManifestResourceStream(fullpath),
+                Encoding.UTF8).ReadToEnd();
+
+            return contents;
         }
 
         /// <summary>
-        /// Gets fixture data from stripe-mock for a resource expected to be at the given API path.
-        /// stripe-mock ignores whether IDs are actually valid, so it's only important to make sure
-        /// that the route exists, rather than the actual resource. It's common to use a symbolic
-        /// ID stand-in like <code>ch_123</code>
+        /// Asserts that a single HTTP request was made with the specified method and path.
         /// </summary>
-        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
-        /// <returns>Fixture data encoded as JSON</returns>
-        protected static string GetFixture(string path)
+        protected void AssertRequest(HttpMethod method, string path)
         {
-            return GetFixture(path, null);
+            if (this.MockHttpClientFixture == null)
+            {
+                throw new StripeTestException(
+                    "AssertRequest called from a test class that doesn't have access to "
+                    + "MockHttpClientFixture. Make sure that the constructor for "
+                    + $"{this.GetType().Name} receives MockHttpClientFixture and calls the "
+                    + "base constructor.");
+            }
+
+            this.MockHttpClientFixture.AssertRequest(method, path);
         }
 
         /// <summary>
@@ -62,131 +81,18 @@ namespace StripeTests
         /// <param name="path">API path to use to get a fixture for stripe-mock</param>
         /// <param name="expansions">Set of expansions that should be applied</param>
         /// <returns>Fixture data encoded as JSON</returns>
-        protected static string GetFixture(string path, string[] expansions)
+        protected string GetFixture(string path, string[] expansions = null)
         {
-            string url = $"http://localhost:{port}{path}";
-
-            if (expansions != null)
+            if (this.StripeMockFixture == null)
             {
-                string query = string.Join("&", expansions.Select(x => $"expand[]={x}").ToArray());
-                url += $"?{query}";
+                throw new StripeTestException(
+                    "GetFixture called from a test class that doesn't have access to "
+                    + "StripeMockFixture. Make sure that the constructor for "
+                    + $"{this.GetType().Name} receives StripeMockFixture and calls the "
+                    + "base constructor.");
             }
 
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Authorization
-                    = new System.Net.Http.Headers.AuthenticationHeaderValue(
-                        "Bearer",
-                        "sk_test_123");
-
-                HttpResponseMessage response;
-
-                try
-                {
-                    response = client.GetAsync(url).Result;
-                }
-                catch (Exception)
-                {
-                    throw new Exception(
-                        $"Couldn't reach stripe-mock at `localhost:{port}`. "
-                        + "Is it running? Please see README for setup instructions.");
-                }
-
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    throw new Exception(
-                        $"stripe-mock returned status code: {response.StatusCode}.");
-                }
-
-                return response.Content.ReadAsStringAsync().Result;
-            }
-        }
-
-        /// <summary>
-        /// Gets a resource file and returns its contents in a string.
-        /// </summary>
-        /// <param name="path">Path to the resource file</param>
-        /// <returns>File contents</returns>
-        protected static string GetResourceAsString(string path)
-        {
-            var fullpath = "StripeTests.Resources." + path;
-            var json = new StreamReader(
-                typeof(BaseStripeTest).GetTypeInfo().Assembly.GetManifestResourceStream(fullpath),
-                Encoding.UTF8).ReadToEnd();
-
-            return json;
-        }
-
-        protected void AssertRequest(HttpMethod method, string path)
-        {
-            mockHandler.Protected().Verify(
-                "SendAsync",
-                Times.Once(),
-                ItExpr.Is<HttpRequestMessage>(m =>
-                    m.Method == method &&
-                    m.RequestUri.AbsolutePath == path),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        /// <summary>
-        /// Checks that stripe-mock is running and that it's a recent enough version.
-        /// </summary>
-        private static object InitStripeMock()
-        {
-            port = Environment.GetEnvironmentVariable("STRIPE_MOCK_PORT") ?? "12111";
-            string url = $"http://localhost:{port}";
-
-            using (HttpClient client = new HttpClient())
-            {
-                HttpResponseMessage response;
-
-                try
-                {
-                    response = client.GetAsync(url).Result;
-                }
-                catch (Exception)
-                {
-                    throw new Exception(
-                        $"Couldn't reach stripe-mock at `localhost:{port}`. "
-                        + "Is it running? Please see README for setup instructions.");
-                }
-
-                string version = response.Headers.GetValues("Stripe-Mock-Version").FirstOrDefault();
-
-                if (!version.Equals("master") &&
-                    (CompareVersions(version, MockMinimumVersion) > 0))
-                {
-                    throw new Exception(
-                        $"Your version of stripe-mock ({version}) is too old. The minimum "
-                        + $"version to run this test suite is {MockMinimumVersion}. Please see its "
-                        + "repository for upgrade instructions.");
-                }
-            }
-
-            StripeConfiguration.SetApiBase($"http://localhost:{port}/v1");
-            StripeConfiguration.SetFilesBase($"http://localhost:{port}/v1");
-            StripeConfiguration.SetApiKey("sk_test_123");
-
-            mockHandler = new Mock<HttpClientHandler>
-            {
-                CallBase = true
-            };
-            StripeConfiguration.HttpMessageHandler = mockHandler.Object;
-
-            return null;
-        }
-
-        /// <summary>
-        /// Compares two version strings.
-        /// </summary>
-        /// <param name="a">A version string (e.g. "1.2.3").</param>
-        /// <param name="b">Another version string.</param>
-        /// <returns>-1 if a > b, 1 if a < b, 0 if a == b</returns>
-        private static int CompareVersions(string a, string b)
-        {
-            var version1 = new Version(a);
-            var version2 = new Version(b);
-            return version2.CompareTo(version1);
+            return this.StripeMockFixture.GetFixture(path, expansions);
         }
     }
 }

--- a/src/StripeTests/Entities/Accounts/AccountTest.cs
+++ b/src/StripeTests/Entities/Accounts/AccountTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class AccountTest : BaseStripeTest
     {
+        public AccountTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/accounts/acct_123");
+            string json = this.GetFixture("/v1/accounts/acct_123");
             var account = JsonConvert.DeserializeObject<Account>(json);
             Assert.NotNull(account);
             Assert.IsType<Account>(account);
@@ -25,7 +30,7 @@ namespace StripeTests
               "business_logo",
             };
 
-            string json = GetFixture("/v1/accounts/acct_123", expansions);
+            string json = this.GetFixture("/v1/accounts/acct_123", expansions);
             var account = JsonConvert.DeserializeObject<Account>(json);
 
             Assert.NotNull(account);

--- a/src/StripeTests/Entities/ApplePayDomains/ApplePayDomainTest.cs
+++ b/src/StripeTests/Entities/ApplePayDomains/ApplePayDomainTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ApplePayDomainTest : BaseStripeTest
     {
+        public ApplePayDomainTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/apple_pay/domains/apwc_123");
+            string json = this.GetFixture("/v1/apple_pay/domains/apwc_123");
             var domain = JsonConvert.DeserializeObject<ApplePayDomain>(json);
             Assert.NotNull(domain);
             Assert.IsType<ApplePayDomain>(domain);

--- a/src/StripeTests/Entities/ApplicationFeeRefunds/ApplicationFeeRefundTest.cs
+++ b/src/StripeTests/Entities/ApplicationFeeRefunds/ApplicationFeeRefundTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ApplicationFeeRefundTest : BaseStripeTest
     {
+        public ApplicationFeeRefundTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/application_fees/fee_123/refunds/fr_123");
+            string json = this.GetFixture("/v1/application_fees/fee_123/refunds/fr_123");
             var applicationFeeRefund = JsonConvert.DeserializeObject<ApplicationFeeRefund>(json);
             Assert.NotNull(applicationFeeRefund);
             Assert.IsType<ApplicationFeeRefund>(applicationFeeRefund);

--- a/src/StripeTests/Entities/ApplicationFees/ApplicationFeeTest.cs
+++ b/src/StripeTests/Entities/ApplicationFees/ApplicationFeeTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ApplicationFeeTest : BaseStripeTest
     {
+        public ApplicationFeeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/application_fees/fee_123");
+            string json = this.GetFixture("/v1/application_fees/fee_123");
             var applicationFee = JsonConvert.DeserializeObject<ApplicationFee>(json);
             Assert.NotNull(applicationFee);
             Assert.IsType<ApplicationFee>(applicationFee);
@@ -29,7 +34,7 @@ namespace StripeTests
               "originating_transaction",
             };
 
-            string json = GetFixture("/v1/application_fees/fee_123", expansions);
+            string json = this.GetFixture("/v1/application_fees/fee_123", expansions);
             var applicationFee = JsonConvert.DeserializeObject<ApplicationFee>(json);
             Assert.NotNull(applicationFee);
             Assert.IsType<ApplicationFee>(applicationFee);

--- a/src/StripeTests/Entities/Balance/BalanceTest.cs
+++ b/src/StripeTests/Entities/Balance/BalanceTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class BalanceTest : BaseStripeTest
     {
+        public BalanceTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/balance");
+            string json = this.GetFixture("/v1/balance");
             var balance = JsonConvert.DeserializeObject<Balance>(json);
             Assert.NotNull(balance);
             Assert.IsType<Balance>(balance);

--- a/src/StripeTests/Entities/BalanceTransactions/BalanceTransactionTest.cs
+++ b/src/StripeTests/Entities/BalanceTransactions/BalanceTransactionTest.cs
@@ -7,10 +7,15 @@ namespace StripeTests
 
     public class BalanceTransactionTest : BaseStripeTest
     {
+        public BalanceTransactionTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/balance/history/txn_123");
+            string json = this.GetFixture("/v1/balance/history/txn_123");
             var balanceTransaction = JsonConvert.DeserializeObject<BalanceTransaction>(json);
             Assert.NotNull(balanceTransaction);
             Assert.IsType<BalanceTransaction>(balanceTransaction);

--- a/src/StripeTests/Entities/BankAccounts/BankAccountTest.cs
+++ b/src/StripeTests/Entities/BankAccounts/BankAccountTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class BankAccountTest : BaseStripeTest
     {
+        public BankAccountTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void DeserializeForAccount()
         {
-            string json = GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
+            string json = this.GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
             var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);
@@ -20,7 +25,7 @@ namespace StripeTests
         [Fact]
         public void DeserializeForCustomer()
         {
-            string json = GetFixture("/v1/customers/cus_123/bank_accounts/ba_123");
+            string json = this.GetFixture("/v1/customers/cus_123/bank_accounts/ba_123");
             var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);
@@ -36,7 +41,7 @@ namespace StripeTests
               "customer",
             };
 
-            string json = GetFixture("/v1/customers/cus_123/bank_accounts/ba_123", expansions);
+            string json = this.GetFixture("/v1/customers/cus_123/bank_accounts/ba_123", expansions);
             var bankAccount = JsonConvert.DeserializeObject<BankAccount>(json);
             Assert.NotNull(bankAccount);
             Assert.IsType<BankAccount>(bankAccount);

--- a/src/StripeTests/Entities/Cards/CardTest.cs
+++ b/src/StripeTests/Entities/Cards/CardTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class CardTest : BaseStripeTest
     {
+        public CardTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/customers/cus_123/cards/card_123");
+            string json = this.GetFixture("/v1/customers/cus_123/cards/card_123");
             var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
             Assert.IsType<Card>(card);
@@ -26,7 +31,7 @@ namespace StripeTests
               "recipient",
             };
 
-            string json = GetFixture("/v1/customers/cus_123/cards/card_123", expansions);
+            string json = this.GetFixture("/v1/customers/cus_123/cards/card_123", expansions);
             var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
             Assert.IsType<Card>(card);

--- a/src/StripeTests/Entities/Charges/ChargeTest.cs
+++ b/src/StripeTests/Entities/Charges/ChargeTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ChargeTest : BaseStripeTest
     {
+        public ChargeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/charges/ch_123");
+            string json = this.GetFixture("/v1/charges/ch_123");
             var charge = JsonConvert.DeserializeObject<Charge>(json);
             Assert.NotNull(charge);
             Assert.IsType<Charge>(charge);
@@ -36,7 +41,7 @@ namespace StripeTests
               "transfer",
             };
 
-            string json = GetFixture("/v1/charges/ch_123", expansions);
+            string json = this.GetFixture("/v1/charges/ch_123", expansions);
             var charge = JsonConvert.DeserializeObject<Charge>(json);
             Assert.NotNull(charge);
             Assert.IsType<Charge>(charge);

--- a/src/StripeTests/Entities/CountrySpecs/CountrySpecTest.cs
+++ b/src/StripeTests/Entities/CountrySpecs/CountrySpecTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class CountrySpecTest : BaseStripeTest
     {
+        public CountrySpecTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/country_specs/US");
+            string json = this.GetFixture("/v1/country_specs/US");
             var countrySpec = JsonConvert.DeserializeObject<CountrySpec>(json);
             Assert.NotNull(countrySpec);
             Assert.IsType<CountrySpec>(countrySpec);

--- a/src/StripeTests/Entities/Coupons/CouponTest.cs
+++ b/src/StripeTests/Entities/Coupons/CouponTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class CouponTest : BaseStripeTest
     {
+        public CouponTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/coupons/co_123");
+            string json = this.GetFixture("/v1/coupons/co_123");
             var coupon = JsonConvert.DeserializeObject<Coupon>(json);
             Assert.NotNull(coupon);
             Assert.IsType<Coupon>(coupon);

--- a/src/StripeTests/Entities/Customers/CustomerTest.cs
+++ b/src/StripeTests/Entities/Customers/CustomerTest.cs
@@ -7,10 +7,15 @@ namespace StripeTests
 
     public class CustomerTest : BaseStripeTest
     {
+        public CustomerTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/customers/cus_123");
+            string json = this.GetFixture("/v1/customers/cus_123");
             var customer = JsonConvert.DeserializeObject<Customer>(json);
             Assert.NotNull(customer);
             Assert.IsType<Customer>(customer);

--- a/src/StripeTests/Entities/Discounts/DiscountTest.cs
+++ b/src/StripeTests/Entities/Discounts/DiscountTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class DiscountTest : BaseStripeTest
     {
+        public DiscountTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Disputes/DisputeTest.cs
+++ b/src/StripeTests/Entities/Disputes/DisputeTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class DisputeTest : BaseStripeTest
     {
+        public DisputeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/disputes/dp_123");
+            string json = this.GetFixture("/v1/disputes/dp_123");
             var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
             Assert.IsType<Dispute>(dispute);
@@ -25,7 +30,7 @@ namespace StripeTests
               "charge",
             };
 
-            string json = GetFixture("/v1/disputes/dp_123", expansions);
+            string json = this.GetFixture("/v1/disputes/dp_123", expansions);
             var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
             Assert.IsType<Dispute>(dispute);

--- a/src/StripeTests/Entities/EphemeralKeys/EphemeralKeyTest.cs
+++ b/src/StripeTests/Entities/EphemeralKeys/EphemeralKeyTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class EphemeralKeyTest : BaseStripeTest
     {
+        public EphemeralKeyTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Events/EventTest.cs
+++ b/src/StripeTests/Entities/Events/EventTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class EventTest : BaseStripeTest
     {
+        public EventTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/ExchangeRates/ExchangeRateTest.cs
+++ b/src/StripeTests/Entities/ExchangeRates/ExchangeRateTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ExchangeRateTest : BaseStripeTest
     {
+        public ExchangeRateTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/exchange_rates/usd");
+            string json = this.GetFixture("/v1/exchange_rates/usd");
             var exchangeRate = JsonConvert.DeserializeObject<ExchangeRate>(json);
             Assert.NotNull(exchangeRate);
             Assert.IsType<ExchangeRate>(exchangeRate);

--- a/src/StripeTests/Entities/ExternalAccounts/ExternalAccountTest.cs
+++ b/src/StripeTests/Entities/ExternalAccounts/ExternalAccountTest.cs
@@ -5,10 +5,15 @@ namespace StripeTests
 
     public class ExternalAccountTest : BaseStripeTest
     {
+        public ExternalAccountTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
+            string json = this.GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
             var externalAccount = Mapper<IExternalAccount>.MapFromJson(json);
             Assert.NotNull(externalAccount);
             Assert.IsType<BankAccount>(externalAccount);
@@ -23,7 +28,7 @@ namespace StripeTests
               "account",
             };
 
-            string json = GetFixture("/v1/accounts/acct_123/external_accounts/ba_123", expansions);
+            string json = this.GetFixture("/v1/accounts/acct_123/external_accounts/ba_123", expansions);
             var externalAccount = Mapper<IExternalAccount>.MapFromJson(json);
             Assert.NotNull(externalAccount);
             Assert.IsType<BankAccount>(externalAccount);

--- a/src/StripeTests/Entities/FileLinks/FileLinkTest.cs
+++ b/src/StripeTests/Entities/FileLinks/FileLinkTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class FileLinkTest : BaseStripeTest
     {
+        public FileLinkTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/file_links/link_123");
+            string json = this.GetFixture("/v1/file_links/link_123");
             var fileLink = JsonConvert.DeserializeObject<FileLink>(json);
             Assert.NotNull(fileLink);
             Assert.IsType<FileLink>(fileLink);
@@ -25,7 +30,7 @@ namespace StripeTests
               "file",
             };
 
-            string json = GetFixture("/v1/file_links/link_123", expansions);
+            string json = this.GetFixture("/v1/file_links/link_123", expansions);
             var fileLink = JsonConvert.DeserializeObject<FileLink>(json);
             Assert.NotNull(fileLink);
             Assert.IsType<FileLink>(fileLink);

--- a/src/StripeTests/Entities/Files/FileTest.cs
+++ b/src/StripeTests/Entities/Files/FileTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class FileTest : BaseStripeTest
     {
+        public FileTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/files/file_123");
+            string json = this.GetFixture("/v1/files/file_123");
             var file = JsonConvert.DeserializeObject<File>(json);
             Assert.NotNull(file);
             Assert.IsType<File>(file);

--- a/src/StripeTests/Entities/InvoiceItems/InvoiceItemTest.cs
+++ b/src/StripeTests/Entities/InvoiceItems/InvoiceItemTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class InvoiceItemTest : BaseStripeTest
     {
+        public InvoiceItemTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/invoiceitems/ii_123");
+            string json = this.GetFixture("/v1/invoiceitems/ii_123");
             var invoiceItem = JsonConvert.DeserializeObject<InvoiceItem>(json);
             Assert.NotNull(invoiceItem);
             Assert.IsType<InvoiceItem>(invoiceItem);
@@ -27,7 +32,7 @@ namespace StripeTests
               "subscription",
             };
 
-            string json = GetFixture("/v1/invoiceitems/ii_123", expansions);
+            string json = this.GetFixture("/v1/invoiceitems/ii_123", expansions);
             var invoiceItem = JsonConvert.DeserializeObject<InvoiceItem>(json);
             Assert.NotNull(invoiceItem);
             Assert.IsType<InvoiceItem>(invoiceItem);

--- a/src/StripeTests/Entities/Invoices/InvoiceLineItemTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceLineItemTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class InvoiceLineItemTest : BaseStripeTest
     {
+        public InvoiceLineItemTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/invoices/in_123/lines");
+            string json = this.GetFixture("/v1/invoices/in_123/lines");
             var lineItems = JsonConvert.DeserializeObject<StripeList<InvoiceLineItem>>(json);
             Assert.NotNull(lineItems);
 

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class InvoiceTest : BaseStripeTest
     {
+        public InvoiceTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/invoices/in_123");
+            string json = this.GetFixture("/v1/invoices/in_123");
             var invoice = JsonConvert.DeserializeObject<Invoice>(json);
             Assert.NotNull(invoice);
             Assert.IsType<Invoice>(invoice);
@@ -27,7 +32,7 @@ namespace StripeTests
               "subscription",
             };
 
-            string json = GetFixture("/v1/invoices/in_123", expansions);
+            string json = this.GetFixture("/v1/invoices/in_123", expansions);
             var invoice = JsonConvert.DeserializeObject<Invoice>(json);
             Assert.NotNull(invoice);
             Assert.IsType<Invoice>(invoice);

--- a/src/StripeTests/Entities/Issuing/Authorizations/AuthorizationTest.cs
+++ b/src/StripeTests/Entities/Issuing/Authorizations/AuthorizationTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Issuing
 
     public class AuthorizationTest : BaseStripeTest
     {
+        public AuthorizationTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/issuing/authorizations/iauth_123");
+            string json = this.GetFixture("/v1/issuing/authorizations/iauth_123");
             var authorization = JsonConvert.DeserializeObject<Authorization>(json);
             Assert.NotNull(authorization);
             Assert.IsType<Authorization>(authorization);
@@ -28,7 +33,7 @@ namespace StripeTests.Issuing
               "cardholder",
             };
 
-            string json = GetFixture("/v1/issuing/authorizations/iauth_123", expansions);
+            string json = this.GetFixture("/v1/issuing/authorizations/iauth_123", expansions);
             var authorization = JsonConvert.DeserializeObject<Authorization>(json);
             Assert.NotNull(authorization);
             Assert.IsType<Authorization>(authorization);

--- a/src/StripeTests/Entities/Issuing/Cardholders/CardholderTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cardholders/CardholderTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Issuing
 
     public class CardholderTest : BaseStripeTest
     {
+        public CardholderTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/issuing/cardholders/ich_123");
+            string json = this.GetFixture("/v1/issuing/cardholders/ich_123");
             var cardholder = JsonConvert.DeserializeObject<Cardholder>(json);
             Assert.NotNull(cardholder);
             Assert.IsType<Cardholder>(cardholder);

--- a/src/StripeTests/Entities/Issuing/Cards/CardDetailsTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cards/CardDetailsTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests.Issuing
 
     public class CardDetailsTest : BaseStripeTest
     {
+        public CardDetailsTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Issuing/Cards/CardTest.cs
+++ b/src/StripeTests/Entities/Issuing/Cards/CardTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Issuing
 
     public class CardTest : BaseStripeTest
     {
+        public CardTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/issuing/cards/ic_123");
+            string json = this.GetFixture("/v1/issuing/cards/ic_123");
             var card = JsonConvert.DeserializeObject<Card>(json);
             Assert.NotNull(card);
             Assert.IsType<Card>(card);

--- a/src/StripeTests/Entities/Issuing/Disputes/DisputeTest.cs
+++ b/src/StripeTests/Entities/Issuing/Disputes/DisputeTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Issuing
 
     public class DisputeTest : BaseStripeTest
     {
+        public DisputeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/issuing/disputes/idp_123");
+            string json = this.GetFixture("/v1/issuing/disputes/idp_123");
             var dispute = JsonConvert.DeserializeObject<Dispute>(json);
             Assert.NotNull(dispute);
             Assert.IsType<Dispute>(dispute);

--- a/src/StripeTests/Entities/Issuing/Transactions/TransactionTest.cs
+++ b/src/StripeTests/Entities/Issuing/Transactions/TransactionTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Issuing
 
     public class TransactionTest : BaseStripeTest
     {
+        public TransactionTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/issuing/transactions/ipi_123");
+            string json = this.GetFixture("/v1/issuing/transactions/ipi_123");
             var transaction = JsonConvert.DeserializeObject<Transaction>(json);
             Assert.NotNull(transaction);
             Assert.IsType<Transaction>(transaction);

--- a/src/StripeTests/Entities/LoginLinks/LoginLinkTest.cs
+++ b/src/StripeTests/Entities/LoginLinks/LoginLinkTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class LoginLinkTest : BaseStripeTest
     {
+        public LoginLinkTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Orders/OrderTest.cs
+++ b/src/StripeTests/Entities/Orders/OrderTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class OrderTest : BaseStripeTest
     {
+        public OrderTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/orders/or_123");
+            string json = this.GetFixture("/v1/orders/or_123");
             var order = JsonConvert.DeserializeObject<Order>(json);
             Assert.NotNull(order);
             Assert.IsType<Order>(order);
@@ -26,7 +31,7 @@ namespace StripeTests
               "customer",
             };
 
-            string json = GetFixture("/v1/orders/or_123", expansions);
+            string json = this.GetFixture("/v1/orders/or_123", expansions);
             var order = JsonConvert.DeserializeObject<Order>(json);
             Assert.NotNull(order);
             Assert.IsType<Order>(order);

--- a/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
+++ b/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class PaymentIntentTest : BaseStripeTest
     {
+        public PaymentIntentTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/payment_intents/pi_123");
+            string json = this.GetFixture("/v1/payment_intents/pi_123");
             var intent = JsonConvert.DeserializeObject<PaymentIntent>(json);
             Assert.NotNull(intent);
             Assert.IsType<PaymentIntent>(intent);
@@ -29,7 +34,7 @@ namespace StripeTests
               "transfer_data.destination",
             };
 
-            string json = GetFixture("/v1/payment_intents/pi_123", expansions);
+            string json = this.GetFixture("/v1/payment_intents/pi_123", expansions);
             var intent = JsonConvert.DeserializeObject<PaymentIntent>(json);
             Assert.NotNull(intent);
             Assert.IsType<PaymentIntent>(intent);

--- a/src/StripeTests/Entities/Payouts/PayoutTest.cs
+++ b/src/StripeTests/Entities/Payouts/PayoutTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class PayoutTest : BaseStripeTest
     {
+        public PayoutTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/payouts/po_123");
+            string json = this.GetFixture("/v1/payouts/po_123");
             var payout = JsonConvert.DeserializeObject<Payout>(json);
             Assert.NotNull(payout);
             Assert.IsType<Payout>(payout);
@@ -27,7 +32,7 @@ namespace StripeTests
               "failure_balance_transaction",
             };
 
-            string json = GetFixture("/v1/payouts/po_123", expansions);
+            string json = this.GetFixture("/v1/payouts/po_123", expansions);
             var payout = JsonConvert.DeserializeObject<Payout>(json);
             Assert.NotNull(payout);
             Assert.IsType<Payout>(payout);

--- a/src/StripeTests/Entities/Persons/PersonTest.cs
+++ b/src/StripeTests/Entities/Persons/PersonTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class PersonTest : BaseStripeTest
     {
+        public PersonTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/accounts/acct_123/persons/person_123");
+            string json = this.GetFixture("/v1/accounts/acct_123/persons/person_123");
             var person = JsonConvert.DeserializeObject<Person>(json);
             Assert.NotNull(person);
             Assert.IsType<Person>(person);

--- a/src/StripeTests/Entities/Plans/PlanTest.cs
+++ b/src/StripeTests/Entities/Plans/PlanTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class PlanTest : BaseStripeTest
     {
+        public PlanTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/plans/plan_123");
+            string json = this.GetFixture("/v1/plans/plan_123");
             var plan = JsonConvert.DeserializeObject<Plan>(json);
             Assert.NotNull(plan);
             Assert.IsType<Plan>(plan);
@@ -25,7 +30,7 @@ namespace StripeTests
               "product",
             };
 
-            string json = GetFixture("/v1/plans/plan_123", expansions);
+            string json = this.GetFixture("/v1/plans/plan_123", expansions);
             var plan = JsonConvert.DeserializeObject<Plan>(json);
             Assert.NotNull(plan);
             Assert.IsType<Plan>(plan);

--- a/src/StripeTests/Entities/Products/ProductTest.cs
+++ b/src/StripeTests/Entities/Products/ProductTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ProductTest : BaseStripeTest
     {
+        public ProductTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/products/prod_123");
+            string json = this.GetFixture("/v1/products/prod_123");
             var product = JsonConvert.DeserializeObject<Product>(json);
             Assert.NotNull(product);
             Assert.IsType<Product>(product);

--- a/src/StripeTests/Entities/Radar/ValueListItems/ValueListItemTest.cs
+++ b/src/StripeTests/Entities/Radar/ValueListItems/ValueListItemTest.cs
@@ -11,10 +11,15 @@ namespace StripeTests.Radar
 
     public class ValueListItemTest : BaseStripeTest
     {
+        public ValueListItemTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/radar/value_list_items/rsli_123");
+            string json = this.GetFixture("/v1/radar/value_list_items/rsli_123");
             var valueListItem = Mapper<ValueListItem>.MapFromJson(json);
             Assert.NotNull(valueListItem);
             Assert.IsType<ValueListItem>(valueListItem);

--- a/src/StripeTests/Entities/Radar/ValueLists/ValueListTest.cs
+++ b/src/StripeTests/Entities/Radar/ValueLists/ValueListTest.cs
@@ -11,10 +11,15 @@ namespace StripeTests.Radar
 
     public class ValueListTest : BaseStripeTest
     {
+        public ValueListTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/radar/value_lists/rsl_123");
+            string json = this.GetFixture("/v1/radar/value_lists/rsl_123");
             var valueList = Mapper<ValueList>.MapFromJson(json);
             Assert.NotNull(valueList);
             Assert.IsType<ValueList>(valueList);

--- a/src/StripeTests/Entities/Refunds/RefundTest.cs
+++ b/src/StripeTests/Entities/Refunds/RefundTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class RefundTest : BaseStripeTest
     {
+        public RefundTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/refunds/re_123");
+            string json = this.GetFixture("/v1/refunds/re_123");
             var refund = JsonConvert.DeserializeObject<Refund>(json);
             Assert.NotNull(refund);
             Assert.IsType<Refund>(refund);
@@ -29,7 +34,7 @@ namespace StripeTests
               "transfer_reversal",
             };
 
-            string json = GetFixture("/v1/refunds/re_123", expansions);
+            string json = this.GetFixture("/v1/refunds/re_123", expansions);
             var refund = JsonConvert.DeserializeObject<Refund>(json);
             Assert.NotNull(refund);
             Assert.IsType<Refund>(refund);

--- a/src/StripeTests/Entities/Reporting/ReportRuns/ReportRunTest.cs
+++ b/src/StripeTests/Entities/Reporting/ReportRuns/ReportRunTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Reporting
 
     public class ReportRunTest : BaseStripeTest
     {
+        public ReportRunTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/reporting/report_runs/frr_123");
+            string json = this.GetFixture("/v1/reporting/report_runs/frr_123");
             var reportRun = JsonConvert.DeserializeObject<ReportRun>(json);
             Assert.NotNull(reportRun);
             Assert.IsType<ReportRun>(reportRun);

--- a/src/StripeTests/Entities/Reporting/ReportTypes/ReportTypeTest.cs
+++ b/src/StripeTests/Entities/Reporting/ReportTypes/ReportTypeTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Reporting
 
     public class ReportTypeTest : BaseStripeTest
     {
+        public ReportTypeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/reporting/report_types/activity.summary.1");
+            string json = this.GetFixture("/v1/reporting/report_types/activity.summary.1");
             var reportType = JsonConvert.DeserializeObject<ReportType>(json);
             Assert.NotNull(reportType);
             Assert.IsType<ReportType>(reportType);

--- a/src/StripeTests/Entities/Reviews/ReviewTest.cs
+++ b/src/StripeTests/Entities/Reviews/ReviewTest.cs
@@ -5,10 +5,15 @@ namespace StripeTests
 
     public class ReviewTest : BaseStripeTest
     {
+        public ReviewTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/reviews/prv_123");
+            string json = this.GetFixture("/v1/reviews/prv_123");
             var review = Mapper<Review>.MapFromJson(json);
             Assert.NotNull(review);
             Assert.IsType<Review>(review);
@@ -25,7 +30,7 @@ namespace StripeTests
               "payment_intent",
             };
 
-            string json = GetFixture("/v1/reviews/prv_123", expansions);
+            string json = this.GetFixture("/v1/reviews/prv_123", expansions);
             var review = Mapper<Review>.MapFromJson(json);
             Assert.NotNull(review);
             Assert.IsType<Review>(review);

--- a/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
+++ b/src/StripeTests/Entities/Sigma/ScheduledQueryRunTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Sigma
 
     public class ScheduledQueryRunTest : BaseStripeTest
     {
+        public ScheduledQueryRunTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/sigma/scheduled_query_runs/sqr_123");
+            string json = this.GetFixture("/v1/sigma/scheduled_query_runs/sqr_123");
             var run = JsonConvert.DeserializeObject<ScheduledQueryRun>(json);
             Assert.NotNull(run);
             Assert.IsType<ScheduledQueryRun>(run);

--- a/src/StripeTests/Entities/Skus/SkuTest.cs
+++ b/src/StripeTests/Entities/Skus/SkuTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class SkuTest : BaseStripeTest
     {
+        public SkuTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/skus/sku_123");
+            string json = this.GetFixture("/v1/skus/sku_123");
             var sku = JsonConvert.DeserializeObject<Sku>(json);
             Assert.NotNull(sku);
             Assert.IsType<Sku>(sku);
@@ -25,7 +30,7 @@ namespace StripeTests
               "product",
             };
 
-            string json = GetFixture("/v1/skus/sku_123", expansions);
+            string json = this.GetFixture("/v1/skus/sku_123", expansions);
             var sku = JsonConvert.DeserializeObject<Sku>(json);
             Assert.NotNull(sku);
             Assert.IsType<Sku>(sku);

--- a/src/StripeTests/Entities/SourceMandateNotifications/SourceMandateNotificationTest.cs
+++ b/src/StripeTests/Entities/SourceMandateNotifications/SourceMandateNotificationTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class SourceMandateNotificationTest : BaseStripeTest
     {
+        public SourceMandateNotificationTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Sources/SourceTest.cs
+++ b/src/StripeTests/Entities/Sources/SourceTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class SourceTest : BaseStripeTest
     {
+        public SourceTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/sources/src_123");
+            string json = this.GetFixture("/v1/sources/src_123");
             var source = JsonConvert.DeserializeObject<Source>(json);
             Assert.NotNull(source);
             Assert.IsType<Source>(source);

--- a/src/StripeTests/Entities/SubscriptionItems/SubscriptionItemTest.cs
+++ b/src/StripeTests/Entities/SubscriptionItems/SubscriptionItemTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class SubscriptionItemTest : BaseStripeTest
     {
+        public SubscriptionItemTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/subscription_items/si_123");
+            string json = this.GetFixture("/v1/subscription_items/si_123");
             var subscriptionItem = JsonConvert.DeserializeObject<SubscriptionItem>(json);
             Assert.NotNull(subscriptionItem);
             Assert.IsType<SubscriptionItem>(subscriptionItem);

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class SubscriptionTest : BaseStripeTest
     {
+        public SubscriptionTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/subscriptions/sub_123");
+            string json = this.GetFixture("/v1/subscriptions/sub_123");
             var subscription = JsonConvert.DeserializeObject<Subscription>(json);
             Assert.NotNull(subscription);
             Assert.IsType<Subscription>(subscription);
@@ -25,7 +30,7 @@ namespace StripeTests
               "customer",
             };
 
-            string json = GetFixture("/v1/subscriptions/sub_123", expansions);
+            string json = this.GetFixture("/v1/subscriptions/sub_123", expansions);
             var subscription = JsonConvert.DeserializeObject<Subscription>(json);
             Assert.NotNull(subscription);
             Assert.IsType<Subscription>(subscription);

--- a/src/StripeTests/Entities/Terminal/ConnectionTokens/ConnectionTokenTest.cs
+++ b/src/StripeTests/Entities/Terminal/ConnectionTokens/ConnectionTokenTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests.Terminal
 
     public class ConnectionTokenTest : BaseStripeTest
     {
+        public ConnectionTokenTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/Terminal/Locations/LocationTest.cs
+++ b/src/StripeTests/Entities/Terminal/Locations/LocationTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Terminal
 
     public class LocationTest : BaseStripeTest
     {
+        public LocationTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/terminal/locations/loc_123");
+            string json = this.GetFixture("/v1/terminal/locations/loc_123");
             var location = JsonConvert.DeserializeObject<Location>(json);
             Assert.NotNull(location);
             Assert.IsType<Location>(location);

--- a/src/StripeTests/Entities/Terminal/Readers/ReaderTest.cs
+++ b/src/StripeTests/Entities/Terminal/Readers/ReaderTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests.Terminal
 
     public class ReaderTest : BaseStripeTest
     {
+        public ReaderTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/terminal/readers/ds_123");
+            string json = this.GetFixture("/v1/terminal/readers/ds_123");
             var reader = JsonConvert.DeserializeObject<Reader>(json);
             Assert.NotNull(reader);
             Assert.IsType<Reader>(reader);

--- a/src/StripeTests/Entities/ThreeDSecure/ThreeDSecureTest.cs
+++ b/src/StripeTests/Entities/ThreeDSecure/ThreeDSecureTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class ThreeDSecureTest : BaseStripeTest
     {
+        public ThreeDSecureTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/3d_secure/tdsrc_123");
+            string json = this.GetFixture("/v1/3d_secure/tdsrc_123");
             var resource = JsonConvert.DeserializeObject<ThreeDSecure>(json);
             Assert.NotNull(resource);
             Assert.IsType<ThreeDSecure>(resource);

--- a/src/StripeTests/Entities/Tokens/TokenTest.cs
+++ b/src/StripeTests/Entities/Tokens/TokenTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class TokenTest : BaseStripeTest
     {
+        public TokenTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/tokens/tok_123");
+            string json = this.GetFixture("/v1/tokens/tok_123");
             var token = JsonConvert.DeserializeObject<Token>(json);
             Assert.NotNull(token);
             Assert.IsType<Token>(token);

--- a/src/StripeTests/Entities/Topups/TopupTest.cs
+++ b/src/StripeTests/Entities/Topups/TopupTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class TopupTest : BaseStripeTest
     {
+        public TopupTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/topups/tu_123");
+            string json = this.GetFixture("/v1/topups/tu_123");
             var topup = JsonConvert.DeserializeObject<Topup>(json);
             Assert.NotNull(topup);
             Assert.IsType<Topup>(topup);
@@ -26,7 +31,7 @@ namespace StripeTests
               "source",
             };
 
-            string json = GetFixture("/v1/topups/tu_123", expansions);
+            string json = this.GetFixture("/v1/topups/tu_123", expansions);
             var topup = JsonConvert.DeserializeObject<Topup>(json);
             Assert.NotNull(topup);
             Assert.IsType<Topup>(topup);

--- a/src/StripeTests/Entities/TransferReversals/TransferReversalTest.cs
+++ b/src/StripeTests/Entities/TransferReversals/TransferReversalTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class TransferReversalTest : BaseStripeTest
     {
+        public TransferReversalTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/transfers/tr_123/reversals/trr_123");
+            string json = this.GetFixture("/v1/transfers/tr_123/reversals/trr_123");
             var transferReversal = JsonConvert.DeserializeObject<TransferReversal>(json);
             Assert.NotNull(transferReversal);
             Assert.IsType<TransferReversal>(transferReversal);
@@ -26,7 +31,7 @@ namespace StripeTests
               "transfer",
             };
 
-            string json = GetFixture("/v1/transfers/tr_123/reversals/trr_123", expansions);
+            string json = this.GetFixture("/v1/transfers/tr_123/reversals/trr_123", expansions);
             var transferReversal = JsonConvert.DeserializeObject<TransferReversal>(json);
             Assert.NotNull(transferReversal);
             Assert.IsType<TransferReversal>(transferReversal);

--- a/src/StripeTests/Entities/Transfers/TransferTest.cs
+++ b/src/StripeTests/Entities/Transfers/TransferTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class TransferTest : BaseStripeTest
     {
+        public TransferTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/transfers/tr_123");
+            string json = this.GetFixture("/v1/transfers/tr_123");
             var transfer = JsonConvert.DeserializeObject<Transfer>(json);
             Assert.NotNull(transfer);
             Assert.IsType<Transfer>(transfer);
@@ -28,7 +33,7 @@ namespace StripeTests
               "source_transaction",
             };
 
-            string json = GetFixture("/v1/transfers/tr_123", expansions);
+            string json = this.GetFixture("/v1/transfers/tr_123", expansions);
             var transfer = JsonConvert.DeserializeObject<Transfer>(json);
             Assert.NotNull(transfer);
             Assert.IsType<Transfer>(transfer);

--- a/src/StripeTests/Entities/UsageRecordSummaries/UsageRecordSummaryTest.cs
+++ b/src/StripeTests/Entities/UsageRecordSummaries/UsageRecordSummaryTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class UsageRecordSummaryTest : BaseStripeTest
     {
+        public UsageRecordSummaryTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/subscription_items/si_123/usage_record_summaries");
+            string json = this.GetFixture("/v1/subscription_items/si_123/usage_record_summaries");
             var summaries = JsonConvert.DeserializeObject<StripeList<UsageRecordSummary>>(json);
             Assert.NotNull(summaries);
 

--- a/src/StripeTests/Entities/UsageRecords/UsageRecordTest.cs
+++ b/src/StripeTests/Entities/UsageRecords/UsageRecordTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class UsageRecordTest : BaseStripeTest
     {
+        public UsageRecordTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {

--- a/src/StripeTests/Entities/WebhookEndpoints/WebhookEndpointTest.cs
+++ b/src/StripeTests/Entities/WebhookEndpoints/WebhookEndpointTest.cs
@@ -6,10 +6,15 @@ namespace StripeTests
 
     public class WebhookEndpointTest : BaseStripeTest
     {
+        public WebhookEndpointTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public void Deserialize()
         {
-            string json = GetFixture("/v1/webhook_endpoints/we_123");
+            string json = this.GetFixture("/v1/webhook_endpoints/we_123");
             var endpoint = JsonConvert.DeserializeObject<WebhookEndpoint>(json);
             Assert.NotNull(endpoint);
             Assert.IsType<WebhookEndpoint>(endpoint);

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -1,19 +1,16 @@
 namespace StripeTests
 {
-    using System.Linq;
-    using System.Net.Http;
-    using Newtonsoft.Json.Linq;
+    using System.Threading.Tasks;
     using Stripe;
-    using Stripe.Infrastructure;
     using Xunit;
 
     public class StripeExceptionTest : BaseStripeTest
     {
         [Fact]
-        public void SetsStripeResponse()
+        public async Task SetsStripeResponse()
         {
-            var exception = Assert.Throws<StripeException>(() =>
-                new CouponService().Create(new CouponCreateOptions()));
+            var exception = await Assert.ThrowsAsync<StripeException>(async () =>
+                await new CouponService().CreateAsync(new CouponCreateOptions()));
 
             Assert.NotNull(exception);
             Assert.NotNull(exception.StripeError);

--- a/src/StripeTests/MockHttpClientFixture.cs
+++ b/src/StripeTests/MockHttpClientFixture.cs
@@ -1,0 +1,54 @@
+namespace StripeTests
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using Moq;
+    using Moq.Protected;
+    using Stripe;
+
+    public class MockHttpClientFixture : IDisposable
+    {
+        private Mock<HttpClientHandler> mockHandler;
+
+        private HttpMessageHandler origHandler;
+
+        public MockHttpClientFixture()
+        {
+            this.mockHandler = new Mock<HttpClientHandler>
+            {
+                CallBase = true
+            };
+
+            this.origHandler = StripeConfiguration.HttpMessageHandler;
+            StripeConfiguration.HttpMessageHandler = this.mockHandler.Object;
+        }
+
+        public void Dispose()
+        {
+            StripeConfiguration.HttpMessageHandler = this.origHandler;
+        }
+
+        /// <summary>
+        /// Resets all invocations recorded for the mock client.
+        /// </summary>
+        public void Reset()
+        {
+            this.mockHandler.Invocations.Clear();
+        }
+
+        /// <summary>
+        /// Asserts that a single HTTP request was made with the specified method and path.
+        /// </summary>
+        public void AssertRequest(HttpMethod method, string path)
+        {
+            this.mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.Method == method &&
+                    m.RequestUri.AbsolutePath == path),
+                ItExpr.IsAny<CancellationToken>());
+        }
+    }
+}

--- a/src/StripeTests/Services/Accounts/AccountCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountCreateOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly AccountService service;
 
-        public AccountCreateOptionsTest()
+        public AccountCreateOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new AccountService();
         }

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly AccountListOptions listOptions;
         private readonly AccountRejectOptions rejectOptions;
 
-        public AccountServiceTest()
+        public AccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new AccountService();
 

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests
         private readonly ApplePayDomainCreateOptions createOptions;
         private readonly ApplePayDomainListOptions listOptions;
 
-        public ApplePayDomainServiceTest()
+        public ApplePayDomainServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ApplePayDomainService();
 

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly ApplicationFeeRefundUpdateOptions updateOptions;
         private readonly ApplicationFeeRefundListOptions listOptions;
 
-        public ApplicationFeeRefundServiceTest()
+        public ApplicationFeeRefundServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ApplicationFeeRefundService();
 

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly ApplicationFeeService service;
         private readonly ApplicationFeeListOptions listOptions;
 
-        public ApplicationFeeServiceTest()
+        public ApplicationFeeServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ApplicationFeeService();
 

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -11,7 +11,8 @@ namespace StripeTests
     {
         private readonly BalanceService service;
 
-        public BalanceServiceTest()
+        public BalanceServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new BalanceService();
         }

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly BalanceTransactionService service;
         private readonly BalanceTransactionListOptions listOptions;
 
-        public BalanceTransactionServiceTest()
+        public BalanceTransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new BalanceTransactionService();
 

--- a/src/StripeTests/Services/BankAccounts/BankAccountListOptionsTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountListOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly BankAccountService service;
 
-        public BankAccountListOptionsTest()
+        public BankAccountListOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new BankAccountService();
         }

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -18,7 +18,8 @@ namespace StripeTests
         private readonly BankAccountListOptions listOptions;
         private readonly BankAccountVerifyOptions verifyOptions;
 
-        public BankAccountServiceTest()
+        public BankAccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new BankAccountService();
 

--- a/src/StripeTests/Services/Cards/CardListOptionsTest.cs
+++ b/src/StripeTests/Services/Cards/CardListOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly CardService service;
 
-        public CardListOptionsTest()
+        public CardListOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CardService();
         }

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -21,7 +21,8 @@ namespace StripeTests
         private readonly CardUpdateOptions updateOptions;
         private readonly CardListOptions listOptions;
 
-        public CardServiceTest()
+        public CardServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CardService();
 

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly ChargeUpdateOptions updateOptions;
         private readonly ChargeListOptions listOptions;
 
-        public ChargeServiceTest()
+        public ChargeServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ChargeService();
 

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly CountrySpecService service;
         private readonly CountrySpecListOptions listOptions;
 
-        public CountrySpecServiceTest()
+        public CountrySpecServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CountrySpecService();
 

--- a/src/StripeTests/Services/Coupons/CouponCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponCreateOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly CouponService service;
 
-        public CouponCreateOptionsTest()
+        public CouponCreateOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CouponService();
         }

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly CouponUpdateOptions updateOptions;
         private readonly CouponListOptions listOptions;
 
-        public CouponServiceTest()
+        public CouponServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CouponService();
 

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly CustomerUpdateOptions updateOptions;
         private readonly CustomerListOptions listOptions;
 
-        public CustomerServiceTest()
+        public CustomerServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CustomerService();
 

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -11,7 +11,8 @@ namespace StripeTests
     {
         private readonly DiscountService service;
 
-        public DiscountServiceTest()
+        public DiscountServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new DiscountService();
         }

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests
         private readonly DisputeUpdateOptions updateOptions;
         private readonly DisputeListOptions listOptions;
 
-        public DisputeServiceTest()
+        public DisputeServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new DisputeService();
 

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly EphemeralKeyService service;
         private readonly EphemeralKeyCreateOptions createOptions;
 
-        public EphemeralKeyServiceTest()
+        public EphemeralKeyServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new EphemeralKeyService();
 

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly EventService service;
         private readonly EventListOptions listOptions;
 
-        public EventServiceTest()
+        public EventServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new EventService();
 

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -10,7 +10,8 @@ namespace StripeTests
         private readonly string json;
         private readonly string secret;
 
-        public EventUtilityTest()
+        public EventUtilityTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.eventTimestamp = 1533204620;
             this.secret = "webhook_secret";

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
         private readonly ExchangeRateService service;
         private readonly ExchangeRateListOptions listOptions;
 
-        public ExchangeRateServiceTest()
+        public ExchangeRateServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ExchangeRateService();
 

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly ExternalAccountUpdateOptions updateOptions;
         private readonly ExternalAccountListOptions listOptions;
 
-        public ExternalAccountServiceTest()
+        public ExternalAccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ExternalAccountService();
 

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly FileLinkUpdateOptions updateOptions;
         private readonly FileLinkListOptions listOptions;
 
-        public FileLinkServiceTest()
+        public FileLinkServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new FileLinkService();
 

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -19,7 +19,8 @@ namespace StripeTests
         private readonly FileCreateOptions createOptions;
         private readonly FileListOptions listOptions;
 
-        public FileServiceTest()
+        public FileServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new FileService();
 

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly InvoiceItemUpdateOptions updateOptions;
         private readonly InvoiceItemListOptions listOptions;
 
-        public InvoiceItemServiceTest()
+        public InvoiceItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new InvoiceItemService();
 

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -24,7 +24,8 @@ namespace StripeTests
         private readonly InvoiceSendOptions sendOptions;
         private readonly InvoiceVoidOptions voidOptions;
 
-        public InvoiceServiceTest()
+        public InvoiceServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new InvoiceService();
 

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests.Issuing
         private readonly AuthorizationUpdateOptions updateOptions;
         private readonly AuthorizationListOptions listOptions;
 
-        public AuthorizationServiceTest()
+        public AuthorizationServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new AuthorizationService();
 

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests.Issuing
         private readonly CardholderUpdateOptions updateOptions;
         private readonly CardholderListOptions listOptions;
 
-        public CardholderServiceTest()
+        public CardholderServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CardholderService();
 

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests.Issuing
         private readonly CardUpdateOptions updateOptions;
         private readonly CardListOptions listOptions;
 
-        public IssuingCardServiceTest()
+        public IssuingCardServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new CardService();
 

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests.Issuing
         private readonly DisputeUpdateOptions updateOptions;
         private readonly DisputeListOptions listOptions;
 
-        public IssuingDisputeServiceTest()
+        public IssuingDisputeServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new DisputeService();
 

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests.Issuing
         private readonly TransactionUpdateOptions updateOptions;
         private readonly TransactionListOptions listOptions;
 
-        public TransactionServiceTest()
+        public TransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new TransactionService();
 

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly LoginLinkService service;
         private readonly LoginLinkCreateOptions createOptions;
 
-        public LoginLinkServiceTest()
+        public LoginLinkServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new LoginLinkService();
 

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly OrderPayOptions payOptions;
         private readonly OrderListOptions listOptions;
 
-        public OrderServiceTest()
+        public OrderServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new OrderService();
 

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -19,7 +19,8 @@ namespace StripeTests
         private readonly PaymentIntentListOptions listOptions;
         private readonly PaymentIntentUpdateOptions updateOptions;
 
-        public PaymentIntentServiceTest()
+        public PaymentIntentServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new PaymentIntentService();
 

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly PayoutUpdateOptions updateOptions;
         private readonly PayoutListOptions listOptions;
 
-        public PayoutServiceTest()
+        public PayoutServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new PayoutService();
 

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly PersonUpdateOptions updateOptions;
         private readonly PersonListOptions listOptions;
 
-        public PersonServiceTest()
+        public PersonServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new PersonService();
 

--- a/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly PlanService service;
 
-        public PlanCreateOptionsTest()
+        public PlanCreateOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new PlanService();
         }

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly PlanUpdateOptions updateOptions;
         private readonly PlanListOptions listOptions;
 
-        public PlanServiceTest()
+        public PlanServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new PlanService();
 

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly ProductUpdateOptions updateOptions;
         private readonly ProductListOptions listOptions;
 
-        public ProductServiceTest()
+        public ProductServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ProductService();
 

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests.Radar
         private readonly ValueListItemCreateOptions createOptions;
         private readonly ValueListItemListOptions listOptions;
 
-        public ValueListItemServiceTest()
+        public ValueListItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ValueListItemService();
 

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests.Radar
         private readonly ValueListUpdateOptions updateOptions;
         private readonly ValueListListOptions listOptions;
 
-        public ValueListServiceTest()
+        public ValueListServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ValueListService();
 

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly RefundUpdateOptions updateOptions;
         private readonly RefundListOptions listOptions;
 
-        public RefundServiceTest()
+        public RefundServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new RefundService();
 

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests.Reporting
         private readonly ReportRunCreateOptions createOptions;
         private readonly ReportRunListOptions listOptions;
 
-        public ReportRunServiceTest()
+        public ReportRunServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ReportRunService();
 

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests.Reporting
         private readonly ReportTypeService service;
         private readonly ReportTypeListOptions listOptions;
 
-        public ReportTypeServiceTest()
+        public ReportTypeServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ReportTypeService();
 

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly ReviewApproveOptions approveOptions;
         private readonly ReviewListOptions listOptions;
 
-        public ReviewServiceTest()
+        public ReviewServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ReviewService();
 

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private readonly ScheduledQueryRunService service;
         private readonly ScheduledQueryRunListOptions listOptions;
 
-        public ScheduledQueryRunServiceTest()
+        public ScheduledQueryRunServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ScheduledQueryRunService();
 

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly SkuUpdateOptions updateOptions;
         private readonly SkuListOptions listOptions;
 
-        public SkuServiceTest()
+        public SkuServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SkuService();
 

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests
         private readonly SourceTransactionService service;
         private readonly SourceTransactionsListOptions listOptions;
 
-        public SourceTransactionServiceTest()
+        public SourceTransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SourceTransactionService();
 

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -20,7 +20,8 @@ namespace StripeTests
         private readonly SourceUpdateOptions updateOptions;
         private readonly SourceVerifyOptions verifyOptions;
 
-        public SourceServiceTest()
+        public SourceServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SourceService();
 

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly SubscriptionItemUpdateOptions updateOptions;
         private readonly SubscriptionItemListOptions listOptions;
 
-        public SubscriptionItemServiceTest()
+        public SubscriptionItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SubscriptionItemService();
 

--- a/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
     {
         private readonly SubscriptionService service;
 
-        public SubscriptionCreateOptionsTest()
+        public SubscriptionCreateOptionsTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SubscriptionService();
         }

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly SubscriptionUpdateOptions updateOptions;
         private readonly SubscriptionListOptions listOptions;
 
-        public SubscriptionServiceTest()
+        public SubscriptionServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new SubscriptionService();
 

--- a/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
@@ -13,7 +13,8 @@ namespace StripeTests.Terminal
         private readonly ConnectionTokenService service;
         private readonly ConnectionTokenCreateOptions createOptions;
 
-        public ConnectionTokenServiceTest()
+        public ConnectionTokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ConnectionTokenService();
 

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -18,7 +18,8 @@ namespace StripeTests.Terminal
         private readonly LocationListOptions listOptions;
         private readonly LocationUpdateOptions updateOptions;
 
-        public LocationServiceTest()
+        public LocationServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new LocationService();
 

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests.Terminal
         private readonly ReaderListOptions listOptions;
         private readonly ReaderUpdateOptions updateOptions;
 
-        public ReaderServiceTest()
+        public ReaderServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ReaderService();
 

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -12,7 +12,8 @@ namespace StripeTests
         private readonly ThreeDSecureService service;
         private readonly ThreeDSecureCreateOptions createOptions;
 
-        public ThreeDSecureServiceTest()
+        public ThreeDSecureServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new ThreeDSecureService();
 

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -15,7 +15,8 @@ namespace StripeTests
         private readonly TokenService service;
         private readonly TokenCreateOptions createOptions;
 
-        public TokenServiceTest()
+        public TokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new TokenService();
 

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly TopupUpdateOptions updateOptions;
         private readonly TopupListOptions listOptions;
 
-        public TopupServiceTest()
+        public TopupServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new TopupService();
 

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -17,7 +17,8 @@ namespace StripeTests
         private readonly TransferReversalUpdateOptions updateOptions;
         private readonly TransferReversalListOptions listOptions;
 
-        public TransferReversalServiceTest()
+        public TransferReversalServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new TransferReversalService();
 

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly TransferUpdateOptions updateOptions;
         private readonly TransferListOptions listOptions;
 
-        public TransferServiceTest()
+        public TransferServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new TransferService();
 

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -13,7 +13,8 @@ namespace StripeTests
         private readonly UsageRecordSummaryService service;
         private readonly UsageRecordSummaryListOptions listOptions;
 
-        public UsageRecordSummaryServiceTest()
+        public UsageRecordSummaryServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new UsageRecordSummaryService();
 

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -13,7 +13,8 @@ namespace StripeTests
         private readonly UsageRecordService service;
         private readonly UsageRecordCreateOptions createOptions;
 
-        public UsageRecordServiceTest()
+        public UsageRecordServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new UsageRecordService();
 

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -16,7 +16,8 @@ namespace StripeTests
         private readonly WebhookEndpointUpdateOptions updateOptions;
         private readonly WebhookEndpointListOptions listOptions;
 
-        public WebhookEndpointServiceTest()
+        public WebhookEndpointServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
         {
             this.service = new WebhookEndpointService();
 

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -1,0 +1,138 @@
+namespace StripeTests
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using Stripe;
+
+    public class StripeMockFixture : IDisposable
+    {
+        /// <value>Minimum required version of stripe-mock</value>
+        /// <remarks>
+        /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
+        /// </remarks>
+        private const string MockMinimumVersion = "0.39.0";
+
+        private string origApiBase;
+        private string origFilesBase;
+        private string origApiKey;
+
+        private string port;
+
+        public StripeMockFixture()
+        {
+            this.port = Environment.GetEnvironmentVariable("STRIPE_MOCK_PORT") ?? "12111";
+            this.EnsureStripeMockMinimumVersion();
+
+            this.origApiBase = StripeConfiguration.GetApiBase();
+            this.origFilesBase = StripeConfiguration.GetFilesBase();
+            this.origApiKey = StripeConfiguration.GetApiKey();
+
+            StripeConfiguration.SetApiBase($"http://localhost:{this.port}/v1");
+            StripeConfiguration.SetFilesBase($"http://localhost:{this.port}/v1");
+            StripeConfiguration.SetApiKey("sk_test_123");
+        }
+
+        public void Dispose()
+        {
+            StripeConfiguration.SetApiBase(this.origApiBase);
+            StripeConfiguration.SetFilesBase(this.origFilesBase);
+            StripeConfiguration.SetApiKey(this.origApiKey);
+        }
+
+        /// <summary>
+        /// Gets fixture data with expansions specified. Expansions are specified the same way as
+        /// they are in the normal API like <code>customer</code> or <code>data.customer</code>.
+        /// Use the special <code>*</code> character to specify that all fields should be
+        /// expanded.
+        /// </summary>
+        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
+        /// <param name="expansions">Set of expansions that should be applied</param>
+        /// <returns>Fixture data encoded as JSON</returns>
+        public string GetFixture(string path, string[] expansions = null)
+        {
+            string url = $"http://localhost:{this.port}{path}";
+
+            if (expansions != null)
+            {
+                string query = string.Join("&", expansions.Select(x => $"expand[]={x}").ToArray());
+                url += $"?{query}";
+            }
+
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization
+                    = new System.Net.Http.Headers.AuthenticationHeaderValue(
+                        "Bearer",
+                        "sk_test_123");
+
+                HttpResponseMessage response;
+
+                try
+                {
+                    response = client.GetAsync(url).Result;
+                }
+                catch (Exception)
+                {
+                    throw new StripeTestException(
+                        $"Couldn't reach stripe-mock at `localhost:{this.port}`. "
+                        + "Is it running? Please see README for setup instructions.");
+                }
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new StripeTestException(
+                        $"stripe-mock returned status code: {response.StatusCode}.");
+                }
+
+                return response.Content.ReadAsStringAsync().Result;
+            }
+        }
+
+        /// <summary>
+        /// Compares two version strings.
+        /// </summary>
+        /// <param name="a">A version string (e.g. "1.2.3").</param>
+        /// <param name="b">Another version string.</param>
+        /// <returns>-1 if a > b, 1 if a < b, 0 if a == b</returns>
+        private static int CompareVersions(string a, string b)
+        {
+            var version1 = new Version(a);
+            var version2 = new Version(b);
+            return version2.CompareTo(version1);
+        }
+
+        private void EnsureStripeMockMinimumVersion()
+        {
+            string url = $"http://localhost:{this.port}";
+
+            using (HttpClient client = new HttpClient())
+            {
+                HttpResponseMessage response;
+
+                try
+                {
+                    response = client.GetAsync(url).Result;
+                }
+                catch (Exception)
+                {
+                    throw new StripeTestException(
+                        $"Couldn't reach stripe-mock at `localhost:{this.port}`. "
+                        + "Is it running? Please see README for setup instructions.");
+                }
+
+                string version = response.Headers.GetValues("Stripe-Mock-Version").FirstOrDefault();
+
+                if (!version.Equals("master") &&
+                    (CompareVersions(version, MockMinimumVersion) > 0))
+                {
+                    throw new StripeTestException(
+                        $"Your version of stripe-mock ({version}) is too old. The minimum "
+                        + $"version to run this test suite is {MockMinimumVersion}. Please see its "
+                        + "repository for upgrade instructions.");
+                }
+            }
+        }
+    }
+}

--- a/src/StripeTests/StripeMockTestCollection.cs
+++ b/src/StripeTests/StripeMockTestCollection.cs
@@ -1,0 +1,13 @@
+namespace StripeTests
+{
+    using Xunit;
+
+    [CollectionDefinition("stripe-mock tests")]
+    public class StripeMockTestCollection :
+        ICollectionFixture<MockHttpClientFixture>,
+        ICollectionFixture<StripeMockFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply to be the place to
+        // apply [CollectionDefinition] and all the ICollectionFixture<> interfaces.
+    }
+}

--- a/src/StripeTests/StripeTestException.cs
+++ b/src/StripeTests/StripeTestException.cs
@@ -1,0 +1,20 @@
+namespace StripeTests
+{
+    using System;
+
+    /// <summary>
+    /// Represents errors that are related to tests themselves rather than the
+    /// features under test.
+    /// </summary>
+    public class StripeTestException : Exception
+    {
+        public StripeTestException()
+        {
+        }
+
+        public StripeTestException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -16,16 +16,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
+++ b/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
@@ -1,3 +1,4 @@
+#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -8,8 +9,7 @@ namespace StripeTests
     using Stripe.Infrastructure;
     using Xunit;
 
-#if NETCOREAPP
-    public class AllStripeObjectClassesPresentInDictionary
+    public class AllStripeObjectClassesPresentInDictionary : WholesomeTest
     {
         // Checks that all Stripe object classes (i.e. model classes that implement IHasObject)
         // have an entry in the Stripe.Util.ObjectsToTypes dictionary.
@@ -19,11 +19,7 @@ namespace StripeTests
             List<string> results = new List<string>();
 
             // Get all classes that implement IHasObject
-            var type = typeof(IHasObject);
-            var assembly = type.GetTypeInfo().Assembly;
-            var modelClasses = assembly.DefinedTypes
-                .Where(t => t.IsClass && t.ImplementedInterfaces.Contains(type))
-                .Select(t => t.AsType());
+            var modelClasses = GetClassesWithInterface(typeof(IHasObject));
 
             foreach (Type modelClass in modelClasses)
             {
@@ -59,5 +55,5 @@ namespace StripeTests
             }
         }
     }
-#endif
 }
+#endif

--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -9,7 +9,7 @@ namespace StripeTests
     using Stripe;
     using Xunit;
 
-    public class DontSerializeNullDeletedAttrs
+    public class DontSerializeNullDeletedAttrs : WholesomeTest
     {
         private const string AssertionMessage =
             "Found at least one invalid Deleted property. Make sure that the property " +
@@ -21,11 +21,7 @@ namespace StripeTests
             List<string> results = new List<string>();
 
             // Get all StripeEntity subclasses
-            var type = typeof(StripeEntity);
-            var assembly = type.GetTypeInfo().Assembly;
-            var entityClasses = assembly.DefinedTypes
-                .Where(t => t.IsClass && t.IsSubclassOf(type))
-                .Select(t => t.AsType());
+            var entityClasses = GetSubclassesOf(typeof(StripeEntity));
 
             foreach (Type entityClass in entityClasses)
             {

--- a/src/StripeTests/Wholesome/NullableValueTypes.cs
+++ b/src/StripeTests/Wholesome/NullableValueTypes.cs
@@ -1,30 +1,23 @@
+#if NETCOREAPP
 namespace StripeTests
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-
-    using Microsoft.Extensions.DependencyModel;
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
-#if NETCOREAPP
-    public class NullableValueTypes
+    public class NullableValueTypes : WholesomeTest
     {
         [Fact]
-        public void EnsureAllValueTypesAreNullable()
+        public void Check()
         {
             List<string> results = new List<string>();
 
             // Get all classes that implement INestedOptions
-            var type = typeof(INestedOptions);
-            var assembly = type.GetTypeInfo().Assembly;
-            var optionsClasses = assembly.DefinedTypes
-                .Where(t => t.IsClass && t.ImplementedInterfaces.Contains(type))
-                .Select(t => t.AsType());
+            var optionsClasses = GetClassesWithInterface(typeof(INestedOptions));
 
             foreach (Type optionsClass in optionsClasses)
             {
@@ -73,5 +66,5 @@ namespace StripeTests
             }
         }
     }
-#endif
 }
+#endif

--- a/src/StripeTests/Wholesome/README.md
+++ b/src/StripeTests/Wholesome/README.md
@@ -1,0 +1,10 @@
+## Wholesome tests
+
+Unlike regular tests that check the behavior of the library, wholesome tests
+contain checks on the state of the Stripe.net codebase and are there to
+prevent programming errors and enforce consistency. They rely heavily on
+reflection.
+
+For example, `AllStripeObjectClassesPresentInDictionary` ensure that when a
+model class is added for a new API resource, developers don't forget to add
+the new type in `StripeTypeRegistry`.

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -1,0 +1,36 @@
+#if NETCOREAPP
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Xunit;
+
+    [Collection("Wholesome tests")]
+    public class WholesomeTest
+    {
+        /// <summary>
+        /// Returns the list of classes that are subclasses of the provided type.
+        /// </summary>
+        protected static IEnumerable<Type> GetSubclassesOf(Type parentClass)
+        {
+            var assembly = parentClass.GetTypeInfo().Assembly;
+            return assembly.DefinedTypes
+                .Where(t => t.IsClass && t.IsSubclassOf(parentClass))
+                .Select(t => t.AsType());
+        }
+
+        /// <summary>
+        /// Returns the list of classes that implement the provided interface.
+        /// </summary>
+        protected static IEnumerable<Type> GetClassesWithInterface(Type implementedInterface)
+        {
+            var assembly = implementedInterface.GetTypeInfo().Assembly;
+            return assembly.DefinedTypes
+                .Where(t => t.IsClass && t.ImplementedInterfaces.Contains(implementedInterface))
+                .Select(t => t.AsType());
+        }
+    }
+}
+#endif

--- a/src/StripeTests/xunit.runner.json
+++ b/src/StripeTests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "appDomain": "denied",
-  "parallelizeTestCollections": false
+  "diagnosticMessages": true,
+  "longRunningTestSeconds": 10
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Alright, some context first. When I initialized the new `StripeTests` stripe-mock based suite a few months back, I set up a hack using a [`Lazy<>`](https://docs.microsoft.com/en-us/dotnet/api/system.lazy-1?view=netframework-4.7.2) object to ensure the initialization (e.g. checking stripe-mock's version) is only done once.

This worked, but it's definitely not how this sort of things should be done with xUnit. Also, while this worked for initializing stuff, it doesn't work for cleaning stuff up afterwards. We handled that by simply not cleaning anything up.

This PR reworks the test suite to do things the proper way. All stripe-mock based tests are now grouped in a ["collection"](https://xunit.github.io/docs/running-tests-in-parallel#parallelism-in-test-frameworks). Tests in the same collection are run sequentially, and can share collection fixtures.

Two collection fixtures are added:
- `MockHttpClientFixture` is used to manage the mock HTTP client, for things like asserting requests (and in the future, stubbing requests)
- `StripeMockFixture` is used to manage stripe-mock

The most annoying part of this PR is that test classes that rely on a particular fixture must define a constructor to receive the fixture instance and pass it to the base constructor. I've added helpful error messages to detect when a test class relies on a fixture but didn't define the needed constructor.

The big motivation behind this PR is that I want to port https://github.com/stripe/stripe-ruby/pull/715 to stripe-dotnet, but to do so I need to be able to set up a global teardown function (in order to stop the stripe-mock process if the test suite starts its own).
