### PR TITLE
Add support for payment_intent on invoice and default_payment_method

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.49.0
+  STRIPE_MOCK_VERSION: 0.52.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
+++ b/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class CustomerInvoiceSettings : StripeEntity
     {
@@ -10,6 +11,33 @@ namespace Stripe
         /// </summary>
         [JsonProperty("custom_fields")]
         public List<InvoiceCustomField> CustomFields { get; set; }
+
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the customer.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId { get; set; }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod { get; set; }
+
+        [JsonProperty("default_payment_method")]
+        internal object InternalDefaultPaymentMethod
+        {
+            get
+            {
+                return this.DefaultPaymentMethod ?? (object)this.DefaultPaymentMethodId;
+            }
+
+            set
+            {
+                StringOrObject<PaymentMethod>.Map(value, s => this.DefaultPaymentMethodId = s, o => this.DefaultPaymentMethod = o);
+            }
+        }
+
+        #endregion
 
         /// <summary>
         /// Default footer to be displayed on invoices for this customer.

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -103,6 +103,36 @@ namespace Stripe
         }
         #endregion
 
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the invoice. It must belong to the customer
+        /// associated with the invoice and be in a chargeable state. If not set, defaults to the
+        /// subscription’s default payment method, if any, or to the customer’s default payment
+        /// method.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId { get; set; }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod { get; set; }
+
+        [JsonProperty("default_payment_method")]
+        internal object InternalDefaultPaymentMethod
+        {
+            get
+            {
+                return this.DefaultPaymentMethod ?? (object)this.DefaultPaymentMethodId;
+            }
+
+            set
+            {
+                StringOrObject<PaymentMethod>.Map(value, s => this.DefaultPaymentMethodId = s, o => this.DefaultPaymentMethod = o);
+            }
+        }
+
+        #endregion
+
         #region Expandable DefaultSource
         [JsonIgnore]
         public string DefaultSourceId { get; set; }
@@ -173,6 +203,14 @@ namespace Stripe
 
         [JsonProperty("paid")]
         public bool Paid { get; set; }
+
+        /// <summary>
+        /// The PaymentIntent associated with this invoice. The PaymentIntent is generated when the
+        /// invoice is finalized, and can then be used to pay the invoice. Note that voiding an
+        /// invoice will cancel the PaymentIntent.
+        /// </summary>
+        [JsonProperty("payment_intent")]
+        public PaymentIntent PaymentIntent { get; set; }
 
         [JsonProperty("period_end")]
         [JsonConverter(typeof(DateTimeConverter))]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -98,6 +98,28 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        #region Expandable Invoice
+        [JsonIgnore]
+        public string InvoiceId { get; set; }
+
+        [JsonIgnore]
+        public Invoice Invoice { get; set; }
+
+        [JsonProperty("invoice")]
+        internal object InternalInvoice
+        {
+            get
+            {
+                return this.Invoice ?? (object)this.InvoiceId;
+            }
+
+            set
+            {
+                StringOrObject<Invoice>.Map(value, s => this.InvoiceId = s, o => this.Invoice = o);
+            }
+        }
+        #endregion
+
         [JsonProperty("last_payment_error")]
         public StripeError LastPaymentError { get; set; }
 

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -90,6 +90,33 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the subscription.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId { get; set; }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod { get; set; }
+
+        [JsonProperty("default_payment_method")]
+        internal object InternalDefaultPaymentMethod
+        {
+            get
+            {
+                return this.DefaultPaymentMethod ?? (object)this.DefaultPaymentMethodId;
+            }
+
+            set
+            {
+                StringOrObject<PaymentMethod>.Map(value, s => this.DefaultPaymentMethodId = s, o => this.DefaultPaymentMethod = o);
+            }
+        }
+
+        #endregion
+
         #region Expandable DefaultSource
         [JsonIgnore]
         public string DefaultSourceId { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerInvoiceSettingsOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerInvoiceSettingsOptions.cs
@@ -12,6 +12,12 @@ namespace Stripe
         public List<InvoiceCustomFieldOptions> CustomFields { get; set; }
 
         /// <summary>
+        /// ID of the default payment method for the customer.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
+
+        /// <summary>
         /// Default footer to be displayed on invoices for this customer.
         /// </summary>
         [JsonProperty("footer")]

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -47,6 +47,12 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        /// <summary>
+        /// ID of the default payment method for the invoice.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
+
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/InvoicePayOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoicePayOptions.cs
@@ -10,14 +10,20 @@ namespace Stripe
         [JsonProperty("forgive")]
         public bool? Forgive { get; set; }
 
-        [JsonProperty("source")]
-        public string SourceId { get; set; }
-
         /// <summary>
         /// Boolean representing whether an invoice is paid outside of Stripe. This will result in
         /// no charge being made.
         /// </summary>
         [JsonProperty("paid_out_of_band")]
         public bool? PaidOutOfBand { get; set; }
+
+        /// <summary>
+        /// ID of the payment method to use for paying the invoice.
+        /// </summary>
+        [JsonProperty("payment_method")]
+        public string PaymentMethodId { get; set; }
+
+        [JsonProperty("source")]
+        public string SourceId { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -26,6 +26,8 @@ namespace Stripe
 
         public bool ExpandCustomer { get; set; }
 
+        public bool ExpandDefaultPaymentMethod { get; set; }
+
         public bool ExpandSubscription { get; set; }
 
         public virtual Invoice Create(InvoiceCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -32,6 +32,12 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        /// <summary>
+        /// ID of the default payment method for the invoice.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
+
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -26,6 +26,12 @@ namespace Stripe
 
         public bool ExpandCustomer { get; set; }
 
+        public bool ExpandOnBehalfOf { get; set; }
+
+        public bool ExpandPaymentMethod { get; set; }
+
+        public bool ExpandReview { get; set; }
+
         public bool ExpandSource { get; set; }
 
         public virtual PaymentIntent Cancel(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -24,6 +24,12 @@ namespace Stripe
 
         public bool ExpandCustomer { get; set; }
 
+        public bool ExpandDefaultPaymentMethod { get; set; }
+
+        public bool ExpandDefaultSource { get; set; }
+
+        public bool ExpandLatestInvoice { get; set; }
+
         public virtual Subscription Cancel(string subscriptionId, SubscriptionCancelOptions options, RequestOptions requestOptions = null)
         {
             return this.DeleteEntity(subscriptionId, options, requestOptions);

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -50,6 +50,12 @@ namespace Stripe
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
+        /// <summary>
+        /// ID of the default payment method for the subscription.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
+
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 

--- a/src/StripeTests/Entities/Customers/CustomerTest.cs
+++ b/src/StripeTests/Entities/Customers/CustomerTest.cs
@@ -26,6 +26,25 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
+            string[] expansions =
+            {
+              "invoice_settings.default_payment_method",
+            };
+
+            string json = this.GetFixture("/v1/customers/cus_123", expansions);
+            var customer = JsonConvert.DeserializeObject<Customer>(json);
+            Assert.NotNull(customer);
+            Assert.IsType<Customer>(customer);
+            Assert.NotNull(customer.Id);
+            Assert.Equal("customer", customer.Object);
+
+            Assert.NotNull(customer.InvoiceSettings.DefaultPaymentMethod);
+            Assert.Equal("payment_method", customer.InvoiceSettings.DefaultPaymentMethod.Object);
+        }
+
+        [Fact]
+        public void DeserializeWithExpansionsDefaultSource()
+        {
             var json = GetResourceAsString("api_fixtures.customer_with_expansions.json");
             var customer = JsonConvert.DeserializeObject<Customer>(json);
 

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -29,6 +29,8 @@ namespace StripeTests
             {
               "charge",
               "customer",
+              "default_payment_method",
+              "payment_intent",
               "subscription",
             };
 
@@ -44,6 +46,12 @@ namespace StripeTests
 
             Assert.NotNull(invoice.Customer);
             Assert.Equal("customer", invoice.Customer.Object);
+
+            Assert.NotNull(invoice.DefaultPaymentMethod);
+            Assert.Equal("payment_method", invoice.DefaultPaymentMethod.Object);
+
+            Assert.NotNull(invoice.PaymentIntent);
+            Assert.Equal("payment_intent", invoice.PaymentIntent.Object);
 
             Assert.NotNull(invoice.Subscription);
             Assert.Equal("subscription", invoice.Subscription.Object);

--- a/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
+++ b/src/StripeTests/Entities/PaymentIntents/PaymentIntentTest.cs
@@ -31,6 +31,7 @@ namespace StripeTests
             {
               "application",
               "customer",
+              "invoice",
               "payment_method",
               "transfer_data.destination",
             };
@@ -47,6 +48,9 @@ namespace StripeTests
 
             Assert.NotNull(intent.Customer);
             Assert.Equal("customer", intent.Customer.Object);
+
+            Assert.NotNull(intent.Invoice);
+            Assert.Equal("invoice", intent.Invoice.Object);
 
             Assert.NotNull(intent.PaymentMethod);
             Assert.Equal("payment_method", intent.PaymentMethod.Object);

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -28,6 +28,7 @@ namespace StripeTests
             string[] expansions =
             {
               "customer",
+              "default_payment_method",
               "latest_invoice",
             };
 
@@ -40,6 +41,9 @@ namespace StripeTests
 
             Assert.NotNull(subscription.Customer);
             Assert.Equal("customer", subscription.Customer.Object);
+
+            Assert.NotNull(subscription.DefaultPaymentMethod);
+            Assert.Equal("payment_method", subscription.DefaultPaymentMethod.Object);
 
             Assert.NotNull(subscription.LatestInvoice);
             Assert.Equal("invoice", subscription.LatestInvoice.Object);

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -12,7 +12,7 @@ namespace StripeTests
         /// <remarks>
         /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.49.0";
+        private const string MockMinimumVersion = "0.52.0";
 
         private readonly string origApiBase;
         private readonly string origFilesBase;


### PR DESCRIPTION
This is now ready to be released. Those fields will be public later this week and are stable. Having this out ahead of time is likely the best approach.

r? @ob-stripe 
cc @stripe/api-libraries 
