### PR TITLE
Add support for passing application information

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ var chargesYesterday = chargeService.List(new ChargeListOptions {
 });
 ```
 
+### Writing a Plugin
+
+If you're writing a plugin that uses the library, we'd appreciate it if you identified using `StripeConfiguration.AppInfo`:
+
+```c#
+StripeConfiguration.AppInfo = new AppInfo
+{
+    Name = "MyAwesomePlugin",
+    URL = "https://myawesomeplugin.info",
+    Version = "1.2.34",
+};
+```
+
+This information is passed along when the library makes calls to the Stripe API. Note that while Name is always required, URL and Version are optional.
+
 ## Contribution Guidelines
 
 We welcome contributions from anyone interested in Stripe or Stripe.net development. If you'd like to submit a pull request, it's best to start with an issue to describe what you'd like to build.

--- a/src/Stripe.net/Infrastructure/Public/AppInfo.cs
+++ b/src/Stripe.net/Infrastructure/Public/AppInfo.cs
@@ -1,0 +1,61 @@
+namespace Stripe
+{
+    using System.Text;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Contains information about the "app" which this integration belongs to. This should be
+    /// reserved for plugins that wish to identify themselves with Stripe.
+    /// </summary>
+    public class AppInfo
+    {
+        /// <summary>Gets or sets the name of your application (e.g. <c>"MyAwesomeApp"</c>).</summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets your Stripe Partner ID (e.g. <c>"pp_partner_1234"</c>), if you have one.
+        /// </summary>
+        [JsonProperty("partner_id")]
+        public string PartnerId { get; set; }
+
+        /// <summary>Gets or sets the version of your application (e.g. <c>"1.2.34"</c>).</summary>
+        [JsonProperty("version")]
+        public string Version { get; set; }
+
+        /// <summary>Gets or sets the website for your application (e.g. <c>"https://myawesomeapp.info"</c>).</summary>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Formats a <see cref="AppInfo"/> in a way that's suitable to be appended to a
+        /// <c>User-Agent</c> string.
+        /// </summary>
+        /// <returns>The formatted app information to be appended.</returns>
+        /// <remarks>
+        /// Note that this format is shared between all libraries so if it's changed, it should be
+        /// changed everywhere.
+        /// </remarks>
+        public string FormatUserAgent()
+        {
+            var b = new StringBuilder();
+
+            b.Append(this.Name);
+
+            if (!string.IsNullOrEmpty(this.Version))
+            {
+                b.Append("/");
+                b.Append(this.Version);
+            }
+
+            if (!string.IsNullOrEmpty(this.Url))
+            {
+                b.Append(" (");
+                b.Append(this.Url);
+                b.Append(")");
+            }
+
+            return b.ToString();
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -12,6 +12,9 @@ namespace Stripe
     public static class StripeConfiguration
     {
         private static string apiKey;
+
+        private static AppInfo appInfo;
+
         private static string clientId;
 
         private static IStripeClient stripeClient;
@@ -154,6 +157,31 @@ namespace Stripe
 
         /// <summary>Gets the version of the Stripe.net client library.</summary>
         public static string StripeNetVersion { get; }
+
+        /// <summary>
+        /// Sets information about the "app" which this integration belongs to. This should be
+        /// reserved for plugins that wish to identify themselves with Stripe.
+        /// </summary>
+        public static AppInfo AppInfo
+        {
+            internal get => appInfo;
+
+            set
+            {
+                if ((value != null) && string.IsNullOrEmpty(value.Name))
+                {
+                    throw new ArgumentException("AppInfo.Name cannot be empty");
+                }
+
+                appInfo = value;
+
+                // This is run when the client is first initialized, but we need to reinitialize
+                // now that we have some app info.
+                // This is done through ugly casting because we don't want to make this part of
+                // the IStripeClient and IHTTP client interfaces.
+                ((StripeClient as StripeClient)?.HttpClient as SystemNetHttpClient)?.InitUserAgentStrings();
+            }
+        }
 
         /// <summary>Gets or sets a value indicating whether to sleep between network retries.</summary>
         /// <remarks>This is an internal property meant to be used in tests.</remarks>

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -1,11 +1,14 @@
 namespace StripeTests
 {
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
     using Moq.Protected;
+    using Newtonsoft.Json.Linq;
     using Stripe;
     using Xunit;
 
@@ -30,6 +33,60 @@ namespace StripeTests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("Hello world!", response.Content);
+        }
+
+        [Fact]
+        public async Task UserAgentIncludesAppInfo()
+        {
+            var origAppInfo = StripeConfiguration.AppInfo;
+
+            try
+            {
+                StripeConfiguration.AppInfo = new AppInfo
+                {
+                    Name = "MyAwesomeApp",
+                    PartnerId = "pp_123",
+                    Version = "1.2.34",
+                    Url = "https://myawesomeapp.info"
+                };
+
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                responseMessage.Content = new StringContent("Hello world!");
+                var mockHandler = new Mock<HttpClientHandler>();
+                mockHandler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>())
+                    .Returns(Task.FromResult(responseMessage));
+
+                var client = new SystemNetHttpClient(new System.Net.Http.HttpClient(mockHandler.Object));
+                var request = new StripeRequest(HttpMethod.Post, "/foo", null, null);
+                await client.MakeRequestAsync(request);
+
+                mockHandler.Protected()
+                    .Verify(
+                        "SendAsync",
+                        Times.Once(),
+                        ItExpr.Is<HttpRequestMessage>(m => this.VerifyHeaders(m.Headers)),
+                        ItExpr.IsAny<CancellationToken>());
+            }
+            finally
+            {
+                StripeConfiguration.AppInfo = origAppInfo;
+            }
+        }
+
+        private bool VerifyHeaders(HttpRequestHeaders headers)
+        {
+            var userAgent = headers.UserAgent.ToString();
+            var appInfo = JObject.Parse(headers.GetValues("X-Stripe-Client-User-Agent").First())["application"];
+
+            return userAgent.Contains("MyAwesomeApp/1.2.34 (https://myawesomeapp.info)") &&
+                appInfo.Value<string>("name") == "MyAwesomeApp" &&
+                appInfo.Value<string>("partner_id") == "pp_123" &&
+                appInfo.Value<string>("version") == "1.2.34" &&
+                appInfo.Value<string>("url") == "https://myawesomeapp.info";
         }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Adds a `StripeConfiguration.SetAppInfo()` method to provide application information that will be passed to Stripe in user-agent headers.
