### PR TITLE
Fix exception when object key is missing in polymorphic resource deserializer

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/AbstractStripeObjectConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/AbstractStripeObjectConverter.cs
@@ -39,7 +39,7 @@ namespace Stripe.Infrastructure
             var incoming = JObject.Load(reader);
             var obj = default(I);
             var objectName = incoming.SelectToken("object")?.ToString();
-            if (this.ObjectsToMapperFuncs.ContainsKey(objectName))
+            if (objectName != null && this.ObjectsToMapperFuncs.ContainsKey(objectName))
             {
                 var mapperFunc = this.ObjectsToMapperFuncs[objectName];
                 obj = mapperFunc(incoming.ToString());

--- a/src/StripeTests/Infrastructure/JsonConverters/AbstractStripeObjectConverterTest.cs
+++ b/src/StripeTests/Infrastructure/JsonConverters/AbstractStripeObjectConverterTest.cs
@@ -54,6 +54,16 @@ namespace StripeTests
             Assert.Null(obj);
         }
 
+        [Fact]
+        public void ReturnsNullWhenObjectKeyIsMissing()
+        {
+            var json = "{\"some_list\": [1, 2, 3]}";
+
+            var obj = JsonConvert.DeserializeObject<IFooOrBar>(json, this.converter);
+
+            Assert.Null(obj);
+        }
+
         private class Foo : IFooOrBar
         {
             [JsonProperty("object")]


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries @da1rren

Gracefully handle the case where the `object` key is missing in the JSON for a polymorphic resource, by returning `null` instead of raising an exception.

Fixes #1452.
