### PR TITLE
Add basic fields in Charge's PMD 3DS field

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
@@ -5,5 +5,10 @@ namespace Stripe
 
     public class ChargePaymentMethodDetailsCardThreeDSecure : StripeEntity
     {
+        [JsonProperty("succeeded")]
+        public bool Succeeded { get; set; }
+
+        [JsonProperty("version")]
+        public string Version { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the fields we just approved for the `payment_method_details[card][three_d_secure]` hash on `Charge`. In the future we will add more information but we want to get those out quickly for users to be able to identify 3DS-based Charges on PaymentMethod.

Related to https://github.com/stripe/stripe-go/pull/832

r? @ob-stripe 
cc @stripe/api-libraries @asolove-stripe