### PR TITLE
Remove StripeConfiguration.EnableTelemetry flag

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
+++ b/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
@@ -24,11 +24,6 @@ namespace Stripe
         /// <param name="headers">The request headers.</param>
         public void MaybeAddTelemetryHeader(IDictionary<string, string> headers)
         {
-            if (!StripeConfiguration.EnableTelemetry)
-            {
-                return;
-            }
-
             if (headers.ContainsKey("X-Stripe-Client-Telemetry"))
             {
                 return;
@@ -53,11 +48,6 @@ namespace Stripe
         /// <param name="duration">The request duration.</param>
         public void MaybeEnqueueMetrics(HttpResponseMessage response, TimeSpan duration)
         {
-            if (!StripeConfiguration.EnableTelemetry)
-            {
-                return;
-            }
-
             if (!response.Headers.Contains("Request-Id"))
             {
                 return;

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -105,9 +105,6 @@ namespace Stripe
         /// <summary>Gets or sets the base URL for Stripe's OAuth API.</summary>
         public static string ConnectBase { get; set; } = DefaultConnectBase;
 
-        /// <summary>Gets or sets a value indicating whether telemetry is enabled.</summary>
-        public static bool EnableTelemetry { get; set; }
-
         /// <summary>Gets or sets the base URL for Stripe's Files API.</summary>
         public static string FilesBase { get; set; } = DefaultFilesBase;
 

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -24,38 +24,15 @@ namespace StripeTests
         public void Dispose()
         {
             this.ResetStripeClient();
-            StripeConfiguration.EnableTelemetry = false;
         }
 
         [Fact]
-        public void TelemetryDisabled()
-        {
-            this.ResetStripeClient();
-            FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
-
-            StripeConfiguration.EnableTelemetry = false;
-            var service = new BalanceService();
-            service.Get();
-            service.Get();
-            service.Get();
-
-            this.MockHttpClientFixture.MockHandler.Protected()
-                .Verify(
-                    "SendAsync",
-                    Times.Exactly(3),
-                    ItExpr.Is<HttpRequestMessage>(m =>
-                        !m.Headers.Contains("X-Stripe-Client-Telemetry")),
-                    ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public void TelemetryEnabled()
+        public void TelemetryWorks()
         {
             this.ResetStripeClient();
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
             fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
-            StripeConfiguration.EnableTelemetry = true;
             var service = new BalanceService();
             service.Get();
             fakeServer.Delay = TimeSpan.FromMilliseconds(40);
@@ -100,7 +77,6 @@ namespace StripeTests
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
             fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
-            StripeConfiguration.EnableTelemetry = true;
             var service = new BalanceService();
 
             // the first 2 requests will not contain telemetry


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Remove the `StripeConfiguration.EnableTelemetry` flag. Telemetry is now always enabled. There's really no good reason to have a flag for this: request telemetry carries no PII and the performance impact should be negligible.

This isn't a breaking change because the flag was added earlier in the integration branch for the unreleased future major version.
