### PR TITLE
Add support for billing thresholds

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -35,7 +35,10 @@ namespace Stripe
         public bool AutoAdvance { get; set; }
 
         /// <summary>
-        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions.
+        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
+        /// this subscription at the end of the cycle using the default source attached to the
+        /// customer. When sending an invoice, Stripe will email your customer an invoice with
+        /// payment instructions.
         /// </summary>
         [JsonProperty("billing")]
         public Billing? Billing { get; set; }
@@ -123,7 +126,8 @@ namespace Stripe
         public Discount Discount { get; set; }
 
         /// <summary>
-        /// The date on which payment for this invoice is due. This value will be null for invoices where billing=charge_automatically.
+        /// The date on which payment for this invoice is due. This value will be null for invoices
+        /// where billing=charge_automatically.
         /// </summary>
         [JsonProperty("due_date")]
         [JsonConverter(typeof(DateTimeConverter))]
@@ -156,7 +160,8 @@ namespace Stripe
         public DateTime? NextPaymentAttempt { get; set; }
 
         /// <summary>
-        /// A unique, identifying string that appears on emails sent to the customer for this invoice.
+        /// A unique, identifying string that appears on emails sent to the customer for this
+        /// invoice.
         /// </summary>
         [JsonProperty("number")]
         public string Number { get; set; }
@@ -218,6 +223,13 @@ namespace Stripe
 
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
+
+        /// <summary>
+        /// If <code>billing_reason</code> is set to <code>subscription_threshold</code> this
+        /// returns more information on which threshold rules triggered the invoice.
+        /// </summary>
+        [JsonProperty("threshold_reason")]
+        public InvoiceThresholdReason ThresholdReason { get; set; }
 
         [JsonProperty("total")]
         public long Total { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceThresholdReason.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceThresholdReason.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class InvoiceThresholdReason : StripeEntity
+    {
+        /// <summary>
+        /// The total invoice amount threshold boundary if it triggered the threshold invoice.
+        /// </summary>
+        [JsonProperty("amount_gte")]
+        public long? AmountGte { get; set; }
+
+        /// <summary>
+        /// Indicates which line items triggered a threshold invoice.
+        /// </summary>
+        [JsonProperty("item_reasons")]
+        public List<InvoiceThresholdReasonItemReason> ItemReasons { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Invoices/InvoiceThresholdReasonItemReason.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceThresholdReasonItemReason.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class InvoiceThresholdReasonItemReason : StripeEntity
+    {
+        /// <summary>
+        /// The IDs of the line items that triggered the threshold invoice.
+        /// </summary>
+        [JsonProperty("line_item_ids")]
+        public List<string> LineItemIds { get; set; }
+
+        /// <summary>
+        /// The quantity threshold boundary that applied to the given line item.
+        /// </summary>
+        [JsonProperty("usage_gte")]
+        public long? UsageGte { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItemBillingThresholds.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItemBillingThresholds.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionItemBillingThresholds : StripeEntity
+    {
+        /// <summary>
+        /// Usage threshold that triggers the subscription to create an invoice.
+        /// </summary>
+        [JsonProperty("usage_gte")]
+        public long? UsageGte { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -17,7 +17,10 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
-        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions.
+        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
+        /// this subscription at the end of the cycle using the default source attached to the
+        /// customer. When sending an invoice, Stripe will email your customer an invoice with
+        /// payment instructions.
         /// </summary>
         [JsonProperty("billing")]
         public Billing? Billing { get; set; }
@@ -25,6 +28,13 @@ namespace Stripe
         [JsonProperty("billing_cycle_anchor")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? BillingCycleAnchor { get; set; }
+
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholds BillingThresholds { get; set; }
 
         [JsonProperty("cancel_at_period_end")]
         public bool CancelAtPeriodEnd { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionBillingThresholds.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionBillingThresholds.cs
@@ -1,0 +1,24 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionBillingThresholds : StripeEntity
+    {
+        /// <summary>
+        /// Monetary threshold that triggers the subscription to advance to a new billing period.
+        /// </summary>
+        [JsonProperty("amount_gte")]
+        public long? AmountGte { get; set; }
+
+        /// <summary>
+        /// Indicates if the <code>billing_cycle_anchor</code> should be reset when a threshold is
+        /// reached. If true, <code>billing_cycle_anchor</code> will be updated to the date/time
+        /// the threshold was last reached; otherwise, the value will remain unchanged. This value
+        /// may not be true if the subscription contains items with plans that have
+        /// <code>aggregate_usage=last_ever</code>.
+        /// </summary>
+        [JsonProperty("reset_billing_cycle_anchor")]
+        public bool? ResetBillingCycleAnchor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemBillingThresholdsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemBillingThresholdsOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionItemBillingThresholdsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Usage threshold that triggers the subscription to create an invoice.
+        /// </summary>
+        [JsonProperty("usage_gte")]
+        public long? UsageGte { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe
     public abstract class SubscriptionItemSharedOptions : BaseOptions
     {
         /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionItemBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
         /// REQUIRED: The identifier of the plan to add to the subscription.
         /// </summary>
         [JsonProperty("plan")]
@@ -19,7 +26,9 @@ namespace Stripe
         public bool? Prorate { get; set; }
 
         /// <summary>
-        /// If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the upcoming invoice endpoint.
+        /// If set, the proration will be calculated as though the subscription was updated at the
+        /// given time. This can be used to apply the same proration that was previewed with the
+        /// upcoming invoice endpoint.
         /// </summary>
         [JsonProperty("proration_date")]
         public DateTime? ProrationDate { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionBillingThresholdsOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionBillingThresholdsOptions.cs
@@ -1,0 +1,22 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionBillingThresholdsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Monetary threshold that triggers the subscription to advance to a new billing period.
+        /// </summary>
+        [JsonProperty("amount_gte")]
+        public long? AmountGte { get; set; }
+
+        /// <summary>
+        /// Indicates if the <code>billing_reason</code>  should be reset when a threshold is
+        /// reached. If true, <code>billing_reason</code>  will be updated to the date/time the
+        /// threshold was last reached; otherwise, the value will remain unchanged.
+        /// </summary>
+        [JsonProperty("reset_billing_cycle_anchor")]
+        public bool? ResetBillingCycleAnchor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -20,6 +20,12 @@ namespace Stripe
         public Billing? Billing { get; set; }
 
         /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current period.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

This one is a bit complex as it's across multiple resources and no specific test was added for it so we need to make sure it matches OpenAPI.

cc @clintonb-stripe Could you double check that I added the right set of properties too and I'm not missing any?

Docs: https://stripe.com/docs/billing/subscriptions/metered-billing/thresholds
Internal PR with gate removal: #126799