### PR TITLE
Add support for `confirmation_method` on `PaymentIntent`

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -11,6 +11,9 @@ namespace Stripe
         [JsonProperty("confirm")]
         public bool? Confirm { get; set; }
 
+        [JsonProperty("confirmation_method")]
+        public string ConfirmationMethod { get; set; }
+
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @garrett-stripe 