### PR TITLE
API key validation

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -70,10 +70,7 @@ namespace Stripe
                 return apiKey;
             }
 
-            set
-            {
-                apiKey = value;
-            }
+            set => apiKey = value;
         }
 
         /// <summary>Gets or sets the base URL for Stripe's OAuth API.</summary>
@@ -126,10 +123,7 @@ namespace Stripe
                 return stripeClient;
             }
 
-            set
-            {
-                stripeClient = value;
-            }
+            set => stripeClient = value;
         }
 
         /// <summary>Gets the version of the Stripe.net client library.</summary>

--- a/src/Stripe.net/Infrastructure/StringUtils.cs
+++ b/src/Stripe.net/Infrastructure/StringUtils.cs
@@ -6,6 +6,8 @@ namespace Stripe.Infrastructure
 
     internal static class StringUtils
     {
+        private static Regex whitespaceRegex = new Regex(@"\s", RegexOptions.CultureInvariant);
+
         /// <summary>Converts the string to snake case.</summary>
         /// <param name="str">The string to convert.</param>
         /// <returns>A string with the contents of the input string converted to snake_case.</returns>
@@ -51,6 +53,22 @@ namespace Stripe.Infrastructure
             }
 
             return result == 0;
+        }
+
+        /// <summary>Checks whether a string contains any whitespace characters or not.</summary>
+        /// <param name="str">The string to check.</param>
+        /// <returns>
+        /// <c>true</c> if the string contains any whitespace characters; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception name="ArgumentNullException">Thrown if <c>str</c> is <c>null</c>.</exception>
+        public static bool ContainsWhitespace(string str)
+        {
+            if (str == null)
+            {
+                throw new ArgumentNullException(nameof(str));
+            }
+
+            return whitespaceRegex.IsMatch(str);
         }
     }
 }

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -284,7 +284,7 @@ namespace Stripe
                 requestOptions = new RequestOptions();
             }
 
-            if (!string.IsNullOrEmpty(this.ApiKey))
+            if (string.IsNullOrEmpty(requestOptions.ApiKey) && !string.IsNullOrEmpty(this.ApiKey))
             {
                 requestOptions.ApiKey = this.ApiKey;
             }

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -3,7 +3,6 @@ namespace StripeTests
     using System.Net.Http;
     using System.Threading.Tasks;
     using Stripe;
-    using Stripe.Infrastructure;
     using StripeTests.Infrastructure.TestData;
     using Xunit;
 
@@ -85,6 +84,77 @@ namespace StripeTests
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Account"));
             Assert.Equal("acct_456", request.StripeHeaders["Stripe-Account"]);
             Assert.Null(request.Content);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyIsNull()
+        {
+            var origKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = null;
+
+                var options = new TestOptions();
+                var requestOptions = new RequestOptions();
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+
+                Assert.Contains("No API key provided.", exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origKey;
+            }
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyIsEmpty()
+        {
+            var origKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = string.Empty;
+
+                var options = new TestOptions();
+                var requestOptions = new RequestOptions();
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+
+                Assert.Contains("No API key provided.", exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origKey;
+            }
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyContainsWhitespace()
+        {
+            var origKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = "sk_test_123\n";
+
+                var options = new TestOptions();
+                var requestOptions = new RequestOptions();
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+
+                Assert.Contains(
+                    "Your API key is invalid, as it contains whitespace.",
+                    exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origKey;
+            }
         }
     }
 }

--- a/src/StripeTests/Infrastructure/StringUtilsTest.cs
+++ b/src/StripeTests/Infrastructure/StringUtilsTest.cs
@@ -48,5 +48,29 @@ namespace StripeTests
                     StringUtils.SecureEquals(testCase.data.a, testCase.data.b));
             }
         }
+
+        [Fact]
+        public void ContainsWhitespace()
+        {
+            var testCases = new[]
+            {
+                new { data = "sk_test_123", want = false },
+                new { data = "sk_test_4eC39HqLyjWDarjtT1zdp7dc", want = false },
+                new { data = "abc", want = false },
+                new { data = "sk-test-123", want = false },
+                new { data = string.Empty, want = false },
+                new { data = "sk_test_123\n", want = true },
+                new { data = "\nsk_test_123", want = true },
+                new { data = "sk_test_\n123", want = true },
+                new { data = "sk_test_123 ", want = true },
+                new { data = " sk_test_123", want = true },
+                new { data = "sk_test_ 123", want = true },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, StringUtils.ContainsWhitespace(testCase.data));
+            }
+        }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 

Validates API keys that are passed to `StripeConfiguration.ApiKey = key;`, `new SomeService(key)` and `new RequestOptions { ApiKey = key }`. If the key contains invalid characters (anything other than alphanumeric characters or underscores), an exception is raised.

Partially fixes #1507.