### PR TITLE
Add support for TaxRate

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -495,6 +495,16 @@ namespace Stripe
         public static string SourceTransactionUpdated => "source.transaction.updated";
 
         /// <summary>
+        /// Occurs whenever a tax rate is created.
+        /// </summary>
+        public static string TaxRateCreated => "tax_rate.created";
+
+        /// <summary>
+        /// Occurs whenever a tax rate changes.
+        /// </summary>
+        public static string TaxRateUpdated => "tax_rate.updated";
+
+        /// <summary>
         /// Occurs whenever a new transfer is created.
         /// </summary>
         public static string TransferCreated => "transfer.created";

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -165,6 +165,13 @@ namespace Stripe
         public StripeList<Subscription> Subscriptions { get; set; }
 
         /// <summary>
+        /// Describes the customer’s tax exemption status. One of <code>none</code>,
+        /// <code>exempt</code>, or <code>reverse</code>.
+        /// </summary>
+        [JsonProperty("tax_exempt")]
+        public string TaxExempt { get; set; }
+
+        /// <summary>
         /// The customer’s current tax ids, if any.
         /// </summary>
         [JsonProperty("tax_ids")]

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -165,8 +165,8 @@ namespace Stripe
         public StripeList<Subscription> Subscriptions { get; set; }
 
         /// <summary>
-        /// Describes the customer’s tax exemption status. One of <code>none</code>,
-        /// <code>exempt</code>, or <code>reverse</code>.
+        /// Describes the customer’s tax exemption status. One of <c>none</c>, <c>exempt</c>, or
+        /// <c>reverse</c>.
         /// </summary>
         [JsonProperty("tax_exempt")]
         public string TaxExempt { get; set; }

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -122,6 +122,12 @@ namespace Stripe
         [JsonProperty("subscription_item")]
         public string SubscriptionItemId { get; set; }
 
+        /// <summary>
+        /// The tax rates which apply to the invoice item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
+
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
     }

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -119,56 +119,56 @@ namespace Stripe
 
         /// <summary>
         /// The customer’s address. Until the invoice is finalized, this field will equal
-        /// <c>customer.address</c>. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.Address" />. Once the invoice is finalized, this field will no
+        /// longer be updated.
         /// </summary>
         [JsonProperty("customer_address")]
         public Address CustomerAddress { get; set; }
 
         /// <summary>
         /// The customer’s email. Until the invoice is finalized, this field will equal
-        /// <c>customer.email</c>. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.Email" />. Once the invoice is finalized, this field will no longer
+        /// be updated.
         /// </summary>
         [JsonProperty("customer_email")]
         public string CustomerEmail { get; set; }
 
         /// <summary>
         /// The customer’s name. Until the invoice is finalized, this field will equal
-        /// <c>customer.name</c>. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.Name" />. Once the invoice is finalized, this field will no longer
+        /// be updated.
         /// </summary>
         [JsonProperty("customer_name")]
         public string CustomerName { get; set; }
 
         /// <summary>
         /// The customer’s phone number. Until the invoice is finalized, this field will equal
-        /// <c>customer.phone</c>. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.Phone" />. Once the invoice is finalized, this field will no longer
+        /// be updated.
         /// </summary>
         [JsonProperty("customer_phone")]
         public string CustomerPhone { get; set; }
 
         /// <summary>
         /// The customer’s shipping information. Until the invoice is finalized, this field will
-        /// equal <c>customer.shipping</c>. Once the invoice is finalized, this field will no
-        /// longer be updated.
+        /// equal <see cref="Customer.Shipping" />. Once the invoice is finalized, this field will
+        /// no longer be updated.
         /// </summary>
         [JsonProperty("customer_shipping")]
         public Shipping CustomerShipping { get; set; }
 
         /// <summary>
         /// The customer’s tax exempt status. Until the invoice is finalized, this field will equal
-        /// customer.tax_exempt. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.TaxExempt" />. Once the invoice is finalized, this field will no
+        /// longer be updated.
         /// </summary>
         [JsonProperty("customer_tax_exempt")]
         public string CustomerTaxExempt { get; set; }
 
         /// <summary>
         /// The customer’s tax ids. Until the invoice is finalized, this field will equal
-        /// <c>customer.tax_ids</c>. Once the invoice is finalized, this field will no longer be
-        /// updated.
+        /// <see cref="Customer.TaxIds" />. Once the invoice is finalized, this field will no
+        /// longer be updated.
         /// </summary>
         [JsonProperty("customer_tax_ids")]
         public List<InvoiceCustomerTaxId> CustomerTaxIds { get; set; }
@@ -383,7 +383,7 @@ namespace Stripe
         public decimal? TaxPercent { get; set; }
 
         /// <summary>
-        /// If <code>billing_reason</code> is set to <code>subscription_threshold</code> this
+        /// If <see cref="BillingReason" /> is set to <c>subscription_threshold</c> this
         /// returns more information on which threshold rules triggered the invoice.
         /// </summary>
         [JsonProperty("threshold_reason")]

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -158,6 +158,14 @@ namespace Stripe
         public Shipping CustomerShipping { get; set; }
 
         /// <summary>
+        /// The customer’s tax exempt status. Until the invoice is finalized, this field will equal
+        /// customer.tax_exempt. Once the invoice is finalized, this field will no longer be
+        /// updated.
+        /// </summary>
+        [JsonProperty("customer_tax_exempt")]
+        public string CustomerTaxExempt { get; set; }
+
+        /// <summary>
         /// The customer’s tax ids. Until the invoice is finalized, this field will equal
         /// <c>customer.tax_ids</c>. Once the invoice is finalized, this field will no longer be
         /// updated.
@@ -216,6 +224,12 @@ namespace Stripe
             }
         }
         #endregion
+
+        /// <summary>
+        /// Tax rates applied to the invoice.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }
@@ -364,15 +378,22 @@ namespace Stripe
         [JsonProperty("tax")]
         public long? Tax { get; set; }
 
+        [Obsolete("Use DefaultTaxRates instead")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
         /// <summary>
-        /// If <c>billing_reason</c> is set to <c>subscription_threshold</c> this
+        /// If <code>billing_reason</code> is set to <code>subscription_threshold</code> this
         /// returns more information on which threshold rules triggered the invoice.
         /// </summary>
         [JsonProperty("threshold_reason")]
         public InvoiceThresholdReason ThresholdReason { get; set; }
+
+        /// <summary>
+        /// The tax amounts which apply to this invoice.
+        /// </summary>
+        [JsonProperty("total_tax_amounts")]
+        public List<InvoiceTaxAmount> TotalTaxAmounts { get; set; }
 
         [JsonProperty("transfer_data")]
         public InvoiceTransferData TransferData { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
@@ -56,6 +56,18 @@ namespace Stripe
         [JsonProperty("subscription_item")]
         public string SubscriptionItemId { get; set; }
 
+        /// <summary>
+        /// The tax amounts which apply to this line item.
+        /// </summary>
+        [JsonProperty("tax_amounts")]
+        public List<InvoiceTaxAmount> TaxAmounts { get; set; }
+
+        /// <summary>
+        /// Tax rates applied to this line item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
+
         [JsonProperty("type")]
         public string Type { get; set; }
     }

--- a/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
@@ -1,0 +1,46 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceTaxAmount : StripeEntity
+    {
+        /// <summary>
+        /// The amount, in cents, of the tax.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// This specifies if the tax rate is inclusive or exclusive.
+        /// </summary>
+        [JsonProperty("inclusive")]
+        public bool Inclusive { get; set; }
+
+        #region Expandable TaxRate
+
+        /// <summary>
+        /// The ID of the tax rate that was applied to get this tax amount.
+        /// </summary>
+        [JsonIgnore]
+        public string TaxRateId { get; set; }
+
+        [JsonIgnore]
+        public Account TaxRate { get; set; }
+
+        [JsonProperty("tax_rate")]
+        internal object InternalTaxRate
+        {
+            get
+            {
+                return this.TaxRate ?? (object)this.TaxRateId;
+            }
+
+            set
+            {
+                StringOrObject<Account>.Map(value, s => this.TaxRateId = s, o => this.TaxRate = o);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
@@ -26,7 +26,7 @@ namespace Stripe
         public string TaxRateId { get; set; }
 
         [JsonIgnore]
-        public Account TaxRate { get; set; }
+        public TaxRate TaxRate { get; set; }
 
         [JsonProperty("tax_rate")]
         internal object InternalTaxRate
@@ -38,7 +38,7 @@ namespace Stripe
 
             set
             {
-                StringOrObject<Account>.Map(value, s => this.TaxRateId = s, o => this.TaxRate = o);
+                StringOrObject<TaxRate>.Map(value, s => this.TaxRateId = s, o => this.TaxRate = o);
             }
         }
         #endregion

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
@@ -34,5 +34,11 @@ namespace Stripe
 
         [JsonProperty("subscription")]
         public string Subscription { get; set; }
+
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionItems/SubscriptionItem.cs
@@ -36,7 +36,7 @@ namespace Stripe
         public string Subscription { get; set; }
 
         /// <summary>
-        /// Ids of the tax rates to apply to this subscription item.
+        /// The tax rates which apply to the subscription item.
         /// </summary>
         [JsonProperty("tax_rates")]
         public List<TaxRate> TaxRates { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -140,7 +140,7 @@ namespace Stripe
         #endregion
 
         /// <summary>
-        /// Tax rates applied to the invoice.
+        /// The default tax rates that apply to this subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
         public List<TaxRate> DefaultTaxRates { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -139,6 +139,12 @@ namespace Stripe
         }
         #endregion
 
+        /// <summary>
+        /// Tax rates applied to the invoice.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
 
@@ -190,6 +196,7 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
@@ -47,6 +47,12 @@ namespace Stripe
         #endregion
 
         /// <summary>
+        /// The default tax rates which apply to the phase of this subscription schedule.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
+        /// <summary>
         /// The end of this phase of the subscription schedule.
         /// </summary>
         [JsonProperty("end_date")]
@@ -70,6 +76,7 @@ namespace Stripe
         /// If provided, each invoice created during this phase of the subscription schedule will
         /// apply the tax rate, increasing the amount billed to the customer.
         /// </summary>
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
@@ -48,5 +48,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("quantity")]
         public long Quantity { get; set; }
+
+        /// <summary>
+        /// The tax rates which apply to this specific item on the phase for a subscription
+        /// schedule.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/TaxRates/TaxRate.cs
+++ b/src/Stripe.net/Entities/TaxRates/TaxRate.cs
@@ -1,0 +1,80 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TaxRate : StripeEntity, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Whether the tax rate is currently available for new subscriptions.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? Created { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The name of the tax rate. This will not be shown to users and could be useful for you
+        /// to identify it internally.
+        /// </summary>
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// This specifies if the tax rate is inclusive or exclusive.
+        /// </summary>
+        [JsonProperty("inclusive")]
+        public bool Inclusive { get; set; }
+
+        /// <summary>
+        /// The jurisdiction for the tax rate.
+        /// </summary>
+        [JsonProperty("jurisdiction")]
+        public string Jurisdiction { get; set; }
+
+        /// <summary>
+        /// Has the value <code>true</code> if the object exists in live mode or the value
+        /// <code>false</code> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// This represents the tax rate percent out of 100.
+        /// </summary>
+        [JsonProperty("percentage")]
+        public decimal Percentage { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/TaxRates/TaxRate.cs
+++ b/src/Stripe.net/Entities/TaxRates/TaxRate.cs
@@ -33,14 +33,15 @@ namespace Stripe
         public DateTime? Created { get; set; }
 
         /// <summary>
-        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// An arbitrary string attached to the tax rate for your internal use only. It will not be
+        /// visible to your customers.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
-        /// The name of the tax rate. This will not be shown to users and could be useful for you
-        /// to identify it internally.
+        /// The display name of the tax rates as it will appear to your customer on their receipt
+        /// email, PDF, and the hosted invoice page.
         /// </summary>
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }
@@ -58,8 +59,8 @@ namespace Stripe
         public string Jurisdiction { get; set; }
 
         /// <summary>
-        /// Has the value <code>true</code> if the object exists in live mode or the value
-        /// <code>false</code> if the object exists in test mode.
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c>
+        /// if the object exists in test mode.
         /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }

--- a/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
@@ -72,6 +72,7 @@ namespace Stripe.Infrastructure
             { "subscription_schedule", typeof(SubscriptionSchedule) },
             { "subscription_schedule_revision", typeof(SubscriptionScheduleRevision) },
             { "tax_id", typeof(TaxId) },
+            { "tax_rate", typeof(TaxRate) },
             { "terminal.connection_token", typeof(Terminal.ConnectionToken) },
             { "terminal.location", typeof(Terminal.Location) },
             { "terminal.reader", typeof(Terminal.Reader) },

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -71,8 +71,8 @@ namespace Stripe
         public CardCreateNestedOptions SourceCard { get; set; }
 
         /// <summary>
-        /// Describes the customer’s tax exemption status. One of <code>none</code>,
-        /// <code>exempt</code>, or <code>reverse</code>.
+        /// Describes the customer’s tax exemption status. One of <c>none</c>, <c>exempt</c>, or
+        /// <c>reverse</c>.
         /// </summary>
         [JsonProperty("tax_exempt")]
         public string TaxExempt { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -71,6 +71,13 @@ namespace Stripe
         public CardCreateNestedOptions SourceCard { get; set; }
 
         /// <summary>
+        /// Describes the customer’s tax exemption status. One of <code>none</code>,
+        /// <code>exempt</code>, or <code>reverse</code>.
+        /// </summary>
+        [JsonProperty("tax_exempt")]
+        public string TaxExempt { get; set; }
+
+        /// <summary>
         /// The customer’s tax IDs.
         /// </summary>
         [JsonProperty("tax_id_data")]

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -64,8 +64,8 @@ namespace Stripe
         public CardCreateNestedOptions SourceCard { get; set; }
 
         /// <summary>
-        /// Describes the customer’s tax exemption status. One of <code>none</code>,
-        /// <code>exempt</code>, or <code>reverse</code>.
+        /// Describes the customer’s tax exemption status. One of <c>none</c>,  <c>exempt</c>, or
+        /// <c>reverse</c>.
         /// </summary>
         [JsonProperty("tax_exempt")]
         public string TaxExempt { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -63,6 +63,13 @@ namespace Stripe
         [JsonProperty("source")]
         public CardCreateNestedOptions SourceCard { get; set; }
 
+        /// <summary>
+        /// Describes the customer’s tax exemption status. One of <code>none</code>,
+        /// <code>exempt</code>, or <code>reverse</code>.
+        /// </summary>
+        [JsonProperty("tax_exempt")]
+        public string TaxExempt { get; set; }
+
         [Obsolete("Use TaxIdService.Create() instead")]
         [JsonProperty("tax_info")]
         public CustomerTaxInfoOptions TaxInfo { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
@@ -32,6 +32,12 @@ namespace Stripe
         [JsonProperty("subscription")]
         public string SubscriptionId { get; set; }
 
+        /// <summary>
+        /// Ids of the tax rates to apply to this invoice item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
+
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
     }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
@@ -36,7 +36,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this invoice item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
 
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
@@ -20,6 +20,12 @@ namespace Stripe
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
+        /// <summary>
+        /// Ids of the tax rates to apply to this invoice item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
+
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
     }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
@@ -24,7 +24,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this invoice item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
 
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -56,6 +56,12 @@ namespace Stripe
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -95,6 +101,7 @@ namespace Stripe
         /// <summary>
         /// The percent tax rate applied to the invoice, represented as a decimal number.
         /// </summary>
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -60,7 +60,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
-        public List<TaxRate> DefaultTaxRates { get; set; }
+        public List<string> DefaultTaxRates { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class InvoiceSubscriptionItemOptions : BaseOptions
@@ -15,5 +16,11 @@ namespace Stripe
 
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
@@ -21,6 +21,6 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -33,7 +33,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this invoice item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
 
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -29,6 +29,12 @@ namespace Stripe
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
+        /// <summary>
+        /// Ids of the tax rates to apply to this invoice item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
+
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -41,6 +41,12 @@ namespace Stripe
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -63,6 +69,7 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -45,7 +45,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
-        public List<TaxRate> DefaultTaxRates { get; set; }
+        public List<string> DefaultTaxRates { get; set; }
 
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -113,8 +113,16 @@ namespace Stripe
         /// that tax percent. If set, one of <c>subscription_items</c> or
         /// <c>subscription is required</c>.
         /// </summary>
+        [Obsolete("Use SubscriptionTaxRates")]
         [JsonProperty("subscription_tax_percent")]
         public decimal? SubscriptionTaxPercent { get; set; }
+
+        /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// those tax rates applied.
+        /// </summary>
+        [JsonProperty("subscription_tax_rates")]
+        public List<TaxRate> SubscriptionTaxRates { get; set; }
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -72,6 +72,13 @@ namespace Stripe
         public bool? SubscriptionCancelAtPeriodEnd { get; set; }
 
         /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// those tax rates applied.
+        /// </summary>
+        [JsonProperty("subscription_default_tax_rates")]
+        public List<string> SubscriptionDefaultTaxRates { get; set; }
+
+        /// <summary>
         /// The identifier of the subscription for which you’d like to retrieve the upcoming
         /// invoice. If not provided, but a <c>subscription_items</c> is provided, you will preview
         /// creating a subscription with those items. If neither <c>subscription</c> nor
@@ -113,16 +120,9 @@ namespace Stripe
         /// that tax percent. If set, one of <c>subscription_items</c> or
         /// <c>subscription is required</c>.
         /// </summary>
-        [Obsolete("Use SubscriptionTaxRates")]
+        [Obsolete("Use SubscriptionDefaultTaxRates")]
         [JsonProperty("subscription_tax_percent")]
         public decimal? SubscriptionTaxPercent { get; set; }
-
-        /// <summary>
-        /// If provided, the invoice returned will preview updating or creating a subscription with
-        /// those tax rates applied.
-        /// </summary>
-        [JsonProperty("subscription_tax_rates")]
-        public List<string> SubscriptionTaxRates { get; set; }
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -122,7 +122,7 @@ namespace Stripe
         /// those tax rates applied.
         /// </summary>
         [JsonProperty("subscription_tax_rates")]
-        public List<TaxRate> SubscriptionTaxRates { get; set; }
+        public List<string> SubscriptionTaxRates { get; set; }
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -72,6 +72,13 @@ namespace Stripe
         public bool? SubscriptionCancelAtPeriodEnd { get; set; }
 
         /// <summary>
+        /// If provided, the invoice returned will preview updating or creating a subscription with
+        /// those tax rates applied.
+        /// </summary>
+        [JsonProperty("subscription_default_tax_rates")]
+        public List<TaxRate> SubscriptionDefaultTaxRates { get; set; }
+
+        /// <summary>
         /// The identifier of the subscription for which you’d like to retrieve the upcoming
         /// invoice. If not provided, but a <c>subscription_items</c> is provided, you will preview
         /// creating a subscription with those items. If neither <c>subscription</c> nor
@@ -113,6 +120,7 @@ namespace Stripe
         /// that tax percent. If set, one of <c>subscription_items</c> or
         /// <c>subscription is required</c>.
         /// </summary>
+        [Obsolete("Use SubscriptionDefaultTaxRates")]
         [JsonProperty("subscription_tax_percent")]
         public decimal? SubscriptionTaxPercent { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -76,7 +76,7 @@ namespace Stripe
         /// those tax rates applied.
         /// </summary>
         [JsonProperty("subscription_default_tax_rates")]
-        public List<TaxRate> SubscriptionDefaultTaxRates { get; set; }
+        public List<string> SubscriptionDefaultTaxRates { get; set; }
 
         /// <summary>
         /// The identifier of the subscription for which you’d like to retrieve the upcoming

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -38,5 +39,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemSharedOptions.cs
@@ -44,6 +44,6 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class SubscriptionSchedulePhaseItemOptions : INestedOptions
@@ -22,5 +23,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// Ids of the tax rates to apply to this item for a phase on the subscription schedule.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
@@ -28,6 +28,6 @@ namespace Stripe
         /// Ids of the tax rates to apply to this item for a phase on the subscription schedule.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -25,7 +25,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this phase on the subscription schedule.
         /// </summary>
         [JsonProperty("default_tax_rates")]
-        public List<TaxRate> DefaultTaxRates { get; set; }
+        public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
         /// The date at which this phase of the subscription schedule ends. If set,

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -22,6 +22,12 @@ namespace Stripe
         public string CouponId { get; set; }
 
         /// <summary>
+        /// Ids of the tax rates to apply to this phase on the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
+        /// <summary>
         /// The date at which this phase of the subscription schedule ends. If set,
         /// <c>iterations</c> must not be set.
         /// </summary>
@@ -50,11 +56,12 @@ namespace Stripe
         /// and added as tax to the final amount each billing period. For example, a plan which
         /// charges $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per invoice.
         /// </summary>
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
         /// <summary>
-        /// If set to <c>true</c> the entire phase is counted as a trial and the customer
+        /// If set to <code>true</code> the entire phase is counted as a trial and the customer
         /// will not be charged for any fees.
         /// </summary>
         [JsonProperty("trial")]

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -61,8 +61,8 @@ namespace Stripe
         public decimal? TaxPercent { get; set; }
 
         /// <summary>
-        /// If set to <code>true</code> the entire phase is counted as a trial and the customer
-        /// will not be charged for any fees.
+        /// If set to <c>true</c> the entire phase is counted as a trial and the customer will not
+        /// be charged for any fees.
         /// </summary>
         [JsonProperty("trial")]
         public bool? Trial { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class SubscriptionItemOption : INestedOptions
@@ -15,5 +16,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// Ids of the tax rates to apply to this subscription item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<TaxRate> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
@@ -21,6 +21,6 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription item.
         /// </summary>
         [JsonProperty("tax_rates")]
-        public List<TaxRate> TaxRates { get; set; }
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -60,6 +60,12 @@ namespace Stripe
         public string DefaultSource { get; set; }
 
         /// <summary>
+        /// Ids of the tax rates to apply to this subscription.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<TaxRate> DefaultTaxRates { get; set; }
+
+        /// <summary>
         /// A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.
         /// </summary>
         [JsonProperty("metadata")]
@@ -74,6 +80,7 @@ namespace Stripe
         /// <summary>
         /// A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per invoice.
         /// </summary>
+        [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -63,7 +63,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
-        public List<TaxRate> DefaultTaxRates { get; set; }
+        public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
         /// A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.

--- a/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
@@ -1,0 +1,54 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TaxRateCreateOptions : BaseOptions
+    {
+        /// <summary>
+        /// Whether the tax rate is currently available for new subscriptions.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The name of the tax rate. This will not be shown to users and could be useful for you
+        /// to identify it internally.
+        /// </summary>
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// This specifies if the tax rate is inclusive or exclusive.
+        /// </summary>
+        [JsonProperty("inclusive")]
+        public bool? Inclusive { get; set; }
+
+        /// <summary>
+        /// The jurisdiction for the tax rate.
+        /// </summary>
+        [JsonProperty("jurisdiction")]
+        public string Jurisdiction { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription object. It can be useful
+        /// for storing additional information about the subscription in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// This represents the tax rate percent out of 100.
+        /// </summary>
+        [JsonProperty("percentage")]
+        public decimal? Percentage { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
@@ -14,14 +14,15 @@ namespace Stripe
         public bool? Active { get; set; }
 
         /// <summary>
-        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// An arbitrary string attached to the tax rate for your internal use only. It will not be
+        /// visible to your customers.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
-        /// The name of the tax rate. This will not be shown to users and could be useful for you
-        /// to identify it internally.
+        /// The display name of the tax rates as it will appear to your customer on their receipt
+        /// email, PDF, and the hosted invoice page.
         /// </summary>
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }

--- a/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
@@ -1,0 +1,32 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class TaxRateListOptions : ListOptionsWithCreated
+    {
+        /// <summary>
+        /// Optional flag to filter by tax rates that are either active or not active (archived).
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// Optional flag to filter by tax rates that are inclusive or not.
+        /// </summary>
+        [JsonProperty("inclusive")]
+        public bool? Inclusive { get; set; }
+
+        /// <summary>
+        /// A filter on the list based on the object percentage field.
+        /// </summary>
+        [JsonProperty("percentage")]
+        public decimal? Percentage { get; set; }
+
+        /// <summary>
+        /// A filter on the list based on the object percentage field.
+        /// </summary>
+        [JsonProperty("percentage")]
+        public TaxRatePercentageRangeOptions PercentageRange { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRatePercentageRangeOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRatePercentageRangeOptions.cs
@@ -1,0 +1,20 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class TaxRatePercentageRangeOptions : INestedOptions
+    {
+        [JsonProperty("gt")]
+        public decimal? GreaterThan { get; set; }
+
+        [JsonProperty("gte")]
+        public decimal? GreaterThanOrEqual { get; set; }
+
+        [JsonProperty("lt")]
+        public decimal? LessThan { get; set; }
+
+        [JsonProperty("lte")]
+        public decimal? LessThanOrEqual { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -1,0 +1,72 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class TaxRateService : Service<TaxRate>,
+        ICreatable<TaxRate, TaxRateCreateOptions>,
+        IListable<TaxRate, TaxRateListOptions>,
+        IRetrievable<TaxRate>,
+        IUpdatable<TaxRate, TaxRateUpdateOptions>
+    {
+        public TaxRateService()
+            : base(null)
+        {
+        }
+
+        public TaxRateService(string apiKey)
+            : base(apiKey)
+        {
+        }
+
+        public override string BasePath => "/tax_rates";
+
+        public bool ExpandCustomer { get; set; }
+
+        public virtual TaxRate Create(TaxRateCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<TaxRate> CreateAsync(TaxRateCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual TaxRate Get(string taxRateId, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(taxRateId, null, requestOptions);
+        }
+
+        public virtual Task<TaxRate> GetAsync(string taxRateId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetEntityAsync(taxRateId, null, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<TaxRate> List(TaxRateListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<TaxRate>> ListAsync(TaxRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<TaxRate> ListAutoPaging(TaxRateListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual TaxRate Update(string taxRateId, TaxRateUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(taxRateId, options, requestOptions);
+        }
+
+        public virtual Task<TaxRate> UpdateAsync(string taxRateId, TaxRateUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.UpdateEntityAsync(taxRateId, options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
@@ -1,0 +1,42 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TaxRateUpdateOptions : BaseOptions
+    {
+        /// <summary>
+        /// Whether the tax rate is currently available for new subscriptions.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The name of the tax rate. This will not be shown to users and could be useful for you
+        /// to identify it internally.
+        /// </summary>
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The jurisdiction for the tax rate.
+        /// </summary>
+        [JsonProperty("jurisdiction")]
+        public string Jurisdiction { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription object. It can be useful
+        /// for storing additional information about the subscription in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
@@ -14,14 +14,15 @@ namespace Stripe
         public bool? Active { get; set; }
 
         /// <summary>
-        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// An arbitrary string attached to the tax rate for your internal use only. It will not be
+        /// visible to your customers.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
-        /// The name of the tax rate. This will not be shown to users and could be useful for you
-        /// to identify it internally.
+        /// The display name of the tax rates as it will appear to your customer on their receipt
+        /// email, PDF, and the hosted invoice page.
         /// </summary>
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -25,6 +25,7 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
+            // TODO: assert that tax_rate is not null. Today stripe-mock does not support this
             string[] expansions =
             {
               "charge",

--- a/src/StripeTests/Entities/TaxRates/TaxRateTest.cs
+++ b/src/StripeTests/Entities/TaxRates/TaxRateTest.cs
@@ -1,0 +1,25 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class TaxRateTest : BaseStripeTest
+    {
+        public TaxRateTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            string json = this.GetFixture("/v1/tax_rates/txr_123");
+            var taxRate = JsonConvert.DeserializeObject<TaxRate>(json);
+            Assert.NotNull(taxRate);
+            Assert.IsType<TaxRate>(taxRate);
+            Assert.NotNull(taxRate.Id);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -1,0 +1,130 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class TaxRateServiceTest : BaseStripeTest
+    {
+        private const string TaxRateId = "txr_123";
+
+        private readonly TaxRateService service;
+        private readonly TaxRateCreateOptions createOptions;
+        private readonly TaxRateUpdateOptions updateOptions;
+        private readonly TaxRateListOptions listOptions;
+
+        public TaxRateServiceTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.service = new TaxRateService();
+
+            this.createOptions = new TaxRateCreateOptions
+            {
+                DisplayName = "Name",
+                Inclusive = true,
+                Percentage = 12.5m,
+            };
+
+            this.updateOptions = new TaxRateUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
+            };
+
+            this.listOptions = new TaxRateListOptions
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var taxRate = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tax_rates");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var taxRate = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tax_rates");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var taxRate = this.service.Get(TaxRateId);
+            this.AssertRequest(HttpMethod.Get, "/v1/tax_rates/txr_123");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var taxRate = await this.service.GetAsync(TaxRateId);
+            this.AssertRequest(HttpMethod.Get, "/v1/tax_rates/txr_123");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var taxRates = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/tax_rates");
+            Assert.NotNull(taxRates);
+            Assert.Equal("list", taxRates.Object);
+            Assert.Single(taxRates.Data);
+            Assert.Equal("tax_rate", taxRates.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var taxRates = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/tax_rates");
+            Assert.NotNull(taxRates);
+            Assert.Equal("list", taxRates.Object);
+            Assert.Single(taxRates.Data);
+            Assert.Equal("tax_rate", taxRates.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var taxRates = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(taxRates);
+            Assert.Equal("tax_rate", taxRates[0].Object);
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var taxRate = this.service.Update(TaxRateId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tax_rates/txr_123");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+
+        [Fact]
+        public async Task UpdateAsync()
+        {
+            var taxRate = await this.service.UpdateAsync(TaxRateId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/tax_rates/txr_123");
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the `TaxRate` resource and APIs. It also modifies all relevant objects that are impacted by this new ship.

cc @stripe/api-libraries 
cc @vihari-stripe @george-stripe 