### PR TITLE
Add `created` and `status_transitions` on `Invoice`

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -22,10 +22,6 @@ namespace Stripe
         [JsonProperty("amount_remaining")]
         public long AmountRemaining { get; set; }
 
-        [Obsolete("Use ApplicationFeeAmount")]
-        [JsonProperty("application_fee")]
-        public long? ApplicationFee { get; set; }
-
         /// <summary>
         /// The amount of the application application fee (if any) for the invoice. See the Connect documentation for details.
         /// </summary>
@@ -75,6 +71,10 @@ namespace Stripe
         }
         #endregion
 
+        [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime Created { get; set; }
+
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
@@ -102,10 +102,6 @@ namespace Stripe
             }
         }
         #endregion
-
-        [JsonProperty("date")]
-        [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? Date { get; set; }
 
         #region Expandable DefaultSource
         [JsonIgnore]
@@ -202,6 +198,9 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        [JsonProperty("status_transitions")]
+        public InvoiceStatusTransitions StatusTransitions { get; set; }
+
         #region Expandable Subscription
         [JsonIgnore]
         public string SubscriptionId { get; set; }
@@ -253,5 +252,14 @@ namespace Stripe
         [JsonProperty("webhooks_delivered_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? WebhooksDeliveredAt { get; set; }
+
+        [Obsolete("Use ApplicationFeeAmount instead")]
+        [JsonProperty("application_fee")]
+        public long? ApplicationFee { get; set; }
+
+        [Obsolete("Use Created instead")]
+        [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? Date { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Invoices/InvoiceStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceStatusTransitions.cs
@@ -1,0 +1,25 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceStatusTransitions : StripeEntity
+    {
+        [JsonProperty("finalized_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? FinalizedAt { get; set; }
+
+        [JsonProperty("marked_uncollectible_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? MarkedUncollectibleAt { get; set; }
+
+        [JsonProperty("paid_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? PaidAt { get; set; }
+
+        [JsonProperty("voided_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? VoidedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
@@ -11,17 +11,17 @@ namespace Stripe
         [JsonProperty("billing")]
         public Billing? Billing { get; set; }
 
-        [JsonProperty("customer")]
-        public string CustomerId { get; set; }
-
-        [JsonProperty("date")]
-        public DateTime? Date { get; set; }
+        [JsonProperty("created")]
+        public DateTime? Created { get; set; }
 
         /// <summary>
-        /// A filter on the list based on the object date field.
+        /// A filter on the list based on the object created field.
         /// </summary>
-        [JsonProperty("date")]
-        public DateRangeOptions DateRange { get; set; }
+        [JsonProperty("created")]
+        public DateRangeOptions CreatedRange { get; set; }
+
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
 
         [JsonProperty("due_date")]
         public DateTime? DueDate { get; set; }
@@ -40,5 +40,13 @@ namespace Stripe
 
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
+
+        [Obsolete("Use Created instead")]
+        [JsonProperty("date")]
+        public DateTime? Date { get; set; }
+
+        [Obsolete("Use CreatedRange instead")]
+        [JsonProperty("date")]
+        public DateRangeOptions DateRange { get; set; }
     }
 }


### PR DESCRIPTION
Technically the List Invoice API does not yet take `created` but will tomorrow or the day after. I want the PR to be ready/approved and I'll only merge once it works.

r? @ob-stripe 
cc @stripe/api-libraries 