### PR TITLE
Fix BillingDetails on PaymentMethod creation to have the right params

### DIFF
--- a/src/Stripe.net/Services/PaymentMethods/BillingDetailsOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/BillingDetailsOptions.cs
@@ -7,19 +7,13 @@ namespace Stripe
         [JsonProperty("address")]
         public AddressOptions Address { get; set; }
 
-        [JsonProperty("country")]
-        public string Country { get; set; }
+        [JsonProperty("email")]
+        public string Email { get; set; }
 
-        [JsonProperty("line1")]
-        public string Line1 { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-        [JsonProperty("line2")]
-        public string Line2 { get; set; }
-
-        [JsonProperty("postal_code")]
-        public string PostalCode { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
+        [JsonProperty("phone")]
+        public string Phone { get; set; }
     }
 }


### PR DESCRIPTION
I'm thinking this is still worth doing a major release for even though it's a fix.

r? @ob-stripe
cc @stripe/api-libraries 