### PR TITLE
Add support for invoice_now and prorate on subscription cancelation

### DIFF
--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCancelOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCancelOptions.cs
@@ -7,6 +7,16 @@ namespace Stripe
 
     public class SubscriptionCancelOptions : BaseOptions
     {
-      // Empty for now but we will soon add new properties to the Cancel Subscription API
+        /// <summary>
+        /// Will generate a final invoice that invoices for any un-invoiced metered usage and new/pending proration invoice items.
+        /// </summary>
+        [JsonProperty("invoice_now")]
+        public bool? InvoiceNow { get; set; }
+
+        /// <summary>
+        /// Boolean (default <c>true</c>). Use with a <c>billing_cycle_anchor</c> timestamp to determine whether the customer will be invoiced a prorated amount until the anchor date. If <c>false</c>, the anchor period will be free (similar to a trial).
+        /// </summary>
+        [JsonProperty("prorate")]
+        public bool? Prorate { get; set; }
     }
 }

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -23,6 +23,8 @@ namespace StripeTests
 
             this.cancelOptions = new SubscriptionCancelOptions
             {
+                InvoiceNow = true,
+                Prorate = true,
             };
 
             this.createOptions = new SubscriptionCreateOptions


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

Fixes https://github.com/stripe/stripe-dotnet/issues/1448