### PR TITLE
Add support for setting API key and client ID in StripeClient

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
@@ -13,6 +13,14 @@ namespace Stripe
         /// <value>The base URL for Stripe's API.</value>
         string ApiBase { get; }
 
+        /// <summary>Gets the API key used by the client to send requests.</summary>
+        /// <value>The API key used by the client to send requests.</value>
+        string ApiKey { get; }
+
+        /// <summary>Gets the client ID used by the client in OAuth requests.</summary>
+        /// <value>The client ID used by the client in OAuth requests.</value>
+        string ClientId { get; }
+
         /// <summary>Gets the base URL for Stripe's OAuth API.</summary>
         /// <value>The base URL for Stripe's OAuth API.</value>
         string ConnectBase { get; }

--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -39,7 +39,7 @@ namespace Stripe
 
             this.Uri = BuildUri(client, method, path, options, requestOptions);
 
-            this.AuthorizationHeader = BuildAuthorizationHeader(requestOptions);
+            this.AuthorizationHeader = BuildAuthorizationHeader(client, requestOptions);
 
             this.StripeHeaders = BuildStripeHeaders(method, requestOptions);
         }
@@ -107,29 +107,10 @@ namespace Stripe
         }
 
         private static AuthenticationHeaderValue BuildAuthorizationHeader(
+            IStripeClient client,
             RequestOptions requestOptions)
         {
-            string apiKey = requestOptions?.ApiKey ?? StripeConfiguration.ApiKey;
-
-            if (string.IsNullOrEmpty(apiKey))
-            {
-                var message = "No API key provided. Set your API key using "
-                    + "`StripeConfiguration.ApiKey = \"<API-KEY>\"`. You can generate API keys "
-                    + "from the Stripe Dashboard. See "
-                    + "https://stripe.com/docs/api/authentication for details or contact support "
-                    + "at https://support.stripe.com/email if you have any questions.";
-                throw new StripeException(message);
-            }
-
-            if (StringUtils.ContainsWhitespace(apiKey))
-            {
-                var message = "Your API key is invalid, as it contains whitespace. You can "
-                    + "double-check your API key from the Stripe Dashboard. See "
-                    + "https://stripe.com/docs/api/authentication for details or contact support "
-                    + "at https://support.stripe.com/email if you have any questions.";
-                throw new StripeException(message);
-            }
-
+            string apiKey = requestOptions?.ApiKey ?? client.ApiKey;
             return new AuthenticationHeaderValue("Bearer", apiKey);
         }
 

--- a/src/Stripe.net/Services/OAuth/OAuthAuthorizeUrlOptions.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthAuthorizeUrlOptions.cs
@@ -17,7 +17,7 @@ namespace Stripe
         /// <see href="https://dashboard.stripe.com/account/applications/settings">application settings</see>.
         /// </summary>
         [JsonProperty("client_id")]
-        public string ClientId { get; set; } = StripeConfiguration.ClientId;
+        public string ClientId { get; set; }
 
         /// <summary>The only option at the moment is <c>code</c>.</summary>
         [JsonProperty("response_type")]

--- a/src/Stripe.net/Services/OAuth/OAuthDeauthorizeOptions.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthDeauthorizeOptions.cs
@@ -9,7 +9,7 @@ namespace Stripe
         /// The account must be connected to this application.
         /// </summary>
         [JsonProperty("client_id")]
-        public string ClientId { get; set; } = StripeConfiguration.ClientId;
+        public string ClientId { get; set; }
 
         /// <summary>The account you'd like to disconnect from.</summary>
         [JsonProperty("stripe_user_id")]

--- a/src/Stripe.net/Services/OAuth/OAuthTokenCreateOptions.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenCreateOptions.cs
@@ -24,7 +24,7 @@ namespace Stripe
         /// depends on whether the <c>client_id</c> used was production or development).
         /// </summary>
         [JsonProperty("client_secret")]
-        public string ClientSecret { get; set; } = StripeConfiguration.ApiKey;
+        public string ClientSecret { get; set; }
 
         /// <summary>The value of the <c>code</c>, depending on the <c>grant_type</c>.</summary>
         [JsonProperty("code")]

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -31,28 +31,82 @@ namespace Stripe
                 path = "/express" + path;
             }
 
+            options = this.SetupOAuthAuthorizeUrlOptions(options);
+
             return new Uri(this.Client.ConnectBase + path + "?" +
                 FormEncoder.CreateQueryString(options));
         }
 
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
+            options = this.SetupOAuthTokenCreateOptions(options);
             return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            options = this.SetupOAuthTokenCreateOptions(options);
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(OAuthDeauthorizeOptions options, RequestOptions requestOptions = null)
         {
+            options = this.SetupOAuthDeauthorizeOptions(options);
             return this.Request<OAuthDeauthorize>(HttpMethod.Post, "/oauth/deauthorize", options, requestOptions);
         }
 
         public virtual Task<OAuthDeauthorize> DeauthorizeAsync(OAuthDeauthorizeOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            options = this.SetupOAuthDeauthorizeOptions(options);
             return this.RequestAsync<OAuthDeauthorize>(HttpMethod.Post, "/oauth/deauthorize", options, requestOptions, cancellationToken);
+        }
+
+        private OAuthAuthorizeUrlOptions SetupOAuthAuthorizeUrlOptions(
+            OAuthAuthorizeUrlOptions options)
+        {
+            if (options == null)
+            {
+                options = new OAuthAuthorizeUrlOptions();
+            }
+
+            if (options.ClientId == null)
+            {
+                options.ClientId = this.Client.ClientId;
+            }
+
+            return options;
+        }
+
+        private OAuthTokenCreateOptions SetupOAuthTokenCreateOptions(
+            OAuthTokenCreateOptions options)
+        {
+            if (options == null)
+            {
+                options = new OAuthTokenCreateOptions();
+            }
+
+            if (options.ClientSecret == null)
+            {
+                options.ClientSecret = this.Client.ApiKey;
+            }
+
+            return options;
+        }
+
+        private OAuthDeauthorizeOptions SetupOAuthDeauthorizeOptions(
+            OAuthDeauthorizeOptions options)
+        {
+            if (options == null)
+            {
+                options = new OAuthDeauthorizeOptions();
+            }
+
+            if (options.ClientId == null)
+            {
+                options.ClientId = this.Client.ClientId;
+            }
+
+            return options;
         }
     }
 }

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -75,7 +75,9 @@ namespace StripeTests
                 // Set up StripeClient with the mock HTTP client
                 var httpClient = new SystemNetHttpClient(
                     new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                StripeConfiguration.StripeClient = new StripeClient(httpClient: httpClient);
+                StripeConfiguration.StripeClient = new StripeClient(
+                    "sk_test_123",
+                    httpClient: httpClient);
 
                 // Reset the mock before each test
                 this.MockHttpClientFixture.Reset();

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -141,7 +141,9 @@ namespace StripeTests
 
             var httpClient = new System.Net.Http.HttpClient(
                 this.MockHttpClientFixture.MockHandler.Object);
-            var stripeClient = new StripeClient(new Stripe.SystemNetHttpClient(httpClient));
+            var stripeClient = new StripeClient(
+                "sk_test_123",
+                httpClient: new Stripe.SystemNetHttpClient(httpClient));
 
             StripeConfiguration.StripeClient = stripeClient;
         }

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
@@ -17,7 +18,9 @@ namespace StripeTests
         public StripeClientTest()
         {
             this.httpClient = new DummyHttpClient();
-            this.stripeClient = new StripeClient(this.httpClient);
+            this.stripeClient = new StripeClient(
+                "sk_test_123",
+                httpClient: this.httpClient);
             this.options = new ChargeCreateOptions
             {
                 Amount = 123,
@@ -25,6 +28,26 @@ namespace StripeTests
                 Source = "tok_visa",
             };
             this.requestOptions = new RequestOptions();
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StripeClient(null));
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyIsEmpty()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => new StripeClient(string.Empty));
+            Assert.Contains("API key cannot be the empty string.", exception.Message);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyContainsWhitespace()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => new StripeClient("sk_test_123\n"));
+            Assert.Contains("API key cannot contain whitespace.", exception.Message);
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -1,0 +1,97 @@
+namespace StripeTests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe;
+    using Xunit;
+
+    public class StripeConfigurationTest : BaseStripeTest
+    {
+        [Fact]
+        public void StripeClient_Getter_CreatesNewStripeClientIfNull()
+        {
+            var origApiKey = StripeConfiguration.ApiKey;
+            var origClientId = StripeConfiguration.ClientId;
+
+            try
+            {
+                StripeConfiguration.ApiKey = "sk_key_stripeconfiguration";
+                StripeConfiguration.ClientId = "ca_stripeconfiguration";
+                StripeConfiguration.StripeClient = null;
+
+                var client = StripeConfiguration.StripeClient;
+                Assert.NotNull(client);
+                Assert.Equal(StripeConfiguration.ApiKey, client.ApiKey);
+                Assert.Equal(StripeConfiguration.ClientId, client.ClientId);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origApiKey;
+                StripeConfiguration.ClientId = origClientId;
+            }
+        }
+
+        [Fact]
+        public void StripeClient_Getter_ThrowsIfClientIsNullAndApiKeyIsNull()
+        {
+            var origApiKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = null;
+                StripeConfiguration.StripeClient = null;
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    StripeConfiguration.StripeClient);
+                Assert.Contains("No API key provided.", exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origApiKey;
+            }
+        }
+
+        [Fact]
+        public void StripeClient_Getter_ThrowsIfClientIsNullAndApiKeyIsEmpty()
+        {
+            var origApiKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = string.Empty;
+                StripeConfiguration.StripeClient = null;
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    StripeConfiguration.StripeClient);
+                Assert.Contains("No API key provided.", exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origApiKey;
+            }
+        }
+
+        [Fact]
+        public void StripeClient_Getter_ThrowsIfClientIsNullAndApiKeyContainsWhitespace()
+        {
+            var origApiKey = StripeConfiguration.ApiKey;
+
+            try
+            {
+                StripeConfiguration.ApiKey = "sk_stripeconfiguration\n";
+                StripeConfiguration.StripeClient = null;
+
+                var exception = Assert.Throws<StripeException>(() =>
+                    StripeConfiguration.StripeClient);
+                Assert.Contains("Your API key is invalid, as it contains whitespace.", exception.Message);
+            }
+            finally
+            {
+                StripeConfiguration.ApiKey = origApiKey;
+            }
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -12,7 +12,10 @@ namespace StripeTests
 
         public StripeRequestTest()
         {
-            this.stripeClient = new StripeClient { ApiBase = "https://client.example.com" };
+            this.stripeClient = new StripeClient("sk_test_123")
+            {
+                ApiBase = "https://client.example.com"
+            };
         }
 
         [Fact]
@@ -28,7 +31,7 @@ namespace StripeTests
             Assert.Equal(HttpMethod.Get, request.Method);
             Assert.Equal($"{this.stripeClient.ApiBase}/get?string=string!", request.Uri.ToString());
             Assert.Equal(
-                $"Bearer {StripeConfiguration.ApiKey}",
+                $"Bearer {this.stripeClient.ApiKey}",
                 request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
@@ -50,7 +53,7 @@ namespace StripeTests
             Assert.Equal(HttpMethod.Post, request.Method);
             Assert.Equal($"{this.stripeClient.ApiBase}/post", request.Uri.ToString());
             Assert.Equal(
-                $"Bearer {StripeConfiguration.ApiKey}",
+                $"Bearer {this.stripeClient.ApiKey}",
                 request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
@@ -76,7 +79,7 @@ namespace StripeTests
                 $"{this.stripeClient.ApiBase}/delete?string=string!",
                 request.Uri.ToString());
             Assert.Equal(
-                $"Bearer {StripeConfiguration.ApiKey}",
+                $"Bearer {this.stripeClient.ApiKey}",
                 request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal(StripeConfiguration.ApiVersion, request.StripeHeaders["Stripe-Version"]);
@@ -88,6 +91,7 @@ namespace StripeTests
         [Fact]
         public void Ctor_RequestOptions()
         {
+            var client = new StripeClient("sk_test_123");
             var requestOptions = new RequestOptions
             {
                 ApiKey = "sk_override",
@@ -105,7 +109,7 @@ namespace StripeTests
 
             Assert.Equal(HttpMethod.Get, request.Method);
             Assert.Equal($"{requestOptions.BaseUrl}/get", request.Uri.ToString());
-            Assert.Equal("Bearer sk_override", request.AuthorizationHeader.ToString());
+            Assert.Equal($"Bearer {requestOptions.ApiKey}", request.AuthorizationHeader.ToString());
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
             Assert.Equal("2012-12-21", request.StripeHeaders["Stripe-Version"]);
             Assert.True(request.StripeHeaders.ContainsKey("Idempotency-Key"));
@@ -113,83 +117,6 @@ namespace StripeTests
             Assert.True(request.StripeHeaders.ContainsKey("Stripe-Account"));
             Assert.Equal("acct_456", request.StripeHeaders["Stripe-Account"]);
             Assert.Null(request.Content);
-        }
-
-        [Fact]
-        public void Ctor_ThrowsIfApiKeyIsNull()
-        {
-            var origKey = StripeConfiguration.ApiKey;
-
-            try
-            {
-                StripeConfiguration.ApiKey = null;
-
-                var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(
-                        this.stripeClient,
-                        HttpMethod.Get,
-                        "/get",
-                        new TestOptions(),
-                        new RequestOptions()));
-
-                Assert.Contains("No API key provided.", exception.Message);
-            }
-            finally
-            {
-                StripeConfiguration.ApiKey = origKey;
-            }
-        }
-
-        [Fact]
-        public void Ctor_ThrowsIfApiKeyIsEmpty()
-        {
-            var origKey = StripeConfiguration.ApiKey;
-
-            try
-            {
-                StripeConfiguration.ApiKey = string.Empty;
-
-                var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(
-                        this.stripeClient,
-                        HttpMethod.Get,
-                        "/get",
-                        new TestOptions(),
-                        new RequestOptions()));
-
-                Assert.Contains("No API key provided.", exception.Message);
-            }
-            finally
-            {
-                StripeConfiguration.ApiKey = origKey;
-            }
-        }
-
-        [Fact]
-        public void Ctor_ThrowsIfApiKeyContainsWhitespace()
-        {
-            var origKey = StripeConfiguration.ApiKey;
-
-            try
-            {
-                StripeConfiguration.ApiKey = "sk_test_123\n";
-
-                var exception = Assert.Throws<StripeException>(() =>
-                    new StripeRequest(
-                        this.stripeClient,
-                        HttpMethod.Get,
-                        "/get",
-                        new TestOptions(),
-                        new RequestOptions()));
-
-                Assert.Contains(
-                    "Your API key is invalid, as it contains whitespace.",
-                    exception.Message);
-            }
-            finally
-            {
-                StripeConfiguration.ApiKey = origKey;
-            }
         }
     }
 }

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -44,6 +44,7 @@ namespace StripeTests
         {
             var options = new OAuthAuthorizeUrlOptions
             {
+                ClientId = "ca_my_client_id",
                 Scope = "read_write",
                 State = "csrf_token",
                 StripeUser = new OAuthAuthorizeUrlStripeUserOptions
@@ -61,7 +62,7 @@ namespace StripeTests
             Assert.Equal("/oauth/authorize", uri.AbsolutePath);
 
             var query = this.ParseQueryString(uri.Query);
-            Assert.Equal("ca_123", query["client_id"]);
+            Assert.Equal("ca_my_client_id", query["client_id"]);
             Assert.Equal("code", query["response_type"]);
             Assert.Equal("read_write", query["scope"]);
             Assert.Equal("csrf_token", query["state"]);
@@ -88,6 +89,17 @@ namespace StripeTests
         }
 
         [Fact]
+        public void AuthorizeUrl_UseClientIdFromStripeClientIfNotProvided()
+        {
+            var options = new OAuthAuthorizeUrlOptions { Scope = "read_write" };
+
+            var uri = this.service.AuthorizeUrl(options);
+
+            var query = this.ParseQueryString(uri.Query);
+            Assert.Equal(StripeConfiguration.StripeClient.ClientId, query["client_id"]);
+        }
+
+        [Fact]
         public void Create()
         {
             // stripe-mock doesn't support OAuth endpoints, so stub the request
@@ -97,7 +109,7 @@ namespace StripeTests
             var oauthToken = this.service.Create(this.createOptions);
             this.AssertRequest(HttpMethod.Post, "/oauth/token");
             Assert.NotNull(oauthToken);
-            Assert.Equal("sk_test_access_token", oauthToken.AccessToken);
+            Assert.Equal("acct_test_token", oauthToken.StripeUserId);
         }
 
         [Fact]

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -70,6 +70,10 @@ namespace StripeTests
         {
             public string ApiBase { get; }
 
+            public string ApiKey { get; }
+
+            public string ClientId { get; }
+
             public string ConnectBase { get; }
 
             public string FilesBase { get; }

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -14,9 +14,6 @@ namespace StripeTests
         /// </remarks>
         private const string MockMinimumVersion = "0.57.0";
 
-        private readonly string origApiKey;
-        private readonly string origClientId;
-
         private readonly string port;
 
         public StripeMockFixture()
@@ -31,19 +28,10 @@ namespace StripeTests
             }
 
             this.EnsureStripeMockMinimumVersion();
-
-            this.origApiKey = StripeConfiguration.ApiKey;
-            this.origClientId = StripeConfiguration.ClientId;
-
-            StripeConfiguration.ApiKey = "sk_test_123";
-            StripeConfiguration.ClientId = "ca_123";
         }
 
         public void Dispose()
         {
-            StripeConfiguration.ApiKey = this.origApiKey;
-            StripeConfiguration.ClientId = this.origClientId;
-
             StripeMockHandler.StopStripeMock();
         }
 
@@ -57,7 +45,10 @@ namespace StripeTests
         /// </param>
         public StripeClient BuildStripeClient(IHttpClient httpClient = null)
         {
-            return new StripeClient(httpClient: httpClient)
+            return new StripeClient(
+                "sk_test_123",
+                "ca_123",
+                httpClient: httpClient)
             {
                 ApiBase = $"http://localhost:{this.port}",
                 FilesBase = $"http://localhost:{this.port}",


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This PR adds support for setting the API key and the client ID directly in the `StripeClient` instance instead of relying on the global `StripeConfiguration` object.

Setting these values via `StripeConfiguration` is still supported. Whenever `StripeConfiguration.ApiKey` or `StripeConfiguration.ClientId` is set, `StripeConfiguration.StripeClient` is reset to `null` so that on the next request, a new `StripeClient` instance will be created with the updated values.

I will update the documentation to clarify that when setting a custom `StripeClient` instance directly via `StripeConfiguration.StripeClient`, you must 1. pass the API key (and optionally the client ID) in the `StripeClient`'s constructor and 2. _not_ set `StripeConfiguration.ApiKey` or `StripeConfiguration.ClientId` afterwards, otherwise your custom `StripeClient` will be lost.
