### PR TITLE
Fixes to FileService and OAuthTokenService

### DIFF
--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -1,11 +1,8 @@
 namespace Stripe
 {
     using System.Collections.Generic;
-    using System.IO;
-    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class FileService : Service<File>,
         ICreatable<File, FileCreateOptions>,
@@ -26,11 +23,15 @@ namespace Stripe
 
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            requestOptions.BaseUrl = requestOptions.BaseUrl ?? StripeConfiguration.FilesBase;
             return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<File> CreateAsync(FileCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            requestOptions.BaseUrl = requestOptions.BaseUrl ?? StripeConfiguration.FilesBase;
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -17,18 +17,18 @@ namespace Stripe
         {
         }
 
-        public override string BasePath => null;
+        public override string BasePath => "/oauth/token";
 
         public override string BaseUrl => StripeConfiguration.ConnectBase;
 
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, "/oauth/token", options, requestOptions);
+            return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync(HttpMethod.Post, "/oauth/token", options, requestOptions, cancellationToken);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(OAuthTokenDeauthorizeOptions options, RequestOptions requestOptions = null)


### PR DESCRIPTION
r? @remi-stripe 

In #1504, I inadvertently removed the part of the code that sends file creation requests to `files.stripe.com` rather than `api.stripe.com` 😱  Tests were still passing because in the test suite, we replace both hostnames with `localhost` since stripe-mock handles both.

It should be easier to test this once I'm done refactoring the requestor code.

The changes to `OAuthTokenService` isn't a fix, it's just to make the code a bit cleaner by using standard creation methods.