### PR TITLE
Make `parent` on `OrderItem` expandable

### DIFF
--- a/src/Stripe.net/Entities/Orders/OrderItem.cs
+++ b/src/Stripe.net/Entities/Orders/OrderItem.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class OrderItem : StripeEntity<OrderItem>, IHasObject
     {
@@ -25,11 +26,21 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        #region Expandable Parent
+
         /// <summary>
-        /// The ID of the associated object for this line item.
+        /// ID of the parent associated with this order item.
         /// </summary>
+        [JsonIgnore]
+        public string ParentId => this.InternalParent.Id;
+
+        [JsonIgnore]
+        public Sku Parent => this.InternalParent.ExpandedObject;
+
         [JsonProperty("parent")]
-        public string Parent { get; set; }
+        [JsonConverter(typeof(ExpandableFieldConverter<Sku>))]
+        internal ExpandableField<Sku> InternalParent { get; set; }
+        #endregion
 
         /// <summary>
         /// A positive integer representing the number of instances of parent that are included in this order item. Applicable/present only if type is sku.


### PR DESCRIPTION
Make `parent` on `OrderItem` expandable. This helps fix part of https://github.com/stripe/stripe-dotnet/issues/1515

This is a tricky one though. First because it's a breaking change as we original chose `Parent` and not `ParentId` as the name. Second, because `parent` is only expandable when it refers to a SKU and not otherwise. In stripe-go this is implemented [here](https://github.com/stripe/stripe-go/blob/master/order.go#L228-L257). In stripe-java, we avoided the issue by simply assuming that the expanded object is `HasId`.

Here, I used `Sku` but the alternative is likely to build an Interface just for it as we do for other polymorphic properties. Wanted to get your opinion first though.

r? @ob-stripe 
cc @stripe/api-libraries 