### PR TITLE
Mark OperatorAccount as deprecated across all Terminal APIs.

### DIFF
--- a/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenCreateOptions.cs
+++ b/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenCreateOptions.cs
@@ -1,9 +1,11 @@
 namespace Stripe.Terminal
 {
+    using System;
     using Newtonsoft.Json;
 
     public class ConnectionTokenCreateOptions : BaseOptions
     {
+        [Obsolete("This feature has been deprecated and should not be used moving forward.")]
         [JsonProperty("operator_account")]
         public string OperatorAccount { get; set; }
     }

--- a/src/Stripe.net/Services/Terminal/Locations/LocationListOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationListOptions.cs
@@ -1,9 +1,11 @@
 namespace Stripe.Terminal
 {
+    using System;
     using Newtonsoft.Json;
 
     public class LocationListOptions : ListOptions
     {
+        [Obsolete("This feature has been deprecated and should not be used moving forward.")]
         [JsonProperty("operator_account")]
         public string OperatorAccount { get; set; }
     }

--- a/src/Stripe.net/Services/Terminal/Locations/LocationSharedOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationSharedOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe.Terminal
 {
+    using System;
     using Newtonsoft.Json;
 
     public class LocationSharedOptions : BaseOptions
@@ -10,6 +11,7 @@ namespace Stripe.Terminal
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }
 
+        [Obsolete("This feature has been deprecated and should not be used moving forward.")]
         [JsonProperty("operator_account")]
         public string OperatorAccount { get; set; }
     }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderListOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderListOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe.Terminal
 {
+    using System;
     using Newtonsoft.Json;
 
     public class ReaderListOptions : ListOptions
@@ -7,6 +8,7 @@ namespace Stripe.Terminal
         [JsonProperty("location")]
         public string Location { get; set; }
 
+        [Obsolete("This feature has been deprecated and should not be used moving forward.")]
         [JsonProperty("operator_account")]
         public string OperatorAccount { get; set; }
     }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderSharedOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderSharedOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe.Terminal
 {
+    using System;
     using Newtonsoft.Json;
 
     public class ReaderSharedOptions : BaseOptions
@@ -7,6 +8,7 @@ namespace Stripe.Terminal
         [JsonProperty("label")]
         public string Label { get; set; }
 
+        [Obsolete("This feature has been deprecated and should not be used moving forward.")]
         [JsonProperty("operator_account")]
         public string OperatorAccount { get; set; }
     }


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 
cc @daz-stripe 