### PR TITLE
Automatic request retries

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -33,7 +33,17 @@ namespace Stripe
         public static string DefaultFilesBase => "https://files.stripe.com";
 
         /// <summary>Default timespan before the request times out.</summary>
-        public static TimeSpan DefaultHttpTimeout => new TimeSpan(80 * TimeSpan.TicksPerSecond);
+        public static TimeSpan DefaultHttpTimeout => TimeSpan.FromSeconds(80);
+
+        /// <summary>
+        /// Maximum sleep time between tries to send HTTP requests after network failure.
+        /// </summary>
+        public static TimeSpan MaxNetworkRetriesDelay => TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Minimum sleep time between tries to send HTTP requests after network failure.
+        /// </summary>
+        public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
 
         /// <summary>Gets or sets the base URL for Stripe's API.</summary>
         public static string ApiBase { get; set; } = DefaultApiBase;
@@ -86,6 +96,12 @@ namespace Stripe
         public static JsonSerializerSettings SerializerSettings { get; set; } = DefaultSerializerSettings();
 
         /// <summary>
+        /// Gets or sets the maximum number of times that the library will retry requests that
+        /// appear to have failed due to an intermittent problem.
+        /// </summary>
+        public static int MaxNetworkRetries { get; set; } = 0;
+
+        /// <summary>
         /// Gets or sets a custom <see cref="StripeClient"/> for sending requests to Stripe's
         /// API. You can use this to use a custom message handler, set proxy parameters, etc.
         /// </summary>
@@ -118,6 +134,10 @@ namespace Stripe
 
         /// <summary>Gets the version of the Stripe.net client library.</summary>
         public static string StripeNetVersion { get; }
+
+        /// <summary>Gets or sets a value indicating whether to sleep between network retries.</summary>
+        /// <remarks>This is an internal property meant to be used in tests.</remarks>
+        internal static bool NetworkRetriesSleep { get; set; } = true;
 
         /// <summary>
         /// Returns a new instance of <see cref="Newtonsoft.Json.JsonSerializerSettings"/> with

--- a/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
@@ -65,6 +65,8 @@ namespace Stripe
         [Obsolete("Use Date instead")]
         public DateTime RequestDate => this.Date?.DateTime ?? default(DateTime);
 
+        internal int NumRetries { get; set; }
+
         /// <summary>Returns a string that represents the <see cref="StripeResponse"/>.</summary>
         /// <returns>A string that represents the <see cref="StripeResponse"/>.</returns>
         public override string ToString()

--- a/src/StripeTests/Functional/NetworkRetriesTest.cs
+++ b/src/StripeTests/Functional/NetworkRetriesTest.cs
@@ -1,0 +1,250 @@
+namespace StripeTests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq.Protected;
+    using Stripe;
+    using Xunit;
+
+    public class NetworkRetriesTest : BaseStripeTest, IDisposable
+    {
+        public NetworkRetriesTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            StripeConfiguration.MaxNetworkRetries = 2;
+            StripeConfiguration.NetworkRetriesSleep = false;
+        }
+
+        public void Dispose()
+        {
+            StripeConfiguration.MaxNetworkRetries = 0;
+            StripeConfiguration.NetworkRetriesSleep = true;
+            this.MockHttpClientFixture.Reset();
+        }
+
+        [Fact]
+        public void RetryOnConflict()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.Conflict)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var balance = service.Get();
+
+            Assert.NotNull(balance);
+            Assert.Equal(1, balance.StripeResponse.NumRetries);
+        }
+
+        [Fact]
+        public void RetryOnServiceUnavailable()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var balance = service.Get();
+
+            Assert.NotNull(balance);
+            Assert.Equal(1, balance.StripeResponse.NumRetries);
+        }
+
+        [Fact]
+        public void RetryOnInternalServerErrorIfNotPost()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var balance = service.Get();
+
+            Assert.NotNull(balance);
+            Assert.Equal(1, balance.StripeResponse.NumRetries);
+        }
+
+        [Fact]
+        public void DoNotRetryOnInternalServerErrorIfPost()
+        {
+            var requestCount = 0;
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(() =>
+                    {
+                        requestCount += 1;
+                        return Task.FromResult(
+                            new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                            {
+                                Content = new StringContent("{}", Encoding.UTF8),
+                            });
+                    })
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new CustomerService();
+            Assert.Throws<StripeException>(() => service.Create(null));
+
+            Assert.Equal(1, requestCount);
+        }
+
+        [Fact]
+        public void RetryOnHttpRequestException()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(new HttpRequestException("Connection error"))
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var balance = service.Get();
+
+            Assert.NotNull(balance);
+            Assert.Equal(1, balance.StripeResponse.NumRetries);
+        }
+
+        [Fact]
+        public void RethrowHttpRequestExceptionAfterAllAttempts()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(new HttpRequestException("Connection error 1"))
+                .Throws(new HttpRequestException("Connection error 2"))
+                .Throws(new HttpRequestException("Connection error 3"))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var exception = Assert.Throws<HttpRequestException>(() => service.Get());
+
+            Assert.NotNull(exception);
+            Assert.Equal("Connection error 3", exception.Message);
+        }
+
+        [Fact]
+        public void RetryOnTimeout()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(new OperationCanceledException("Timeout"))
+                .Returns(Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8),
+                    }))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var balance = service.Get();
+
+            Assert.NotNull(balance);
+            Assert.Equal(1, balance.StripeResponse.NumRetries);
+        }
+
+        [Fact]
+        public void RethrowTimeoutExceptionAfterAllAttempts()
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(new TaskCanceledException("Timeout 1"))
+                .Throws(new TaskCanceledException("Timeout 2"))
+                .Throws(new TaskCanceledException("Timeout 3"))
+                .Throws(new StripeTestException("Unexpected invocation"));
+
+            var service = new BalanceService();
+            var exception = Assert.Throws<TaskCanceledException>(() => service.Get());
+
+            Assert.NotNull(exception);
+            Assert.Equal("Timeout 3", exception.Message);
+        }
+
+        [Fact]
+        public async Task DoNotRetryOnCancel()
+        {
+            var requestCount = 0;
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (_, t) =>
+                    {
+                        requestCount += 1;
+                        await Task.Delay(TimeSpan.FromSeconds(1), t);
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent("{}", Encoding.UTF8),
+                        };
+                    });
+
+            var service = new BalanceService();
+            var source = new CancellationTokenSource();
+            source.CancelAfter(TimeSpan.FromMilliseconds(10));
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await service.GetAsync(null, source.Token));
+
+            Assert.Equal(1, requestCount);
+        }
+    }
+}

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -53,12 +53,12 @@ namespace StripeTests
         {
             this.ResetStripeClient();
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
-            fakeServer.DelayMilliseconds = 10;
+            fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
             StripeConfiguration.EnableTelemetry = true;
             var service = new BalanceService();
             service.Get();
-            fakeServer.DelayMilliseconds = 20;
+            fakeServer.Delay = TimeSpan.FromMilliseconds(40);
             service.Get();
             service.Get();
 
@@ -78,7 +78,7 @@ namespace StripeTests
                         TelemetryHeaderMatcher(
                             m.Headers,
                             (s) => s == "req_1",
-                            (d) => d >= 10)),
+                            (d) => d >= 15)),
                     ItExpr.IsAny<CancellationToken>());
 
             this.MockHttpClientFixture.MockHandler.Protected()
@@ -89,7 +89,7 @@ namespace StripeTests
                         TelemetryHeaderMatcher(
                             m.Headers,
                             (s) => s == "req_2",
-                            (d) => d >= 20)),
+                            (d) => d >= 30)),
                     ItExpr.IsAny<CancellationToken>());
         }
 
@@ -98,7 +98,7 @@ namespace StripeTests
         {
             this.ResetStripeClient();
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
-            fakeServer.DelayMilliseconds = 10;
+            fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
             StripeConfiguration.EnableTelemetry = true;
             var service = new BalanceService();
@@ -125,7 +125,7 @@ namespace StripeTests
                         TelemetryHeaderMatcher(
                             m.Headers,
                             (s) => s == "req_1",
-                            (d) => d >= 10)),
+                            (d) => d >= 15)),
                     ItExpr.IsAny<CancellationToken>());
 
             this.MockHttpClientFixture.MockHandler.Protected()
@@ -136,7 +136,7 @@ namespace StripeTests
                         TelemetryHeaderMatcher(
                             m.Headers,
                             (s) => s == "req_2",
-                            (d) => d >= 10)),
+                            (d) => d >= 15)),
                     ItExpr.IsAny<CancellationToken>());
         }
 
@@ -174,7 +174,7 @@ namespace StripeTests
         {
             private object lockObject = new object();
 
-            public int DelayMilliseconds { get; set; } = 0;
+            public TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
             public int RequestCount { get; protected set; }
 
@@ -200,7 +200,7 @@ namespace StripeTests
                     requestId = $"req_{this.RequestCount}";
                 }
 
-                await Task.Delay(this.DelayMilliseconds);
+                await Task.Delay(this.Delay);
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -88,6 +88,50 @@ namespace StripeTests
             Assert.Equal(response, exception.StripeResponse);
         }
 
+        [Fact]
+        public async Task RequestAsync_Error_InvalidJson()
+        {
+            var response = new StripeResponse(
+                HttpStatusCode.InternalServerError,
+                null,
+                "this isn't JSON");
+            this.httpClient.Response = response;
+
+            var exception = await Assert.ThrowsAsync<StripeException>(async () =>
+                await this.stripeClient.RequestAsync<Charge>(
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions));
+
+            Assert.NotNull(exception);
+            Assert.Equal(HttpStatusCode.InternalServerError, exception.HttpStatusCode);
+            Assert.Equal("Invalid response object from API: this isn't JSON", exception.Message);
+            Assert.Equal(response, exception.StripeResponse);
+        }
+
+        [Fact]
+        public async Task RequestAsync_Error_InvalidErrorObject()
+        {
+            var response = new StripeResponse(
+                HttpStatusCode.InternalServerError,
+                null,
+                "{}");
+            this.httpClient.Response = response;
+
+            var exception = await Assert.ThrowsAsync<StripeException>(async () =>
+                await this.stripeClient.RequestAsync<Charge>(
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions));
+
+            Assert.NotNull(exception);
+            Assert.Equal(HttpStatusCode.InternalServerError, exception.HttpStatusCode);
+            Assert.Equal("Invalid response object from API: {}", exception.Message);
+            Assert.Equal(response, exception.StripeResponse);
+        }
+
         private class DummyHttpClient : IHttpClient
         {
             public DummyHttpClient()

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -38,7 +38,7 @@ namespace StripeTests
             Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
-            Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
+            Assert.True(request.StripeHeaders.ContainsKey("Idempotency-Key"));
             Assert.False(request.StripeHeaders.ContainsKey("Stripe-Account"));
             Assert.NotNull(request.Content);
             var content = await request.Content.ReadAsStringAsync();


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Add support for automatic request retries.

The implementation is based on stripe-go, so the retry conditions are the same: requests are retried on connection errors (timeouts) and 409's. Given the recent discussions in e.g. https://github.com/stripe/stripe-node/pull/559, let me know if you want me to change the conditions (e.g. to retry on 500's).
