### PR TITLE
Simplify Service request methods

### DIFF
--- a/src/Stripe.net/Infrastructure/Requestor.cs
+++ b/src/Stripe.net/Infrastructure/Requestor.cs
@@ -100,7 +100,7 @@ namespace Stripe.Infrastructure
             return ExecuteRequestAsync(wr, cancellationToken);
         }
 
-        private static async Task<StripeResponse> ExecuteRequestAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default(CancellationToken))
+        internal static async Task<StripeResponse> ExecuteRequestAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default(CancellationToken))
         {
             var response = await HttpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
             var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -1,9 +1,9 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class AccountService : Service<Account>,
         ICreatable<Account, AccountCreateOptions>,
@@ -58,12 +58,12 @@ namespace Stripe
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Account>($"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions, false);
+            return this.Request(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions);
         }
 
         public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Account>($"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions, false, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
@@ -83,12 +83,12 @@ namespace Stripe
 
         public virtual Account Reject(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Account>($"{this.InstanceUrl(accountId)}/reject", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(accountId)}/reject", options, requestOptions);
         }
 
         public virtual Task<Account> RejectAsync(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Account>($"{this.InstanceUrl(accountId)}/reject", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(accountId)}/reject", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Update(string accountId, AccountUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Balance/BalanceService.cs
+++ b/src/Stripe.net/Services/Balance/BalanceService.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
@@ -23,12 +24,12 @@ namespace Stripe
 
         public virtual Balance Get(RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Balance>(this.ClassUrl(), null, requestOptions, false);
+            return this.Request(HttpMethod.Get, this.ClassUrl(), null, requestOptions);
         }
 
         public virtual Task<Balance> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Balance>(this.ClassUrl(), null, requestOptions, false, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, this.ClassUrl(), null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -82,12 +83,12 @@ namespace Stripe
 
         public virtual BankAccount Verify(string customerId, string bankAccountId, BankAccountVerifyOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<BankAccount>($"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions);
         }
 
         public virtual Task<BankAccount> VerifyAsync(string customerId, string bankAccountId, BankAccountVerifyOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<BankAccount>($"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(customerId, bankAccountId)}/verify", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -50,12 +51,12 @@ namespace Stripe
 
         public virtual Charge Capture(string chargeId, ChargeCaptureOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Charge>($"{this.InstanceUrl(chargeId)}/capture", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(chargeId)}/capture", options, requestOptions);
         }
 
         public virtual Task<Charge> CaptureAsync(string chargeId, ChargeCaptureOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Charge>($"{this.InstanceUrl(chargeId)}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(chargeId)}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Create(ChargeCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Discounts/DiscountService.cs
+++ b/src/Stripe.net/Services/Discounts/DiscountService.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class DiscountService : Service<Discount>
     {
@@ -20,22 +20,22 @@ namespace Stripe
 
         public virtual Discount DeleteCustomerDiscount(string customerId, RequestOptions requestOptions = null)
         {
-            return this.DeleteRequest<Discount>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions);
+            return this.Request(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteCustomerDiscountAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteRequestAsync<Discount>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions, cancellationToken);
         }
 
         public virtual Discount DeleteSubscriptionDiscount(string subscriptionId, RequestOptions requestOptions = null)
         {
-            return this.DeleteRequest<Discount>($"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions);
+            return this.Request(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteSubscriptionDiscountAsync(string subscriptionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteRequestAsync<Discount>($"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,12 +26,12 @@ namespace Stripe
 
         public virtual Dispute Close(string disputeId, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Dispute>($"{this.InstanceUrl(disputeId)}/close", null, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(disputeId)}/close", null, requestOptions);
         }
 
         public virtual Task<Dispute> CloseAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Dispute>($"{this.InstanceUrl(disputeId)}/close", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(disputeId)}/close", null, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Get(string disputeId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -50,12 +51,12 @@ namespace Stripe
 
         public virtual Invoice FinalizeInvoice(string invoiceId, InvoiceFinalizeOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions);
         }
 
         public virtual Task<Invoice> FinalizeInvoiceAsync(string invoiceId, InvoiceFinalizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Get(string invoiceId, RequestOptions requestOptions = null)
@@ -85,12 +86,12 @@ namespace Stripe
 
         public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true);
+            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, true, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InvoiceLineItem> ListLineItemsAutoPaging(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
@@ -100,12 +101,12 @@ namespace Stripe
 
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true);
+            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<InvoiceLineItem>>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, true, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPaging(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
@@ -115,42 +116,42 @@ namespace Stripe
 
         public virtual Invoice MarkUncollectible(string invoiceId, InvoiceMarkUncollectibleOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions);
         }
 
         public virtual Task<Invoice> MarkUncollectibleAsync(string invoiceId, InvoiceMarkUncollectibleOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/mark_uncollectible", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Pay(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions);
         }
 
         public virtual Task<Invoice> PayAsync(string invoiceId, InvoicePayOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/pay", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice SendInvoice(string invoiceId, InvoiceSendOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/send", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/send", options, requestOptions);
         }
 
         public virtual Task<Invoice> SendInvoiceAsync(string invoiceId, InvoiceSendOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/send", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/send", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Upcoming(UpcomingInvoiceOptions options, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, false);
+            return this.Request(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions);
         }
 
         public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<Invoice>($"{this.InstanceUrl("upcoming")}", options, requestOptions, false, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Update(string invoiceId, InvoiceUpdateOptions options, RequestOptions requestOptions = null)
@@ -165,12 +166,12 @@ namespace Stripe
 
         public virtual Invoice VoidInvoice(string invoiceId, InvoiceVoidOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Invoice>($"{this.InstanceUrl(invoiceId)}/void", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/void", options, requestOptions);
         }
 
         public virtual Task<Invoice> VoidInvoiceAsync(string invoiceId, InvoiceVoidOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Invoice>($"{this.InstanceUrl(invoiceId)}/void", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/void", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -1,6 +1,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,22 +24,22 @@ namespace Stripe.Issuing
 
         public virtual Authorization Approve(string authorizationId, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Authorization>($"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions);
         }
 
         public virtual Task<Authorization> ApproveAsync(string authorizationId, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Authorization>($"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(authorizationId)}/approve", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Decline(string authorizationId, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Authorization>($"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions);
         }
 
         public virtual Task<Authorization> DeclineAsync(string authorizationId, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Authorization>($"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Get(string authorizationId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -1,6 +1,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -34,12 +35,12 @@ namespace Stripe.Issuing
 
         public virtual CardDetails Details(string cardId, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, false);
+            return this.Request<CardDetails>(HttpMethod.Get, $"{this.InstanceUrl(cardId)}/details", null, requestOptions);
         }
 
         public virtual Task<CardDetails> DetailsAsync(string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<CardDetails>($"{this.InstanceUrl(cardId)}/details", null, requestOptions, false, cancellationToken);
+            return this.RequestAsync<CardDetails>(HttpMethod.Get, $"{this.InstanceUrl(cardId)}/details", null, requestOptions, cancellationToken);
         }
 
         public virtual Card Get(string cardId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class OAuthTokenService : Service<OAuthToken>,
         ICreatable<OAuthToken, OAuthTokenCreateOptions>
@@ -21,22 +21,22 @@ namespace Stripe
 
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<OAuthToken>($"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions);
+            return this.Request<OAuthToken>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<OAuthToken>($"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OAuthToken>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<OAuthDeauthorize>($"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions);
+            return this.Request<OAuthDeauthorize>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions);
         }
 
         public virtual Task<OAuthDeauthorize> DeauthorizeAsync(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<OAuthDeauthorize>($"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OAuthDeauthorize>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -63,12 +64,12 @@ namespace Stripe
 
         public virtual Order Pay(string orderId, OrderPayOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Order>($"{this.InstanceUrl(orderId)}/pay", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/pay", options, requestOptions);
         }
 
         public virtual Task<Order> PayAsync(string orderId, OrderPayOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Order>($"{this.InstanceUrl(orderId)}/pay", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/pay", options, requestOptions, cancellationToken);
         }
 
         public virtual Order Update(string orderId, OrderUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -30,32 +31,32 @@ namespace Stripe
 
         public virtual PaymentIntent Cancel(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CancelAsync(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Capture(string paymentIntentId, PaymentIntentCaptureOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CaptureAsync(string paymentIntentId, PaymentIntentCaptureOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Confirm(string paymentIntentId, PaymentIntentConfirmOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> ConfirmAsync(string paymentIntentId, PaymentIntentConfirmOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<PaymentIntent>($"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Create(PaymentIntentCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -30,12 +31,12 @@ namespace Stripe
 
         public virtual Payout Cancel(string payoutId, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Payout>($"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions);
         }
 
         public virtual Task<Payout> CancelAsync(string payoutId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Payout>($"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(payoutId)}/cancel", null, requestOptions, cancellationToken);
         }
 
         public virtual Payout Create(PayoutCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -22,12 +23,12 @@ namespace Stripe
 
         public virtual Review Approve(string reviewId, ReviewApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Review>($"{this.InstanceUrl(reviewId)}/approve", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(reviewId)}/approve", options, requestOptions);
         }
 
         public virtual Task<Review> ApproveAsync(string reviewId, ReviewApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Review>($"{this.InstanceUrl(reviewId)}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(reviewId)}/approve", options, requestOptions, cancellationToken);
         }
 
         public virtual Review Get(string reviewId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
@@ -25,12 +26,12 @@ namespace Stripe
 
         public virtual Source Attach(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Source>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<Source> AttachAsync(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Source>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Create(SourceCreateOptions options, RequestOptions requestOptions = null)
@@ -45,12 +46,12 @@ namespace Stripe
 
         public virtual Source Detach(string customerId, string sourceId, RequestOptions requestOptions = null)
         {
-            return this.DeleteRequest<Source>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions);
+            return this.Request<Source>(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions);
         }
 
         public virtual Task<Source> DetachAsync(string customerId, string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteRequestAsync<Source>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
         }
 
         public virtual Source Get(string sourceId, RequestOptions requestOptions = null)
@@ -75,12 +76,12 @@ namespace Stripe
 
         public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetRequest<StripeList<Source>>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, true);
+            return this.Request<StripeList<Source>>(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRequestAsync<StripeList<Source>>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, true, cancellationToken);
+            return this.RequestAsync<StripeList<Source>>(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Source> ListAutoPaging(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
@@ -100,12 +101,12 @@ namespace Stripe
 
         public virtual Source Verify(string sourceId, SourceVerifyOptions options, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Source>($"{this.InstanceUrl(sourceId)}/verify", options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"{this.InstanceUrl(sourceId)}/verify", options, requestOptions);
         }
 
         public virtual Task<Source> VerifyAsync(string sourceId, SourceVerifyOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Source>($"{this.InstanceUrl(sourceId)}/verify", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"{this.InstanceUrl(sourceId)}/verify", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -28,12 +29,12 @@ namespace Stripe
 
         public virtual Topup Cancel(string topupId, RequestOptions requestOptions = null)
         {
-            return this.PostRequest<Topup>($"{this.InstanceUrl(topupId)}/cancel", null, requestOptions);
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(topupId)}/cancel", null, requestOptions);
         }
 
         public virtual Task<Topup> CancelAsync(string topupId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.PostRequestAsync<Topup>($"{this.InstanceUrl(topupId)}/cancel", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(topupId)}/cancel", null, requestOptions, cancellationToken);
         }
 
         public virtual Topup Create(TopupCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/_base/BaseOptions.cs
+++ b/src/Stripe.net/Services/_base/BaseOptions.cs
@@ -2,22 +2,15 @@ namespace Stripe
 {
     using System.Collections.Generic;
 
+    /// <summary>
+    /// Base class for Stripe options classes, i.e. classes representing parameters for Stripe
+    /// API requests.
+    /// </summary>
     public class BaseOptions : INestedOptions
     {
-        private Dictionary<string, string> extraParams = new Dictionary<string, string>();
-        private List<string> expand = new List<string>();
+        public Dictionary<string, string> ExtraParams { get; set; } = new Dictionary<string, string>();
 
-        public Dictionary<string, string> ExtraParams
-        {
-            get { return this.extraParams; }
-            set { this.extraParams = value; }
-        }
-
-        public List<string> Expand
-        {
-            get { return this.expand; }
-            set { this.expand = value; }
-        }
+        public List<string> Expand { get; set; } = new List<string>();
 
         public void AddExtraParam(string key, string value)
         {

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -2,6 +2,8 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using System.Net;
+    using System.Net.Http;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
@@ -25,96 +27,204 @@ namespace Stripe
 
         protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
-            return this.PostRequest<EntityReturned>(this.ClassUrl(), options, requestOptions);
+            return this.Request(
+                HttpMethod.Post,
+                this.ClassUrl(),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> CreateEntityAsync(BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> CreateEntityAsync(
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.PostRequestAsync<EntityReturned>(this.ClassUrl(), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Post,
+                this.ClassUrl(),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected EntityReturned DeleteEntity(string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned DeleteEntity(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.DeleteRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
+            return this.Request(
+                HttpMethod.Delete,
+                this.InstanceUrl(id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> DeleteEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> DeleteEntityAsync(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.DeleteRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Delete,
+                this.InstanceUrl(id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected EntityReturned GetEntity(string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned GetEntity(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.GetRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions, false);
+            return this.Request(
+                HttpMethod.Get,
+                this.InstanceUrl(id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> GetEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> GetEntityAsync(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, false, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Get,
+                this.InstanceUrl(id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected StripeList<EntityReturned> ListEntities(ListOptions options, RequestOptions requestOptions)
+        protected StripeList<EntityReturned> ListEntities(
+            ListOptions options,
+            RequestOptions requestOptions)
         {
-            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, true);
+            return this.Request<StripeList<EntityReturned>>(
+                HttpMethod.Get,
+                this.ClassUrl(),
+                options,
+                requestOptions);
         }
 
-        protected Task<StripeList<EntityReturned>> ListEntitiesAsync(ListOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<StripeList<EntityReturned>> ListEntitiesAsync(
+            ListOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(), options, requestOptions, true, cancellationToken);
+            return this.RequestAsync<StripeList<EntityReturned>>(
+                HttpMethod.Get,
+                this.ClassUrl(),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected IEnumerable<EntityReturned> ListEntitiesAutoPaging(ListOptions options, RequestOptions requestOptions)
+        protected IEnumerable<EntityReturned> ListEntitiesAutoPaging(
+            ListOptions options,
+            RequestOptions requestOptions)
         {
-            return this.ListRequestAutoPaging<EntityReturned>(this.ClassUrl(), options, requestOptions);
+            return this.ListRequestAutoPaging<EntityReturned>(
+                this.ClassUrl(),
+                options,
+                requestOptions);
         }
 
-        protected EntityReturned UpdateEntity(string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned UpdateEntity(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.PostRequest<EntityReturned>(this.InstanceUrl(id), options, requestOptions);
+            return this.Request(
+                HttpMethod.Post,
+                this.InstanceUrl(id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> UpdateEntityAsync(string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> UpdateEntityAsync(
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.PostRequestAsync<EntityReturned>(this.InstanceUrl(id), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Post,
+                this.InstanceUrl(id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected T DeleteRequest<T>(string url, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned Request(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return Mapper<T>.MapFromJson(
-                Requestor.Delete(
-                    this.ApplyAllParameters(options, url),
-                    this.SetupRequestOptions(requestOptions)));
+            return this.Request<EntityReturned>(
+                method,
+                path,
+                options,
+                requestOptions);
         }
 
-        protected async Task<T> DeleteRequestAsync<T>(string url, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> RequestAsync(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Mapper<T>.MapFromJson(
-                await Requestor.DeleteAsync(
-                    this.ApplyAllParameters(options, url),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
+            return this.RequestAsync<EntityReturned>(
+                method,
+                path,
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected T GetRequest<T>(string url, BaseOptions options, RequestOptions requestOptions, bool isListMethod)
+        protected T Request<T>(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions)
+            where T : IStripeEntity
         {
-            return Mapper<T>.MapFromJson(
-                Requestor.GetString(
-                    this.ApplyAllParameters(options, url, isListMethod),
-                    this.SetupRequestOptions(requestOptions)));
+            return this.RequestAsync<T>(method, path, options, requestOptions)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        protected async Task<T> GetRequestAsync<T>(string url, BaseOptions options, RequestOptions requestOptions, bool isListMethod, CancellationToken cancellationToken)
+        protected async Task<T> RequestAsync<T>(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where T : IStripeEntity
         {
-            return Mapper<T>.MapFromJson(
-                await Requestor.GetStringAsync(
-                    this.ApplyAllParameters(options, url, isListMethod),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            var wr = Requestor.GetRequestMessage(
+                this.ApplyAllParameters(options, path, IsStripeList<T>()),
+                method,
+                requestOptions);
+            return Mapper<T>.MapFromJson(await Requestor.ExecuteRequestAsync(wr));
         }
 
-        protected IEnumerable<T> ListRequestAutoPaging<T>(string url, ListOptions options, RequestOptions requestOptions)
+        protected IEnumerable<T> ListRequestAutoPaging<T>(
+            string url,
+            ListOptions options,
+            RequestOptions requestOptions)
+            where T : IStripeEntity
         {
-            var page = this.GetRequest<StripeList<T>>(url, options, requestOptions, true);
+            var page = this.Request<StripeList<T>>(
+                HttpMethod.Get,
+                url,
+                options,
+                requestOptions);
 
             while (true)
             {
@@ -131,25 +241,12 @@ namespace Stripe
                 }
 
                 options.StartingAfter = itemId;
-                page = this.GetRequest<StripeList<T>>(this.ClassUrl(), options, requestOptions, true);
+                page = this.Request<StripeList<T>>(
+                    HttpMethod.Get,
+                    url,
+                    options,
+                    requestOptions);
             }
-        }
-
-        protected T PostRequest<T>(string url, BaseOptions options, RequestOptions requestOptions)
-        {
-            return Mapper<T>.MapFromJson(
-                Requestor.PostString(
-                    this.ApplyAllParameters(options, url),
-                    this.SetupRequestOptions(requestOptions)));
-        }
-
-        protected async Task<T> PostRequestAsync<T>(string url, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
-        {
-            return Mapper<T>.MapFromJson(
-                await Requestor.PostStringAsync(
-                    this.ApplyAllParameters(options, url),
-                    this.SetupRequestOptions(requestOptions),
-                    cancellationToken).ConfigureAwait(false));
         }
 
         protected RequestOptions SetupRequestOptions(RequestOptions requestOptions)
@@ -176,6 +273,13 @@ namespace Stripe
         protected virtual string InstanceUrl(string id, string baseUrl = null)
         {
             return $"{this.ClassUrl(baseUrl)}/{WebUtility.UrlEncode(id)}";
+        }
+
+        private static bool IsStripeList<T>()
+        {
+            var typeInfo = typeof(T).GetTypeInfo();
+            return typeInfo.IsGenericType
+                && typeInfo.GetGenericTypeDefinition() == typeof(StripeList<>);
         }
     }
 }

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using System.Net;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -18,59 +19,151 @@ namespace Stripe
         {
         }
 
-        protected EntityReturned CreateNestedEntity(string parentId, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned CreateNestedEntity(
+            string parentId,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.PostRequest<EntityReturned>(this.ClassUrl(parentId), options, requestOptions);
+            return this.Request(
+                HttpMethod.Post,
+                this.ClassUrl(parentId),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> CreateNestedEntityAsync(string parentId, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> CreateNestedEntityAsync(
+            string parentId,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.PostRequestAsync<EntityReturned>(this.ClassUrl(parentId), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Post,
+                this.ClassUrl(parentId),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected EntityReturned DeleteNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned DeleteNestedEntity(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.DeleteRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+            return this.Request(
+                HttpMethod.Delete,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> DeleteNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> DeleteNestedEntityAsync(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.DeleteRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Delete,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected EntityReturned GetNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned GetNestedEntity(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.GetRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, false);
+            return this.Request(
+                HttpMethod.Get,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> GetNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> GetNestedEntityAsync(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, false, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Get,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected StripeList<EntityReturned> ListNestedEntities(string parentId, ListOptions options, RequestOptions requestOptions)
+        protected StripeList<EntityReturned> ListNestedEntities(
+            string parentId,
+            ListOptions options,
+            RequestOptions requestOptions)
         {
-            return this.GetRequest<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true);
+            return this.Request<StripeList<EntityReturned>>(
+                HttpMethod.Get,
+                this.ClassUrl(parentId),
+                options,
+                requestOptions);
         }
 
-        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(string parentId, ListOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(
+            string parentId,
+            ListOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.GetRequestAsync<StripeList<EntityReturned>>(this.ClassUrl(parentId), options, requestOptions, true, cancellationToken);
+            return this.RequestAsync<StripeList<EntityReturned>>(
+                HttpMethod.Get,
+                this.ClassUrl(parentId),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
-        protected IEnumerable<EntityReturned> ListNestedEntitiesAutoPaging(string parentId, ListOptions options, RequestOptions requestOptions)
+        protected IEnumerable<EntityReturned> ListNestedEntitiesAutoPaging(
+            string parentId,
+            ListOptions options,
+            RequestOptions requestOptions)
         {
-            return this.ListRequestAutoPaging<EntityReturned>(this.ClassUrl(parentId), options, requestOptions);
+            return this.ListRequestAutoPaging<EntityReturned>(
+                this.ClassUrl(parentId),
+                options,
+                requestOptions);
         }
 
-        protected EntityReturned UpdateNestedEntity(string parentId, string id, BaseOptions options, RequestOptions requestOptions)
+        protected EntityReturned UpdateNestedEntity(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions)
         {
-            return this.PostRequest<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions);
+            return this.Request(
+                HttpMethod.Post,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions);
         }
 
-        protected Task<EntityReturned> UpdateNestedEntityAsync(string parentId, string id, BaseOptions options, RequestOptions requestOptions, CancellationToken cancellationToken)
+        protected Task<EntityReturned> UpdateNestedEntityAsync(
+            string parentId,
+            string id,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
-            return this.PostRequestAsync<EntityReturned>(this.InstanceUrl(parentId, id), options, requestOptions, cancellationToken);
+            return this.RequestAsync(
+                HttpMethod.Post,
+                this.InstanceUrl(parentId, id),
+                options,
+                requestOptions,
+                cancellationToken);
         }
 
         protected virtual string ClassUrl(string parentId, string baseUrl = null)

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -2,15 +2,21 @@ namespace Stripe
 {
     public class RequestOptions
     {
+        /// <summary>The API key to use for the request.</summary>
         public string ApiKey { get; set; }
 
-        public string StripeConnectAccountId { get; set; }
-
+        /// <summary>Idempotency key for safely retrying requests.</summary>
         public string IdempotencyKey { get; set; }
 
-        // This is used specifically for Ephemeral Keys as they have to be created
-        // with a specific API version. It should not be used for anything else which
-        // is why it is set as internal.
+        /// <summary>For Connect requests, the connected account's ID.</summary>
+        public string StripeConnectAccountId { get; set; }
+
+        /// <summary>The API version for the request.</summary>
+        /// <remarks>
+        /// This is an internal property. For most requests, the API version is always set to the
+        /// library's pinned version (<see cref="StripeConfiguration.ApiVersion"/>). This property
+        /// is only used for creating ephemeral keys, which require a specific API version.
+        /// </remarks>
         internal string StripeVersion { get; set; }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This PR is in preparation of the upcoming refactor in #1487.

It removes the `GetRequest<T> / PostRequest<T> / DeleteRequest<T>` methods and their `Async` counterparts in `Service` and replaces them with just `Request<T> / RequestAsync<T>` methods that take the HTTP verb as their first parameter.

The two methods also have non-typed counterparts `Request / RequestAsync` that use the service's type (since in most cases, when you're sending a request from a service, you're expecting the same resource as the service's).

It also gets rid of the super annoying `isListMethod` flag by using a little introspection: if the return type is a `StripeList<>`, then it's a list request, otherwise it's not.
