### PR TITLE
Check validity of JSON in OK responses

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -62,7 +62,16 @@ namespace Stripe
                 throw BuildStripeException(response);
             }
 
-            var obj = StripeEntity.FromJson<T>(response.Content);
+            T obj;
+            try
+            {
+                obj = StripeEntity.FromJson<T>(response.Content);
+            }
+            catch (Newtonsoft.Json.JsonException)
+            {
+                throw BuildInvalidResponseException(response);
+            }
+
             obj.StripeResponse = response;
 
             return obj;
@@ -111,7 +120,7 @@ namespace Stripe
             return new StripeException(
                 response.StatusCode,
                 null,
-                $"Invalid response object from API: {response.Content}")
+                $"Invalid response object from API: \"{response.Content}\"")
             {
                 StripeResponse = response,
             };

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -45,6 +45,25 @@ namespace StripeTests
         }
 
         [Fact]
+        public async Task RequestAsync_OkResponse_InvalidJson()
+        {
+            var response = new StripeResponse(HttpStatusCode.OK, null, "this isn't JSON");
+            this.httpClient.Response = response;
+
+            var exception = await Assert.ThrowsAsync<StripeException>(async () =>
+                await this.stripeClient.RequestAsync<Charge>(
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions));
+
+            Assert.NotNull(exception);
+            Assert.Equal(HttpStatusCode.OK, exception.HttpStatusCode);
+            Assert.Equal("Invalid response object from API: \"this isn't JSON\"", exception.Message);
+            Assert.Equal(response, exception.StripeResponse);
+        }
+
+        [Fact]
         public async Task RequestAsync_ApiError()
         {
             var response = new StripeResponse(
@@ -106,7 +125,7 @@ namespace StripeTests
 
             Assert.NotNull(exception);
             Assert.Equal(HttpStatusCode.InternalServerError, exception.HttpStatusCode);
-            Assert.Equal("Invalid response object from API: this isn't JSON", exception.Message);
+            Assert.Equal("Invalid response object from API: \"this isn't JSON\"", exception.Message);
             Assert.Equal(response, exception.StripeResponse);
         }
 
@@ -128,7 +147,7 @@ namespace StripeTests
 
             Assert.NotNull(exception);
             Assert.Equal(HttpStatusCode.InternalServerError, exception.HttpStatusCode);
-            Assert.Equal("Invalid response object from API: {}", exception.Message);
+            Assert.Equal("Invalid response object from API: \"{}\"", exception.Message);
             Assert.Equal(response, exception.StripeResponse);
         }
 


### PR DESCRIPTION
r? @remi-stripe 

Checks the validity of JSON in OK responses, and throw a `StripeException` if invalid. I already added this for error responses in #1518.

Partially fixes #1507.