### PR TITLE
Refactor StripeClient setup in tests

### DIFF
--- a/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
@@ -8,8 +8,8 @@ namespace StripeTests
 
     public class StripeResponseTest : BaseStripeTest
     {
-        public StripeResponseTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public StripeResponseTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
         {
         }
 

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -14,19 +14,24 @@ namespace StripeTests
 
     public class SystemNetHttpClientTest : BaseStripeTest
     {
+        public SystemNetHttpClientTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+        }
+
         [Fact]
         public async Task MakeRequestAsync()
         {
             var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
             responseMessage.Content = new StringContent("Hello world!");
-            var mockHandler = new Mock<HttpClientHandler>();
-            mockHandler.Protected()
+            this.MockHttpClientFixture.MockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.FromResult(responseMessage));
-            var client = new SystemNetHttpClient(new System.Net.Http.HttpClient(mockHandler.Object));
+            var client = new SystemNetHttpClient(
+                new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
             var request = new StripeRequest(HttpMethod.Post, "/foo", null, null);
 
             var response = await client.MakeRequestAsync(request);
@@ -52,19 +57,19 @@ namespace StripeTests
 
                 var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
                 responseMessage.Content = new StringContent("Hello world!");
-                var mockHandler = new Mock<HttpClientHandler>();
-                mockHandler.Protected()
+                this.MockHttpClientFixture.MockHandler.Protected()
                     .Setup<Task<HttpResponseMessage>>(
                         "SendAsync",
                         ItExpr.IsAny<HttpRequestMessage>(),
                         ItExpr.IsAny<CancellationToken>())
                     .Returns(Task.FromResult(responseMessage));
 
-                var client = new SystemNetHttpClient(new System.Net.Http.HttpClient(mockHandler.Object));
+                var client = new SystemNetHttpClient(
+                    new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
                 var request = new StripeRequest(HttpMethod.Post, "/foo", null, null);
                 await client.MakeRequestAsync(request);
 
-                mockHandler.Protected()
+                this.MockHttpClientFixture.MockHandler.Protected()
                     .Verify(
                         "SendAsync",
                         Times.Once(),

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -6,6 +6,11 @@ namespace StripeTests
 
     public class StripeExceptionTest : BaseStripeTest
     {
+        public StripeExceptionTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
         [Fact]
         public async Task SetsStripeResponse()
         {

--- a/src/StripeTests/MockHttpClientFixture.cs
+++ b/src/StripeTests/MockHttpClientFixture.cs
@@ -1,6 +1,5 @@
 namespace StripeTests
 {
-    using System;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
@@ -8,31 +7,22 @@ namespace StripeTests
     using Moq;
     using Moq.Protected;
     using Stripe;
-    using Stripe.Infrastructure;
 
-    public class MockHttpClientFixture : IDisposable
+    public class MockHttpClientFixture
     {
-        private readonly IStripeClient origClient;
-
         public MockHttpClientFixture()
         {
             this.MockHandler = new Mock<HttpClientHandler>
             {
                 CallBase = true
             };
-            var httpClient = new System.Net.Http.HttpClient(this.MockHandler.Object);
-            var stripeClient = new StripeClient(new Stripe.SystemNetHttpClient(httpClient));
-
-            this.origClient = StripeConfiguration.StripeClient;
-            StripeConfiguration.StripeClient = stripeClient;
+            this.HttpClient = new SystemNetHttpClient(
+                new System.Net.Http.HttpClient(this.MockHandler.Object));
         }
 
         public Mock<HttpClientHandler> MockHandler { get; }
 
-        public void Dispose()
-        {
-            StripeConfiguration.StripeClient = this.origClient;
-        }
+        public SystemNetHttpClient HttpClient { get; }
 
         /// <summary>
         /// Resets the mock's state.

--- a/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
+++ b/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
@@ -12,8 +12,10 @@ namespace StripeTests
         private readonly AccountLinkService service;
         private readonly AccountLinkCreateOptions createOptions;
 
-        public AccountLinkServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public AccountLinkServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new AccountLinkService();
 

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -19,8 +19,10 @@ namespace StripeTests
         private readonly AccountListOptions listOptions;
         private readonly AccountRejectOptions rejectOptions;
 
-        public AccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public AccountServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new AccountService();
 

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests
         private readonly ApplePayDomainCreateOptions createOptions;
         private readonly ApplePayDomainListOptions listOptions;
 
-        public ApplePayDomainServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ApplePayDomainServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ApplePayDomainService();
 

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly ApplicationFeeRefundUpdateOptions updateOptions;
         private readonly ApplicationFeeRefundListOptions listOptions;
 
-        public ApplicationFeeRefundServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ApplicationFeeRefundServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ApplicationFeeRefundService();
 

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly ApplicationFeeService service;
         private readonly ApplicationFeeListOptions listOptions;
 
-        public ApplicationFeeServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ApplicationFeeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ApplicationFeeService();
 

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -11,8 +11,10 @@ namespace StripeTests
     {
         private readonly BalanceService service;
 
-        public BalanceServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public BalanceServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new BalanceService();
         }

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly BalanceTransactionService service;
         private readonly BalanceTransactionListOptions listOptions;
 
-        public BalanceTransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public BalanceTransactionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new BalanceTransactionService();
 

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -19,8 +19,10 @@ namespace StripeTests
         private readonly BankAccountListOptions listOptions;
         private readonly BankAccountVerifyOptions verifyOptions;
 
-        public BankAccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public BankAccountServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new BankAccountService();
 

--- a/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
@@ -16,8 +16,10 @@ namespace StripeTests
         private readonly CapabilityUpdateOptions updateOptions;
         private readonly CapabilityListOptions listOptions;
 
-        public CapabilityServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CapabilityServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CapabilityService();
 

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -22,8 +22,10 @@ namespace StripeTests
         private readonly CardUpdateOptions updateOptions;
         private readonly CardListOptions listOptions;
 
-        public CardServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CardServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CardService();
 

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly ChargeUpdateOptions updateOptions;
         private readonly ChargeListOptions listOptions;
 
-        public ChargeServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ChargeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ChargeService();
 

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests.Checkout
         private readonly SessionService service;
         private readonly SessionCreateOptions createOptions;
 
-        public SessionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SessionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SessionService();
 

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly CountrySpecService service;
         private readonly CountrySpecListOptions listOptions;
 
-        public CountrySpecServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CountrySpecServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CountrySpecService();
 

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly CouponUpdateOptions updateOptions;
         private readonly CouponListOptions listOptions;
 
-        public CouponServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CouponServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CouponService();
 

--- a/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
+++ b/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly CreditNoteListOptions listOptions;
         private readonly CreditNoteVoidOptions voidOptions;
 
-        public CreditNoteServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CreditNoteServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CreditNoteService();
 

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly CustomerUpdateOptions updateOptions;
         private readonly CustomerListOptions listOptions;
 
-        public CustomerServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CustomerServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CustomerService();
 

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -11,8 +11,10 @@ namespace StripeTests
     {
         private readonly DiscountService service;
 
-        public DiscountServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public DiscountServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new DiscountService();
         }

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -16,8 +16,10 @@ namespace StripeTests
         private readonly DisputeUpdateOptions updateOptions;
         private readonly DisputeListOptions listOptions;
 
-        public DisputeServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public DisputeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new DisputeService();
 

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly EphemeralKeyService service;
         private readonly EphemeralKeyCreateOptions createOptions;
 
-        public EphemeralKeyServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public EphemeralKeyServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new EphemeralKeyService();
 

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly EventService service;
         private readonly EventListOptions listOptions;
 
-        public EventServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public EventServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new EventService();
 

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -10,8 +10,8 @@ namespace StripeTests
         private readonly string json;
         private readonly string secret;
 
-        public EventUtilityTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public EventUtilityTest()
+            : base()
         {
             this.eventTimestamp = 1533204620;
             this.secret = "webhook_secret";

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -12,8 +12,10 @@ namespace StripeTests
         private readonly ExchangeRateService service;
         private readonly ExchangeRateListOptions listOptions;
 
-        public ExchangeRateServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ExchangeRateServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ExchangeRateService();
 

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly ExternalAccountUpdateOptions updateOptions;
         private readonly ExternalAccountListOptions listOptions;
 
-        public ExternalAccountServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ExternalAccountServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ExternalAccountService();
 

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly FileLinkUpdateOptions updateOptions;
         private readonly FileLinkListOptions listOptions;
 
-        public FileLinkServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public FileLinkServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new FileLinkService();
 

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly FileCreateOptions createOptions;
         private readonly FileListOptions listOptions;
 
-        public FileServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public FileServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new FileService();
 

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly InvoiceItemUpdateOptions updateOptions;
         private readonly InvoiceItemListOptions listOptions;
 
-        public InvoiceItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public InvoiceItemServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new InvoiceItemService();
 

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -25,8 +25,10 @@ namespace StripeTests
         private readonly InvoiceSendOptions sendOptions;
         private readonly InvoiceVoidOptions voidOptions;
 
-        public InvoiceServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public InvoiceServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new InvoiceService();
 

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -16,8 +16,10 @@ namespace StripeTests.Issuing
         private readonly AuthorizationUpdateOptions updateOptions;
         private readonly AuthorizationListOptions listOptions;
 
-        public AuthorizationServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public AuthorizationServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new AuthorizationService();
 

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests.Issuing
         private readonly CardholderUpdateOptions updateOptions;
         private readonly CardholderListOptions listOptions;
 
-        public CardholderServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public CardholderServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CardholderService();
 

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests.Issuing
         private readonly CardUpdateOptions updateOptions;
         private readonly CardListOptions listOptions;
 
-        public IssuingCardServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public IssuingCardServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new CardService();
 

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests.Issuing
         private readonly DisputeUpdateOptions updateOptions;
         private readonly DisputeListOptions listOptions;
 
-        public IssuingDisputeServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public IssuingDisputeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new DisputeService();
 

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -16,8 +16,10 @@ namespace StripeTests.Issuing
         private readonly TransactionUpdateOptions updateOptions;
         private readonly TransactionListOptions listOptions;
 
-        public TransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TransactionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TransactionService();
 

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly LoginLinkService service;
         private readonly LoginLinkCreateOptions createOptions;
 
-        public LoginLinkServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public LoginLinkServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new LoginLinkService();
 

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -19,8 +19,10 @@ namespace StripeTests
         private readonly OAuthTokenCreateOptions createOptions;
         private readonly OAuthDeauthorizeOptions deauthorizeOptions;
 
-        public OAuthTokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public OAuthTokenServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new OAuthTokenService();
 

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly OrderPayOptions payOptions;
         private readonly OrderListOptions listOptions;
 
-        public OrderServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public OrderServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new OrderService();
 

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -20,8 +20,10 @@ namespace StripeTests
         private readonly PaymentIntentListOptions listOptions;
         private readonly PaymentIntentUpdateOptions updateOptions;
 
-        public PaymentIntentServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public PaymentIntentServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new PaymentIntentService();
 

--- a/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
+++ b/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
@@ -19,8 +19,10 @@ namespace StripeTests
         private readonly PaymentMethodListOptions listOptions;
         private readonly PaymentMethodUpdateOptions updateOptions;
 
-        public PaymentMethodServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public PaymentMethodServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new PaymentMethodService();
 

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly PayoutUpdateOptions updateOptions;
         private readonly PayoutListOptions listOptions;
 
-        public PayoutServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public PayoutServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new PayoutService();
 

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly PersonUpdateOptions updateOptions;
         private readonly PersonListOptions listOptions;
 
-        public PersonServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public PersonServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new PersonService();
 

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly PlanUpdateOptions updateOptions;
         private readonly PlanListOptions listOptions;
 
-        public PlanServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public PlanServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new PlanService();
 

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly ProductUpdateOptions updateOptions;
         private readonly ProductListOptions listOptions;
 
-        public ProductServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ProductServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ProductService();
 

--- a/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
+++ b/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests.Radar
         private readonly EarlyFraudWarningService service;
         private readonly EarlyFraudWarningListOptions listOptions;
 
-        public EarlyFraudWarningServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public EarlyFraudWarningServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new EarlyFraudWarningService();
 

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests.Radar
         private readonly ValueListItemCreateOptions createOptions;
         private readonly ValueListItemListOptions listOptions;
 
-        public ValueListItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ValueListItemServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ValueListItemService();
 

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests.Radar
         private readonly ValueListUpdateOptions updateOptions;
         private readonly ValueListListOptions listOptions;
 
-        public ValueListServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ValueListServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ValueListService();
 

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -17,9 +17,11 @@ namespace StripeTests
         private readonly RefundUpdateOptions updateOptions;
         private readonly RefundListOptions listOptions;
 
-        public RefundServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
-        {
+        public RefundServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+       {
             this.service = new RefundService();
 
             this.createOptions = new RefundCreateOptions

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -16,9 +16,11 @@ namespace StripeTests.Reporting
         private readonly ReportRunCreateOptions createOptions;
         private readonly ReportRunListOptions listOptions;
 
-        public ReportRunServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
-        {
+        public ReportRunServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+       {
             this.service = new ReportRunService();
 
             this.createOptions = new ReportRunCreateOptions

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests.Reporting
         private readonly ReportTypeService service;
         private readonly ReportTypeListOptions listOptions;
 
-        public ReportTypeServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ReportTypeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ReportTypeService();
 

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests
         private readonly ReviewApproveOptions approveOptions;
         private readonly ReviewListOptions listOptions;
 
-        public ReviewServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ReviewServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ReviewService();
 

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly ScheduledQueryRunService service;
         private readonly ScheduledQueryRunListOptions listOptions;
 
-        public ScheduledQueryRunServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ScheduledQueryRunServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ScheduledQueryRunService();
 

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly SkuUpdateOptions updateOptions;
         private readonly SkuListOptions listOptions;
 
-        public SkuServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SkuServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SkuService();
 

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -14,8 +14,10 @@ namespace StripeTests
         private readonly SourceTransactionService service;
         private readonly SourceTransactionsListOptions listOptions;
 
-        public SourceTransactionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SourceTransactionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SourceTransactionService();
 

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -21,8 +21,10 @@ namespace StripeTests
         private readonly SourceUpdateOptions updateOptions;
         private readonly SourceVerifyOptions verifyOptions;
 
-        public SourceServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SourceServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SourceService();
 

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly SubscriptionItemUpdateOptions updateOptions;
         private readonly SubscriptionItemListOptions listOptions;
 
-        public SubscriptionItemServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SubscriptionItemServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SubscriptionItemService();
 

--- a/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests
         private readonly SubscriptionScheduleRevisionService service;
         private readonly SubscriptionScheduleRevisionListOptions listOptions;
 
-        public SubscriptionScheduleRevisionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SubscriptionScheduleRevisionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SubscriptionScheduleRevisionService();
 

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -19,8 +19,10 @@ namespace StripeTests
         private readonly SubscriptionScheduleReleaseOptions releaseOptions;
         private readonly SubscriptionScheduleUpdateOptions updateOptions;
 
-        public SubscriptionScheduleServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SubscriptionScheduleServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SubscriptionScheduleService();
 

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly SubscriptionUpdateOptions updateOptions;
         private readonly SubscriptionListOptions listOptions;
 
-        public SubscriptionServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public SubscriptionServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new SubscriptionService();
 

--- a/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
+++ b/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
@@ -16,8 +16,10 @@ namespace StripeTests
         private readonly TaxIdCreateOptions createOptions;
         private readonly TaxIdListOptions listOptions;
 
-        public TaxIdServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TaxIdServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TaxIdService();
 

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly TaxRateUpdateOptions updateOptions;
         private readonly TaxRateListOptions listOptions;
 
-        public TaxRateServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TaxRateServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TaxRateService();
 

--- a/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
@@ -13,8 +13,10 @@ namespace StripeTests.Terminal
         private readonly ConnectionTokenService service;
         private readonly ConnectionTokenCreateOptions createOptions;
 
-        public ConnectionTokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ConnectionTokenServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ConnectionTokenService();
 

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests.Terminal
         private readonly LocationListOptions listOptions;
         private readonly LocationUpdateOptions updateOptions;
 
-        public LocationServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public LocationServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new LocationService();
 

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests.Terminal
         private readonly ReaderListOptions listOptions;
         private readonly ReaderUpdateOptions updateOptions;
 
-        public ReaderServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ReaderServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ReaderService();
 

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -12,8 +12,10 @@ namespace StripeTests
         private readonly ThreeDSecureService service;
         private readonly ThreeDSecureCreateOptions createOptions;
 
-        public ThreeDSecureServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public ThreeDSecureServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new ThreeDSecureService();
 

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -15,8 +15,10 @@ namespace StripeTests
         private readonly TokenService service;
         private readonly TokenCreateOptions createOptions;
 
-        public TokenServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TokenServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TokenService();
 

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly TopupUpdateOptions updateOptions;
         private readonly TopupListOptions listOptions;
 
-        public TopupServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TopupServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TopupService();
 

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -18,8 +18,10 @@ namespace StripeTests
         private readonly TransferReversalUpdateOptions updateOptions;
         private readonly TransferReversalListOptions listOptions;
 
-        public TransferReversalServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TransferReversalServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TransferReversalService();
 

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly TransferUpdateOptions updateOptions;
         private readonly TransferListOptions listOptions;
 
-        public TransferServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public TransferServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new TransferService();
 

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -13,8 +13,10 @@ namespace StripeTests
         private readonly UsageRecordSummaryService service;
         private readonly UsageRecordSummaryListOptions listOptions;
 
-        public UsageRecordSummaryServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public UsageRecordSummaryServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new UsageRecordSummaryService();
 

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -13,8 +13,10 @@ namespace StripeTests
         private readonly UsageRecordService service;
         private readonly UsageRecordCreateOptions createOptions;
 
-        public UsageRecordServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public UsageRecordServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new UsageRecordService();
 

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -17,8 +17,10 @@ namespace StripeTests
         private readonly WebhookEndpointUpdateOptions updateOptions;
         private readonly WebhookEndpointListOptions listOptions;
 
-        public WebhookEndpointServiceTest(MockHttpClientFixture mockHttpClientFixture)
-            : base(mockHttpClientFixture)
+        public WebhookEndpointServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
         {
             this.service = new WebhookEndpointService();
 

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -56,6 +56,19 @@ namespace StripeTests
         }
 
         /// <summary>
+        /// Creates and returns a new instance of <see cref="StripeClient"/> suitable for use with
+        /// stripe-mock.
+        /// </summary>
+        /// <param name="httpClient">
+        /// The <see cref="IHttpClient"/> client to use. If <c>null</c>, an HTTP client will be
+        /// created with default parameters.
+        /// </param>
+        public StripeClient BuildStripeClient(IHttpClient httpClient = null)
+        {
+            return new StripeClient(httpClient: httpClient);
+        }
+
+        /// <summary>
         /// Gets fixture data with expansions specified. Expansions are specified the same way as
         /// they are in the normal API like <c>customer</c> or <c>data.customer</c>.
         /// Use the special <c>*</c> character to specify that all fields should be


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Changes the way `StripeClient` is set up in tests.

To clarify what's happening here:
- `MockHttpClientFixture` is only created once for the entire test suite (because it's set up as a ["collection fixture"](https://xunit.net/docs/shared-context#collection-fixture) [here](https://github.com/stripe/stripe-dotnet/blob/136c8b39afd8bf97e770a86eea8dbdce8ab5aedc/src/StripeTests/StripeMockTestCollection.cs#L7))
- `BaseStripeTest` is the parent class for all tests, so its constructor is called for each test class

The problem with the previous implementation is that since we set up the global `StripeClient` (via `StripeConfiguration.StripeClient`) in `MockHttpClientFixture`, the client was applied for all tests (even those that don't need mocking capabilities). More importantly, if a test needs to modify `StripeConfiguration.StripeClient` for its own purposes, it needs to save the original client and restore it afterwards because other test classes might need the `StripeClient` set up by `MockHttpClientFixture`.

With this change, we create a new `StripeClient` instance for each test class, and use the mock client from `MockHttpClientFixture` if needed. This provides better test isolation, and enables some followup changes I want to make to `StripeClient`.