### PR TITLE
Force the use of lists over arrays

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountVerification.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountVerification.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -14,6 +15,6 @@ namespace Stripe
         public DateTime? DueBy { get; set; }
 
         [JsonProperty("fields_needed")]
-        public string[] FieldsNeeded { get; set; }
+        public List<string> FieldsNeeded { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -59,7 +59,7 @@ namespace Stripe
         public string AddressZipCheck { get; set; }
 
         [JsonProperty("available_payout_methods")]
-        public string[] AvailablePayoutMethods { get; set; }
+        public List<string> AvailablePayoutMethods { get; set; }
 
         [JsonProperty("brand")]
         public string Brand { get; set; }

--- a/src/Stripe.net/Entities/Persons/Requirements.cs
+++ b/src/Stripe.net/Entities/Persons/Requirements.cs
@@ -1,16 +1,17 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class Requirements : StripeEntity
     {
         [JsonProperty("currently_due")]
-        public string[] CurrentlyDue { get; set; }
+        public List<string> CurrentlyDue { get; set; }
 
         [JsonProperty("eventually_due")]
-        public string[] EventuallyDue { get; set; }
+        public List<string> EventuallyDue { get; set; }
 
         [JsonProperty("past_due")]
-        public string[] PastDue { get; set; }
+        public List<string> PastDue { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Products/Product.cs
+++ b/src/Stripe.net/Entities/Products/Product.cs
@@ -23,7 +23,7 @@ namespace Stripe
         /// A list of up to 5 attributes that each SKU can provide values for (e.g. ["color", "size"]).
         /// </summary>
         [JsonProperty("attributes")]
-        public string[] Attributes { get; set; }
+        public List<string> Attributes { get; set; }
 
         /// <summary>
         /// A short one-line description of the product, meant to be displayable to the customer.
@@ -42,7 +42,7 @@ namespace Stripe
         /// An array of connect application identifiers that cannot purchase this product.
         /// </summary>
         [JsonProperty("deactivate_on")]
-        public string[] DeactivateOn { get; set; }
+        public List<string> DeactivateOn { get; set; }
 
         /// <summary>
         /// Whether this object is deleted or not.
@@ -60,7 +60,7 @@ namespace Stripe
         /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("images")]
-        public string[] Images { get; set; }
+        public List<string> Images { get; set; }
 
         /// <summary>
         /// Flag indicating whether the object exists in live mode or test mode.

--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -27,7 +27,7 @@ namespace Stripe
         public bool? Deleted { get; set; }
 
         [JsonProperty("enabled_events")]
-        public string[] EnabledEvents { get; set; }
+        public List<string> EnabledEvents { get; set; }
 
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountVerifyOptions.cs
@@ -1,10 +1,11 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class BankAccountVerifyOptions : BaseOptions
     {
         [JsonProperty("amounts")]
-        public long[] Amounts { get; set; }
+        public List<long> Amounts { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Orders/OrderListOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderListOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
         /// Only return orders with the given IDs.
         /// </summary>
         [JsonProperty("ids")]
-        public string[] Ids { get; set; }
+        public List<string> Ids { get; set; }
 
         /// <summary>
         /// Only return orders that have the given status. One of created, paid, fulfilled, or refunded.
@@ -33,6 +33,6 @@ namespace Stripe
         /// Only return orders with the given upstream order IDs.
         /// </summary>
         [JsonProperty("upstream_ids")]
-        public string[] UpstreamIds { get; set; }
+        public List<string> UpstreamIds { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Products/ProductListOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductListOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class ProductListOptions : ListOptionsWithCreated
@@ -8,7 +9,7 @@ namespace Stripe
         public bool? Active { get; set; }
 
         [JsonProperty("ids")]
-        public string[] Ids { get; set; }
+        public List<string> Ids { get; set; }
 
         [JsonProperty("shippable")]
         public bool? Shippable { get; set; }

--- a/src/Stripe.net/Services/Products/ProductSharedOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductSharedOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
         /// A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g. ["color", "size"]).
         /// </summary>
         [JsonProperty("attributes")]
-        public string[] Attributes { get; set; }
+        public List<string> Attributes { get; set; }
 
         /// <summary>
         /// A short one-line description of the product, meant to be displayable to the customer.
@@ -27,7 +27,7 @@ namespace Stripe
         /// An array of Connect application names or identifiers that should not be able to order the SKUs for this product.
         /// </summary>
         [JsonProperty("deactivate_on")]
-        public string[] DeactivateOn { get; set; }
+        public List<string> DeactivateOn { get; set; }
 
         /// <summary>
         /// The product’s description, meant to be displayable to the customer.
@@ -39,7 +39,7 @@ namespace Stripe
         /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("images")]
-        public string[] Images { get; set; }
+        public List<string> Images { get; set; }
 
         /// <summary>
         /// A set of key/value pairs that you can attach to a product object. It can be useful for storing additional information about the product in a structured format.

--- a/src/Stripe.net/Services/Skus/SkuListOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuListOptions.cs
@@ -12,7 +12,7 @@ namespace Stripe
         public Dictionary<string, string> Attributes { get; set; }
 
         [JsonProperty("ids")]
-        public string[] Ids { get; set; }
+        public List<string> Ids { get; set; }
 
         [JsonProperty("in_stock")]
         public bool? InStock { get; set; }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointSharedOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointSharedOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public abstract class WebhookEndpointSharedOptions : BaseOptions
     {
         [JsonProperty("enabled_events")]
-        public string[] EnabledEvents { get; set; }
+        public List<string> EnabledEvents { get; set; }
 
         [JsonProperty("url")]
         public string Url { get; set; }

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -55,7 +55,7 @@ namespace StripeTests
 
             this.verifyOptions = new BankAccountVerifyOptions
             {
-                Amounts = new long[]
+                Amounts = new List<long>
                 {
                     32,
                     45,

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
 
             this.createOptions = new ProductCreateOptions
             {
-                Attributes = new[]
+                Attributes = new List<string>
                 {
                     "attr1",
                     "attr2",

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
 
             this.createOptions = new WebhookEndpointCreateOptions
             {
-                EnabledEvents = new[]
+                EnabledEvents = new List<string>
                 {
                     "charge.succeeded",
                 },
@@ -32,7 +32,7 @@ namespace StripeTests
 
             this.updateOptions = new WebhookEndpointUpdateOptions
             {
-                EnabledEvents = new[]
+                EnabledEvents = new List<string>
                 {
                     "charge.succeeded",
                 },

--- a/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
+++ b/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
@@ -4,15 +4,20 @@ namespace StripeTests
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using Stripe;
     using Stripe.Infrastructure;
     using Xunit;
 
+    /// <summary>
+    /// This test checks that all Stripe object classes (i.e. model classes that implement
+    /// <see cref="Stripe.IHasObject" />) have an entry in the
+    /// <see cref="Stripe.Infrastructure.StripeTypeRegistry.ObjectsToTypes" /> dictionary.
+    /// </summary>
     public class AllStripeObjectClassesPresentInDictionary : WholesomeTest
     {
-        // Checks that all Stripe object classes (i.e. model classes that implement IHasObject)
-        // have an entry in the Stripe.Util.ObjectsToTypes dictionary.
+        private const string AssertionMessage =
+            "Found at least one model class missing in ObjectsToTypes dictionary";
+
         [Fact]
         public void Check()
         {
@@ -38,21 +43,7 @@ namespace StripeTests
                 results.Add(modelClass.Name);
             }
 
-            if (results.Any())
-            {
-                // Sort results alphabetically
-                results = results.OrderBy(i => i).ToList();
-
-                // Display our own error message (because Assert.Empty truncates the results)
-                Console.WriteLine("Found IHasObject classes not present in ObjectsToTypes dictionary:");
-                foreach (string item in results)
-                {
-                    Console.WriteLine($"- {item}");
-                }
-
-                // Actually fail test
-                Assert.True(false, "Found at least one model class missing in ObjectsToTypes dictionary");
-            }
+            AssertEmpty(results, AssertionMessage);
         }
     }
 }

--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -9,6 +9,12 @@ namespace StripeTests
     using Stripe;
     using Xunit;
 
+    /// <summary>
+    /// This test checks that <see cref="Stripe.StripeEntity" /> subclasses that have a
+    /// <code>Deleted</code> property have <see cref="Newtonsoft.Json.NullValueHandling" />
+    /// set to <see cref="Newtonsoft.Json.NullValueHandling.Ignore" /> so that the property is not
+    /// serialized when its value is <code>null</code>.
+    /// </summary>
     public class DontSerializeNullDeletedAttrs : WholesomeTest
     {
         private const string AssertionMessage =

--- a/src/StripeTests/Wholesome/NullableValueTypes.cs
+++ b/src/StripeTests/Wholesome/NullableValueTypes.cs
@@ -3,14 +3,21 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
+    /// <summary>
+    /// This test checks that all properties in request parameter classes (i.e. classes that
+    /// implement <see cref="Stripe.INestedOptions" />) with value types are nullable. This ensures
+    /// that only values explicitly set by users are sent to Stripe's API.
+    /// </summary>
     public class NullableValueTypes : WholesomeTest
     {
+        private const string AssertionMessage =
+            "Found at least one non-nullable value type";
+
         [Fact]
         public void Check()
         {
@@ -49,21 +56,7 @@ namespace StripeTests
                 }
             }
 
-            if (results.Any())
-            {
-                // Sort results alphabetically
-                results = results.OrderBy(i => i).ToList();
-
-                // Display our own error message (because Assert.Empty truncates the results)
-                Console.WriteLine("Found non-nullable value types:");
-                foreach (string item in results)
-                {
-                    Console.WriteLine($"- {item}");
-                }
-
-                // Actually fail test
-                Assert.True(false, "Found at least one non-nullable value type");
-            }
+            AssertEmpty(results, AssertionMessage);
         }
     }
 }

--- a/src/StripeTests/Wholesome/README.md
+++ b/src/StripeTests/Wholesome/README.md
@@ -5,6 +5,6 @@ contain checks on the state of the Stripe.net codebase and are there to
 prevent programming errors and enforce consistency. They rely heavily on
 reflection.
 
-For example, `AllStripeObjectClassesPresentInDictionary` ensure that when a
+For example, `AllStripeObjectClassesPresentInDictionary` ensures that when a
 model class is added for a new API resource, developers don't forget to add
 the new type in `StripeTypeRegistry`.

--- a/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
+++ b/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
@@ -1,0 +1,57 @@
+#if NETCOREAPP
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    /// <summary>
+    /// This wholesome test ensures that lists (as in `List<>`) are used instead of arrays (`[]`)
+    /// in Stripe entities and options classes.
+    /// </summary>
+    public class UseListsInsteadOfArrays : WholesomeTest
+    {
+        private const string AssertionMessage =
+            "Found at least one array type. Please use List<> instead.";
+
+        [Fact]
+        public void Check()
+        {
+            List<string> results = new List<string>();
+
+            // Get all classes that derive from StripeEntity or implement INestedOptions
+            var stripeClasses = GetSubclassesOf(typeof(StripeEntity));
+            stripeClasses.Concat(GetClassesWithInterface(typeof(INestedOptions)));
+
+            foreach (Type stripeClass in stripeClasses)
+            {
+                foreach (PropertyInfo property in stripeClass.GetProperties())
+                {
+                    var propType = property.PropertyType;
+
+                    // Skip properties that don't have a `JsonProperty` attribute
+                    var attribute = property.GetCustomAttribute<JsonPropertyAttribute>();
+                    if (attribute == null)
+                    {
+                        continue;
+                    }
+
+                    // Skip non-array types
+                    if (!propType.GetTypeInfo().IsArray)
+                    {
+                        continue;
+                    }
+
+                    results.Add($"{stripeClass.Name}.{property.Name}");
+                }
+            }
+
+            AssertEmpty(results, AssertionMessage);
+        }
+    }
+}
+#endif

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -7,9 +7,36 @@ namespace StripeTests
     using System.Reflection;
     using Xunit;
 
+    /// <summary>
+    /// Parent class for all wholesome tests. Wholesome tests check the state of the Stripe.net
+    /// codebase and prevent inconsistencies and programming mistakes.
+    /// </summary>
     [Collection("Wholesome tests")]
     public class WholesomeTest
     {
+        /// <summary>
+        /// Verifies that a list of strings is empty. If not, display the sorted contents of the
+        /// list and fail the test with the provided message.
+        /// <summary>
+        protected static void AssertEmpty(List<string> results, string message)
+        {
+            if (results.Any())
+            {
+                // Sort results alphabetically
+                var sortedResults = results.OrderBy(i => i).ToList();
+
+                // Display our own error message (because Assert.Empty truncates the results)
+                Console.WriteLine("Non-empty results:");
+                foreach (string item in sortedResults)
+                {
+                    Console.WriteLine($"- {item}");
+                }
+
+                // Actually fail test
+                Assert.True(false, message);
+            }
+        }
+
         /// <summary>
         /// Returns the list of classes that are subclasses of the provided type.
         /// </summary>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Replace arrays (`[]`) with lists (`List<>`) in all Stripe model and request parameters classes, and add a wholesome test to enforce this going forward.

This is a breaking change:

Property | Old type | New type
---|---|---
`AccountVerification.FieldsNeeded` | `string[]` | `List<string>`
`Card.AvailablePayoutMethods` | `string[]` | `List<string>`
`Requirements.CurrentlyDue` | `string[]` | `List<string>`
`Requirements.EventuallyDue` | `string[]` | `List<string>`
`Requirements.PastDue` | `string[]` | `List<string>`
`Product.Attributes` | `string[]` | `List<string>`
`Product.DeactivateOn` | `string[]` | `List<string>`
`Product.Images` | `string[]` | `List<string>`
`WebhookEndpoint.EnabledEvents` | `string[]` | `List<string>`
`BankAccountVerifyOptions.Amounts` | `long[]` | `List<long>`
`OrderListOptions.Ids` | `string[]` | `List<string>`
`OrderListOptions.UpstreamIds` | `string[]` | `List<string>`
`ProductCreateOptions.Attributes` | `string[]` | `List<string>`
`ProductCreateOptions.DeactivateOn` | `string[]` | `List<string>`
`ProductCreateOptions.Images` | `string[]` | `List<string>`
`ProductListOptions.Ids` | `string[]` | `List<string>`
`ProductUpdateOptions.Attributes` | `string[]` | `List<string>`
`ProductUpdateOptions.DeactivateOn` | `string[]` | `List<string>`
`ProductUpdateOptions.Images` | `string[]` | `List<string>`
`SkuListOptions.Ids` | `string[]` | `List<string>`
`WebhookEndpointCreateOptions.EnabledEvents` | `string[]` | `List<string>`
`WebhookEndpointUpdateOptions.EnabledEvents` | `string[]` | `List<string>`

