### PR TITLE
Add Application to the list of objects that can be deserialized for events

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/StripeObjectConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/StripeObjectConverter.cs
@@ -17,6 +17,7 @@ namespace Stripe.Infrastructure
         {
             { "account", Mapper<Account>.MapFromJson },
             { "apple_pay_domain", Mapper<ApplePayDomain>.MapFromJson },
+            { "application", Mapper<Application>.MapFromJson },
             { "application_fee", Mapper<ApplicationFee>.MapFromJson },
             { "balance", Mapper<Balance>.MapFromJson },
             { "balance_transaction", Mapper<BalanceTransaction>.MapFromJson },


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This allows deserializing `account.application.*` events