### PR TITLE
Add support for `transfer_data[amount]` on Charge

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
+++ b/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class ChargeTransferData : StripeEntity
     {
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
         #region Expandable Destination (Account)
         [JsonIgnore]
         public string DestinationId { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeTransferDataOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeTransferDataOptions.cs
@@ -4,6 +4,9 @@ namespace Stripe
 
     public class ChargeTransferDataOptions : INestedOptions
     {
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
         [JsonProperty("destination")]
         public string Destination { get; set; }
     }


### PR DESCRIPTION
We decided to support `transfer_data[amount]` on Charges for 2/19, at least for a few months. We think developers should use `application_fee_amount` instead but many integrations already used `destination[amount]` and would be quite blocked if we removed this.

r? @ob-stripe 
cc @stripe/api-libraries 