### PR TITLE
`AnyOf<>` generic class to handle polymorphic parameters

### DIFF
--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -100,6 +100,10 @@ namespace Stripe.Infrastructure.FormEncoding
                     flatParams = SingleParam(keyPrefix, string.Empty);
                     break;
 
+                case IAnyOf anyOf:
+                    flatParams = FlattenParamsValue(anyOf.Value, keyPrefix);
+                    break;
+
                 case INestedOptions options:
                     flatParams = FlattenParamsOptions(options, keyPrefix);
                     break;

--- a/src/Stripe.net/Infrastructure/JsonConverters/AnyOfConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/AnyOfConverter.cs
@@ -1,0 +1,106 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converts a <see cref="IAnyOf"/> to and from JSON.
+    /// </summary>
+    public class AnyOfConverter : JsonConverter
+    {
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.
+        /// </value>
+        public override bool CanWrite => true;
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            switch (value)
+            {
+                case null:
+                    serializer.Serialize(writer, null);
+                    break;
+
+                case IAnyOf anyOf:
+                    serializer.Serialize(writer, anyOf.Value);
+                    break;
+
+                default:
+                    throw new JsonSerializationException(string.Format(
+                        "Unexpected value when converting AnyOf. Expected IAnyOf, got {0}.",
+                        value.GetType()));
+            }
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            object o = null;
+
+            // Try to deserialize with each possible type
+            var jToken = JToken.Load(reader);
+            foreach (var type in objectType.GenericTypeArguments)
+            {
+                try
+                {
+                    using (var subReader = jToken.CreateReader())
+                    {
+                        o = serializer.Deserialize(subReader, type);
+                    }
+
+                    // If deserialization succeeds, stop
+                    break;
+                }
+                catch (JsonException)
+                {
+                    // Do nothing, just try the next type
+                }
+            }
+
+            if (o == null)
+            {
+                throw new JsonSerializationException(string.Format(
+                    "Cannot deserialize the current JSON object into any of the expected types ({0}).",
+                    string.Join(", ", objectType.GenericTypeArguments.Select(t => t.FullName))));
+            }
+
+            return Activator.CreateInstance(objectType, o);
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        ///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(IAnyOf).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+}

--- a/src/Stripe.net/Services/Account/AccountSharedOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountSharedOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
@@ -25,14 +24,22 @@ namespace Stripe
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// <para>
+        /// A card or bank account to attach to the account. You can provide either a token, like
+        /// the ones returned by <a href="https://stripe.com/docs/stripe.js">Stripe.js</a>, or a
+        /// <see cref="AccountBankAccountOptions"/> or <see cref="AccountCardOptions"/> instance.
+        /// </para>
+        /// <para>
+        /// By default, providing an external account sets it as the new default external account
+        /// for its currency, and deletes the old default if one exists. To add additional external
+        /// accounts without replacing the existing default for the currency, use the bank account
+        /// or card creation API.
+        /// </para>
+        /// </summary>
         [JsonProperty("external_account")]
-        public string ExternalAccountId { get; set; }
-
-        [JsonProperty("external_account")]
-        public AccountCardOptions ExternalCardAccount { get; set; }
-
-        [JsonProperty("external_account")]
-        public AccountBankAccountOptions ExternalBankAccount { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, AccountBankAccountOptions, AccountCardOptions> ExternalAccount { get; set; }
 
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionListOptions.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionListOptions.cs
@@ -2,14 +2,17 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class BalanceTransactionListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// A filter on the list based on the object available_on field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("available_on")]
-        public DateTime? AvailableOn { get; set; }
-
-        [JsonProperty("available_on")]
-        public DateRangeOptions AvailableOnRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> AvailableOn { get; set; }
 
         [JsonProperty("currency")]
         public string Currency { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountCreateOptions.cs
@@ -1,13 +1,18 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class BankAccountCreateOptions : BaseOptions
     {
+        /// <summary>
+        /// REQUIRED. Either a token, like the ones returned by
+        /// <a href="https://stripe.com/docs/stripe.js">Stripe.js</a>, or a
+        /// <see cref="SourceBankAccount"/> instance containing a user’s bank account
+        /// details.
+        /// </summary>
         [JsonProperty("source")]
-        public string SourceToken { get; set; }
-
-        [JsonProperty("source")]
-        public SourceBankAccount SourceBankAccount { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, SourceBankAccount> Source { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Cards/CardCreateOptions.cs
+++ b/src/Stripe.net/Services/Cards/CardCreateOptions.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class CardCreateOptions : BaseOptions
     {
@@ -12,11 +12,15 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// REQUIRED. Either a token, like the ones returned by
+        /// <a href="https://stripe.com/docs/stripe.js">Stripe.js</a>, or a
+        /// <see cref="CardCreateNestedOptions"/> instance containing a user’s card
+        /// details.
+        /// </summary>
         [JsonProperty("source")]
-        public string SourceToken { get; set; }
-
-        [JsonProperty("source")]
-        public CardCreateNestedOptions SourceCard { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         [JsonProperty("validate")]
         public bool? Validate { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -3,6 +3,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class ChargeCreateOptions : BaseOptions
     {
@@ -92,11 +93,15 @@ namespace Stripe
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        /// <summary>
+        /// A payment source to be charged. This can be the ID of a card (i.e., credit or debit
+        /// card), a bank account, a source, a token, or a connected account. For certain
+        /// sources—namely, cards, bank accounts, and attached sources—you must also pass the ID of
+        /// the associated customer.
+        /// </summary>
         [JsonProperty("source")]
-        public string SourceId { get; set; }
-
-        [JsonProperty("source")]
-        public CardCreateNestedOptions SourceCard { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         /// <summary>
         /// An arbitrary string to be displayed on your customer's credit card statement. This may

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -64,11 +64,23 @@ namespace Stripe
         [JsonProperty("shipping")]
         public ShippingOptions Shipping { get; set; }
 
+        /// <summary>
+        /// The source can either be a Token or a Source, as returned by
+        /// <a href="https://stripe.com/docs/elements">Elements</a>, or a
+        /// <see cref="CardCreateNestedOptions"/> containing a user’s credit card details. You must
+        /// provide a source if the customer does not already have a valid source attached, and you
+        /// are subscribing the customer to be charged automatically for a plan that is not free.
+        /// Passing <c>source</c> will create a new source object, make it the customer default
+        /// source, and delete the old customer default if one exists. If you want to add an
+        /// additional source, instead use
+        /// <see cref="CardService.Create(string, CardCreateOptions, RequestOptions)"/> to add the
+        /// card and then <see cref="CustomerService.Update(string, CustomerUpdateOptions, RequestOptions)"/>
+        /// to set it as the default. Whenever you attach a card to a customer, Stripe will
+        /// automatically validate the card.
+        /// </summary>
         [JsonProperty("source")]
-        public string SourceToken { get; set; }
-
-        [JsonProperty("source")]
-        public CardCreateNestedOptions SourceCard { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         /// <summary>
         /// Describes the customer’s tax exemption status. One of <c>none</c>, <c>exempt</c>, or
@@ -90,35 +102,8 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
-        #region Trial End
-
-        [JsonIgnore]
-        public DateTime? TrialEnd { get; set; }
-
-        [JsonIgnore]
-        public bool EndTrialNow { get; set; }
-
         [JsonProperty("trial_end")]
-        internal string TrialEndInternal
-        {
-            get
-            {
-                if (this.EndTrialNow)
-                {
-                    return "now";
-                }
-                else if (this.TrialEnd.HasValue)
-                {
-                    return EpochTime.ConvertDateTimeToEpoch(this.TrialEnd.Value).ToString();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
-
-        #endregion
+        public AnyOf<DateTime?, SubscriptionTrialEnd?> TrialEnd { get; set; }
 
         [JsonProperty("validate")]
         public bool? Validate { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -3,6 +3,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class CustomerUpdateOptions : BaseOptions
     {
@@ -57,11 +58,18 @@ namespace Stripe
         [JsonProperty("shipping")]
         public ShippingOptions Shipping { get; set; }
 
+        /// <summary>
+        /// A Token’s or a Source’s ID, as returned by
+        /// <a href="https://stripe.com/docs/elements">Elements</a>. Passing <c>source</c> will
+        /// create a new source object, make it the new customer default source, and delete the old\
+        /// customer default if one exists. If you want to add additional sources instead of
+        /// replacing the existing default, use
+        /// <see cref="CardService.Create(string, CardCreateOptions, RequestOptions)"/>. Whenever
+        /// you attach a card to a customer, Stripe will automatically validate the card.
+        /// </summary>
         [JsonProperty("source")]
-        public string SourceToken { get; set; }
-
-        [JsonProperty("source")]
-        public CardCreateNestedOptions SourceCard { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         /// <summary>
         /// Describes the customer’s tax exemption status. One of <c>none</c>,  <c>exempt</c>, or

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
@@ -2,19 +2,33 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class ExternalAccountCreateOptions : BaseOptions
     {
+        /// <summary>
+        /// REQUIRED. Either a token, like the ones returned by
+        /// <a href="https://stripe.com/docs/stripe.js">Stripe.js</a>, or a
+        /// <see cref="AccountBankAccountOptions"/> instance containing a user’s bank account
+        /// details.
+        /// </summary>
         [JsonProperty("external_account")]
-        public string ExternalAccountTokenId { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, AccountBankAccountOptions> ExternalAccount { get; set; }
 
-        [JsonProperty("external_account")]
-        public AccountBankAccountOptions ExternalAccountBankAccount { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
-
+        /// <summary>
+        /// When set to <c>true</c>, or if this is the first external account added in this
+        /// currency, this account becomes the default external account for its currency.
+        /// </summary>
         [JsonProperty("default_for_currency")]
         public bool? DefaultForCurrency { get; set; }
-    }
+
+        /// <summary>
+        /// A set of key-value pairs that you can attach to an external account object. It can be
+        /// useful for storing additional information about the external account in a structured
+        /// format.
+        /// </summary>
+         [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+   }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class InvoiceListOptions : ListOptions
     {
@@ -11,26 +12,36 @@ namespace Stripe
         [JsonProperty("billing")]
         public Billing? Billing { get; set; }
 
-        [JsonProperty("created")]
-        public DateTime? Created { get; set; }
-
         /// <summary>
-        /// A filter on the list based on the object created field.
+        /// A filter on the list based on the object <c>created</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
         /// </summary>
         [JsonProperty("created")]
-        public DateRangeOptions CreatedRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
+        /// <summary>
+        /// Only return invoices for the customer specified by this customer ID.
+        /// </summary>
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
-        [JsonProperty("due_date")]
-        public DateTime? DueDate { get; set; }
+        /// <summary>
+        /// A filter on the list based on the object <c>date</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
+        [Obsolete("Use Created instead")]
+        [JsonProperty("date")]
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Date { get; set; }
 
         /// <summary>
-        /// A filter on the list based on the object due_date field.
+        /// A filter on the list based on the object <c>due_date</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
         /// </summary>
         [JsonProperty("due_date")]
-        public DateRangeOptions DueDateRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> DueDate { get; set; }
 
         /// <summary>
         /// A filter on the list based on the object paid field.
@@ -38,6 +49,9 @@ namespace Stripe
         [JsonProperty("paid")]
         public bool? Paid { get; set; }
 
+        /// <summary>
+        /// Only return invoices for the subscription specified by this subscription ID.
+        /// </summary>
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -29,43 +29,16 @@ namespace Stripe
         [JsonProperty("invoice_items")]
         public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
 
-        #region SubscriptionBillingCycleAnchor
-
         /// <summary>
-        /// For new subscriptions, a future timestamp to anchor the subscription’s
-        /// <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
-        /// This is used to determine the date of the first full invoice, and, for plans with
-        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.For
-        /// existing subscriptions, the value can only be set to <c>now</c> or <c>unchanged</c>.
+        /// For new subscriptions, a future <see cref="DateTime"/> to anchor the subscription’s
+        /// <a href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</a>. This
+        /// is used to determine the date of the first full invoice, and, for plans with
+        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices. For
+        /// existing subscriptions, the value can only be set to one of
+        /// <see cref="Stripe.SubscriptionBillingCycleAnchor"/>.
         /// </summary>
-        [JsonIgnore]
-        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
-
-        [JsonIgnore]
-        public bool SubscriptionBillingCycleAnchorNow { get; set; }
-
-        [JsonIgnore]
-        public bool SubscriptionBillingCycleAnchorUnchanged { get; set; }
-
         [JsonProperty("subscription_billing_cycle_anchor")]
-        internal string SubscriptionBillingCycleAnchorInternal
-        {
-            get
-            {
-                if (this.SubscriptionBillingCycleAnchorNow)
-                {
-                    return "now";
-                }
-
-                if (this.SubscriptionBillingCycleAnchorUnchanged)
-                {
-                    return "unchanged";
-                }
-
-                return this.SubscriptionBillingCycleAnchor?.ConvertDateTimeToEpoch().ToString();
-            }
-        }
-        #endregion
+        public AnyOf<DateTime?, SubscriptionBillingCycleAnchor?> SubscriptionBillingCycleAnchor { get; set; }
 
         /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -29,43 +29,16 @@ namespace Stripe
         [JsonProperty("invoice_items")]
         public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
 
-        #region SubscriptionBillingCycleAnchor
-
         /// <summary>
-        /// For new subscriptions, a future timestamp to anchor the subscription’s
-        /// <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
-        /// This is used to determine the date of the first full invoice, and, for plans with
-        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.For
-        /// existing subscriptions, the value can only be set to <c>now</c> or <c>unchanged</c>.
+        /// For new subscriptions, a future <see cref="DateTime"/> to anchor the subscription’s
+        /// <a href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</a>. This
+        /// is used to determine the date of the first full invoice, and, for plans with
+        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices. For
+        /// existing subscriptions, the value can only be set to one of
+        /// <see cref="Stripe.SubscriptionBillingCycleAnchor"/>.
         /// </summary>
-        [JsonIgnore]
-        public DateTime? SubscriptionBillingCycleAnchor { get; set; }
-
-        [JsonIgnore]
-        public bool SubscriptionBillingCycleAnchorNow { get; set; }
-
-        [JsonIgnore]
-        public bool SubscriptionBillingCycleAnchorUnchanged { get; set; }
-
         [JsonProperty("subscription_billing_cycle_anchor")]
-        internal string SubscriptionBillingCycleAnchorInternal
-        {
-            get
-            {
-                if (this.SubscriptionBillingCycleAnchorNow)
-                {
-                    return "now";
-                }
-
-                if (this.SubscriptionBillingCycleAnchorUnchanged)
-                {
-                    return "unchanged";
-                }
-
-                return this.SubscriptionBillingCycleAnchor?.ConvertDateTimeToEpoch().ToString();
-            }
-        }
-        #endregion
+        public AnyOf<DateTime?, SubscriptionBillingCycleAnchor?> SubscriptionBillingCycleAnchor { get; set; }
 
         /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current

--- a/src/Stripe.net/Services/Orders/OrderStatusTransitionsOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderStatusTransitionsOptions.cs
@@ -2,31 +2,40 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class OrderStatusTransitionsOptions : INestedOptions
     {
+        /// <summary>
+        /// A filter on the list based on the object <c>canceled</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("canceled")]
-        public DateTime? Canceled { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Canceled { get; set; }
 
-        [JsonProperty("canceled")]
-        public DateRangeOptions CanceledRange { get; set; }
-
+        /// <summary>
+        /// A filter on the list based on the object <c>fulfilled</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("fulfilled")]
-        public DateTime? Fulfilled { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Fulfilled { get; set; }
 
-        [JsonProperty("fulfilled")]
-        public DateRangeOptions FulfilledRange { get; set; }
-
+        /// <summary>
+        /// A filter on the list based on the object <c>paid</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("paid")]
-        public DateTime? Paid { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Paid { get; set; }
 
-        [JsonProperty("paid")]
-        public DateRangeOptions PaidRange { get; set; }
-
+        /// <summary>
+        /// A filter on the list based on the object <c>returned</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("returned")]
-        public DateTime? Returned { get; set; }
-
-        [JsonProperty("returned")]
-        public DateRangeOptions ReturnedRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Returned { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Payouts/PayoutListOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutListOptions.cs
@@ -2,14 +2,17 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class PayoutListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// A filter on the list based on the object <c>arrival_date</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("arrival_date")]
-        public DateTime? ArrivalDate { get; set; }
-
-        [JsonProperty("arrival_date")]
-        public DateRangeOptions ArrivalDateRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> ArrivalDate { get; set; }
 
         [JsonProperty("destination")]
         public string Destination { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class PlanCreateOptions : BaseOptions
     {
@@ -35,11 +36,14 @@ namespace Stripe
         [JsonProperty("nickname")]
         public string Nickname { get; set; }
 
+        /// <summary>
+        /// The product whose pricing the created plan will represent. This can either be the ID of
+        /// an existing product, or a <see cref="PlanProductCreateOptions"/> instance containing
+        /// fields used to create a service product.
+        /// </summary>
         [JsonProperty("product")]
-        public PlanProductCreateOptions Product { get; set; }
-
-        [JsonProperty("product")]
-        public string ProductId { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, PlanProductCreateOptions> Product { get; set; }
 
         [JsonProperty("tiers")]
         public List<PlanTierOptions> Tiers { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanTierOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanTierOptions.cs
@@ -4,31 +4,25 @@ namespace Stripe
 
     public class PlanTierOptions : INestedOptions
     {
+        /// <summary>
+        /// The flat billing amount for an entire tier, regardless of the number of units in the
+        /// tier.
+        /// </summary>
         [JsonProperty("flat_amount")]
         public long? FlatAmount { get; set; }
 
+        /// <summary>
+        /// The per unit billing amount for each individual unit for which this tier applies.
+        /// </summary>
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
 
-        #region UpTo
-        [JsonIgnore]
-        public UpToOption UpTo { get; set; }
-
+        /// <summary>
+        /// Specifies the upper bound of this tier. The lower bound of a tier is the upper bound of
+        /// the previous tier adding one. Use <see cref="PlanTierUpTo.Inf"/> to define a fallback
+        /// tier.
+        /// </summary>
         [JsonProperty("up_to")]
-        internal string UpToInternal => this.UpTo is UpToInf ? "inf" : ((UpToBound)this.UpTo).Bound.ToString();
-        #endregion
-
-        public class UpToOption
-        {
-        }
-
-        public class UpToInf : UpToOption
-        {
-        }
-
-        public class UpToBound : UpToOption
-        {
-            public long Bound { get; set; }
-        }
+        public AnyOf<long?, PlanTierUpTo?> UpTo { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Plans/PlanTierUpTo.cs
+++ b/src/Stripe.net/Services/Plans/PlanTierUpTo.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PlanTierUpTo
+    {
+        /// <summary>Use this value to define a fallback tier.</summary>
+        [EnumMember(Value = "inf")]
+        Inf,
+    }
+}

--- a/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class SourceCreateOptions : BaseOptions
     {
@@ -38,9 +39,6 @@ namespace Stripe
         /// </summary>
         [JsonProperty("flow")]
         public string Flow { get; set; }
-
-        [JsonProperty("card")]
-        public string CardId { get; set; }
 
         /// <summary>
         /// Information about a mandate possiblity attached to a source object (generally for bank debits) as well as its acceptance status.
@@ -105,7 +103,8 @@ namespace Stripe
         public SourceBancontactCreateOptions Bancontact { get; set; }
 
         [JsonProperty("card")]
-        public CreditCardOptions Card { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, CreditCardOptions> Card { get; set; }
 
         [JsonProperty("ideal")]
         public SourceIdealCreateOptions Ideal { get; set; }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
@@ -2,20 +2,25 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class SubscriptionScheduleListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// A filter on the list based on the object <c>canceled_at</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("canceled_at")]
-        public DateTime? CanceledAt { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> CanceledAt { get; set; }
 
-        [JsonProperty("canceled_at")]
-        public DateRangeOptions CanceledAtRange { get; set; }
-
+        /// <summary>
+        /// A filter on the list based on the object <c>completed_at</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("completed_at")]
-        public DateTime? CompletedAt { get; set; }
-
-        [JsonProperty("completed_at")]
-        public DateRangeOptions CompletedAtRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> CompletedAt { get; set; }
 
         /// <summary>
         /// Only return subscription schedules for the given customer.
@@ -23,11 +28,13 @@ namespace Stripe
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        /// <summary>
+        /// A filter on the list based on the object <c>released_at</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("released_at")]
-        public DateTime? ReleasedAt { get; set; }
-
-        [JsonProperty("released_at")]
-        public DateRangeOptions ReleasedAtRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> ReleasedAt { get; set; }
 
         /// <summary>
         /// Only return subscription schedules that have not started yet.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionBillingCycleAnchor.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionBillingCycleAnchor.cs
@@ -1,0 +1,18 @@
+namespace Stripe
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum SubscriptionBillingCycleAnchor
+    {
+        /// <summary>Resets the subscription's billing cycle anchor to the current time.</summary>
+        [EnumMember(Value = "now")]
+        Now,
+
+        /// <summary>Leaves the subscription's billing cycle anchor unchanged.</summary>
+        [EnumMember(Value = "unchanged")]
+        Unchanged,
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class SubscriptionListOptions : ListOptionsWithCreated
     {
@@ -12,28 +13,20 @@ namespace Stripe
         public Billing? Billing { get; set; }
 
         /// <summary>
-        /// A filter on the list based on the object current_period_end field.
+        /// A filter on the list based on the object <c>current_period_end</c> field. The value can
+        /// be a <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
         /// </summary>
         [JsonProperty("current_period_end")]
-        public DateTime? CurrentPeriodEnd { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> CurrentPeriodEnd { get; set; }
 
         /// <summary>
-        /// A filter on the list based on the object current_period_end field.
-        /// </summary>
-        [JsonProperty("current_period_end")]
-        public DateRangeOptions CurrentPeriodEndRange { get; set; }
-
-        /// <summary>
-        /// A filter on the list based on the object current_period_start field.
+        /// A filter on the list based on the object <c>current_period_start</c> field. The value
+        /// can be a <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
         /// </summary>
         [JsonProperty("current_period_start")]
-        public DateTime? CurrentPeriodStart { get; set; }
-
-        /// <summary>
-        /// A filter on the list based on the object current_period_start field.
-        /// </summary>
-        [JsonProperty("current_period_start")]
-        public DateRangeOptions CurrentPeriodStartRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> CurrentPeriodStart { get; set; }
 
         /// <summary>
         /// The ID of the customer whose subscriptions will be retrieved.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -84,20 +84,16 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
-        #region TrialEnd
-
         /// <summary>
-        /// Date representing the end of the trial period the customer will get before being charged for the first time. Set <see cref="EndTrialNow"/> to <c>true</c> to end the customer’s trial immediately.
+        /// <see cref="DateTime"/> representing the end of the trial period the customer will get
+        /// before being charged for the first time. This will always overwrite any trials that
+        /// might apply via a subscribed plan. If set, <see cref="TrialEnd"/> will override the
+        /// default trial period of the plan the customer is being subscribed to. The special value
+        /// <see cref="SubscriptionTrialEnd.Now"/> can be provided to end the customer’s trial
+        /// immediately.
         /// </summary>
-        [JsonIgnore]
-        public DateTime? TrialEnd { get; set; }
-
-        [JsonIgnore]
-        public bool EndTrialNow { get; set; }
-
         [JsonProperty("trial_end")]
-        internal string TrialEndInternal => this.EndTrialNow ? "now" : this.TrialEnd?.ConvertDateTimeToEpoch().ToString();
-        #endregion
+        public AnyOf<DateTime?, SubscriptionTrialEnd?> TrialEnd { get; set; }
 
         /// <summary>
         /// Boolean. Decide whether to use the default trial on the plan when creating a subscription.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionTrialEnd.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionTrialEnd.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum SubscriptionTrialEnd
+    {
+        /// <summary>Special value used to end a customer's trial immediately.</summary>
+        [EnumMember(Value = "now")]
+        Now,
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -6,32 +6,14 @@ namespace Stripe
 
     public class SubscriptionUpdateOptions : SubscriptionSharedOptions
     {
-        #region BillingCycleAnchor
-        [JsonIgnore]
-        public bool BillingCycleAnchorNow { get; set; }
-
-        [JsonIgnore]
-        public bool BillingCycleAnchorUnchanged { get; set; }
-
+        /// <summary>
+        /// One of <see cref="SubscriptionBillingCycleAnchor"/>. Setting the value to
+        /// <see cref="SubscriptionBillingCycleAnchor.Now"/> resets the subscription’s billing
+        /// cycle anchor to the current time. For more information, see the billing cycle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+        /// </summary>
         [JsonProperty("billing_cycle_anchor")]
-        internal string BillingCycleAnchorInternal
-        {
-            get
-            {
-                if (this.BillingCycleAnchorNow)
-                {
-                    return "now";
-                }
-
-                if (this.BillingCycleAnchorUnchanged)
-                {
-                    return "unchanged";
-                }
-
-                return null;
-            }
-        }
-        #endregion
+        public SubscriptionBillingCycleAnchor? BillingCycleAnchor { get; set; }
 
         /// <summary>
         /// List of subscription items, each with an attached plan.

--- a/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class TaxRateListOptions : ListOptionsWithCreated
     {
@@ -18,15 +19,11 @@ namespace Stripe
         public bool? Inclusive { get; set; }
 
         /// <summary>
-        /// A filter on the list based on the object percentage field.
+        /// A filter on the list based on the object <c>percentage</c> field. The value can be a
+        /// <see cref="decimal"/> or a <see cref="TaxRatePercentageRangeOptions"/>.
         /// </summary>
         [JsonProperty("percentage")]
-        public decimal? Percentage { get; set; }
-
-        /// <summary>
-        /// A filter on the list based on the object percentage field.
-        /// </summary>
-        [JsonProperty("percentage")]
-        public TaxRatePercentageRangeOptions PercentageRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<decimal?, TaxRatePercentageRangeOptions> Percentage { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
@@ -1,22 +1,39 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class TokenCreateOptions : BaseOptions
     {
+        /// <summary>
+        /// The customer (owned by the application's account) for which to create a token. For use
+        /// only with <a href="https://stripe.com/docs/connect">Stripe Connect</a>. Also, this can
+        /// be used only with an <a href="https://stripe.com/docs/connect/standard-accounts">OAuth
+        /// access token</a> or
+        /// <a href="https://stripe.com/docs/connect/authentication">Stripe-Account header</a>. For
+        /// more details, see <a href="https://stripe.com/docs/connect/shared-customers">Shared
+        /// Customers</a>.
+        /// </summary>
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        /// <summary>
+        /// The card this token will represent. If you also pass in a customer, the card must be the
+        /// ID of a card belonging to the customer. Otherwise, if you do not pass in a customer,
+        /// this is a <see cref="CreditCardOptions"/> instance containing a user's credit card
+        /// details.
+        /// </summary>
         [JsonProperty("card")]
-        public CreditCardOptions Card { get; set; }
+        public AnyOf<string, CreditCardOptions> Card { get; set; }
 
-        [JsonProperty("card")]
-        public string CardId { get; set; }
-
+        /// <summary>
+        /// The bank account this token will represent. If you also pass in a customer, the bank
+        /// account must be the ID of a bank account belonging to the customer. Otherwise, if you do
+        /// not pass in a customer, this is a <see cref="BankAccountOptions"/> instance containing a
+        /// user's bank account details.
+        /// </summary>
         [JsonProperty("bank_account")]
-        public BankAccountOptions BankAccount { get; set; }
-
-        [JsonProperty("bank_account")]
-        public string BankAccountId { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, BankAccountOptions> BankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/_base/AnyOf.cs
+++ b/src/Stripe.net/Services/_base/AnyOf.cs
@@ -1,0 +1,287 @@
+namespace Stripe
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Abstract base class for <c>AnyOf&lt;&gt;</c> generic classes.
+    /// </summary>
+    public abstract class AnyOf : IAnyOf
+    {
+        /// <summary>Gets the value of the current <see cref="AnyOf"/> object.</summary>
+        /// <returns>The value of the current <see cref="AnyOf"/> object.</returns>
+        public abstract object Value { get; }
+
+        /// <summary>Gets the type of the current <see cref="AnyOf"/> object.</summary>
+        /// <returns>The type of the current <see cref="AnyOf"/> object.</returns>
+        public abstract Type Type { get; }
+
+        public override bool Equals(object other) => this.Value.Equals(other);
+
+        public override int GetHashCode() => this.Value.GetHashCode();
+
+        public override string ToString() => this.Value.ToString();
+    }
+
+    /// <summary>
+    /// <see cref="AnyOf{T1, T2}"/> is a generic class that can hold a value of one of two different
+    /// types. It uses implicit conversion operators to seamlessly accept or return either type.
+    /// This is used to represent polymorphic request parameters, i.e. parameters that can
+    /// be different types (typically a string or an options class).
+    /// </summary>
+    /// <typeparam name="T1">The first possible type of the value.</typeparam>
+    /// <typeparam name="T2">The second possible type of the value.</typeparam>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Generic variant")]
+    public class AnyOf<T1, T2> : AnyOf
+    {
+        private readonly T1 value1;
+        private readonly T2 value2;
+        private readonly Values setValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyOf{T1, T2}"/> class with type <c>T1</c>.
+        /// </summary>
+        /// <param name="value">The value to hold.</param>
+        public AnyOf(T1 value)
+        {
+            this.value1 = value;
+            this.setValue = Values.Value1;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyOf{T1, T2}"/> class with type <c>T2</c>.
+        /// </summary>
+        /// <param name="value">The value to hold.</param>
+        public AnyOf(T2 value)
+        {
+            this.value2 = value;
+            this.setValue = Values.Value2;
+        }
+
+        private enum Values
+        {
+            Value1,
+            Value2,
+        }
+
+        /// <summary>Gets the value of the current <see cref="AnyOf{T1, T2}"/> object.</summary>
+        /// <returns>The value of the current <see cref="AnyOf{T1, T2}"/> object.</returns>
+        public override object Value
+        {
+            get
+            {
+                switch (this.setValue)
+                {
+                    case Values.Value1:
+                        return this.value1;
+                    case Values.Value2:
+                        return this.value2;
+                    default:
+                        throw new InvalidOperationException($"Unexpected state, setValue={this.setValue}");
+                }
+            }
+        }
+
+        /// <summary>Gets the type of the current <see cref="AnyOf{T1, T2}"/> object.</summary>
+        /// <returns>The type of the current <see cref="AnyOf{T1, T2}"/> object.</returns>
+        public override Type Type
+        {
+            get
+            {
+                switch (this.setValue)
+                {
+                    case Values.Value1:
+                        return typeof(T1);
+                    case Values.Value2:
+                        return typeof(T2);
+                    default:
+                        throw new InvalidOperationException($"Unexpected state, setValue={this.setValue}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a value of type <c>T1</c> to an <see cref="AnyOf{T1, T2}"/> object.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
+        public static implicit operator AnyOf<T1, T2>(T1 value) => new AnyOf<T1, T2>(value);
+
+        /// <summary>
+        /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2}"/> object.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
+        public static implicit operator AnyOf<T1, T2>(T2 value) => new AnyOf<T1, T2>(value);
+
+        /// <summary>
+        /// Converts an <see cref="AnyOf{T1, T2}"/> object to a value of type <c>T1</c>,
+        /// </summary>
+        /// <param name="anyOf">The <see cref="AnyOf{T1, T2}"/> object to convert.</param>
+        /// <returns>
+        /// A value of type <c>T1</c>. If the <see cref="AnyOf{T1, T2}"/> object currently
+        /// holds a value of a different type, the default value for type <c>T1</c> is returned.
+        /// </returns>
+        public static implicit operator T1(AnyOf<T1, T2> anyOf) => anyOf.value1;
+
+        /// <summary>
+        /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2}"/> object.
+        /// </summary>
+        /// <param name="anyOf">The <see cref="AnyOf{T1, T2}"/> object to convert.</param>
+        /// <returns>
+        /// A value of type <c>T2</c>. If the <see cref="AnyOf{T1, T2}"/> object currently
+        /// holds a value of a different type, the default value for type <c>T2</c> is returned.
+        /// </returns>
+        public static implicit operator T2(AnyOf<T1, T2> anyOf) => anyOf.value2;
+    }
+
+    /// <summary>
+    /// <see cref="AnyOf{T1, T2, T3}"/> is a generic class that can hold a value of one of three
+    /// different types. It uses implicit conversion operators to seamlessly accept or return any
+    /// of the possible types.
+    /// This is used to represent polymorphic request parameters, i.e. parameters that can
+    /// be different types (typically a string or an options class).
+    /// </summary>
+    /// <typeparam name="T1">The first possible type of the value.</typeparam>
+    /// <typeparam name="T2">The second possible type of the value.</typeparam>
+    /// <typeparam name="T3">The third possible type of the value.</typeparam>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Generic variant")]
+    public class AnyOf<T1, T2, T3> : AnyOf
+    {
+        private readonly T1 value1;
+        private readonly T2 value2;
+        private readonly T3 value3;
+        private readonly Values setValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyOf{T1, T2, T3}"/> class with type
+        /// <c>T1</c>.
+        /// </summary>
+        /// <param name="value">The value to hold.</param>
+        public AnyOf(T1 value)
+        {
+            this.value1 = value;
+            this.setValue = Values.Value1;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyOf{T1, T2, T3}"/> class with type
+        /// <c>T2</c>.
+        /// </summary>
+        /// <param name="value">The value to hold.</param>
+        public AnyOf(T2 value)
+        {
+            this.value2 = value;
+            this.setValue = Values.Value2;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyOf{T1, T2, T3}"/> class with type
+        /// <c>T3</c>.
+        /// </summary>
+        /// <param name="value">The value to hold.</param>
+        public AnyOf(T3 value)
+        {
+            this.value3 = value;
+            this.setValue = Values.Value3;
+        }
+
+        private enum Values
+        {
+            Value1,
+            Value2,
+            Value3,
+        }
+
+        /// <summary>Gets the value of the current <see cref="AnyOf{T1, T2, T3}"/> object.</summary>
+        /// <returns>The value of the current <see cref="AnyOf{T1, T2, T3}"/> object.</returns>
+        public override object Value
+        {
+            get
+            {
+                switch (this.setValue)
+                {
+                    case Values.Value1:
+                        return this.value1;
+                    case Values.Value2:
+                        return this.value2;
+                    case Values.Value3:
+                        return this.value3;
+                    default:
+                        throw new InvalidOperationException($"Unexpected state, setValue={this.setValue}");
+                }
+            }
+        }
+
+        /// <summary>Gets the type of the current <see cref="AnyOf{T1, T2, T3}"/> object.</summary>
+        /// <returns>The type of the current <see cref="AnyOf{T1, T2, T3}"/> object.</returns>
+        public override Type Type
+        {
+            get
+            {
+                switch (this.setValue)
+                {
+                    case Values.Value1:
+                        return typeof(T1);
+                    case Values.Value2:
+                        return typeof(T2);
+                    case Values.Value3:
+                        return typeof(T3);
+                    default:
+                        throw new InvalidOperationException($"Unexpected state, setValue={this.setValue}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a value of type <c>T1</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
+        public static implicit operator AnyOf<T1, T2, T3>(T1 value) => new AnyOf<T1, T2, T3>(value);
+
+        /// <summary>
+        /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
+        public static implicit operator AnyOf<T1, T2, T3>(T2 value) => new AnyOf<T1, T2, T3>(value);
+
+        /// <summary>
+        /// Converts a value of type <c>T3</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
+        public static implicit operator AnyOf<T1, T2, T3>(T3 value) => new AnyOf<T1, T2, T3>(value);
+
+        /// <summary>
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T1</c>,
+        /// </summary>
+        /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
+        /// <returns>
+        /// A value of type <c>T1</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
+        /// holds a value of a different type, the default value for type <c>T3</c> is returned.
+        /// </returns>
+        public static implicit operator T1(AnyOf<T1, T2, T3> anyOf) => anyOf.value1;
+
+        /// <summary>
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T2</c>,
+        /// </summary>
+        /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
+        /// <returns>
+        /// A value of type <c>T2</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
+        /// holds a value of a different type, the default value for type <c>T3</c> is returned.
+        /// </returns>
+        public static implicit operator T2(AnyOf<T1, T2, T3> anyOf) => anyOf.value2;
+
+        /// <summary>
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T3</c>,
+        /// </summary>
+        /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
+        /// <returns>
+        /// A value of type <c>T3</c>. If the <see cref="AnyOf{T1, T2, T3}"/> object currently
+        /// holds a value of a different type, the default value for type <c>T3</c> is returned.
+        /// </returns>
+        public static implicit operator T3(AnyOf<T1, T2, T3> anyOf) => anyOf.value3;
+    }
+}

--- a/src/Stripe.net/Services/_base/ListOptionsWithCreated.cs
+++ b/src/Stripe.net/Services/_base/ListOptionsWithCreated.cs
@@ -2,13 +2,16 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class ListOptionsWithCreated : ListOptions
     {
+        /// <summary>
+        /// A filter on the list based on the object <c>created</c> field. The value can be a
+        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
+        /// </summary>
         [JsonProperty("created")]
-        public DateTime? Created { get; set; }
-
-        [JsonProperty("created")]
-        public DateRangeOptions CreatedRange { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IAnyOf.cs
+++ b/src/Stripe.net/Services/_interfaces/IAnyOf.cs
@@ -1,0 +1,18 @@
+namespace Stripe
+{
+    using System;
+
+    /// <summary>
+    /// Represents a value that may be of one of several different types.
+    /// </summary>
+    public interface IAnyOf
+    {
+        /// <summary>Gets the value of the current <see cref="IAnyOf"/> object.</summary>
+        /// <returns>The value of the current <see cref="IAnyOf"/> object.</returns>
+        object Value { get; }
+
+        /// <summary>Gets the type of the current <see cref="IAnyOf"/> object.</summary>
+        /// <returns>The type of the current <see cref="IAnyOf"/> object.</returns>
+        Type Type { get; }
+    }
+}

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -105,6 +105,24 @@ namespace StripeTests
                     want = string.Empty
                 },
 
+                // AnyOf
+                new
+                {
+                    data = new TestOptions
+                    {
+                        AnyOf = "foo",
+                    },
+                    want = "any_of=foo"
+                },
+                new
+                {
+                    data = new TestOptions
+                    {
+                        AnyOf = new Dictionary<string, string> { { "foo", "bar" } },
+                    },
+                    want = "any_of[foo]=bar"
+                },
+
                 // Array
                 new
                 {

--- a/src/StripeTests/Infrastructure/JsonConverters/AnyOfConverterTest.cs
+++ b/src/StripeTests/Infrastructure/JsonConverters/AnyOfConverterTest.cs
@@ -1,0 +1,110 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class AnyOfConverterTest : BaseStripeTest
+    {
+        [Fact]
+        public void DeserializeFirstType()
+        {
+            var json = "{\n  \"any_of\": \"String!\"\n}";
+            var obj = JsonConvert.DeserializeObject<TestObject>(json);
+
+            Assert.NotNull(obj.AnyOf);
+            Assert.Equal("String!", obj.AnyOf);
+        }
+
+        [Fact]
+        public void DeserializeSecondType()
+        {
+            var json = "{\n  \"any_of\": {\n    \"id\": \"id_123\",\n    \"bar\": 42\n  }\n}";
+            var obj = JsonConvert.DeserializeObject<TestObject>(json);
+
+            Assert.NotNull(obj.AnyOf);
+            Assert.Equal("id_123", ((TestSubObject)obj.AnyOf).Id);
+            Assert.Equal(42, ((TestSubObject)obj.AnyOf).Bar);
+        }
+
+        [Fact]
+        public void DeserializeNull()
+        {
+            var json = "{\n  \"any_of\": null\n}";
+            var obj = JsonConvert.DeserializeObject<TestObject>(json);
+
+            Assert.Null(obj.AnyOf);
+        }
+
+        [Fact]
+        public void DeserializeUnexpectedType()
+        {
+            var json = "{\n  \"any_of\": []\n}";
+
+            var exception = Assert.Throws<JsonSerializationException>(() =>
+                JsonConvert.DeserializeObject<TestObject>(json));
+
+            Assert.Contains(
+                "Cannot deserialize the current JSON object into any of the expected types",
+                exception.Message);
+        }
+
+        [Fact]
+        public void SerializeFirstType()
+        {
+            var obj = new TestObject
+            {
+                AnyOf = "String!",
+            };
+
+            var expected = "{\n  \"any_of\": \"String!\"\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        [Fact]
+        public void SerializeSecondType()
+        {
+            var obj = new TestObject
+            {
+                AnyOf = new TestSubObject
+                {
+                    Id = "id_123",
+                    Bar = 42,
+                }
+            };
+
+            var expected =
+                "{\n  \"any_of\": {\n    \"id\": \"id_123\",\n    \"bar\": 42\n  }\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        [Fact]
+        public void SerializeNull()
+        {
+            var obj = new TestObject
+            {
+                AnyOf = null,
+            };
+
+            var expected = "{\n  \"any_of\": null\n}";
+            Assert.Equal(expected, obj.ToJson().Replace("\r\n", "\n"));
+        }
+
+        private class TestSubObject : StripeEntity<TestSubObject>, IHasId
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("bar")]
+            public int Bar { get; set; }
+        }
+
+        private class TestObject : StripeEntity<TestObject>
+        {
+            [JsonProperty("any_of")]
+            [JsonConverter(typeof(AnyOfConverter))]
+            internal AnyOf<string, TestSubObject> AnyOf { get; set; }
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             {
                 Amount = 123,
                 Currency = "usd",
-                SourceId = "tok_visa",
+                Source = "tok_visa",
             };
             this.requestOptions = new RequestOptions();
         }

--- a/src/StripeTests/Infrastructure/TestData/TestOptions.cs
+++ b/src/StripeTests/Infrastructure/TestData/TestOptions.cs
@@ -7,6 +7,7 @@ namespace StripeTests.Infrastructure.TestData
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using Stripe;
+    using Stripe.Infrastructure;
 
     public class TestOptions : BaseOptions
     {
@@ -19,6 +20,10 @@ namespace StripeTests.Infrastructure.TestData
             // TestTwo purposefully doesn't define a serialization value
             TestTwo,
         }
+
+        [JsonProperty("any_of")]
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<string, Dictionary<string, string>> AnyOf { get; set; }
 
         [JsonProperty("array")]
         public string[] Array { get; set; }

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -45,7 +45,7 @@ namespace StripeTests
                     },
                     Name = "Company name",
                 },
-                ExternalAccountId = "tok_visa_debit",
+                ExternalAccount = "tok_visa_debit",
                 RequestedCapabilities = new List<string>
                 {
                     "card_payments",

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -26,7 +26,7 @@ namespace StripeTests
 
             this.createOptions = new BankAccountCreateOptions
             {
-                SourceToken = "btok_123",
+                Source = "btok_123",
             };
 
             this.updateOptions = new BankAccountUpdateOptions

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -29,7 +29,7 @@ namespace StripeTests
 
             this.createOptions = new CardCreateOptions
             {
-                SourceToken = "tok_123",
+                Source = "tok_123",
             };
 
             this.updateOptions = new CardUpdateOptions

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -32,7 +32,7 @@ namespace StripeTests
             {
                 Amount = 123,
                 Currency = "usd",
-                SourceId = "tok_123",
+                Source = "tok_123",
             };
 
             this.updateOptions = new ChargeUpdateOptions

--- a/src/StripeTests/Services/Customers/CustomerCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerCreateOptionsTest.cs
@@ -1,0 +1,39 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class CustomerCreateOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeTrialEnd()
+        {
+            var testCases = new[]
+            {
+                new
+                {
+                    options = new CustomerCreateOptions
+                    {
+                        TrialEnd = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "trial_end=1234567890",
+                },
+                new
+                {
+                    options = new CustomerCreateOptions
+                    {
+                        TrialEnd = SubscriptionTrialEnd.Now,
+                    },
+                    want = "trial_end=now",
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, FormEncoder.CreateQueryString(testCase.options));
+            }
+        }
+    }
+}

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
             this.createOptions = new CustomerCreateOptions
             {
                 Email = "example@example.com",
-                SourceToken = "tok_123",
+                Source = "tok_123",
             };
 
             this.updateOptions = new CustomerUpdateOptions

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
 
             this.createOptions = new ExternalAccountCreateOptions
             {
-                ExternalAccountTokenId = "btok_123",
+                ExternalAccount = "btok_123",
             };
 
             this.updateOptions = new ExternalAccountUpdateOptions

--- a/src/StripeTests/Services/Invoices/UpcomingInvoiceListLineItemsOptionsTest.cs
+++ b/src/StripeTests/Services/Invoices/UpcomingInvoiceListLineItemsOptionsTest.cs
@@ -1,0 +1,47 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class UpcomingInvoiceListLineItemsOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeSubscriptionBillingCycleAnchor()
+        {
+            var testCases = new[]
+            {
+                new
+                {
+                    options = new UpcomingInvoiceListLineItemsOptions
+                    {
+                        SubscriptionBillingCycleAnchor = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "subscription_billing_cycle_anchor=1234567890",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceListLineItemsOptions
+                    {
+                        SubscriptionBillingCycleAnchor = SubscriptionBillingCycleAnchor.Now,
+                    },
+                    want = "subscription_billing_cycle_anchor=now",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceListLineItemsOptions
+                    {
+                        SubscriptionBillingCycleAnchor = SubscriptionBillingCycleAnchor.Unchanged,
+                    },
+                    want = "subscription_billing_cycle_anchor=unchanged",
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, FormEncoder.CreateQueryString(testCase.options));
+            }
+        }
+    }
+}

--- a/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
+++ b/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
@@ -1,0 +1,47 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class UpcomingInvoiceOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeSubscriptionBillingCycleAnchor()
+        {
+            var testCases = new[]
+            {
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionBillingCycleAnchor = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "subscription_billing_cycle_anchor=1234567890",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionBillingCycleAnchor = SubscriptionBillingCycleAnchor.Now,
+                    },
+                    want = "subscription_billing_cycle_anchor=now",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionBillingCycleAnchor = SubscriptionBillingCycleAnchor.Unchanged,
+                    },
+                    want = "subscription_billing_cycle_anchor=unchanged",
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, FormEncoder.CreateQueryString(testCase.options));
+            }
+        }
+    }
+}

--- a/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
@@ -17,15 +17,12 @@ namespace StripeTests
                     new PlanTierOptions
                     {
                         UnitAmount = 1000,
-                        UpTo = new PlanTierOptions.UpToBound
-                        {
-                            Bound = 10
-                        }
+                        UpTo = 10,
                     },
                     new PlanTierOptions
                     {
                         UnitAmount = 2000,
-                        UpTo = new PlanTierOptions.UpToInf()
+                        UpTo = PlanTierUpTo.Inf,
                     }
                 },
             };

--- a/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Collections.Generic;
     using Stripe;
     using Stripe.Infrastructure.FormEncoding;
@@ -8,7 +9,7 @@ namespace StripeTests
     public class SubscriptionCreateOptionsTest : BaseStripeTest
     {
         [Fact]
-        public void Serialize()
+        public void SerializeItems()
         {
             var options = new SubscriptionCreateOptions
             {
@@ -33,6 +34,28 @@ namespace StripeTests
                 "items[0][plan]=plan_123&items[0][quantity]=2&" +
                 "items[1][plan]=plan_124&items[1][quantity]=3",
                 FormEncoder.CreateQueryString(options));
+        }
+
+        [Fact]
+        public void SerializeTrialEndDateTime()
+        {
+            var options = new SubscriptionCreateOptions
+            {
+                TrialEnd = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+            };
+
+            Assert.Equal("trial_end=1234567890", FormEncoder.CreateQueryString(options));
+        }
+
+        [Fact]
+        public void SerializeTrialEndNow()
+        {
+            var options = new SubscriptionCreateOptions
+            {
+                TrialEnd = SubscriptionTrialEnd.Now,
+            };
+
+            Assert.Equal("trial_end=now", FormEncoder.CreateQueryString(options));
         }
     }
 }

--- a/src/StripeTests/Services/_base/AnyOfTest.cs
+++ b/src/StripeTests/Services/_base/AnyOfTest.cs
@@ -1,0 +1,124 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Xunit;
+
+    public class AnyOfTest : BaseStripeTest
+    {
+        [Fact]
+        public void Variant2Types()
+        {
+            var testCases = new[]
+            {
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string>(default(int)),
+                    WantValue = default(int),
+                    WantType = typeof(int),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string>(234),
+                    WantValue = 234,
+                    WantType = typeof(int),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string>(default(string)),
+                    WantValue = default(string),
+                    WantType = typeof(string),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string>("Hello!"),
+                    WantValue = "Hello!",
+                    WantType = typeof(string),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int?, string>(default(int?)),
+                    WantValue = default(int?),
+                    WantType = typeof(int?),
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.WantValue, testCase.AnyOf.Value);
+                Assert.Equal(testCase.WantType, testCase.AnyOf.Type);
+            }
+        }
+
+        [Fact]
+        public void Variant3Types()
+        {
+            var someClass = new SomeClass { SomeString = "foo" };
+            var testCases = new[]
+            {
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string, SomeClass>(default(int)),
+                    WantValue = default(int),
+                    WantType = typeof(int),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string, SomeClass>(234),
+                    WantValue = 234,
+                    WantType = typeof(int),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string, SomeClass>(default(string)),
+                    WantValue = default(string),
+                    WantType = typeof(string),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int, string, SomeClass>("Hello!"),
+                    WantValue = "Hello!",
+                    WantType = typeof(string),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int?, string, SomeClass>(default(int?)),
+                    WantValue = default(int?),
+                    WantType = typeof(int?),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int?, string, SomeClass>(default(SomeClass)),
+                    WantValue = default(SomeClass),
+                    WantType = typeof(SomeClass),
+                },
+                new TestCase
+                {
+                    AnyOf = new AnyOf<int?, string, SomeClass>(someClass),
+                    WantValue = someClass,
+                    WantType = typeof(SomeClass),
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.WantValue, testCase.AnyOf.Value);
+                Assert.Equal(testCase.WantType, testCase.AnyOf.Type);
+            }
+        }
+
+        private class TestCase
+        {
+            public IAnyOf AnyOf { get; set; }
+
+            public object WantValue { get; set; }
+
+            public Type WantType { get; set; }
+        }
+
+        private class SomeClass
+        {
+            public string SomeString { get; set; }
+        }
+    }
+}

--- a/src/StripeTests/Services/_base/ListOptionsWithCreatedTest.cs
+++ b/src/StripeTests/Services/_base/ListOptionsWithCreatedTest.cs
@@ -1,0 +1,60 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class ListOptionsWithCreatedTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeNull()
+        {
+            var options = new ListOptionsWithCreated
+            {
+                Created = null,
+            };
+
+            Assert.Equal(string.Empty, FormEncoder.CreateQueryString(options));
+        }
+
+        [Fact]
+        public void SerializeDateTime()
+        {
+            var options = new ListOptionsWithCreated
+            {
+                Created = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+            };
+
+            Assert.Equal("created=1234567890", FormEncoder.CreateQueryString(options));
+        }
+
+        [Fact]
+        public void SerializeDateTimeNull()
+        {
+            var options = new ListOptionsWithCreated
+            {
+                Created = (DateTime?)null,
+            };
+
+            Assert.Equal("created=", FormEncoder.CreateQueryString(options));
+        }
+
+        [Fact]
+        public void SerializeDateRangeOptions()
+        {
+            var options = new ListOptionsWithCreated
+            {
+                Created = new DateRangeOptions
+                {
+                    GreaterThanOrEqual = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    LessThan = DateTime.Parse("Sun, 1 May 2044 01:28:21Z"),
+                },
+            };
+
+            Assert.Equal(
+                "created[gte]=1234567890&created[lt]=2345678901",
+                FormEncoder.CreateQueryString(options));
+        }
+    }
+}

--- a/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
+++ b/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
@@ -1,0 +1,60 @@
+#if NETCOREAPP
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    /// <summary>
+    /// This wholesome test ensures that no entity or options class reuses the same name in
+    /// different `JsonProperty` attributes.
+    /// </summary>
+    public class NoDuplicateJsonPropertyValues : WholesomeTest
+    {
+        private const string AssertionMessage =
+            "Found at least one duplicate JsonProperty name.";
+
+        [Fact]
+        public void Check()
+        {
+            List<string> results = new List<string>();
+
+            // Get all classes that derive from StripeEntity or implement INestedOptions
+            var stripeClasses = GetSubclassesOf(typeof(StripeEntity));
+            stripeClasses.AddRange(GetClassesWithInterface(typeof(INestedOptions)));
+
+            foreach (Type stripeClass in stripeClasses)
+            {
+                var jsonPropertyNames = new List<string>();
+
+                foreach (PropertyInfo property in stripeClass.GetProperties())
+                {
+                    var propType = property.PropertyType;
+
+                    // Skip properties that don't have a `JsonProperty` attribute
+                    var attribute = property.GetCustomAttribute<JsonPropertyAttribute>();
+                    if (attribute == null)
+                    {
+                        continue;
+                    }
+
+                    if (jsonPropertyNames.Contains(attribute.PropertyName))
+                    {
+                        results.Add($"{stripeClass.Name}.{property.Name}");
+                    }
+                    else
+                    {
+                        jsonPropertyNames.Add(attribute.PropertyName);
+                    }
+                }
+            }
+
+            AssertEmpty(results, AssertionMessage);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Here's a little experiment for better handling of polymorphic request parameters. The `AnyOf<T1, T2>` generic class uses implicit operators to seamlessly accept a value of either type.

One major inconvenience is that this only works for two types. In order to work with three types, we'd need to define another `AnyOf<T1, T2, T3>` overload, etc. Hopefully we don't have too many parameters that accept many different types!

cc @remi-stripe @brandur-stripe What do you think of this approach?