### PR TITLE
Make ChargeTransferData.Amount nullable

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
+++ b/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public class ChargeTransferData : StripeEntity
     {
         [JsonProperty("amount")]
-        public long Amount { get; set; }
+        public long? Amount { get; set; }
 
         #region Expandable Destination (Account)
         [JsonIgnore]


### PR DESCRIPTION
cc @remi-stripe 

The API can return `null` for this attribute, so the Stripe.net property needs to be nullable, otherwise trying to deserialize `null` will cause an exception.

Fixes the issue described in the second part of this comment: https://github.com/stripe/stripe-dotnet/issues/1528#issuecomment-465342165.

(We should start thinking about a larger solution to this problem since it's so easy to get this wrong. The sledgehammer solution would be to make all value types nullable, like we already in options classes.)