### PR TITLE
Fix two properties to be string as expected on PaymentMethodDetails

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresentReceipt.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresentReceipt.cs
@@ -15,10 +15,10 @@ namespace Stripe
         public string AuthorizationCode { get; set; }
 
         [JsonProperty("authorization_response_code")]
-        public long AuthorizationResponseCode { get; set; }
+        public string AuthorizationResponseCode { get; set; }
 
         [JsonProperty("cardholder_verification_method")]
-        public long CardholderVerificationMethod { get; set; }
+        public string CardholderVerificationMethod { get; set; }
 
         [JsonProperty("dedicated_file_name")]
         public string DedicatedFileName { get; set; }


### PR DESCRIPTION
In `payment_method_details[card_present][receipt]` two fields were incorrectly marked as `long` instead of `string`.

Since deserialization would fail, this is likely more a patch release and not a breaking change.

r? @ob-stripe 
cc @stripe/api-libraries @jd-stripe 