### PR TITLE
Make PaymentIntent expandable on Invoice to fix deserialization issues

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -204,13 +204,36 @@ namespace Stripe
         [JsonProperty("paid")]
         public bool Paid { get; set; }
 
+        #region Expandable PaymentIntent
+
+        /// <summary>
+        /// ID of the PaymentIntent associated with this invoice.
+        /// </summary>
+        [JsonIgnore]
+        public string PaymentIntentId { get; set; }
+
         /// <summary>
         /// The PaymentIntent associated with this invoice. The PaymentIntent is generated when the
         /// invoice is finalized, and can then be used to pay the invoice. Note that voiding an
         /// invoice will cancel the PaymentIntent.
         /// </summary>
-        [JsonProperty("payment_intent")]
+        [JsonIgnore]
         public PaymentIntent PaymentIntent { get; set; }
+
+        [JsonProperty("payment_intent")]
+        internal object InternalPaymentIntent
+        {
+            get
+            {
+                return this.PaymentIntent ?? (object)this.PaymentIntentId;
+            }
+
+            set
+            {
+                StringOrObject<PaymentIntent>.Map(value, s => this.PaymentIntentId = s, o => this.PaymentIntent = o);
+            }
+        }
+        #endregion
 
         [JsonProperty("period_end")]
         [JsonConverter(typeof(DateTimeConverter))]


### PR DESCRIPTION
The `Invoice` resource has a `payment_intent` property that is supposed to be the fully expanded `PaymentIntent` resource associated with that invoice.

Today though, the events of type `invoice.*` will send `payment_intent: "pi_123"` for performance reasons. Because of this, deserialization fails which causes crashes as seen in https://github.com/stripe/stripe-dotnet/issues/1579.

This approach allows users to deserialize those events and access the PaymentIntent id. This is not a perfect solution but a good temporary fix. I will not merge/release until we've met internally to decide if this is the right path forward but I wanted the PR to be ready.

r? @ob-stripe 
cc @stripe/api-libraries @mickjermsurawong-stripe @py-stripe 