### PR TITLE
Add support for Subscription Schedule

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.43.0
+  STRIPE_MOCK_VERSION: 0.44.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -19,6 +19,9 @@ namespace Stripe
         [JsonProperty("account_balance")]
         public long AccountBalance { get; set; }
 
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
@@ -74,6 +77,9 @@ namespace Stripe
         [JsonProperty("delinquent")]
         public bool Delinquent { get; set; }
 
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -83,21 +89,42 @@ namespace Stripe
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
 
+        /// <summary>
+        /// The customer’s email address.
+        /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// The prefix for the customer used to generate unique invoice numbers.
+        /// </summary>
         [JsonProperty("invoice_prefix")]
         public string InvoicePrefix { get; set; }
 
+        /// <summary>
+        /// The customer’s default invoice settings.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public CustomerInvoiceSettings InvoiceSettings { get; set; }
+
+        /// <summary>
+        /// Has the value <code>true</code> if the object exists in live mode or the value
+        /// <code>false</code> if the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
         /// <summary>
-        /// A set of key/value pairs that you can attach to a customer object. It can be useful for storing additional information about the customer in a structured format
+        /// A set of key/value pairs that you can attach to a customer object. It can be useful for
+        /// storing additional information about the customer in a structured format
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// Mailing and shipping address for the customer. Appears on invoices emailed to this
+        /// customer.
+        /// </summary>
         [JsonProperty("shipping")]
         public Shipping Shipping { get; set; }
 
@@ -113,9 +140,15 @@ namespace Stripe
         [JsonProperty("subscriptions")]
         public StripeList<Subscription> Subscriptions { get; set; }
 
+        /// <summary>
+        /// The customer’s tax information. Appears on invoices emailed to this customer.
+        /// </summary>
         [JsonProperty("tax_info")]
         public CustomerTaxInfo TaxInfo { get; set; }
 
+        /// <summary>
+        /// Describes the status of looking up the tax ID provided in <code>tax_info</code>.
+        /// </summary>
         [JsonProperty("tax_info_verification")]
         public CustomerTaxInfoVerification TaxInfoVerification { get; set; }
     }

--- a/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
+++ b/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class CustomerInvoiceSettings : StripeEntity
+    {
+        /// <summary>
+        /// Default custom fields to be displayed on invoices for this customer.
+        /// </summary>
+        [JsonProperty("custom_fields")]
+        public List<InvoiceCustomField> CustomFields { get; set; }
+
+        /// <summary>
+        /// Default footer to be displayed on invoices for this customer.
+        /// </summary>
+        [JsonProperty("footer")]
+        public string Footer { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -13,9 +13,6 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
-        [JsonProperty("allowed_source_types")]
-        public List<string> AllowedSourceTypes { get; set; }
-
         [JsonProperty("amount")]
         public long? Amount { get; set; }
 
@@ -135,6 +132,9 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("payment_method_types")]
+        public List<string> PaymentMethodTypes { get; set; }
+
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }
 
@@ -196,5 +196,9 @@ namespace Stripe
 
         [JsonProperty("transfer_group")]
         public string TransferGroup { get; set; }
+
+        [Obsolete("Use PaymentMethodTypes")]
+        [JsonProperty("allowed_source_types")]
+        public List<string> AllowedSourceTypes { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SubscriptionsScheduleRevisions/SubscriptionScheduleRevision.cs
+++ b/src/Stripe.net/Entities/SubscriptionsScheduleRevisions/SubscriptionScheduleRevision.cs
@@ -1,0 +1,74 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleRevision : StripeEntity, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? Created { get; set; }
+
+        /// <summary>
+        /// The schedule's default invoice settings.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
+
+        /// <summary>
+        /// Has the value <code>true</code> if the object exists in live mode or the value
+        /// <code>false</code> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Configuration for the subscription schedule’s phases.
+        /// </summary>
+        [JsonProperty("phases")]
+        public List<SubscriptionSchedulePhase> Phases { get; set; }
+
+        /// <summary>
+        /// ID of the previous subscription schedule revision.
+        /// </summary>
+        [JsonProperty("previous_revision")]
+        public string PreviousRevisionId { get; set; }
+
+        /// <summary>
+        /// Interval and duration at which the subscription schedule renews for when it ends if
+        /// <code>renewal_behavior</code> is <code>renew</code>.
+        /// </summary>
+        [JsonProperty("renewal_behavior")]
+        public string RenewalBehavior { get; set; }
+
+        /// <summary>
+        /// Interval and duration at which the subscription schedule renews for when it ends if
+        /// <code>renewal_behavior</code> is <code>renew</code>.
+        /// </summary>
+        [JsonProperty("renewal_interval")]
+        public SubscriptionScheduleRenewalInterval RenewalInterval { get; set; }
+
+        /// <summary>
+        /// ID of the subscription schedule the revision points to.
+        /// </summary>
+        [JsonProperty("schedule")]
+        public string ScheduleId { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -1,0 +1,193 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionSchedule : StripeEntity, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
+        /// this subscription at the end of the cycle using the default source attached to the
+        /// customer. When sending an invoice, Stripe will email your customer an invoice with
+        /// payment instructions.
+        /// </summary>
+        [JsonProperty("billing")]
+        public Billing? Billing { get; set; }
+
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholds BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Time at which the subscription schedule was canceled. Measured in seconds since the
+        /// Unix epoch.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Time at which the subscription schedule was completed. Measured in seconds since the
+        /// Unix epoch.
+        /// </summary>
+        [JsonProperty("completed_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? CompletedAt { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? Created { get; set; }
+
+        /// <summary>
+        /// Object representing the start and end dates for the current phase of the subscription
+        /// schedule, if it is <code>active</code>.
+        /// </summary>
+        [JsonProperty("current_phase")]
+        public SubscriptionScheduleCurrentPhase CurrentPhase { get; set; }
+
+        #region Expandable Customer
+
+        /// <summary>
+        /// ID of the <see cref="Customer"/> associated with the subscription schedule.
+        /// <para>Expandable.</para>
+        /// </summary>
+        [JsonIgnore]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// (Expanded) The <see cref="Customer"/> associated with the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public Customer Customer { get; set; }
+
+        [JsonProperty("customer")]
+        internal object InternalCustomer
+        {
+            get
+            {
+                return this.Customer ?? (object)this.CustomerId;
+            }
+
+            set
+            {
+                StringOrObject<Customer>.Map(value, s => this.CustomerId = s, o => this.Customer = o);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// The schedule's default invoice settings.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
+
+        /// <summary>
+        /// Has the value <code>true</code> if the object exists in live mode or the value
+        /// <code>false</code> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription schedule object.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Configuration for the subscription schedule’s phases.
+        /// </summary>
+        [JsonProperty("phases")]
+        public List<SubscriptionSchedulePhase> Phases { get; set; }
+
+        /// <summary>
+        /// Time at which the subscription schedule was released. Measured in seconds since the
+        /// Unix epoch.
+        /// </summary>
+        [JsonProperty("released_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? ReleasedAt { get; set; }
+
+        /// <summary>
+        /// ID of the subscription once managed by the subscription schedule (if it is released).
+        /// </summary>
+        [JsonProperty("released_subscription")]
+        public string ReleasedSubscriptionId { get; set; }
+
+        /// <summary>
+        /// Behavior of the subscription schedule and underlying subscription when it ends.
+        /// </summary>
+        [JsonProperty("renewal_behavior")]
+        public string RenewalBehavior { get; set; }
+
+        /// <summary>
+        /// Interval and duration at which the subscription schedule renews for when it ends if
+        /// <code>renewal_behavior</code> is <code>renew</code>.
+        /// </summary>
+        [JsonProperty("renewal_interval")]
+        public SubscriptionScheduleRenewalInterval RenewalInterval { get; set; }
+
+        /// <summary>
+        /// ID of the current revision of the subscription schedule.
+        /// </summary>
+        [JsonProperty("revision")]
+        public string RevisionId { get; set; }
+
+        /// <summary>
+        /// Possible values are <code>active</code>, <code>canceled</code>, <code>completed</code>,
+        /// <code>not_started</code>, <code>released</code> and <code>renewal_behavior</code>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        #region Expandable Subscription
+
+        /// <summary>
+        /// ID of the <see cref="Subscription"/> associated with the subscription schedule.
+        /// <para>Expandable.</para>
+        /// </summary>
+        [JsonIgnore]
+        public string SubscriptionId { get; set; }
+
+        /// <summary>
+        /// (Expanded) The <see cref="Subscription"/> associated with the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public Subscription Subscription { get; set; }
+
+        [JsonProperty("subscription")]
+        internal object InternalSubscription
+        {
+            get
+            {
+                return this.Subscription ?? (object)this.SubscriptionId;
+            }
+
+            set
+            {
+                StringOrObject<Subscription>.Map(value, s => this.SubscriptionId = s, o => this.Subscription = o);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleCurrentPhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleCurrentPhase.cs
@@ -1,0 +1,24 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleCurrentPhase : StripeEntity
+    {
+        /// <summary>
+        /// The end of the this phase of the subscription schedule.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// The start of this phase of the subscription schedule.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? StartDate { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleInvoiceSettings.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleInvoiceSettings.cs
@@ -1,0 +1,16 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleInvoiceSettings : StripeEntity
+    {
+        /// <summary>
+        /// The number of days from which the invoice is created until it is due.
+        /// </summary>
+        [JsonProperty("days_until_due")]
+        public long? DaysUntilDue { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
@@ -1,0 +1,83 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionSchedulePhase : StripeEntity
+    {
+        /// <summary>
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner’s Stripe account during this phase of the schedule.
+        /// </summary>
+        [JsonProperty("application_fee_percent")]
+        public decimal? ApplicationFeePercent { get; set; }
+
+        #region Expandable Coupon
+
+        /// <summary>
+        /// ID of the <see cref="Coupon"/> associated with this phase for the subscription schedule.
+        /// <para>Expandable.</para>
+        /// </summary>
+        [JsonIgnore]
+        public string CouponId { get; set; }
+
+        /// <summary>
+        /// (Expanded) The <see cref="Coupon"/> associated with this phase for the subscription
+        /// schedule.
+        /// </summary>
+        [JsonIgnore]
+        public Coupon Coupon { get; set; }
+
+        [JsonProperty("coupon")]
+        internal object InternalCoupon
+        {
+            get
+            {
+                return this.Coupon ?? (object)this.CouponId;
+            }
+
+            set
+            {
+                StringOrObject<Coupon>.Map(value, s => this.CouponId = s, o => this.Coupon = o);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// The end of this phase of the subscription schedule.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Plans to subscribe during this phase of the subscription schedule.
+        /// </summary>
+        [JsonProperty("plans")]
+        public List<SubscriptionSchedulePhaseItem> Plans { get; set; }
+
+        /// <summary>
+        /// The start of this phase of the subscription schedule.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>
+        /// If provided, each invoice created during this phase of the subscription schedule will
+        /// apply the tax rate, increasing the amount billed to the customer.
+        /// </summary>
+        [JsonProperty("tax_percent")]
+        public decimal? TaxPercent { get; set; }
+
+        /// <summary>
+        /// When the trial ends within the phase.
+        /// </summary>
+        [JsonProperty("trial_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? TrialEnd { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
@@ -1,0 +1,52 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionSchedulePhaseItem : StripeEntity
+    {
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionItemBillingThresholds BillingThresholds { get; set; }
+
+        #region Expandable Plan
+
+        /// <summary>
+        /// ID of the <see cref="Plan"/> included in the phase for this subscription schedule.
+        /// <para>Expandable.</para>
+        /// </summary>
+        [JsonIgnore]
+        public string PlanId { get; set; }
+
+        /// <summary>
+        /// (Expanded) The <see cref="Plan"/> included in the phase for this subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public Plan Plan { get; set; }
+
+        [JsonProperty("plan")]
+        internal object InternalPlan
+        {
+            get
+            {
+                return this.Plan ?? (object)this.PlanId;
+            }
+
+            set
+            {
+                StringOrObject<Plan>.Map(value, s => this.PlanId = s, o => this.Plan = o);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Quantity of the plan to which the customer should be subscribed.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long Quantity { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleRenewalInterval.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleRenewalInterval.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleRenewalInterval : StripeEntity
+    {
+        /// <summary>
+        /// Interval at which to renew the subscription schedule for when it ends.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// Number of intervals to renew the subscription schedule for when it ends.
+        /// </summary>
+        [JsonProperty("length")]
+        public long Length { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
@@ -66,6 +66,8 @@ namespace Stripe.Infrastructure
             { "source_transaction", typeof(SourceTransaction) },
             { "subscription", typeof(Subscription) },
             { "subscription_item", typeof(SubscriptionItem) },
+            { "subscription_schedule", typeof(SubscriptionSchedule) },
+            { "subscription_schedule_revision", typeof(SubscriptionScheduleRevision) },
             { "terminal.connection_token", typeof(Terminal.ConnectionToken) },
             { "terminal.location", typeof(Terminal.Location) },
             { "terminal.reader", typeof(Terminal.Reader) },

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -22,6 +22,9 @@ namespace Stripe
         [JsonProperty("invoice_prefix")]
         public string InvoicePrefix { get; set; }
 
+        [JsonProperty("invoice_settings")]
+        public CustomerInvoiceSettingsOptions InvoiceSettings { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 

--- a/src/Stripe.net/Services/Customers/CustomerInvoiceSettingsOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerInvoiceSettingsOptions.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class CustomerInvoiceSettingsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Default custom fields to be displayed on invoices for this customer.
+        /// </summary>
+        [JsonProperty("custom_fields")]
+        public List<InvoiceCustomFieldOptions> CustomFields { get; set; }
+
+        /// <summary>
+        /// Default footer to be displayed on invoices for this customer.
+        /// </summary>
+        [JsonProperty("footer")]
+        public string Footer { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -24,6 +24,9 @@ namespace Stripe
         [JsonProperty("invoice_prefix")]
         public string InvoicePrefix { get; set; }
 
+        [JsonProperty("invoice_settings")]
+        public CustomerInvoiceSettingsOptions InvoiceSettings { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -5,9 +5,6 @@ namespace Stripe
 
     public class PaymentIntentCreateOptions : PaymentIntentSharedOptions
     {
-        [JsonProperty("allowed_source_types")]
-        public List<string> AllowedSourceTypes { get; set; }
-
         [JsonProperty("confirm")]
         public bool? Confirm { get; set; }
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentSharedOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentSharedOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
@@ -26,6 +27,9 @@ namespace Stripe
         [JsonProperty("on_behalf_of")]
         public string OnBehalfOf { get; set; }
 
+        [JsonProperty("payment_method_types")]
+        public List<string> PaymentMethodTypes { get; set; }
+
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }
 
@@ -40,5 +44,9 @@ namespace Stripe
 
         [JsonProperty("transfer_group")]
         public string TransferGroup { get; set; }
+
+        [Obsolete("Use PaymentMethodTypes")]
+        [JsonProperty("allowed_source_types")]
+        public List<string> AllowedSourceTypes { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionListOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionListOptions.cs
@@ -1,0 +1,8 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleRevisionListOptions : ListOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
@@ -1,0 +1,48 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class SubscriptionScheduleRevisionService : ServiceNested<SubscriptionScheduleRevision>,
+        INestedListable<SubscriptionScheduleRevision, SubscriptionScheduleRevisionListOptions>,
+        INestedRetrievable<SubscriptionScheduleRevision>
+    {
+        public SubscriptionScheduleRevisionService()
+            : base(null)
+        {
+        }
+
+        public SubscriptionScheduleRevisionService(string apiKey)
+            : base(apiKey)
+        {
+        }
+
+        public override string BasePath => "/subscription_schedules/{PARENT_ID}/revisions";
+
+        public virtual SubscriptionScheduleRevision Get(string scheduleId, string revisionId, RequestOptions requestOptions = null)
+        {
+            return this.GetNestedEntity(scheduleId, revisionId, null, requestOptions);
+        }
+
+        public virtual Task<SubscriptionScheduleRevision> GetAsync(string scheduleId, string revisionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetNestedEntityAsync(scheduleId, revisionId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<SubscriptionScheduleRevision> List(string scheduleId, SubscriptionScheduleRevisionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntities(scheduleId, options, requestOptions);
+        }
+
+        public virtual Task<StripeList<SubscriptionScheduleRevision>> ListAsync(string scheduleId, SubscriptionScheduleRevisionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListNestedEntitiesAsync(scheduleId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<SubscriptionScheduleRevision> ListAutoPaging(string scheduleId, SubscriptionScheduleRevisionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListNestedEntitiesAutoPaging(scheduleId, options, requestOptions);
+        }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCancelOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCancelOptions.cs
@@ -1,0 +1,23 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleCancelOptions : BaseOptions
+    {
+        /// <summary>
+        /// Will generate a final invoice that invoices for any un-invoiced metered usage and new/pending proration invoice items.
+        /// </summary>
+        [JsonProperty("invoice_now")]
+        public bool? InvoiceNow { get; set; }
+
+        /// <summary>
+        /// If the subscription schedule is <code>active</code>, indicates if the cancellation
+        /// should be prorated. Defaults to <code>true</code>.
+        /// </summary>
+        [JsonProperty("prorate")]
+        public bool? Prorate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCreateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCreateOptions.cs
@@ -1,0 +1,31 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleCreateOptions : SubscriptionScheduleSharedOptions
+    {
+        /// <summary>
+        /// The identifier of the customer to create the subscription schedule for.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        /// <summary>
+        /// Migrate an existing subscription to be managed by a subscription schedule. If this
+        /// parameter is set, a subscription schedule will be created using the subscription’s
+        /// plan(s), set to auto-renew using the subscription’s interval. Other parameters cannot
+        /// be set since their values will be inferred from the subscription.
+        /// </summary>
+        [JsonProperty("from_subscription")]
+        public string FromSubscriptionId { get; set; }
+
+        /// <summary>
+        /// The date at which the subscription schedule starts.
+        /// </summary>
+        [JsonProperty("start_date")]
+        public DateTime? StartDate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleInvoiceSettingsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleInvoiceSettingsOptions.cs
@@ -1,0 +1,15 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleInvoiceSettingsOptions : StripeEntity
+    {
+        /// <summary>
+        /// The number of days from which the invoice is created until it is due. Only valid for
+        /// invoices where <c>billing=send_invoice</c>.
+        /// </summary>
+        [JsonProperty("days_until_due")]
+        public long? DaysUntilDue { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
@@ -1,0 +1,38 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleListOptions : ListOptionsWithCreated
+    {
+        [JsonProperty("canceled_at")]
+        public DateTime? CanceledAt { get; set; }
+
+        [JsonProperty("canceled_at")]
+        public DateRangeOptions CanceledAtRange { get; set; }
+
+        [JsonProperty("completed_at")]
+        public DateTime? CompletedAt { get; set; }
+
+        [JsonProperty("completed_at")]
+        public DateRangeOptions CompletedAtRange { get; set; }
+
+        /// <summary>
+        /// Only return subscription schedules for the given customer.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        [JsonProperty("released_at")]
+        public DateTime? ReleasedAt { get; set; }
+
+        [JsonProperty("released_at")]
+        public DateRangeOptions ReleasedAtRange { get; set; }
+
+        /// <summary>
+        /// Only return subscription schedules that have not started yet.
+        /// </summary>
+        [JsonProperty("scheduled")]
+        public bool? Scheduled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
@@ -1,0 +1,26 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionSchedulePhaseItemOptions : INestedOptions
+    {
+        /// <summary>
+        /// Plan ID for this item.
+        /// </summary>
+        [JsonProperty("plan")]
+        public string PlanId { get; set; }
+
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionItemBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Quantity for this item.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long? Quantity { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -1,0 +1,70 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionSchedulePhaseOptions : INestedOptions
+    {
+        /// <summary>
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner’s Stripe account.
+        /// </summary>
+        [JsonProperty("application_fee_percent")]
+        public decimal? ApplicationFeePercent { get; set; }
+
+        /// <summary>
+        /// The code of the coupon to apply to this subscription. A coupon applied to a
+        /// subscription will only affect invoices created for that particular subscription.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string CouponId { get; set; }
+
+        /// <summary>
+        /// The date at which this phase of the subscription schedule ends. If set,
+        /// <code>iterations</code> must not be set.
+        /// </summary>
+        [JsonProperty("end_date")]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Integer representing the multiplier applied to the plan interval. For example,
+        /// <code>iterations=2</code> applied to a plan with <code>interval=month</code> and
+        /// <code>interval_count=3</code> results in a phase of duration 2 * 3 months = 6 months.
+        /// If set, <code>end_date</code> must not be set.
+        /// </summary>
+        [JsonProperty("iterations")]
+        public long? Iterations { get; set; }
+
+        /// <summary>
+        /// List of configuration items, each with an attached plan, to apply during this phase of
+        /// the subscription schedule.
+        /// </summary>
+        [JsonProperty("plans")]
+        public List<SubscriptionSchedulePhaseItemOptions> Plans { get; set; }
+
+        /// <summary>
+        /// A non-negative decimal (with at most four decimal places) between 0 and 100. This
+        /// represents the percentage of the subscription invoice subtotal that will be calculated
+        /// and added as tax to the final amount each billing period. For example, a plan which
+        /// charges $10/month with a <code>tax_percent</code> of 20.0 will charge $12 per invoice.
+        /// </summary>
+        [JsonProperty("tax_percent")]
+        public decimal? TaxPercent { get; set; }
+
+        /// <summary>
+        /// If set to <code>true</code> the entire phase is counted as a trial and the customer
+        /// will not be charged for any fees.
+        /// </summary>
+        [JsonProperty("trial")]
+        public bool? Trial { get; set; }
+
+        /// <summary>
+        /// Sets the phase to trialing from the start date to this date. Must be before the phase
+        /// end date, can not be combined with <code>trial</code>.
+        /// </summary>
+        [JsonProperty("trial_end")]
+        public DateTime? TrialEnd { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleReleaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleReleaseOptions.cs
@@ -1,0 +1,16 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleReleaseOptions : BaseOptions
+    {
+        /// <summary>
+        /// Keep any cancellation on the subscription that the schedule has set.
+        /// </summary>
+        [JsonProperty("preserve_cancel_date")]
+        public bool? PreserveCancelDate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleRenewalIntervalOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleRenewalIntervalOptions.cs
@@ -1,0 +1,21 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleRenewalIntervalOptions : StripeEntity
+    {
+        /// <summary>
+        /// Interval at which to renew the subscription schedule for when it ends. Possible values
+        /// are <code>day</code>, <code>week</code>, <code>month</code>, or <code>year</code>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// Number of intervals to renew the subscription schedule for when it ends.
+        /// </summary>
+        [JsonProperty("length")]
+        public long? Length { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -1,0 +1,90 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class SubscriptionScheduleService : Service<SubscriptionSchedule>,
+        ICreatable<SubscriptionSchedule, SubscriptionScheduleCreateOptions>,
+        IListable<SubscriptionSchedule, SubscriptionScheduleListOptions>,
+        IRetrievable<SubscriptionSchedule>,
+        IUpdatable<SubscriptionSchedule, SubscriptionScheduleUpdateOptions>
+    {
+        public SubscriptionScheduleService()
+            : base(null)
+        {
+        }
+
+        public SubscriptionScheduleService(string apiKey)
+            : base(apiKey)
+        {
+        }
+
+        public override string BasePath => "/subscription_schedules";
+
+        public virtual SubscriptionSchedule Cancel(string scheduleId, SubscriptionScheduleCancelOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<SubscriptionSchedule>($"{this.InstanceUrl(scheduleId)}/cancel", options, requestOptions);
+        }
+
+        public virtual Task<SubscriptionSchedule> CancelAsync(string scheduleId, SubscriptionScheduleCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<SubscriptionSchedule>($"{this.InstanceUrl(scheduleId)}/cancel", options, requestOptions, cancellationToken);
+        }
+
+        public virtual SubscriptionSchedule Create(SubscriptionScheduleCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<SubscriptionSchedule> CreateAsync(SubscriptionScheduleCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual SubscriptionSchedule Get(string scheduleId, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(scheduleId, null, requestOptions);
+        }
+
+        public virtual Task<SubscriptionSchedule> GetAsync(string scheduleId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetEntityAsync(scheduleId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<SubscriptionSchedule> List(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<SubscriptionSchedule>> ListAsync(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<SubscriptionSchedule> ListAutoPaging(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual SubscriptionSchedule Release(string scheduleId, SubscriptionScheduleReleaseOptions options, RequestOptions requestOptions = null)
+        {
+            return this.PostRequest<SubscriptionSchedule>($"{this.InstanceUrl(scheduleId)}/release", options, requestOptions);
+        }
+
+        public virtual Task<SubscriptionSchedule> ReleaseAsync(string scheduleId, SubscriptionScheduleReleaseOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.PostRequestAsync<SubscriptionSchedule>($"{this.InstanceUrl(scheduleId)}/release", options, requestOptions, cancellationToken);
+        }
+
+        public virtual SubscriptionSchedule Update(string scheduleId, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(scheduleId, options, requestOptions);
+        }
+
+        public virtual Task<SubscriptionSchedule> UpdateAsync(string scheduleId, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.UpdateEntityAsync(scheduleId, options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
@@ -1,0 +1,66 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public abstract class SubscriptionScheduleSharedOptions : BaseOptions
+    {
+        /// <summary>
+        /// One of <see cref="Billing" />. When charging automatically, Stripe will attempt to pay
+        /// this subscription at the end of the cycle using the default source attached to the
+        /// customer. When sending an invoice, Stripe will email your customer an invoice with
+        /// payment instructions. Defaults to <c>charge_automatically</c>.
+        /// </summary>
+        [JsonProperty("billing")]
+        public Billing? Billing { get; set; }
+
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Define the default settings applied to invoices created by this subscription schedule.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettingsOptions InvoiceSettings { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription schedule object.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// List representing phases of the subscription schedule. Each phase can be customized to
+        /// have different durations, plans, and coupons. If there are multiple phases, the
+        /// <code>end_date</code> of one phase will always equal the <code>start_date</code> of the
+        /// next phase.
+        /// </summary>
+        [JsonProperty("phases")]
+        public List<SubscriptionSchedulePhaseOptions> Phases { get; set; }
+
+        /// <summary>
+        /// Configures how the subscription schedule behaves when it ends. Possible values are
+        /// <code>none</code>, <code>release</code>, or <code>renew</code>. <code>renew</code> will
+        /// create a new subscription schedule revision by adding a new phase using the most recent
+        /// phase’s plans applied to a duration set by <code>renewal_interval</code>.
+        /// <code>none</code> will stop the subscription schedule and cancel the underlying
+        /// subscription. <code>release</code> will stop the subscription schedule, but keep the
+        /// underlying subscription running.
+        /// </summary>
+        [JsonProperty("renewal_behavior")]
+        public string RenewalBehavior { get; set; }
+
+        /// <summary>
+        /// Configuration for renewing the subscription schedule when it ends. Must be set if
+        /// <code>renewal_behavior</code> is <code>renew</code>. Otherwise, must not be set.
+        /// </summary>
+        [JsonProperty("renewal_interval")]
+        public SubscriptionScheduleRenewalIntervalOptions RenewalInterval { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleUpdateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleUpdateOptions.cs
@@ -1,0 +1,17 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleUpdateOptions : SubscriptionScheduleSharedOptions
+    {
+        /// <summary>
+        /// If the update changes the current phase, indicates if the changes should be prorated.
+        /// Defaults to <code>true</code>.
+        /// </summary>
+        [JsonProperty("prorate")]
+        public bool? Prorate { get; set; }
+    }
+}

--- a/src/StripeTests/Entities/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionTest.cs
+++ b/src/StripeTests/Entities/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionTest.cs
@@ -1,0 +1,25 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class SubscriptionScheduleRevisionTest : BaseStripeTest
+    {
+        public SubscriptionScheduleRevisionTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            string json = this.GetFixture("/v1/subscription_schedules/sub_sched_123/revisions/sub_sched_rev_123");
+            var scheduleRevision = JsonConvert.DeserializeObject<SubscriptionScheduleRevision>(json);
+            Assert.NotNull(scheduleRevision);
+            Assert.IsType<SubscriptionScheduleRevision>(scheduleRevision);
+            Assert.NotNull(scheduleRevision.Id);
+            Assert.Equal("subscription_schedule_revision", scheduleRevision.Object);
+        }
+    }
+}

--- a/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
+++ b/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
@@ -1,0 +1,50 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class SubscriptionScheduleTest : BaseStripeTest
+    {
+        public SubscriptionScheduleTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            string json = this.GetFixture("/v1/subscription_schedules/sub_sched_123");
+            var schedule = JsonConvert.DeserializeObject<SubscriptionSchedule>(json);
+            Assert.NotNull(schedule);
+            Assert.IsType<SubscriptionSchedule>(schedule);
+            Assert.NotNull(schedule.Id);
+            Assert.Equal("subscription_schedule", schedule.Object);
+        }
+
+        [Fact]
+        public void DeserializeWithExpansions()
+        {
+            // TODO: support expanding "phases.coupon" and "phases.plans.plan" with stripe-mock
+            string[] expansions =
+            {
+              "customer",
+              "phases.plans.plan",
+              "subscription"
+            };
+
+            string json = this.GetFixture("/v1/subscription_schedules/sub_sched_123", expansions);
+            var schedule = JsonConvert.DeserializeObject<SubscriptionSchedule>(json);
+            Assert.NotNull(schedule);
+            Assert.IsType<SubscriptionSchedule>(schedule);
+            Assert.NotNull(schedule.Id);
+            Assert.Equal("subscription_schedule", schedule.Object);
+
+            Assert.NotNull(schedule.Customer);
+            Assert.Equal("customer", schedule.Customer.Object);
+
+            Assert.NotNull(schedule.Subscription);
+            Assert.Equal("subscription", schedule.Subscription.Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -36,17 +36,17 @@ namespace StripeTests
 
             this.confirmOptions = new PaymentIntentConfirmOptions
             {
-                SaveSourceToCustomer = true,
+                ReceiptEmail = "stripe@stripe.com",
             };
 
             this.createOptions = new PaymentIntentCreateOptions
             {
-                AllowedSourceTypes = new List<string>
+                Amount = 1000,
+                Currency = "usd",
+                PaymentMethodTypes = new List<string>
                 {
                     "card",
                 },
-                Amount = 1000,
-                Currency = "usd",
                 TransferData = new PaymentIntentTransferDataOptions
                 {
                     Amount = 100,

--- a/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
@@ -1,0 +1,77 @@
+namespace StripeTests
+{
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class SubscriptionScheduleRevisionServiceTest : BaseStripeTest
+    {
+        private const string ScheduleId = "sub_sched_123";
+        private const string RevisionId = "sub_sched_rev_123";
+
+        private readonly SubscriptionScheduleRevisionService service;
+        private readonly SubscriptionScheduleRevisionListOptions listOptions;
+
+        public SubscriptionScheduleRevisionServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.service = new SubscriptionScheduleRevisionService();
+
+            this.listOptions = new SubscriptionScheduleRevisionListOptions
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var revision = this.service.Get(ScheduleId, RevisionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123/revisions/sub_sched_rev_123");
+            Assert.NotNull(revision);
+            Assert.Equal("subscription_schedule_revision", revision.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var revision = await this.service.GetAsync(ScheduleId, RevisionId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123/revisions/sub_sched_rev_123");
+            Assert.NotNull(revision);
+            Assert.Equal("subscription_schedule_revision", revision.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var revisions = this.service.List(ScheduleId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123/revisions");
+            Assert.NotNull(revisions);
+            Assert.Equal("list", revisions.Object);
+            Assert.Single(revisions.Data);
+            Assert.Equal("subscription_schedule_revision", revisions.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var revisions = await this.service.ListAsync(ScheduleId, this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123/revisions");
+            Assert.NotNull(revisions);
+            Assert.Equal("list", revisions.Object);
+            Assert.Single(revisions.Data);
+            Assert.Equal("subscription_schedule_revision", revisions.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var revisions = this.service.ListAutoPaging(ScheduleId, this.listOptions).ToList();
+            Assert.NotNull(revisions);
+            Assert.Equal("subscription_schedule_revision", revisions[0].Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -1,0 +1,177 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class SubscriptionScheduleServiceTest : BaseStripeTest
+    {
+        private const string ScheduleId = "sub_sched_123";
+
+        private readonly SubscriptionScheduleService service;
+        private readonly SubscriptionScheduleCancelOptions cancelOptions;
+        private readonly SubscriptionScheduleCreateOptions createOptions;
+        private readonly SubscriptionScheduleListOptions listOptions;
+        private readonly SubscriptionScheduleReleaseOptions releaseOptions;
+        private readonly SubscriptionScheduleUpdateOptions updateOptions;
+
+        public SubscriptionScheduleServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.service = new SubscriptionScheduleService();
+
+            this.cancelOptions = new SubscriptionScheduleCancelOptions
+            {
+                InvoiceNow = true,
+                Prorate = true,
+            };
+
+            this.createOptions = new SubscriptionScheduleCreateOptions
+            {
+                CustomerId = "cus_123",
+            };
+
+            this.releaseOptions = new SubscriptionScheduleReleaseOptions
+            {
+                PreserveCancelDate = true,
+            };
+
+            this.updateOptions = new SubscriptionScheduleUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
+            };
+
+            this.listOptions = new SubscriptionScheduleListOptions
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void Cancel()
+        {
+            var subscription = this.service.Cancel(ScheduleId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123/cancel");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public async Task CancelAsync()
+        {
+            var subscription = await this.service.CancelAsync(ScheduleId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123/cancel");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var subscription = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var subscription = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var subscription = this.service.Get(ScheduleId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var subscription = await this.service.GetAsync(ScheduleId);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules/sub_sched_123");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var subscriptions = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules");
+            Assert.NotNull(subscriptions);
+            Assert.Equal("list", subscriptions.Object);
+            Assert.Single(subscriptions.Data);
+            Assert.Equal("subscription_schedule", subscriptions.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var subscriptions = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/subscription_schedules");
+            Assert.NotNull(subscriptions);
+            Assert.Equal("list", subscriptions.Object);
+            Assert.Single(subscriptions.Data);
+            Assert.Equal("subscription_schedule", subscriptions.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var subscriptions = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(subscriptions);
+            Assert.Equal("subscription_schedule", subscriptions[0].Object);
+        }
+
+        [Fact]
+        public void Release()
+        {
+            var subscription = this.service.Release(ScheduleId, this.releaseOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123/release");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public async Task ReleaseAsync()
+        {
+            var subscription = await this.service.ReleaseAsync(ScheduleId, this.releaseOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123/release");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var subscription = this.service.Update(ScheduleId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+
+        [Fact]
+        public async Task UpdateAsync()
+        {
+            var subscription = await this.service.UpdateAsync(ScheduleId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/subscription_schedules/sub_sched_123");
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+    }
+}

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -12,7 +12,7 @@ namespace StripeTests
         /// <remarks>
         /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.43.0";
+        private const string MockMinimumVersion = "0.44.0";
 
         private readonly string origApiBase;
         private readonly string origFilesBase;


### PR DESCRIPTION
Add support for Subscription Schedule APIs

* Add Subscription Schedule
* Add Subscription Schedule Revisions
* Add `invoice_settings` on the Customer


cc @stripe/api-libraries 