### PR TITLE
Raise ArgumentException on null or empty IDs

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
@@ -301,6 +302,13 @@ namespace Stripe
 
         protected virtual string InstanceUrl(string id)
         {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException(
+                    "The resource ID cannot be null or whitespace.",
+                    nameof(id));
+            }
+
             return $"{this.ClassUrl()}/{WebUtility.UrlEncode(id)}";
         }
 

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net;
     using System.Net.Http;
@@ -168,11 +169,32 @@ namespace Stripe
 
         protected virtual string ClassUrl(string parentId)
         {
+            if (string.IsNullOrWhiteSpace(parentId))
+            {
+                throw new ArgumentException(
+                    "The parent resource ID cannot be null or whitespace.",
+                    nameof(parentId));
+            }
+
             return this.BasePath.Replace("{PARENT_ID}", parentId);
         }
 
         protected virtual string InstanceUrl(string parentId, string id)
         {
+            if (string.IsNullOrWhiteSpace(parentId))
+            {
+                throw new ArgumentException(
+                    "The parent resource ID cannot be null or whitespace.",
+                    nameof(parentId));
+            }
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException(
+                    "The resource ID cannot be null or whitespace.",
+                    nameof(id));
+            }
+
             return $"{this.ClassUrl(parentId)}/{WebUtility.UrlEncode(id)}";
         }
     }

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -22,6 +23,33 @@ namespace StripeTests
 
             Assert.Contains("simple", client.LastOptions.Expand);
             Assert.Contains("multi_word_property", client.LastOptions.Expand);
+        }
+
+        [Fact]
+        public void Get_ThrowsIfIdIsNull()
+        {
+            var client = new TestClient();
+            var service = new TestService { Client = client };
+
+            Assert.Throws<ArgumentException>(() => service.Get(null));
+        }
+
+        [Fact]
+        public void Get_ThrowsIfIdIsEmpty()
+        {
+            var client = new TestClient();
+            var service = new TestService { Client = client };
+
+            Assert.Throws<ArgumentException>(() => service.Get(string.Empty));
+        }
+
+        [Fact]
+        public void Get_ThrowsIfIdIsWhitespace()
+        {
+            var client = new TestClient();
+            var service = new TestService { Client = client };
+
+            Assert.Throws<ArgumentException>(() => service.Get(" "));
         }
 
         [Fact]


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Checks that IDs are not null or empty (or whitespace) when forming instance URLs. Otherwise an invalid URL is formed and the API returns an unclear error (cf. #1614).
