### PR TITLE
Add support for capabilities on the Account resource before major version

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -52,6 +52,13 @@ namespace Stripe
         [JsonProperty("business_url")]
         public string BusinessUrl { get; set; }
 
+        /// <summary>
+        /// A hash containing the set of capabilities that was requested for this account and their
+        /// associated states.
+        /// </summary>
+        [JsonProperty("capabilities")]
+        public AccountCapabilities Capabilities { get; set; }
+
         [JsonProperty("charges_enabled")]
         public bool ChargesEnabled { get; set; }
 

--- a/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
@@ -1,0 +1,28 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class AccountCapabilities : StripeEntity
+    {
+        /// <summary>
+        /// The status of the card payments capability of the account, or whether the account can
+        /// directly process credit and debit card charges.
+        /// </summary>
+        [JsonProperty("card_payments")]
+        public string CardPayments { get; set; }
+
+        /// <summary>
+        /// The status of the legacy payments capability of the account.
+        /// </summary>
+        [JsonProperty("legacy_payments")]
+        public string LegacyPayments { get; set; }
+
+        /// <summary>
+        /// The status of the platform payments capability of the account, or whether your platform
+        /// can process charges on behalf of the account.
+        /// </summary>
+        [JsonProperty("platform_payments")]
+        public string PlatformPayments { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Account/AccountSharedOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountSharedOptions.cs
@@ -58,6 +58,9 @@ namespace Stripe
         [JsonProperty("product_description")]
         public string ProductDescription { get; set; }
 
+        [JsonProperty("requested_capabilities")]
+        public List<string> RequestedCapabilities { get; set; }
+
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 


### PR DESCRIPTION
This adds support for requesting and reading capabilities on the Account resource before the major version released tomorrow.

r? @ob-stripe 
cc @stripe/api-libraries 