### PR TITLE
Add support for file_link_data

### DIFF
--- a/src/Stripe.net/Services/Files/FileCreateOptions.cs
+++ b/src/Stripe.net/Services/Files/FileCreateOptions.cs
@@ -13,6 +13,13 @@ namespace Stripe
         public Stream File { get; set; }
 
         /// <summary>
+        /// Optional parameters to automatically create a <see cref="FileLink"/> for the newly
+        /// created file.
+        /// </summary>
+        [JsonProperty("file_link_data")]
+        public FileLinkDataOptions FileLinkData { get; set; }
+
+        /// <summary>
         /// REQUIRED. The purpose of the uploaded file. Possible values are <c>business_logo</c>,
         /// <c>customer_signature</c>, <c>dispute_evidence</c>, <c>identity_document</c>,
         /// <c>pci_document</c>, or <c>tax_document_user_upload</c>

--- a/src/Stripe.net/Services/Files/FileLinkDataOptions.cs
+++ b/src/Stripe.net/Services/Files/FileLinkDataOptions.cs
@@ -1,0 +1,31 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FileLinkDataOptions : BaseOptions
+    {
+        /// <summary>
+        /// Set this to <c>true</c> to create a file link for the newly created file. Creating a
+        /// link is only possible when the file’s purpose is one of the following:
+        /// <c>business_icon</c>, <c>business_logo</c>, <c>customer_signature</c>,
+        /// <c>dispute_evidence</c>, <c>pci_document</c>, or <c>tax_document_user_upload</c>.
+        /// </summary>
+        [JsonProperty("create")]
+        public bool? Create { get; set; }
+
+        /// <summary>
+        /// A future timestamp after which the link will no longer be usable.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
     using System.Reflection;
@@ -25,6 +26,14 @@ namespace StripeTests
             this.createOptions = new FileCreateOptions
             {
                 File = typeof(FileServiceTest).GetTypeInfo().Assembly.GetManifestResourceStream(FileName),
+                FileLinkData = new FileLinkDataOptions
+                {
+                    Create = true,
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "key", "value" },
+                    },
+                },
                 Purpose = FilePurpose.BusinessLogo,
             };
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add support for `file_link_data` in file creation requests.

Fortunately, nothing special was needed here: the new encoder (#1504) handles nested parameters just fine \o/
