### PR TITLE
Standardize signature of OAuthTokenService.Deauthorize

### DIFF
--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -29,25 +29,13 @@ namespace Stripe
             return this.PostRequestAsync<OAuthToken>($"{Urls.BaseConnectUrl}/oauth/token", options, requestOptions, cancellationToken);
         }
 
-        public virtual OAuthDeauthorize Deauthorize(string clientId, string stripeUserId, RequestOptions requestOptions = null)
+        public virtual OAuthDeauthorize Deauthorize(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null)
         {
-            // TODO: change this method's signature to accept a OAuthTokenDeauthorizeOptions directly
-            var options = new OAuthTokenDeauthorizeOptions
-            {
-                ClientId = clientId,
-                StripeUserId = stripeUserId,
-            };
             return this.PostRequest<OAuthDeauthorize>($"{Urls.BaseConnectUrl}/oauth/deauthorize", options, requestOptions);
         }
 
-        public virtual Task<OAuthDeauthorize> DeauthorizeAsync(string clientId, string stripeUserId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<OAuthDeauthorize> DeauthorizeAsync(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // TODO: change this method's signature to accept a OAuthTokenDeauthorizeOptions directly
-            var options = new OAuthTokenDeauthorizeOptions
-            {
-                ClientId = clientId,
-                StripeUserId = stripeUserId,
-            };
             return this.PostRequestAsync<OAuthDeauthorize>($"{Urls.BaseConnectUrl}/oauth/deauthorize", options, requestOptions, cancellationToken);
         }
     }

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.IO;
+    using System.Net;
     using System.Net.Http;
     using System.Reflection;
     using System.Text;
@@ -70,6 +71,24 @@ namespace StripeTests
             }
 
             this.MockHttpClientFixture.AssertRequest(method, path);
+        }
+
+        /// <summary>
+        /// Stubs an HTTP request with the specified method and path to return the specified status
+        /// code and response body.
+        /// </summary>
+        protected void StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
+        {
+            if (this.MockHttpClientFixture == null)
+            {
+                throw new StripeTestException(
+                    "StubRequest called from a test class that doesn't have access to "
+                    + "MockHttpClientFixture. Make sure that the constructor for "
+                    + $"{this.GetType().Name} receives MockHttpClientFixture and calls the "
+                    + "base constructor.");
+            }
+
+            this.MockHttpClientFixture.StubRequest(method, path, status, response);
         }
 
         /// <summary>

--- a/src/StripeTests/Resources/oauth_fixtures/token_response.json
+++ b/src/StripeTests/Resources/oauth_fixtures/token_response.json
@@ -1,0 +1,9 @@
+{
+  "access_token": "sk_test_access_token",
+  "livemode": false,
+  "refresh_token": "rt_refresh_token",
+  "token_type": "bearer",
+  "stripe_publishable_key": "pk_test_stripe_publishable_key",
+  "stripe_user_id": "acct_test_token",
+  "scope": "read_only"
+}

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -1,0 +1,92 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class OAuthTokenServiceTest : BaseStripeTest
+    {
+        private const string AccountId = "acct_123";
+        private const string AuthorizationCode = "ac_123";
+        private const string ClientId = "ca_123";
+
+        private readonly OAuthTokenService service;
+        private readonly OAuthTokenCreateOptions createOptions;
+        private readonly OAuthTokenDeauthorizeOptions deauthorizeOptions;
+
+        public OAuthTokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.service = new OAuthTokenService();
+
+            this.createOptions = new OAuthTokenCreateOptions
+            {
+                Code = AuthorizationCode,
+                GrantType = "authorization_code",
+            };
+
+            this.deauthorizeOptions = new OAuthTokenDeauthorizeOptions
+            {
+                ClientId = ClientId,
+                StripeUserId = AccountId,
+            };
+        }
+
+        [Fact]
+        public void Create()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = GetResourceAsString("oauth_fixtures.token_response.json");
+            this.StubRequest(HttpMethod.Post, "/oauth/token", HttpStatusCode.OK, json);
+
+            var oauthToken = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/token");
+            Assert.NotNull(oauthToken);
+            Assert.Equal("sk_test_access_token", oauthToken.AccessToken);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = GetResourceAsString("oauth_fixtures.token_response.json");
+            this.StubRequest(HttpMethod.Post, "/oauth/token", HttpStatusCode.OK, json);
+
+            var oauthToken = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/token");
+            Assert.NotNull(oauthToken);
+            Assert.Equal("sk_test_access_token", oauthToken.AccessToken);
+        }
+
+        [Fact]
+        public void Deauthorize()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = $"{{\"stripe_user_id\": \"{AccountId}\"}}";
+            this.StubRequest(HttpMethod.Post, "/oauth/deauthorize", HttpStatusCode.OK, json);
+
+            var deauth = this.service.Deauthorize(this.deauthorizeOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/deauthorize");
+            Assert.NotNull(deauth);
+            Assert.Equal(AccountId, deauth.StripeUserId);
+        }
+
+        [Fact]
+        public async Task DeauthorizeAsync()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = $"{{\"stripe_user_id\": \"{AccountId}\"}}";
+            this.StubRequest(HttpMethod.Post, "/oauth/deauthorize", HttpStatusCode.OK, json);
+
+            var deauth = await this.service.DeauthorizeAsync(this.deauthorizeOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/deauthorize");
+            Assert.NotNull(deauth);
+            Assert.Equal(AccountId, deauth.StripeUserId);
+        }
+    }
+}


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Standardizes the signature of `Deauthorize` / `DeauthorizeAsync` methods on `OAuthTokenService` to accept an options class. (This is a breaking change.)

While I was at it, I also added basic support for stubbing requests in tests and wrote tests for `OAuthTokenService`.