### PR TITLE
Add support for `api_version` on the `WebhookEndpoint` resource

### DIFF
--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -13,6 +13,9 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        [JsonProperty("api_version")]
+        public string ApiVersion { get; set; }
+
         [JsonProperty("application")]
         public string ApplicationId { get; set; }
 

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -24,8 +24,9 @@ namespace Stripe
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "
                     + $"{StripeConfiguration.StripeNetVersion} expects API version "
-                    + $"{StripeConfiguration.StripeApiVersion}. You can disable this exception by "
-                    + "passing `throwOnApiVersionMismatch=false` to "
+                    + $"{StripeConfiguration.StripeApiVersion}. We recommend that you create a "
+                    + "WebhookEndpoint with this API version. Otherwise, you can disable this "
+                    + "exception by passing `throwOnApiVersionMismatch=false` to "
                     + "`Stripe.EventUtility.ParseEvent` or `Stripe.EventUtility.ConstructEvent`, "
                     + "but be wary that objects may be incorrectly deserialized.");
             }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
@@ -7,6 +7,17 @@ namespace Stripe
 
     public class WebhookEndpointCreateOptions : WebhookEndpointSharedOptions
     {
+        /// <summary>
+        /// Events sent to this endpoint will be generated with this API version instead of your
+        /// account's default API version. We recommend that you set this to the API version that
+        /// the library is pinned to in <code>StripeConfiguration.stripeApiVersion</code>
+        /// </summary>
+        [JsonProperty("api_version")]
+        public string ApiVersion { get; set; }
+
+        /// <summary>
+        /// Whether this endpoint should receive events from connected accounts or your account.
+        /// </summary>
         [JsonProperty("connect")]
         public bool? Connect { get; set; }
     }

--- a/src/StripeTests/Entities/Charges/ChargeTest.cs
+++ b/src/StripeTests/Entities/Charges/ChargeTest.cs
@@ -31,7 +31,6 @@ namespace StripeTests
               "application",
               "balance_transaction",
               "customer",
-              "destination",
               "dispute",
               "invoice",
               "on_behalf_of",
@@ -56,9 +55,6 @@ namespace StripeTests
 
             Assert.NotNull(charge.Customer);
             Assert.Equal("customer", charge.Customer.Object);
-
-            Assert.NotNull(charge.Destination);
-            Assert.Equal("account", charge.Destination.Object);
 
             Assert.NotNull(charge.Dispute);
             Assert.Equal("dispute", charge.Dispute.Object);


### PR DESCRIPTION
r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 

The broken test is about charge expansion which is fixed in the other PR.