### PR TITLE
Pin library to API version 2019-05-16

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -9,7 +9,7 @@ namespace Stripe
 
     public static class StripeConfiguration
     {
-        private static string stripeApiVersion = "2019-03-14";
+        private static string stripeApiVersion = "2019-05-16";
 
         private static string apiKey;
         private static string apiBase;


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Like https://github.com/stripe/stripe-java/pull/781. Just like for stripe-go, I'd rather release #1626 first.
