### PR TITLE
Simplify handling of Expand and ExtraParams

### DIFF
--- a/src/Stripe.net/Infrastructure/Extensions/BaseOptionsExtensions.cs
+++ b/src/Stripe.net/Infrastructure/Extensions/BaseOptionsExtensions.cs
@@ -7,15 +7,10 @@ namespace Stripe.Infrastructure.Extensions
     {
         /// <summary>Serializes the parameters with form encoding.</summary>
         /// <param name="options">The options class containing the parameters.</param>
-        /// <param name="includeExtraParams">Whether to include extra parameters in the query string or not.</param>
-        /// <param name="includeExpandParams">Whether to include expand parameters in the query string or not.</param>
         /// <returns>A form-encoded string represensation of the parameters.</returns>
-        public static string ToQueryString(this BaseOptions options, bool includeExtraParams = true, bool includeExpandParams = true)
+        public static string ToQueryString(this BaseOptions options)
         {
-            return FormEncoder.JoinQueries(
-                FormEncoder.EncodeOptions(options),
-                includeExtraParams ? FormEncoder.EncodeDictionary(options.ExtraParams) : null,
-                includeExpandParams ? FormEncoder.EncodeList(options.Expand, "expand") : null);
+            return FormEncoder.EncodeOptions(options);
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/Extensions/ServiceExtensions.cs
+++ b/src/Stripe.net/Infrastructure/Extensions/ServiceExtensions.cs
@@ -19,15 +19,16 @@ namespace Stripe.Infrastructure.Extensions
             where T : IStripeEntity
         {
             var expansions = service.Expansions(isListMethod);
-            if (options != null)
+            if (expansions.Any())
             {
-                expansions.AddRange(options.Expand);
+                options = options ?? new BaseOptions();
+                foreach (var expansion in expansions)
+                {
+                    options.AddExpand(expansion);
+                }
             }
 
-            return FormEncoder.AppendQueries(
-                baseUrl,
-                options?.ToQueryString(includeExtraParams: true, includeExpandParams: false),
-                FormEncoder.EncodeList(expansions, "expand"));
+            return FormEncoder.AppendQueries(baseUrl, options?.ToQueryString());
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/_base/BaseOptions.cs
+++ b/src/Stripe.net/Services/_base/BaseOptions.cs
@@ -1,25 +1,49 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Base class for Stripe options classes, i.e. classes representing parameters for Stripe
     /// API requests.
     /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
     public class BaseOptions : INestedOptions
     {
-        public Dictionary<string, string> ExtraParams { get; set; } = new Dictionary<string, string>();
+        /// <summary>Specifies which fields in the response should be expanded.</summary>
+        [JsonProperty("expand", NullValueHandling=NullValueHandling.Ignore)]
+        public List<string> Expand { get; set; }
 
-        public List<string> Expand { get; set; } = new List<string>();
+        /// <summary>Dictionary containing extra request parameters.</summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> ExtraParams { get; set; }
+            = new Dictionary<string, object>();
 
-        public void AddExtraParam(string key, string value)
-        {
-            this.ExtraParams.Add(key, value);
-        }
-
+        /// <summary>
+        /// Adds an <c>expand</c> value to the request, to request expansion of a specific
+        /// field in the response. When requesting expansions in a list request, don't forget
+        /// to prefix the field names with <c>data.</c>.
+        /// </summary>
+        /// <param name="value">The name of the field to expand.</param>
         public void AddExpand(string value)
         {
+            if (this.Expand == null)
+            {
+                this.Expand = new List<string>();
+            }
+
             this.Expand.Add(value);
+        }
+
+        /// <summary>
+        /// Adds an extra parameter to the request. This can be useful if you need to use
+        /// parameters not available in regular options classes, e.g. for beta features.
+        /// </summary>
+        /// <param name="key">The parameter's key.</param>
+        /// <param name="value">The parameter's value.</param>
+        public void AddExtraParam(string key, object value)
+        {
+            this.ExtraParams.Add(key, value);
         }
     }
 }

--- a/src/StripeTests/Infrastructure/Extensions/ServiceExtensionsTest.cs
+++ b/src/StripeTests/Infrastructure/Extensions/ServiceExtensionsTest.cs
@@ -47,7 +47,7 @@ namespace StripeTests
 
             var url = this.service.ApplyAllParameters(options, string.Empty, false);
             Assert.Equal(
-                "?expand[0]=simple&expand[1]=multi_word_property&expand[2]=foo&expand[3]=bar.baz",
+                "?expand[0]=foo&expand[1]=bar.baz&expand[2]=simple&expand[3]=multi_word_property",
                 url);
         }
     }

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -238,65 +238,6 @@ namespace StripeTests
         }
 
         [Fact]
-        public void EncodeDictionary()
-        {
-            var testCases = new[]
-            {
-                // No data
-                new
-                {
-                    data = new Dictionary<object, object> { },
-                    want = string.Empty
-                },
-
-                // Mixed key types
-                new
-                {
-                    data = new Dictionary<object, object>
-                    {
-                        { "1", "one" },
-                        { 2, "two" },
-                        { 3.14, "pi" },
-                    },
-                    want = "1=one&2=two&3.14=pi"
-                },
-
-                // Container values
-                new
-                {
-                    data = new Dictionary<object, object>
-                    {
-                        { "dictionary", new Dictionary<object, object> { { "foo", "bar" } } },
-                        { "list", new List<object> { 1, "two", 3.14 } },
-                        { "options", new TestOptions { String = "hello world" } },
-                    },
-                    want = "dictionary[foo]=bar&" +
-                        "list[0]=1&list[1]=two&list[2]=3.14&" +
-                        "options[string]=hello+world"
-                },
-            };
-
-            foreach (var testCase in testCases)
-            {
-                Assert.Equal(testCase.want, FormEncoder.EncodeDictionary(testCase.data));
-            }
-        }
-
-        [Fact]
-        public void EncodeList()
-        {
-            Assert.Null(FormEncoder.EncodeList(new List<object> { }, "list", false));
-
-            Assert.Equal(
-                "list=",
-                FormEncoder.EncodeList(new List<object> { }, "list", true));
-
-            Assert.Equal(
-                "list[0]=1&list[1]=two&list[2]=3.14",
-                FormEncoder.EncodeList(new List<object> { 1, "two", 3.14 }, "list"));
-        }
-
-        [Fact]
         public void EnumEncodeUnknownValue()
         {
             var options = new TestOptions

--- a/src/StripeTests/Services/_base/BaseOptionsTest.cs
+++ b/src/StripeTests/Services/_base/BaseOptionsTest.cs
@@ -1,0 +1,28 @@
+namespace StripeTests
+{
+    using System.Linq;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class BaseOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeAndDeserializeExpandAndExtraParams()
+        {
+            var options = new BaseOptions();
+            options.AddExpand("expand_me");
+            options.AddExtraParam("foo", "String!");
+            options.AddExtraParam("bar", 234L);
+
+            var json = JsonConvert.SerializeObject(options);
+            var deserialized = JsonConvert.DeserializeObject<BaseOptions>(json);
+
+            Assert.Equal(options.Expand, deserialized.Expand);
+            Assert.True(options.ExtraParams.Count == deserialized.ExtraParams.Count);
+            Assert.All(
+                deserialized.ExtraParams,
+                kvp => Assert.Equal(options.ExtraParams[kvp.Key], deserialized.ExtraParams[kvp.Key]));
+        }
+    }
+}


### PR DESCRIPTION
r? @remi-stripe 

Simplify handling of `Expand` and `ExtraParams` in `BaseOptions`:
- `Expand` is now annotated with `[JsonProperty("expand")]`
- `ExtraParams` is now annotated with `[JsonExtensionData]`

`JsonExtensionData` is a special attribute in Newtonsoft.Json that instructs the JSON serializer to write the values in the collection during serialization and to deserialize values with no matching class member during deserialization.

I added a few lines of code to `FormEncoder` to do something similar in our own serialization process. I also had to change the type of `ExtraParams` from `Dictionary<string, string>` to `Dictionary<string, object>`, but I think that's better anyway, as it lets uses use non-string extra params (e.g. a list or a hash).

Also, `Expand` is now `null` by default instead of an empty list, because otherwise it would be serialized as `expand=` when the list is empty. Using `AddExpand()` will automatically create the list if necessary.
