### PR TITLE
Add OffSession parameter to PaymentIntent

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
@@ -19,6 +19,9 @@ namespace Stripe
         [JsonProperty("invoice_charge_reason")]
         public string InvoiceChargeReason { get; set; }
 
+        [JsonProperty("off_session")]
+        public string OffSession { get; set; }
+
         [JsonProperty("payment_method")]
         public string PaymentMethodId { get; set; }
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -14,6 +14,9 @@ namespace Stripe
         [JsonProperty("confirmation_method")]
         public string ConfirmationMethod { get; set; }
 
+        [JsonProperty("off_session")]
+        public string OffSession { get; set; }
+
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
 


### PR DESCRIPTION
cc @stripe/api-libraries 
r? @brandur @remi-stripe 

Adds `off_session` parameter [0] to PaymentIntent create and confirm.

[0] https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-off_session