### PR TITLE
Add support for `latest_invoice` on `Subscription`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.45.0
+  STRIPE_MOCK_VERSION: 0.47.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -115,6 +115,28 @@ namespace Stripe
         [JsonProperty("items")]
         public StripeList<SubscriptionItem> Items { get; set; }
 
+        #region Expandable LatestInvoice
+        [JsonIgnore]
+        public string LatestInvoiceId { get; set; }
+
+        [JsonIgnore]
+        public Invoice LatestInvoice { get; set; }
+
+        [JsonProperty("latest_invoice")]
+        internal object InternalLatestInvoice
+        {
+            get
+            {
+                return this.LatestInvoice ?? (object)this.LatestInvoiceId;
+            }
+
+            set
+            {
+                StringOrObject<Invoice>.Map(value, s => this.LatestInvoiceId = s, o => this.LatestInvoice = o);
+            }
+        }
+        #endregion
+
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -28,6 +28,7 @@ namespace StripeTests
             string[] expansions =
             {
               "customer",
+              "latest_invoice",
             };
 
             string json = this.GetFixture("/v1/subscriptions/sub_123", expansions);
@@ -39,6 +40,9 @@ namespace StripeTests
 
             Assert.NotNull(subscription.Customer);
             Assert.Equal("customer", subscription.Customer.Object);
+
+            Assert.NotNull(subscription.LatestInvoice);
+            Assert.Equal("invoice", subscription.LatestInvoice.Object);
         }
     }
 }

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -12,7 +12,7 @@ namespace StripeTests
         /// <remarks>
         /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.45.0";
+        private const string MockMinimumVersion = "0.47.0";
 
         private readonly string origApiBase;
         private readonly string origFilesBase;


### PR DESCRIPTION
Add support for expanding `latest_invoice` on `Subscription. This also fixed a test that is now failing as `destination` on Charge is now undocumented and not in openapi anymore

r? @mickjermsurawong-stripe
cc @stripe/api-libraries