### PR TITLE
Add transfer_data and application_fee_amount to Invoice and Subscriptions

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -22,8 +22,15 @@ namespace Stripe
         [JsonProperty("amount_remaining")]
         public long AmountRemaining { get; set; }
 
+        [Obsolete("Use ApplicationFeeAmount")]
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
+
+        /// <summary>
+        /// The amount of the application application fee (if any) for the invoice. See the Connect documentation for details.
+        /// </summary>
+        [JsonProperty("application_fee_amount")]
+        public long? ApplicationFeeAmount { get; set; }
 
         [JsonProperty("attempt_count")]
         public long AttemptCount { get; set; }

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -237,6 +237,9 @@ namespace Stripe
         [JsonProperty("threshold_reason")]
         public InvoiceThresholdReason ThresholdReason { get; set; }
 
+        [JsonProperty("transfer_data")]
+        public InvoiceTransferData TransferData { get; set; }
+
         [JsonProperty("total")]
         public long Total { get; set; }
 

--- a/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
@@ -1,0 +1,30 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceTransferData : StripeEntity
+    {
+        #region Expandable Destination (Account)
+        [JsonIgnore]
+        public string DestinationId { get; set; }
+
+        [JsonIgnore]
+        public Account Destination { get; set; }
+
+        [JsonProperty("destination")]
+        internal object InternalDestination
+        {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
+            set
+            {
+                StringOrObject<Account>.Map(value, s => this.DestinationId = s, o => this.Destination = o);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -137,6 +137,9 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+        [JsonProperty("transfer_data")]
+        public SubscriptionTransferData TransferData { get; set; }
+
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? TrialEnd { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
@@ -1,0 +1,30 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionTransferData : StripeEntity
+    {
+        #region Expandable Destination (Account)
+        [JsonIgnore]
+        public string DestinationId { get; set; }
+
+        [JsonIgnore]
+        public Account Destination { get; set; }
+
+        [JsonProperty("destination")]
+        internal object InternalDestination
+        {
+            get
+            {
+                return this.Destination ?? (object)this.DestinationId;
+            }
+
+            set
+            {
+                StringOrObject<Account>.Map(value, s => this.DestinationId = s, o => this.Destination = o);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -18,9 +18,7 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <summary>
-        /// This is deprecated in favor of ApplicationFeeAmount.
-        /// </summary>
+        [Obsolete("Use ApplicationFeeAmount")]
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -7,14 +7,18 @@ namespace Stripe
 
     public class InvoiceCreateOptions : BaseOptions
     {
+        [Obsolete("Use ApplicationFeeAmount")]
+        [JsonProperty("application_fee")]
+        public long? ApplicationFee { get; set; }
+
         /// <summary>
         /// A fee in cents that will be applied to the invoice and transferred to the application
         /// owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account
         /// header in order to take an application fee. For more information, see the application
         /// fees <see href="https://stripe.com/docs/connect/subscriptions#working-with-invoices">documentation</see>.
         /// </summary>
-        [JsonProperty("application_fee")]
-        public long? ApplicationFee { get; set; }
+        [JsonProperty("application_fee_amount")]
+        public long? ApplicationFeeAmount { get; set; }
 
         [JsonProperty("auto_advance")]
         public bool? AutoAdvance { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -91,5 +91,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
+
+        [JsonProperty("transfer_data")]
+        public InvoiceTransferDataOptions TransferData { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceTransferDataOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceTransferDataOptions.cs
@@ -1,0 +1,10 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoiceTransferDataOptions : INestedOptions
+    {
+        [JsonProperty("destination")]
+        public string Destination { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -7,8 +7,18 @@ namespace Stripe
 
     public class InvoiceUpdateOptions : BaseOptions
     {
+        [Obsolete("Use ApplicationFeeAmount")]
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
+
+        /// <summary>
+        /// A fee in cents that will be applied to the invoice and transferred to the application
+        /// owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account
+        /// header in order to take an application fee. For more information, see the application
+        /// fees <see href="https://stripe.com/docs/connect/subscriptions#working-with-invoices">documentation</see>.
+        /// </summary>
+        [JsonProperty("application_fee_amount")]
+        public long? ApplicationFeeAmount { get; set; }
 
         [JsonProperty("auto_advance")]
         public bool? AutoAdvance { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -51,5 +51,8 @@ namespace Stripe
 
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
+
+        [JsonProperty("transfer_data")]
+        public InvoiceTransferDataOptions TransferData { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -90,5 +90,8 @@ namespace Stripe
         [Obsolete("Use Items")]
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        [JsonProperty("transfer_data")]
+        public SubscriptionTransferDataOptions TransferData { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionTransferDataOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionTransferDataOptions.cs
@@ -1,0 +1,10 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionTransferDataOptions : INestedOptions
+    {
+        [JsonProperty("destination")]
+        public string Destination { get; set; }
+    }
+}


### PR DESCRIPTION
This PRs add `transfer_data` and `application_fee_amount` support to `Invoice` and `Subscription`

r? @ob-stripe 
cc @stripe/api-libraries 

NOT asking for review yet as I want to double check that we don't need `on_behalf_of` for now.