### PR TITLE
Move base URLs out of resource services where possible

### DIFF
--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -58,12 +58,12 @@ namespace Stripe
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions);
+            return this.Request(HttpMethod.Get, "/v1/account", null, requestOptions);
         }
 
         public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/account", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, "/v1/account", null, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Discounts/DiscountService.cs
+++ b/src/Stripe.net/Services/Discounts/DiscountService.cs
@@ -20,22 +20,22 @@ namespace Stripe
 
         public virtual Discount DeleteCustomerDiscount(string customerId, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions);
+            return this.Request(HttpMethod.Delete, $"/v1/customers/{customerId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteCustomerDiscountAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/discount", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Delete, $"/v1/customers/{customerId}/discount", null, requestOptions, cancellationToken);
         }
 
         public virtual Discount DeleteSubscriptionDiscount(string subscriptionId, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions);
+            return this.Request(HttpMethod.Delete, $"/v1/subscriptions/{subscriptionId}/discount", null, requestOptions);
         }
 
         public virtual Task<Discount> DeleteSubscriptionDiscountAsync(string subscriptionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/subscriptions/{subscriptionId}/discount", null, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Delete, $"/v1/subscriptions/{subscriptionId}/discount", null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -24,22 +24,26 @@ namespace Stripe
 
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            requestOptions.BaseUrl = StripeConfiguration.FilesBase;
             return Mapper<File>.MapFromJson(
                 Requestor.PostFile(
-                    this.ClassUrl(StripeConfiguration.FilesBase),
+                    StripeConfiguration.FilesBase + this.ClassUrl(),
                     options.File,
                     options.Purpose,
-                    this.SetupRequestOptions(requestOptions)));
+                    requestOptions));
         }
 
         public virtual async Task<File> CreateAsync(FileCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            requestOptions.BaseUrl = StripeConfiguration.FilesBase;
             return Mapper<File>.MapFromJson(
                 await Requestor.PostFileAsync(
-                    this.ClassUrl(StripeConfiguration.FilesBase),
+                    StripeConfiguration.FilesBase + this.ClassUrl(),
                     options.File,
                     options.Purpose,
-                    this.SetupRequestOptions(requestOptions),
+                    requestOptions,
                     cancellationToken).ConfigureAwait(false));
         }
 

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -19,24 +19,26 @@ namespace Stripe
 
         public override string BasePath => null;
 
+        public override string BaseUrl => StripeConfiguration.ConnectBase;
+
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<OAuthToken>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions);
+            return this.Request(HttpMethod.Post, "/oauth/token", options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<OAuthToken>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/token", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, "/oauth/token", options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<OAuthDeauthorize>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions);
+            return this.Request<OAuthDeauthorize>(HttpMethod.Post, "/oauth/deauthorize", options, requestOptions);
         }
 
         public virtual Task<OAuthDeauthorize> DeauthorizeAsync(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<OAuthDeauthorize>(HttpMethod.Post, $"{StripeConfiguration.ConnectBase}/oauth/deauthorize", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OAuthDeauthorize>(HttpMethod.Post, "/oauth/deauthorize", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -26,12 +26,12 @@ namespace Stripe
 
         public virtual Source Attach(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Source>(HttpMethod.Post, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"/v1/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<Source> AttachAsync(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<Source>(HttpMethod.Post, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Create(SourceCreateOptions options, RequestOptions requestOptions = null)
@@ -46,12 +46,12 @@ namespace Stripe
 
         public virtual Source Detach(string customerId, string sourceId, RequestOptions requestOptions = null)
         {
-            return this.Request<Source>(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions);
+            return this.Request<Source>(HttpMethod.Delete, $"/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions);
         }
 
         public virtual Task<Source> DetachAsync(string customerId, string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<Source>(HttpMethod.Delete, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Delete, $"/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
         }
 
         public virtual Source Get(string sourceId, RequestOptions requestOptions = null)
@@ -76,17 +76,17 @@ namespace Stripe
 
         public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<Source>>(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
+            return this.Request<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<StripeList<Source>>(HttpMethod.Get, $"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Source> ListAutoPaging(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<Source>($"{StripeConfiguration.ApiBase}/v1/customers/{customerId}/sources", options, requestOptions);
+            return this.ListRequestAutoPaging<Source>($"/v1/customers/{customerId}/sources", options, requestOptions);
         }
 
         public virtual Source Update(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -25,6 +25,8 @@ namespace Stripe
 
         public abstract string BasePath { get; }
 
+        public virtual string BaseUrl => StripeConfiguration.ApiBase;
+
         protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
             return this.Request(
@@ -207,8 +209,9 @@ namespace Stripe
             where T : IStripeEntity
         {
             requestOptions = this.SetupRequestOptions(requestOptions);
+            var url = requestOptions.BaseUrl + path;
             var wr = Requestor.GetRequestMessage(
-                this.ApplyAllParameters(options, path, IsStripeList<T>()),
+                this.ApplyAllParameters(options, url, IsStripeList<T>()),
                 method,
                 requestOptions);
             return Mapper<T>.MapFromJson(await Requestor.ExecuteRequestAsync(wr));
@@ -261,18 +264,19 @@ namespace Stripe
                 requestOptions.ApiKey = this.ApiKey;
             }
 
+            requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.BaseUrl;
+
             return requestOptions;
         }
 
-        protected virtual string ClassUrl(string baseUrl = null)
+        protected virtual string ClassUrl()
         {
-            baseUrl = baseUrl ?? StripeConfiguration.ApiBase;
-            return $"{baseUrl}{this.BasePath}";
+            return this.BasePath;
         }
 
-        protected virtual string InstanceUrl(string id, string baseUrl = null)
+        protected virtual string InstanceUrl(string id)
         {
-            return $"{this.ClassUrl(baseUrl)}/{WebUtility.UrlEncode(id)}";
+            return $"{this.ClassUrl()}/{WebUtility.UrlEncode(id)}";
         }
 
         private static bool IsStripeList<T>()

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -166,15 +166,14 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected virtual string ClassUrl(string parentId, string baseUrl = null)
+        protected virtual string ClassUrl(string parentId)
         {
-            baseUrl = baseUrl ?? StripeConfiguration.ApiBase;
-            return $"{baseUrl}{this.BasePath.Replace("{PARENT_ID}", parentId)}";
+            return this.BasePath.Replace("{PARENT_ID}", parentId);
         }
 
-        protected virtual string InstanceUrl(string parentId, string id, string baseUrl = null)
+        protected virtual string InstanceUrl(string parentId, string id)
         {
-            return $"{this.ClassUrl(parentId, baseUrl)}/{WebUtility.UrlEncode(id)}";
+            return $"{this.ClassUrl(parentId)}/{WebUtility.UrlEncode(id)}";
         }
     }
 }

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -11,6 +11,14 @@ namespace Stripe
         /// <summary>For Connect requests, the connected account's ID.</summary>
         public string StripeConnectAccountId { get; set; }
 
+        /// <summary>The base URL for the request.</summary>
+        /// <remarks>
+        /// This is an internal property. It is set by services or individual request methods when
+        /// they need to send a request to a non-standard destination, e.g. <c>files.stripe.com</c>
+        /// for file creation requests or <c>connect.stripe.com</c> for OAuth requests.
+        /// </remarks>
+        internal string BaseUrl { get; set; }
+
         /// <summary>The API version for the request.</summary>
         /// <remarks>
         /// This is an internal property. For most requests, the API version is always set to the


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Simply base URL handling by centralizing it into `Service` base class.

Individual services can override the base URL in one of two ways:
- by overriding the `BaseUrl` property for the service itself, which will set the base URL for all methods in the service (e.g. `OAuthTokenService`)
- by setting the `BaseUrl` property in `RequestOptions`, which will set the base URL for the specific request (e.g. `FileService.Create / CreateAsync`)
