### PR TITLE
Added Incomplete and Incomplete Expired statuses

### DIFF
--- a/src/Stripe.net/Constants/SubscriptionStatuses.cs
+++ b/src/Stripe.net/Constants/SubscriptionStatuses.cs
@@ -11,9 +11,9 @@ namespace Stripe
         public static string Canceled => "canceled";
 
         public static string Unpaid => "unpaid";
-        
+
         public static string Incomplete => "incomplete";
-        
+
         public static string IncompleteExpired => "incomplete_expired";
     }
 }

--- a/src/Stripe.net/Constants/SubscriptionStatuses.cs
+++ b/src/Stripe.net/Constants/SubscriptionStatuses.cs
@@ -11,5 +11,9 @@ namespace Stripe
         public static string Canceled => "canceled";
 
         public static string Unpaid => "unpaid";
+        
+        public static string Incomplete => "incomplete";
+        
+        public static string IncompleteExpired => "incomplete_expired";
     }
 }


### PR DESCRIPTION
These statuses are part of the [documented API](https://stripe.com/docs/api/subscriptions/object#subscription_object-status) and were missing from this helper class. 