### PR TITLE
Move default values for SystemNetHttpClient

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -36,19 +36,6 @@ namespace Stripe
         /// <summary>Default base URL for Stripe's Files API.</summary>
         public static string DefaultFilesBase => "https://files.stripe.com";
 
-        /// <summary>Default timespan before the request times out.</summary>
-        public static TimeSpan DefaultHttpTimeout => TimeSpan.FromSeconds(80);
-
-        /// <summary>
-        /// Maximum sleep time between tries to send HTTP requests after network failure.
-        /// </summary>
-        public static TimeSpan MaxNetworkRetriesDelay => TimeSpan.FromSeconds(5);
-
-        /// <summary>
-        /// Minimum sleep time between tries to send HTTP requests after network failure.
-        /// </summary>
-        public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
-
         /// <summary>Gets or sets the base URL for Stripe's API.</summary>
         public static string ApiBase { get; set; } = DefaultApiBase;
 

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -44,6 +44,19 @@ namespace Stripe
             this.InitUserAgentStrings();
         }
 
+        /// <summary>Default timespan before the request times out.</summary>
+        public static TimeSpan DefaultHttpTimeout => TimeSpan.FromSeconds(80);
+
+        /// <summary>
+        /// Maximum sleep time between tries to send HTTP requests after network failure.
+        /// </summary>
+        public static TimeSpan MaxNetworkRetriesDelay => TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Minimum sleep time between tries to send HTTP requests after network failure.
+        /// </summary>
+        public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
+
         /// <summary>
         /// Initializes a new instance of the <see cref="System.Net.Http.HttpClient"/> class
         /// with default parameters.
@@ -56,7 +69,7 @@ namespace Stripe
             // want these headers to be present even when a custom HTTP client is used.
             return new System.Net.Http.HttpClient
             {
-                Timeout = StripeConfiguration.DefaultHttpTimeout,
+                Timeout = DefaultHttpTimeout,
             };
         }
 
@@ -249,13 +262,13 @@ namespace Stripe
 
             // Apply exponential backoff with MinNetworkRetriesDelay on the number of numRetries
             // so far as inputs.
-            var delay = TimeSpan.FromTicks((long)(StripeConfiguration.MinNetworkRetriesDelay.Ticks
+            var delay = TimeSpan.FromTicks((long)(MinNetworkRetriesDelay.Ticks
                 * Math.Pow(2, numRetries - 1)));
 
             // Do not allow the number to exceed MaxNetworkRetriesDelay
-            if (delay > StripeConfiguration.MaxNetworkRetriesDelay)
+            if (delay > MaxNetworkRetriesDelay)
             {
-                delay = StripeConfiguration.MaxNetworkRetriesDelay;
+                delay = MaxNetworkRetriesDelay;
             }
 
             // Apply some jitter by randomizing the value in the range of 75%-100%.
@@ -268,9 +281,9 @@ namespace Stripe
             delay = TimeSpan.FromTicks((long)(delay.Ticks * jitter));
 
             // But never sleep less than the base sleep seconds.
-            if (delay < StripeConfiguration.MinNetworkRetriesDelay)
+            if (delay < MinNetworkRetriesDelay)
             {
-                delay = StripeConfiguration.MinNetworkRetriesDelay;
+                delay = MinNetworkRetriesDelay;
             }
 
             return delay;


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Move default values used by `SystemNetHttpClient` out of `StripeConfiguration` and in `SystemNetHttpClient` itself.

There's not much point in having these values in the global `StripeConfiguration` class. Users who are interested in these values for some reason can still look them up directly in the `SystemNetHttpClient` class.

Not a breaking change because these values were added in the integration branch for the unreleased next major version.