### PR TITLE
Set base URLs in StripeClient instead of StripeConfiguration

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
@@ -9,6 +9,18 @@ namespace Stripe
     /// </summary>
     public interface IStripeClient
     {
+        /// <summary>Gets the base URL for Stripe's API.</summary>
+        /// <value>The base URL for Stripe's API.</value>
+        string ApiBase { get; }
+
+        /// <summary>Gets the base URL for Stripe's OAuth API.</summary>
+        /// <value>The base URL for Stripe's OAuth API.</value>
+        string ConnectBase { get; }
+
+        /// <summary>Gets the base URL for Stripe's Files API.</summary>
+        /// <value>The base URL for Stripe's Files API.</value>
+        string FilesBase { get; }
+
         /// <summary>Sends a request to Stripe's API as an asynchronous operation.</summary>
         /// <typeparam name="T">Type of the Stripe entity returned by the API.</typeparam>
         /// <param name="method">The HTTP method.</param>

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -21,6 +21,27 @@ namespace Stripe
             this.HttpClient = httpClient ?? BuildDefaultHttpClient();
         }
 
+        /// <summary>Default base URL for Stripe's API.</summary>
+        public static string DefaultApiBase => "https://api.stripe.com";
+
+        /// <summary>Default base URL for Stripe's OAuth API.</summary>
+        public static string DefaultConnectBase => "https://connect.stripe.com";
+
+        /// <summary>Default base URL for Stripe's Files API.</summary>
+        public static string DefaultFilesBase => "https://files.stripe.com";
+
+        /// <summary>Gets or sets the base URL for Stripe's API.</summary>
+        /// <value>The base URL for Stripe's API.</value>
+        public string ApiBase { get; set; } = DefaultApiBase;
+
+        /// <summary>Gets or sets the base URL for Stripe's OAuth API.</summary>
+        /// <value>The base URL for Stripe's OAuth API.</value>
+        public string ConnectBase { get; set; } = DefaultConnectBase;
+
+        /// <summary>Gets or sets the base URL for Stripe's Files API.</summary>
+        /// <value>The base URL for Stripe's Files API.</value>
+        public string FilesBase { get; set; } = DefaultFilesBase;
+
         /// <summary>Gets the <see cref="IHttpClient"/> used to send HTTP requests.</summary>
         /// <value>The <see cref="IHttpClient"/> used to send HTTP requests.</value>
         public IHttpClient HttpClient { get; }
@@ -42,7 +63,7 @@ namespace Stripe
             CancellationToken cancellationToken = default(CancellationToken))
             where T : IStripeEntity
         {
-            var request = new StripeRequest(method, path, options, requestOptions);
+            var request = new StripeRequest(this, method, path, options, requestOptions);
 
             var response = await this.HttpClient.MakeRequestAsync(request, cancellationToken);
 

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -27,18 +27,6 @@ namespace Stripe
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion => "2019-05-16";
 
-        /// <summary>Default base URL for Stripe's API.</summary>
-        public static string DefaultApiBase => "https://api.stripe.com";
-
-        /// <summary>Default base URL for Stripe's OAuth API.</summary>
-        public static string DefaultConnectBase => "https://connect.stripe.com";
-
-        /// <summary>Default base URL for Stripe's Files API.</summary>
-        public static string DefaultFilesBase => "https://files.stripe.com";
-
-        /// <summary>Gets or sets the base URL for Stripe's API.</summary>
-        public static string ApiBase { get; set; } = DefaultApiBase;
-
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>
@@ -88,12 +76,6 @@ namespace Stripe
 
             set => clientId = value;
         }
-
-        /// <summary>Gets or sets the base URL for Stripe's OAuth API.</summary>
-        public static string ConnectBase { get; set; } = DefaultConnectBase;
-
-        /// <summary>Gets or sets the base URL for Stripe's Files API.</summary>
-        public static string FilesBase { get; set; } = DefaultFilesBase;
 
         /// <summary>
         /// Gets or sets the settings used for deserializing JSON objects returned by Stripe's API.
@@ -191,18 +173,6 @@ namespace Stripe
         // TODO: remove everything below this in a future major version
 
         /// <summary>
-        /// Sets the base URL.for Stripe's API.
-        /// This method is deprecated and will be removed in a future version, please use the
-        /// <see cref="ApiBase"/> property setter instead.
-        /// </summary>
-        /// <param name="baseUrl">Base URL.for Stripe's API.</param>
-        [Obsolete("Use StripeConfiguration.ApiBase getter instead.")]
-        public static void SetApiBase(string baseUrl)
-        {
-            ApiBase = baseUrl;
-        }
-
-        /// <summary>
         /// Sets the API key.
         /// This method is deprecated and will be removed in a future version, please use the
         /// <see cref="ApiKey"/> property setter instead.
@@ -212,30 +182,6 @@ namespace Stripe
         public static void SetApiKey(string newApiKey)
         {
             ApiKey = newApiKey;
-        }
-
-        /// <summary>
-        /// Sets the base URL.for Stripe's OAuth API.
-        /// This method is deprecated and will be removed in a future version, please use the
-        /// <see cref="ConnectBase"/> property setter instead.
-        /// </summary>
-        /// <param name="baseUrl">Base URL.for Stripe's OAuth API.</param>
-        [Obsolete("Use StripeConfiguration.ConnectBase setter instead.")]
-        public static void SetConnectBase(string baseUrl)
-        {
-            ConnectBase = baseUrl;
-        }
-
-        /// <summary>
-        /// Sets the base URL.for Stripe's Files API.
-        /// This method is deprecated and will be removed in a future version, please use the
-        /// <see cref="FilesBase"/> property setter instead.
-        /// </summary>
-        /// <param name="baseUrl">Base URL.for Stripe's Files API.</param>
-        [Obsolete("Use StripeConfiguration.FilesBase setter instead.")]
-        public static void SetFilesBase(string baseUrl)
-        {
-            FilesBase = baseUrl;
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -16,21 +16,28 @@ namespace Stripe
         private readonly BaseOptions options;
 
         /// <summary>Initializes a new instance of the <see cref="StripeRequest"/> class.</summary>
+        /// <param name="client">The client creating the request.</param>
         /// <param name="method">The HTTP method.</param>
         /// <param name="path">The path of the request.</param>
         /// <param name="options">The parameters of the request.</param>
         /// <param name="requestOptions">The special modifiers of the request.</param>
         public StripeRequest(
+            IStripeClient client,
             HttpMethod method,
             string path,
             BaseOptions options,
             RequestOptions requestOptions)
         {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
             this.options = options;
 
             this.Method = method;
 
-            this.Uri = BuildUri(method, path, options, requestOptions);
+            this.Uri = BuildUri(client, method, path, options, requestOptions);
 
             this.AuthorizationHeader = BuildAuthorizationHeader(requestOptions);
 
@@ -75,6 +82,7 @@ namespace Stripe
         }
 
         private static Uri BuildUri(
+            IStripeClient client,
             HttpMethod method,
             string path,
             BaseOptions options,
@@ -82,7 +90,7 @@ namespace Stripe
         {
             var b = new StringBuilder();
 
-            b.Append(requestOptions?.BaseUrl ?? StripeConfiguration.ApiBase);
+            b.Append(requestOptions?.BaseUrl ?? client.ApiBase);
             b.Append(path);
 
             if ((method != HttpMethod.Post) && (options != null))

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -24,14 +24,14 @@ namespace Stripe
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
             requestOptions = this.SetupRequestOptions(requestOptions);
-            requestOptions.BaseUrl = requestOptions.BaseUrl ?? StripeConfiguration.FilesBase;
+            requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.Client.FilesBase;
             return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<File> CreateAsync(FileCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             requestOptions = this.SetupRequestOptions(requestOptions);
-            requestOptions.BaseUrl = requestOptions.BaseUrl ?? StripeConfiguration.FilesBase;
+            requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.Client.FilesBase;
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -21,7 +21,7 @@ namespace Stripe
 
         public override string BasePath => "/oauth/token";
 
-        public override string BaseUrl => StripeConfiguration.ConnectBase;
+        public override string BaseUrl => this.Client.ConnectBase;
 
         public virtual Uri AuthorizeUrl(OAuthAuthorizeUrlOptions options, bool express = false)
         {
@@ -31,7 +31,7 @@ namespace Stripe
                 path = "/express" + path;
             }
 
-            return new Uri(StripeConfiguration.ConnectBase + path + "?" +
+            return new Uri(this.Client.ConnectBase + path + "?" +
                 FormEncoder.CreateQueryString(options));
         }
 

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -13,6 +13,8 @@ namespace Stripe
     public abstract class Service<EntityReturned>
         where EntityReturned : IStripeEntity
     {
+        private IStripeClient client;
+
         protected Service()
         {
         }
@@ -26,13 +28,17 @@ namespace Stripe
 
         public abstract string BasePath { get; }
 
-        public virtual string BaseUrl => StripeConfiguration.ApiBase;
+        public virtual string BaseUrl => this.Client.ApiBase;
 
         /// <summary>
         /// Gets or sets the client used by this service to send requests. If <c>null</c>, then the
         /// default client in <see cref="StripeConfiguration.StripeClient"/> is used instead.
         /// </summary>
-        public IStripeClient Client { get; set; }
+        public IStripeClient Client
+        {
+            get => this.client ?? StripeConfiguration.StripeClient;
+            set => this.client = value;
+        }
 
         protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
@@ -217,8 +223,7 @@ namespace Stripe
         {
             options = this.SetupOptions(options, IsStripeList<T>());
             requestOptions = this.SetupRequestOptions(requestOptions);
-            var client = this.Client ?? StripeConfiguration.StripeClient;
-            return await client.RequestAsync<T>(
+            return await this.Client.RequestAsync<T>(
                 method,
                 path,
                 options,

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -8,16 +8,28 @@ namespace StripeTests
 
     public class StripeRequestTest : BaseStripeTest
     {
+        private readonly IStripeClient stripeClient;
+
+        public StripeRequestTest()
+        {
+            this.stripeClient = new StripeClient { ApiBase = "https://client.example.com" };
+        }
+
         [Fact]
         public void Ctor_GetRequest()
         {
-            var options = new TestOptions { String = "string!" };
-            var requestOptions = new RequestOptions();
-            var request = new StripeRequest(HttpMethod.Get, "/get", options, requestOptions);
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                new TestOptions { String = "string!" },
+                new RequestOptions());
 
             Assert.Equal(HttpMethod.Get, request.Method);
-            Assert.Equal($"{StripeConfiguration.ApiBase}/get?string=string!", request.Uri.ToString());
-            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.Equal($"{this.stripeClient.ApiBase}/get?string=string!", request.Uri.ToString());
+            Assert.Equal(
+                $"Bearer {StripeConfiguration.ApiKey}",
+                request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
             Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
@@ -28,13 +40,18 @@ namespace StripeTests
         [Fact]
         public async Task Ctor_PostRequest()
         {
-            var options = new TestOptions { String = "string!" };
-            var requestOptions = new RequestOptions();
-            var request = new StripeRequest(HttpMethod.Post, "/post", options, requestOptions);
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Post,
+                "/post",
+                new TestOptions { String = "string!" },
+                new RequestOptions());
 
             Assert.Equal(HttpMethod.Post, request.Method);
-            Assert.Equal($"{StripeConfiguration.ApiBase}/post", request.Uri.ToString());
-            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.Equal($"{this.stripeClient.ApiBase}/post", request.Uri.ToString());
+            Assert.Equal(
+                $"Bearer {StripeConfiguration.ApiKey}",
+                request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
             Assert.True(request.StripeHeaders.ContainsKey("Idempotency-Key"));
@@ -47,13 +64,20 @@ namespace StripeTests
         [Fact]
         public void Ctor_DeleteRequest()
         {
-            var options = new TestOptions { String = "string!" };
-            var requestOptions = new RequestOptions();
-            var request = new StripeRequest(HttpMethod.Delete, "/delete", options, requestOptions);
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Delete,
+                "/delete",
+                new TestOptions { String = "string!" },
+                new RequestOptions());
 
             Assert.Equal(HttpMethod.Delete, request.Method);
-            Assert.Equal($"{StripeConfiguration.ApiBase}/delete?string=string!", request.Uri.ToString());
-            Assert.Equal($"Bearer {StripeConfiguration.ApiKey}", request.AuthorizationHeader.ToString());
+            Assert.Equal(
+                $"{this.stripeClient.ApiBase}/delete?string=string!",
+                request.Uri.ToString());
+            Assert.Equal(
+                $"Bearer {StripeConfiguration.ApiKey}",
+                request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
             Assert.False(request.StripeHeaders.ContainsKey("Idempotency-Key"));
@@ -69,13 +93,18 @@ namespace StripeTests
                 ApiKey = "sk_override",
                 IdempotencyKey = "idempotency_key",
                 StripeAccount = "acct_456",
-                BaseUrl = "https://example.com",
+                BaseUrl = "https://override.example.com",
                 StripeVersion = "2012-12-21",
             };
-            var request = new StripeRequest(HttpMethod.Get, "/get", null, requestOptions);
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                null,
+                requestOptions);
 
             Assert.Equal(HttpMethod.Get, request.Method);
-            Assert.Equal("https://example.com/get", request.Uri.ToString());
+            Assert.Equal($"{requestOptions.BaseUrl}/get", request.Uri.ToString());
             Assert.Equal("Bearer sk_override", request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal("2012-12-21", request.StripeHeaders["Stripe-Version"]);
@@ -95,11 +124,13 @@ namespace StripeTests
             {
                 StripeConfiguration.ApiKey = null;
 
-                var options = new TestOptions();
-                var requestOptions = new RequestOptions();
-
                 var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+                    new StripeRequest(
+                        this.stripeClient,
+                        HttpMethod.Get,
+                        "/get",
+                        new TestOptions(),
+                        new RequestOptions()));
 
                 Assert.Contains("No API key provided.", exception.Message);
             }
@@ -118,11 +149,13 @@ namespace StripeTests
             {
                 StripeConfiguration.ApiKey = string.Empty;
 
-                var options = new TestOptions();
-                var requestOptions = new RequestOptions();
-
                 var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+                    new StripeRequest(
+                        this.stripeClient,
+                        HttpMethod.Get,
+                        "/get",
+                        new TestOptions(),
+                        new RequestOptions()));
 
                 Assert.Contains("No API key provided.", exception.Message);
             }
@@ -141,11 +174,13 @@ namespace StripeTests
             {
                 StripeConfiguration.ApiKey = "sk_test_123\n";
 
-                var options = new TestOptions();
-                var requestOptions = new RequestOptions();
-
                 var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(HttpMethod.Get, "/get", options, requestOptions));
+                    new StripeRequest(
+                        this.stripeClient,
+                        HttpMethod.Get,
+                        "/get",
+                        new TestOptions(),
+                        new RequestOptions()));
 
                 Assert.Contains(
                     "Your API key is invalid, as it contains whitespace.",

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -32,7 +32,12 @@ namespace StripeTests
                 .Returns(Task.FromResult(responseMessage));
             var client = new SystemNetHttpClient(
                 new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-            var request = new StripeRequest(HttpMethod.Post, "/foo", null, null);
+            var request = new StripeRequest(
+                StripeConfiguration.StripeClient,
+                HttpMethod.Post,
+                "/foo",
+                null,
+                null);
 
             var response = await client.MakeRequestAsync(request);
 
@@ -66,7 +71,12 @@ namespace StripeTests
 
                 var client = new SystemNetHttpClient(
                     new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                var request = new StripeRequest(HttpMethod.Post, "/foo", null, null);
+                var request = new StripeRequest(
+                    StripeConfiguration.StripeClient,
+                    HttpMethod.Post,
+                    "/foo",
+                    null,
+                    null);
                 await client.MakeRequestAsync(request);
 
                 this.MockHttpClientFixture.MockHandler.Protected()

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -68,6 +68,12 @@ namespace StripeTests
 
         private class TestClient : IStripeClient
         {
+            public string ApiBase { get; }
+
+            public string ConnectBase { get; }
+
+            public string FilesBase { get; }
+
             public BaseOptions LastOptions { get; protected set; }
 
             public Task<T> RequestAsync<T>(

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -14,8 +14,6 @@ namespace StripeTests
         /// </remarks>
         private const string MockMinimumVersion = "0.57.0";
 
-        private readonly string origApiBase;
-        private readonly string origFilesBase;
         private readonly string origApiKey;
         private readonly string origClientId;
 
@@ -34,21 +32,15 @@ namespace StripeTests
 
             this.EnsureStripeMockMinimumVersion();
 
-            this.origApiBase = StripeConfiguration.ApiBase;
-            this.origFilesBase = StripeConfiguration.FilesBase;
             this.origApiKey = StripeConfiguration.ApiKey;
             this.origClientId = StripeConfiguration.ClientId;
 
-            StripeConfiguration.ApiBase = $"http://localhost:{this.port}";
-            StripeConfiguration.FilesBase = $"http://localhost:{this.port}";
             StripeConfiguration.ApiKey = "sk_test_123";
             StripeConfiguration.ClientId = "ca_123";
         }
 
         public void Dispose()
         {
-            StripeConfiguration.ApiBase = this.origApiBase;
-            StripeConfiguration.FilesBase = this.origFilesBase;
             StripeConfiguration.ApiKey = this.origApiKey;
             StripeConfiguration.ClientId = this.origClientId;
 
@@ -65,7 +57,11 @@ namespace StripeTests
         /// </param>
         public StripeClient BuildStripeClient(IHttpClient httpClient = null)
         {
-            return new StripeClient(httpClient: httpClient);
+            return new StripeClient(httpClient: httpClient)
+            {
+                ApiBase = $"http://localhost:{this.port}",
+                FilesBase = $"http://localhost:{this.port}",
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

(This PR targets the `ob-refactor-test-fixtures` branch for now. Once #1631 is merged I'll change the target branch to `integration-v23`.)

This PR changes the way the base URLs for API requests are set. Instead of being set through the global `StripeConfiguration` singleton, they're now set on the `StripeClient` instance. This makes it easier to test things in isolation.

This is a breaking API change, though it will only affect users that change the base URLs (so probably only users using stripe-mock or a similar local server in their test suites). This change is not documented for now because I want to make more changes to `StripeClient`. I'll do a final update to the README to document "advanced" usages of `StripeClient` once all changes have been made.
