### PR TITLE
Add support for `backdate_start_date` and `cancel_at` on `Subscription`

### DIFF
--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -36,6 +36,13 @@ namespace Stripe
         [JsonProperty("billing_thresholds")]
         public SubscriptionBillingThresholds BillingThresholds { get; set; }
 
+        /// <summary>
+        /// A date in the future at which the subscription will automatically get canceled.
+        /// </summary>
+        [JsonProperty("cancel_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? CancelAt { get; set; }
+
         [JsonProperty("cancel_at_period_end")]
         public bool CancelAtPeriodEnd { get; set; }
 

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -8,7 +8,17 @@ namespace Stripe
     public class SubscriptionCreateOptions : SubscriptionSharedOptions
     {
         /// <summary>
-        /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>. This is used to determine the date of the first full invoice, and, for plans with <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
+        /// For new subscriptions, a past timestamp to backdate the subscription’s start date to.
+        /// If set, the first invoice will contain a proration for the timespan between the start
+        /// date and the current time. Can be combined with trials and the billing cycle anchor.
+        /// </summary>
+        [JsonProperty("backdate_start_date")]
+        public DateTime? BackdateStartDate { get; set; }
+
+        /// <summary>
+        /// A future date to anchor the subscription’s <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
+        /// This is used to determine the date of the first full invoice, and, for plans with
+        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
         [JsonProperty("billing_cycle_anchor")]
         public DateTime? BillingCycleAnchor { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -26,6 +26,13 @@ namespace Stripe
         public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
 
         /// <summary>
+        /// A timestamp at which the subscription should cancel. If set to a date before the
+        /// current period ends this will cause a proration if <code>prorate=true</code>.
+        /// </summary>
+        [JsonProperty("cancel_at")]
+        public DateTime? CancelAt { get; set; }
+
+        /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current period.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]


### PR DESCRIPTION
Add support for `backdate_start_date` and `cancel_at` on `Subscription`. This is gated but many users have access to it and I missed it while releasing `SubscriptionSchedule`.

r? @brandur-stripe
@stripe/api-libraries 