### PR TITLE
Remove parameters are internal only on PaymentIntent

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
@@ -6,12 +6,6 @@ namespace Stripe
 
     public class PaymentIntentConfirmOptions : BaseOptions
     {
-        [JsonProperty("invoice")]
-        public string Invoice { get; set; }
-
-        [JsonProperty("invoice_charge_reason")]
-        public string InvoiceChargeReason { get; set; }
-
         [JsonProperty("receipt_email")]
         public string ReceiptEmail { get; set; }
 


### PR DESCRIPTION
Those parameters are not available publicly today and are specific to some internal logic we have so let's remove them.

r? @ob-stripe 
cc @stripe/api-libraries 