### PR TITLE
Remove unnecessary uses of Mapper

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/Mapper.cs
+++ b/src/Stripe.net/Infrastructure/Public/Mapper.cs
@@ -1,28 +1,11 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using Stripe.Infrastructure;
 
     public static class Mapper<T>
     {
-        public static List<T> MapCollectionFromJson(string json, string token = "data", StripeResponse stripeResponse = null)
-        {
-            var jObject = JObject.Parse(json);
-
-            var allTokens = jObject.SelectToken(token);
-
-            return allTokens.Select(tkn => MapFromJson(tkn.ToString(), null, stripeResponse)).ToList();
-        }
-
-        public static List<T> MapCollectionFromJson(StripeResponse stripeResponse, string token = "data")
-        {
-            return MapCollectionFromJson(stripeResponse.ResponseJson, token, stripeResponse);
-        }
-
         // the ResponseJson on a list method is the entire list (as json) returned from stripe.
         // the ObjectJson is so we can store only the json for a single object in the list on that entity for
         // logging and/or debugging

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -16,7 +16,9 @@ namespace Stripe
 
         public static Event ParseEvent(string json, bool throwOnApiVersionMismatch = true)
         {
-            var stripeEvent = Mapper<Event>.MapFromJson(json);
+            var stripeEvent = JsonConvert.DeserializeObject<Event>(
+                json,
+                StripeConfiguration.SerializerSettings);
 
             if (throwOnApiVersionMismatch &&
                 stripeEvent.ApiVersion != StripeConfiguration.StripeApiVersion)

--- a/src/StripeTests/Entities/ExternalAccounts/ExternalAccountTest.cs
+++ b/src/StripeTests/Entities/ExternalAccounts/ExternalAccountTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -14,7 +15,9 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = this.GetFixture("/v1/accounts/acct_123/external_accounts/ba_123");
-            var externalAccount = Mapper<IExternalAccount>.MapFromJson(json);
+            var externalAccount = JsonConvert.DeserializeObject<IExternalAccount>(
+                json,
+                StripeConfiguration.SerializerSettings);
             Assert.NotNull(externalAccount);
             Assert.IsType<BankAccount>(externalAccount);
             Assert.Equal("bank_account", externalAccount.Object);
@@ -29,7 +32,9 @@ namespace StripeTests
             };
 
             string json = this.GetFixture("/v1/accounts/acct_123/external_accounts/ba_123", expansions);
-            var externalAccount = Mapper<IExternalAccount>.MapFromJson(json);
+            var externalAccount = JsonConvert.DeserializeObject<IExternalAccount>(
+                json,
+                StripeConfiguration.SerializerSettings);
             Assert.NotNull(externalAccount);
             Assert.IsType<BankAccount>(externalAccount);
             Assert.Equal("bank_account", externalAccount.Object);

--- a/src/StripeTests/Entities/Radar/ValueListItems/ValueListItemTest.cs
+++ b/src/StripeTests/Entities/Radar/ValueListItems/ValueListItemTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Radar
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Radar;
     using Xunit;
 
@@ -20,7 +15,7 @@ namespace StripeTests.Radar
         public void Deserialize()
         {
             string json = this.GetFixture("/v1/radar/value_list_items/rsli_123");
-            var valueListItem = Mapper<ValueListItem>.MapFromJson(json);
+            var valueListItem = JsonConvert.DeserializeObject<ValueListItem>(json);
             Assert.NotNull(valueListItem);
             Assert.IsType<ValueListItem>(valueListItem);
             Assert.NotNull(valueListItem.Id);

--- a/src/StripeTests/Entities/Radar/ValueLists/ValueListTest.cs
+++ b/src/StripeTests/Entities/Radar/ValueLists/ValueListTest.cs
@@ -1,11 +1,6 @@
 namespace StripeTests.Radar
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     using Newtonsoft.Json;
-    using Stripe;
     using Stripe.Radar;
     using Xunit;
 
@@ -20,7 +15,7 @@ namespace StripeTests.Radar
         public void Deserialize()
         {
             string json = this.GetFixture("/v1/radar/value_lists/rsl_123");
-            var valueList = Mapper<ValueList>.MapFromJson(json);
+            var valueList = JsonConvert.DeserializeObject<ValueList>(json);
             Assert.NotNull(valueList);
             Assert.IsType<ValueList>(valueList);
             Assert.NotNull(valueList.Id);

--- a/src/StripeTests/Entities/Reviews/ReviewTest.cs
+++ b/src/StripeTests/Entities/Reviews/ReviewTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -14,7 +15,7 @@ namespace StripeTests
         public void Deserialize()
         {
             string json = this.GetFixture("/v1/reviews/prv_123");
-            var review = Mapper<Review>.MapFromJson(json);
+            var review = JsonConvert.DeserializeObject<Review>(json);
             Assert.NotNull(review);
             Assert.IsType<Review>(review);
             Assert.NotNull(review.Id);
@@ -31,7 +32,7 @@ namespace StripeTests
             };
 
             string json = this.GetFixture("/v1/reviews/prv_123", expansions);
-            var review = Mapper<Review>.MapFromJson(json);
+            var review = JsonConvert.DeserializeObject<Review>(json);
             Assert.NotNull(review);
             Assert.IsType<Review>(review);
             Assert.NotNull(review.Id);


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

- Replace most uses of `Mapper<T>.MapFromJson()` with `JsonConvert.DeserializeObject<T>()`
- Remove `Mapper<T>.MapCollectionFromJson()` methods (they weren't used anymore)
