### PR TITLE
Add support for new properties on upcoming invoice retrieval

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceItemPeriodOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceItemPeriodOptions.cs
@@ -1,0 +1,21 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class InvoiceItemPeriodOptions : INestedOptions
+    {
+        /// <summary>
+        /// The end of the period, which must be greater than or equal to the start.
+        /// </summary>
+        [JsonProperty("end")]
+        public DateTime? End { get; set; }
+
+        /// <summary>
+        /// he start of the period.
+        /// </summary>
+        [JsonProperty("start")]
+        public DateTime? Start { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -22,5 +22,14 @@ namespace Stripe
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("period")]
+        public InvoiceItemPeriodOptions Period { get; set; }
+
+        [JsonProperty("quantity")]
+        public long? Quantity { get; set; }
+
+        [JsonProperty("unit_amount")]
+        public long? UnitAmount { get; set; }
     }
 }


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This supports new properties added. Docs are here: https://stripe.com/docs/api/invoices/upcoming#upcoming_invoice-invoice_items

This is only supported on that endpoint and not while paginating the next line items which is a bug I raised but this is separate.