### PR TITLE
Introduce new Request class to represent requests to Stripe's API

### DIFF
--- a/src/Stripe.net/Infrastructure/Request.cs
+++ b/src/Stripe.net/Infrastructure/Request.cs
@@ -1,0 +1,119 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
+    using Stripe.Infrastructure.Extensions;
+    using Stripe.Infrastructure.FormEncoding;
+
+    /// <summary>
+    /// Represents a request to Stripe's API.
+    /// </summary>
+    public class Request
+    {
+        /// <summary>Initializes a new instance of the <see cref="Request"/> class.</summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The path of the request.</param>
+        /// <param name="options">The parameters of the request.</param>
+        /// <param name="requestOptions">The special modifiers of the request.</param>
+        public Request(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions)
+        {
+            this.Method = method;
+
+            this.Uri = BuildUri(method, path, options, requestOptions);
+
+            this.AuthorizationHeader = new AuthenticationHeaderValue(
+                "Bearer",
+                requestOptions?.ApiKey ?? StripeConfiguration.ApiKey);
+
+            this.StripeHeaders = BuildStripeHeaders(requestOptions);
+
+            this.Content = BuildContent(method, options);
+        }
+
+        /// <summary>The HTTP method for the request (GET, POST or DELETE).</summary>
+        public HttpMethod Method { get; }
+
+        /// <summary>
+        /// The URL for the request. If this is a GET or DELETE request, the URL also includes
+        /// the request parameters in its query string.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>The value of the <c>Authorization</c> header with the API key.</summary>
+        public AuthenticationHeaderValue AuthorizationHeader { get; }
+
+        /// <summary>
+        /// Dictionary containing Stripe custom headers (<c>Stripe-Version</c>,
+        /// <c>Stripe-Account</c>, <c>Idempotency-Key</c>...).
+        /// </summary>
+        public IDictionary<string, string> StripeHeaders { get; }
+
+        /// <summary>
+        /// The body of the request. For POST requests, this will be either a
+        /// <c>application/x-www-form-urlencoded</c> or a <c>multipart/form-data</c> payload.
+        /// For non-POST requests, this will be <c>null</c>.
+        /// </summary>
+        public HttpContent Content { get; }
+
+        private static Uri BuildUri(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions)
+        {
+            var b = new StringBuilder();
+
+            b.Append(requestOptions?.BaseUrl ?? StripeConfiguration.ApiBase);
+            b.Append(path);
+
+            if ((method != HttpMethod.Post) && (options != null))
+            {
+                var queryString = FormEncoder.CreateQueryString(options);
+                if (!string.IsNullOrEmpty(queryString))
+                {
+                    b.Append("?");
+                    b.Append(queryString);
+                }
+            }
+
+            return new Uri(b.ToString());
+        }
+
+        private static Dictionary<string, string> BuildStripeHeaders(RequestOptions requestOptions)
+        {
+            var stripeHeaders = new Dictionary<string, string>
+            {
+                { "Stripe-Version", requestOptions?.StripeVersion ?? StripeConfiguration.ApiVersion },
+            };
+
+            if (!string.IsNullOrEmpty(requestOptions?.StripeConnectAccountId))
+            {
+                stripeHeaders.Add("Stripe-Account", requestOptions.StripeConnectAccountId);
+            }
+
+            if (!string.IsNullOrEmpty(requestOptions?.IdempotencyKey))
+            {
+                stripeHeaders.Add("Idempotency-Key", requestOptions.IdempotencyKey);
+            }
+
+            return stripeHeaders;
+        }
+
+        private static HttpContent BuildContent(HttpMethod method, BaseOptions options)
+        {
+            if (method != HttpMethod.Post)
+            {
+                return null;
+            }
+
+            return FormEncoder.CreateHttpContent(options);
+        }
+    }
+}

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -211,10 +211,9 @@ namespace Stripe
         {
             options = this.SetupOptions(options, IsStripeList<T>());
             requestOptions = this.SetupRequestOptions(requestOptions);
-            var url = requestOptions.BaseUrl + path;
             var wr = Requestor.GetRequestMessage(
-                url,
                 method,
+                path,
                 options,
                 requestOptions);
             return await Requestor.ExecuteRequestAsync<T>(wr);

--- a/src/StripeTests/Infrastructure/RequestTest.cs
+++ b/src/StripeTests/Infrastructure/RequestTest.cs
@@ -1,0 +1,90 @@
+namespace StripeTests
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Stripe;
+    using Stripe.Infrastructure;
+    using StripeTests.Infrastructure.TestData;
+    using Xunit;
+
+    public class RequestTest : BaseStripeTest
+    {
+        [Fact]
+        public void Ctor_GetRequest()
+        {
+            var options = new TestOptions { String = "string!" };
+            var requestOptions = new RequestOptions();
+            var request = new Request(HttpMethod.Get, "/get", options, requestOptions);
+
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal($"{StripeConfiguration.ApiBase}/get?string=string!", request.Uri.ToString());
+            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
+            Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
+            Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
+            Assert.False(request.StripeHeaders.ContainsKey("Stripe-Account"));
+            Assert.Null(request.Content);
+        }
+
+        [Fact]
+        public async Task Ctor_PostRequest()
+        {
+            var options = new TestOptions { String = "string!" };
+            var requestOptions = new RequestOptions();
+            var request = new Request(HttpMethod.Post, "/post", options, requestOptions);
+
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal($"{StripeConfiguration.ApiBase}/post", request.Uri.ToString());
+            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
+            Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
+            Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
+            Assert.False(request.StripeHeaders.ContainsKey("Stripe-Account"));
+            Assert.NotNull(request.Content);
+            var content = await request.Content.ReadAsStringAsync();
+            Assert.Equal("string=string!", content);
+        }
+
+        [Fact]
+        public void Ctor_DeleteRequest()
+        {
+            var options = new TestOptions { String = "string!" };
+            var requestOptions = new RequestOptions();
+            var request = new Request(HttpMethod.Delete, "/delete", options, requestOptions);
+
+            Assert.Equal(HttpMethod.Delete, request.Method);
+            Assert.Equal($"{StripeConfiguration.ApiBase}/delete?string=string!", request.Uri.ToString());
+            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
+            Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
+            Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
+            Assert.False(request.StripeHeaders.ContainsKey("Stripe-Account"));
+            Assert.Null(request.Content);
+        }
+
+        [Fact]
+        public void Ctor_RequestOptions()
+        {
+            var requestOptions = new RequestOptions
+            {
+                ApiKey = "sk_override",
+                IdempotencyKey = "idempotency_key",
+                StripeConnectAccountId = "acct_456",
+                BaseUrl = "https://example.com",
+                StripeVersion = "2012-12-21",
+            };
+            var request = new Request(HttpMethod.Get, "/get", null, requestOptions);
+
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("https://example.com/get", request.Uri.ToString());
+            Assert.Equal("Bearer sk_override", request.AuthorizationHeader.ToString());
+            Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
+            Assert.Equal("2012-12-21", request.StripeHeaders["Stripe-Version"]);
+            Assert.True(request.StripeHeaders.ContainsKey("Idempotency-Key"));
+            Assert.Equal("idempotency_key", request.StripeHeaders["Idempotency-Key"]);
+            Assert.True(request.StripeHeaders.ContainsKey("Stripe-Account"));
+            Assert.Equal("acct_456", request.StripeHeaders["Stripe-Account"]);
+            Assert.Null(request.Content);
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/RequestorTest.cs
+++ b/src/StripeTests/Infrastructure/RequestorTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests
                 StripeConnectAccountId = "acct_123",
                 IdempotencyKey = "123",
             };
-            var request = Requestor.GetRequestMessage("http://localhost", HttpMethod.Get, null, options);
+            var request = Requestor.GetRequestMessage(HttpMethod.Get, string.Empty, null, options);
             Assert.NotNull(request);
             Assert.Equal($"Bearer {options.ApiKey}", request.Headers.GetValues("Authorization").FirstOrDefault());
             Assert.Equal(options.IdempotencyKey, request.Headers.GetValues("Idempotency-Key").FirstOrDefault());


### PR DESCRIPTION
r? @remi-stripe @brandur-stripe 

This one is fairly straightforward. It adds a new `Stripe.Infrastructure.Request` class whose job is to turn the request parameters provided by services:
- `HttpMethod`: HTTP method (...)
- `path`: relative path, e.g. `/v1/charges`
- `options`: `BaseOptions` instance containing the request parameters, or `null`
- `requestOptions`: `RequestOptions` instance containing the request's "modifiers" to e.g override the global API key or set an idempotency key

into .NET's HTTP library classes:
- `HttpMethod`: this one is untouched
- `Uri`: `System.Net.Uri` instance containing the full URL, including the base path, and for non-POST requests, the parameters encoded in the query string
- `AuthorizationHeader`: `System.Net.Http.Headers.AuthenticationHeaderValue` representing the `Authorization` header with our preferred "Bearer" scheme and the API key
- `StripeHeaders`: a dictionary containing Stripe-specific HTTP headers. All requests include `Stripe-Version`, and may include `Stripe-Account` and/or `Idempotency-Key`
- `Content`: for POST requests, a `System.Net.Http.HttpContent` instance representing the request's body. For non-POST requests, `null`.
