### PR TITLE
Rename DuplicateChargeDocumentation to be more consistent with FileId

### DIFF
--- a/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
@@ -36,7 +36,7 @@ namespace Stripe
         public string CustomerSignatureFileId { get; set; }
 
         [JsonProperty("duplicate_charge_documentation")]
-        public string DuplicateChargeDocumentation { get; set; }
+        public string DuplicateChargeDocumentationFileId { get; set; }
 
         [JsonProperty("duplicate_charge_explanation")]
         public string DuplicateChargeExplanation { get; set; }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1561

This renames a field and is a breaking change

r? @ob-stripe 
cc @stripe/api-libraries 