### PR TITLE
Fix a couple of options classes

### DIFF
--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleInvoiceSettingsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleInvoiceSettingsOptions.cs
@@ -1,9 +1,8 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionScheduleInvoiceSettingsOptions : StripeEntity
+    public class SubscriptionScheduleInvoiceSettingsOptions : INestedOptions
     {
         /// <summary>
         /// The number of days from which the invoice is created until it is due. Only valid for

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleRenewalIntervalOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleRenewalIntervalOptions.cs
@@ -1,9 +1,8 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionScheduleRenewalIntervalOptions : StripeEntity
+    public class SubscriptionScheduleRenewalIntervalOptions : INestedOptions
     {
         /// <summary>
         /// Interval at which to renew the subscription schedule for when it ends. Possible values


### PR DESCRIPTION
r? @remi-stripe 

Just noticed that there are a couple of options classes that inherit `StripeEntity` instead of `INestedOptions`.