### PR TITLE
Add support for `spending_limits` on Issuing Card and Cardholder

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
@@ -13,6 +13,9 @@ namespace Stripe.Issuing
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        [JsonProperty("authorization_controls")]
+        public AuthorizationControls AuthorizationControls { get; set; }
+
         [JsonProperty("billing")]
         public Billing Billing { get; set; }
 

--- a/src/Stripe.net/Entities/Issuing/Cards/AuthorizationControls.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/AuthorizationControls.cs
@@ -1,22 +1,38 @@
 namespace Stripe.Issuing
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class AuthorizationControls : StripeEntity
     {
+        /// <summary>
+        /// Categories of authorizations permitted on this card.
+        /// </summary>
         [JsonProperty("allowed_categories")]
         public List<string> AllowedCategories { get; set; }
 
+        /// <summary>
+        /// Categories of authorizations to always decline on this card.
+        /// </summary>
         [JsonProperty("blocked_categories")]
         public List<string> BlockedCategories { get; set; }
 
+        /// <summary>
+        /// Limit the spending with rules based on time intervals and categories.
+        /// </summary>
+        [JsonProperty("spending_limits")]
+        public List<SpendingLimit> SpendingLimits { get; set; }
+
+        [Obsolete("This is now unsupported")]
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        [Obsolete("Use SpendingLimits")]
         [JsonProperty("max_amount")]
         public long? MaxAmount { get; set; }
 
+        [Obsolete("Use SpendingLimits")]
         [JsonProperty("max_approvals")]
         public long? MaxApprovals { get; set; }
     }

--- a/src/Stripe.net/Entities/Issuing/Cards/SpendingLimit.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/SpendingLimit.cs
@@ -1,0 +1,28 @@
+namespace Stripe.Issuing
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SpendingLimit : StripeEntity
+    {
+        /// <summary>
+        /// Maximum amount allowed to spend per time interval.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Categories on which to apply the spending limit. Leave this empty to limit all charges.
+        /// </summary>
+        [JsonProperty("categories")]
+        public List<string> Categories { get; set; }
+
+        /// <summary>
+        /// The time interval with which to apply this spending limit towards. Allowed values are
+        /// <c>per_authorization</c>, <c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>,
+        /// or <c>all_time</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderCreateOptions.cs
@@ -5,6 +5,9 @@ namespace Stripe.Issuing
 
     public class CardholderCreateOptions : CardholderSharedOptions
     {
+        /// <summary>
+        /// The type of cardholder. Possible values are <c>individual</c> or <c>business_entity</c>.
+        /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
     }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
@@ -4,15 +4,35 @@ namespace Stripe.Issuing
 
     public class CardholderListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// Only return cardholders that have the given email address.
+        /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// Only return the default cardholder.
+        /// </summary>
+        [JsonProperty("is_default")]
+        public bool? IsDefault { get; set; }
+
+        /// <summary>
+        /// Only return cardholders that have the given phone number.
+        /// </summary>
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
 
+        /// <summary>
+        /// Only return cardholders that have the given status. One of <c>active</c>,
+        /// <c>inactive</c>, or <c>blocked</c>.
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        /// <summary>
+        /// Only return cardholders that have the given type. One of <c>individual</c> or
+        /// <c>business_entity</c>.
+        /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
     }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderSharedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderSharedOptions.cs
@@ -5,21 +5,53 @@ namespace Stripe.Issuing
 
     public class CardholderSharedOptions : BaseOptions
     {
+        /// <summary>
+        /// Spending rules that give you control over how your cardholders can make charges.
+        /// </summary>
+        [JsonProperty("authorization_controls")]
+        public AuthorizationControlsOptions AuthorizationControls { get; set; }
+
+        /// <summary>
+        /// The cardholder’s billing address.
+        /// </summary>
         [JsonProperty("billing")]
         public BillingOptions Billing { get; set; }
 
+        /// <summary>
+        /// The cardholder’s email address.
+        /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// Specifies whether to set this as the default cardholder.
+        /// </summary>
+        [JsonProperty("is_default")]
+        public bool? IsDefault { get; set; }
+
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a charge object. It can be useful for
+        /// storing additional information about the charge in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// The cardholder’s name. This will be printed on cards issued to them.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Maximum amount allowed to spend per time interval.
+        /// </summary>
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
 
+        /// <summary>
+        /// Specifies whether to permit authorizations on this cardholder’s cards. Possible values
+        /// are <c>active</c> or <c>inactive</c>.
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
     }

--- a/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
@@ -1,19 +1,34 @@
 namespace Stripe.Issuing
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class AuthorizationControlsOptions : INestedOptions
     {
+        /// <summary>
+        /// Categories of authorizations permitted on this card.
+        /// </summary>
         [JsonProperty("allowed_categories")]
         public List<string> AllowedCategories { get; set; }
 
+        /// <summary>
+        /// Categories of authorizations to always decline on this card.
+        /// </summary>
         [JsonProperty("blocked_categories")]
         public List<string> BlockedCategories { get; set; }
 
+        /// <summary>
+        /// Limit the spending with rules based on time intervals and categories.
+        /// </summary>
+        [JsonProperty("spending_limits")]
+        public List<SpendingLimitOptions> SpendingLimits { get; set; }
+
+        [Obsolete("Use SpendingLimits")]
         [JsonProperty("max_amount")]
         public long? MaxAmount { get; set; }
 
+        [Obsolete("Use SpendingLimits")]
         [JsonProperty("max_approvals")]
         public long? MaxApprovals { get; set; }
     }

--- a/src/Stripe.net/Services/Issuing/Cards/SpendingLimitOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/SpendingLimitOptions.cs
@@ -1,0 +1,28 @@
+namespace Stripe.Issuing
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SpendingLimitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Maximum amount allowed to spend per time interval.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// categories on which to apply the spending limit. Leave this empty to limit all charges.
+        /// </summary>
+        [JsonProperty("categories")]
+        public List<string> Categories { get; set; }
+
+        /// <summary>
+        /// The time interval with which to apply this spending limit towards. Allowed values are
+        /// <c>per_authorization</c>, <c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>,
+        /// or <c>all_time</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+    }
+}

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -26,7 +26,18 @@ namespace StripeTests.Issuing
             {
                 AuthorizationControls = new AuthorizationControlsOptions
                 {
-                    MaxAmount = 123,
+                    SpendingLimits = new List<SpendingLimitOptions>
+                    {
+                        new SpendingLimitOptions
+                        {
+                            Amount = 1000,
+                            Categories = new List<string>
+                            {
+                                "financial_institutions",
+                            },
+                            Interval = "all_time",
+                        },
+                    },
                 },
                 Currency = "usd",
                 Type = "virtual",


### PR DESCRIPTION
Related to https://github.com/stripe/stripe-go/pull/831

r? @ob-stripe 
cc @stripe/api-libraries 