### PR TITLE
Use StripeClient instance in tests

### DIFF
--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -59,7 +59,7 @@ namespace StripeTests
                 // Set up StripeClient to use stripe-mock with the mock HTTP client
                 var httpClient = new SystemNetHttpClient(
                     new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                StripeConfiguration.StripeClient = this.StripeMockFixture.BuildStripeClient(
+                this.StripeClient = this.StripeMockFixture.BuildStripeClient(
                     httpClient: httpClient);
 
                 // Reset the mock before each test
@@ -68,14 +68,14 @@ namespace StripeTests
             else if (this.StripeMockFixture != null)
             {
                 // Set up StripeClient to use stripe-mock
-                StripeConfiguration.StripeClient = this.StripeMockFixture.BuildStripeClient();
+                this.StripeClient = this.StripeMockFixture.BuildStripeClient();
             }
             else if (this.MockHttpClientFixture != null)
             {
                 // Set up StripeClient with the mock HTTP client
                 var httpClient = new SystemNetHttpClient(
                     new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                StripeConfiguration.StripeClient = new StripeClient(
+                this.StripeClient = new StripeClient(
                     "sk_test_123",
                     httpClient: httpClient);
 
@@ -85,9 +85,11 @@ namespace StripeTests
             else
             {
                 // Use the default StripeClient
-                StripeConfiguration.StripeClient = null;
+                this.StripeClient = new StripeClient("sk_test_123");
             }
         }
+
+        protected IStripeClient StripeClient { get; }
 
         protected MockHttpClientFixture MockHttpClientFixture { get; }
 

--- a/src/StripeTests/Functional/NetworkRetriesTest.cs
+++ b/src/StripeTests/Functional/NetworkRetriesTest.cs
@@ -17,12 +17,14 @@ namespace StripeTests
         {
             StripeConfiguration.MaxNetworkRetries = 2;
             StripeConfiguration.NetworkRetriesSleep = false;
+            StripeConfiguration.StripeClient = this.StripeClient;
         }
 
         public void Dispose()
         {
             StripeConfiguration.MaxNetworkRetries = 0;
             StripeConfiguration.NetworkRetriesSleep = true;
+            StripeConfiguration.StripeClient = null;
             this.MockHttpClientFixture.Reset();
         }
 

--- a/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
         [Fact]
         public void Date()
         {
-            var response = new AccountService().GetSelf().StripeResponse;
+            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
 
             Assert.NotNull(response.Date);
         }
@@ -31,7 +31,7 @@ namespace StripeTests
         public void IdempotencyKey_Present()
         {
             var requestOptions = new RequestOptions { IdempotencyKey = "idempotency_key" };
-            var response = new AccountService().GetSelf(requestOptions).StripeResponse;
+            var response = new AccountService { Client = this.StripeClient }.GetSelf(requestOptions).StripeResponse;
 
             Assert.Equal("idempotency_key", response.IdempotencyKey);
         }
@@ -39,7 +39,7 @@ namespace StripeTests
         [Fact]
         public void IdempotencyKey_Absent()
         {
-            var response = new AccountService().GetSelf().StripeResponse;
+            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
 
             Assert.Null(response.IdempotencyKey);
         }
@@ -47,7 +47,7 @@ namespace StripeTests
         [Fact]
         public void RequestId()
         {
-            var response = new AccountService().GetSelf().StripeResponse;
+            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
 
             Assert.NotNull(response.RequestId);
         }

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
@@ -12,11 +13,18 @@ namespace StripeTests
     using Stripe;
     using Xunit;
 
-    public class SystemNetHttpClientTest : BaseStripeTest
+    public class SystemNetHttpClientTest : BaseStripeTest, IDisposable
     {
         public SystemNetHttpClientTest(MockHttpClientFixture mockHttpClientFixture)
             : base(mockHttpClientFixture)
         {
+            // TODO: don't use StripeConfiguration
+            StripeConfiguration.StripeClient = this.StripeClient;
+        }
+
+        public void Dispose()
+        {
+            StripeConfiguration.StripeClient = null;
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -15,7 +15,10 @@ namespace StripeTests
         public async Task SetsStripeResponse()
         {
             var exception = await Assert.ThrowsAsync<StripeException>(async () =>
-                await new CouponService().CreateAsync(new CouponCreateOptions()));
+            {
+                await new CouponService { Client = this.StripeClient }
+                    .CreateAsync(new CouponCreateOptions());
+            });
 
             Assert.NotNull(exception);
             Assert.NotNull(exception.StripeError);

--- a/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
+++ b/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AccountLinkService();
+            this.service = new AccountLinkService { Client = this.StripeClient };
 
             this.createOptions = new AccountLinkCreateOptions
             {

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AccountService();
+            this.service = new AccountService { Client = this.StripeClient };
 
             this.createOptions = new AccountCreateOptions
             {

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplePayDomainService();
+            this.service = new ApplePayDomainService { Client = this.StripeClient };
 
             this.createOptions = new ApplePayDomainCreateOptions
             {

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplicationFeeRefundService();
+            this.service = new ApplicationFeeRefundService { Client = this.StripeClient };
 
             this.createOptions = new ApplicationFeeRefundCreateOptions
             {

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplicationFeeService();
+            this.service = new ApplicationFeeService { Client = this.StripeClient };
 
             this.listOptions = new ApplicationFeeListOptions
             {

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -43,7 +43,7 @@ namespace StripeTests
                 .Throws(new StripeTestException("Unexpected invocation!"));
 
             // Call auto-paging method
-            var service = new PageableService();
+            var service = new PageableService { Client = this.StripeClient };
             var options = new ListOptions
             {
                 Limit = 2,

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BalanceService();
+            this.service = new BalanceService { Client = this.StripeClient };
         }
 
         [Fact]

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BalanceTransactionService();
+            this.service = new BalanceTransactionService { Client = this.StripeClient };
 
             this.listOptions = new BalanceTransactionListOptions
             {

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BankAccountService();
+            this.service = new BankAccountService { Client = this.StripeClient };
 
             this.createOptions = new BankAccountCreateOptions
             {

--- a/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CapabilityService();
+            this.service = new CapabilityService { Client = this.StripeClient };
 
             this.updateOptions = new CapabilityUpdateOptions
             {

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -27,7 +27,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardService();
+            this.service = new CardService { Client = this.StripeClient };
 
             this.createOptions = new CardCreateOptions
             {

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ChargeService();
+            this.service = new ChargeService { Client = this.StripeClient };
 
             this.captureOptions = new ChargeCaptureOptions
             {

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests.Checkout
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SessionService();
+            this.service = new SessionService { Client = this.StripeClient };
 
             this.createOptions = new SessionCreateOptions
             {

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CountrySpecService();
+            this.service = new CountrySpecService { Client = this.StripeClient };
 
             this.listOptions = new CountrySpecListOptions
             {

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CouponService();
+            this.service = new CouponService { Client = this.StripeClient };
 
             this.createOptions = new CouponCreateOptions
             {

--- a/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
+++ b/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CreditNoteService();
+            this.service = new CreditNoteService { Client = this.StripeClient };
 
             this.createOptions = new CreditNoteCreateOptions
             {

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CustomerService();
+            this.service = new CustomerService { Client = this.StripeClient };
 
             this.createOptions = new CustomerCreateOptions
             {

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DiscountService();
+            this.service = new DiscountService { Client = this.StripeClient };
         }
 
         [Fact]

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DisputeService();
+            this.service = new DisputeService { Client = this.StripeClient };
 
             this.updateOptions = new DisputeUpdateOptions
             {

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EphemeralKeyService();
+            this.service = new EphemeralKeyService { Client = this.StripeClient };
 
             this.createOptions = new EphemeralKeyCreateOptions
             {

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EventService();
+            this.service = new EventService { Client = this.StripeClient };
 
             this.listOptions = new EventListOptions
             {

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ExchangeRateService();
+            this.service = new ExchangeRateService { Client = this.StripeClient };
 
             this.listOptions = new ExchangeRateListOptions
             {

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ExternalAccountService();
+            this.service = new ExternalAccountService { Client = this.StripeClient };
 
             this.createOptions = new ExternalAccountCreateOptions
             {

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new FileLinkService();
+            this.service = new FileLinkService { Client = this.StripeClient };
 
             this.createOptions = new FileLinkCreateOptions
             {

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new FileService();
+            this.service = new FileService { Client = this.StripeClient };
 
             this.createOptions = new FileCreateOptions
             {

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new InvoiceItemService();
+            this.service = new InvoiceItemService { Client = this.StripeClient };
 
             this.createOptions = new InvoiceItemCreateOptions
             {

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -30,7 +30,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new InvoiceService();
+            this.service = new InvoiceService { Client = this.StripeClient };
 
             this.createOptions = new InvoiceCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AuthorizationService();
+            this.service = new AuthorizationService { Client = this.StripeClient };
 
             this.updateOptions = new AuthorizationUpdateOptions
             {

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardholderService();
+            this.service = new CardholderService { Client = this.StripeClient };
 
             this.createOptions = new CardholderCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardService();
+            this.service = new CardService { Client = this.StripeClient };
 
             this.createOptions = new CardCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DisputeService();
+            this.service = new DisputeService { Client = this.StripeClient };
 
             this.createOptions = new DisputeCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransactionService();
+            this.service = new TransactionService { Client = this.StripeClient };
 
             this.updateOptions = new TransactionUpdateOptions
             {

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new LoginLinkService();
+            this.service = new LoginLinkService { Client = this.StripeClient };
 
             this.createOptions = new LoginLinkCreateOptions
             {

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new OAuthTokenService();
+            this.service = new OAuthTokenService { Client = this.StripeClient };
 
             this.createOptions = new OAuthTokenCreateOptions
             {
@@ -96,7 +96,7 @@ namespace StripeTests
             var uri = this.service.AuthorizeUrl(options);
 
             var query = this.ParseQueryString(uri.Query);
-            Assert.Equal(StripeConfiguration.StripeClient.ClientId, query["client_id"]);
+            Assert.Equal(this.StripeClient.ClientId, query["client_id"]);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new OrderService();
+            this.service = new OrderService { Client = this.StripeClient };
 
             this.createOptions = new OrderCreateOptions
             {

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PaymentIntentService();
+            this.service = new PaymentIntentService { Client = this.StripeClient };
 
             this.cancelOptions = new PaymentIntentCancelOptions
             {

--- a/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
+++ b/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PaymentMethodService();
+            this.service = new PaymentMethodService { Client = this.StripeClient };
 
             this.attachOptions = new PaymentMethodAttachOptions
             {

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PayoutService();
+            this.service = new PayoutService { Client = this.StripeClient };
 
             this.createOptions = new PayoutCreateOptions
             {

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PersonService();
+            this.service = new PersonService { Client = this.StripeClient };
 
             this.createOptions = new PersonCreateOptions
             {

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PlanService();
+            this.service = new PlanService { Client = this.StripeClient };
 
             this.createOptions = new PlanCreateOptions
             {

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ProductService();
+            this.service = new ProductService { Client = this.StripeClient };
 
             this.createOptions = new ProductCreateOptions
             {

--- a/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
+++ b/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EarlyFraudWarningService();
+            this.service = new EarlyFraudWarningService { Client = this.StripeClient };
 
             this.listOptions = new EarlyFraudWarningListOptions
             {

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ValueListItemService();
+            this.service = new ValueListItemService { Client = this.StripeClient };
 
             this.createOptions = new ValueListItemCreateOptions
             {

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ValueListService();
+            this.service = new ValueListService { Client = this.StripeClient };
 
             this.createOptions = new ValueListCreateOptions
             {

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
        {
-            this.service = new RefundService();
+            this.service = new RefundService { Client = this.StripeClient };
 
             this.createOptions = new RefundCreateOptions
             {

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Reporting
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
        {
-            this.service = new ReportRunService();
+            this.service = new ReportRunService { Client = this.StripeClient };
 
             this.createOptions = new ReportRunCreateOptions
             {

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests.Reporting
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReportTypeService();
+            this.service = new ReportTypeService { Client = this.StripeClient };
 
             this.listOptions = new ReportTypeListOptions
             {

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReviewService();
+            this.service = new ReviewService { Client = this.StripeClient };
 
             this.approveOptions = new ReviewApproveOptions
             {

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ScheduledQueryRunService();
+            this.service = new ScheduledQueryRunService { Client = this.StripeClient };
 
             this.listOptions = new ScheduledQueryRunListOptions
             {

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SkuService();
+            this.service = new SkuService { Client = this.StripeClient };
 
             this.createOptions = new SkuCreateOptions
             {

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SourceTransactionService();
+            this.service = new SourceTransactionService { Client = this.StripeClient };
 
             this.listOptions = new SourceTransactionsListOptions
             {

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -26,7 +26,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SourceService();
+            this.service = new SourceService { Client = this.StripeClient };
 
             this.attachOptions = new SourceAttachOptions
             {

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionItemService();
+            this.service = new SubscriptionItemService { Client = this.StripeClient };
 
             this.createOptions = new SubscriptionItemCreateOptions
             {

--- a/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionScheduleRevisionService();
+            this.service = new SubscriptionScheduleRevisionService { Client = this.StripeClient };
 
             this.listOptions = new SubscriptionScheduleRevisionListOptions
             {

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionScheduleService();
+            this.service = new SubscriptionScheduleService { Client = this.StripeClient };
 
             this.cancelOptions = new SubscriptionScheduleCancelOptions
             {

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionService();
+            this.service = new SubscriptionService { Client = this.StripeClient };
 
             this.cancelOptions = new SubscriptionCancelOptions
             {

--- a/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
+++ b/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TaxIdService();
+            this.service = new TaxIdService { Client = this.StripeClient };
 
             this.createOptions = new TaxIdCreateOptions
             {

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TaxRateService();
+            this.service = new TaxRateService { Client = this.StripeClient };
 
             this.createOptions = new TaxRateCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ConnectionTokenService();
+            this.service = new ConnectionTokenService { Client = this.StripeClient };
 
             this.createOptions = new ConnectionTokenCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new LocationService();
+            this.service = new LocationService { Client = this.StripeClient };
 
             this.createOptions = new LocationCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReaderService();
+            this.service = new ReaderService { Client = this.StripeClient };
 
             this.createOptions = new ReaderCreateOptions
             {

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ThreeDSecureService();
+            this.service = new ThreeDSecureService { Client = this.StripeClient };
 
             this.createOptions = new ThreeDSecureCreateOptions
             {

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TokenService();
+            this.service = new TokenService { Client = this.StripeClient };
 
             this.createOptions = new TokenCreateOptions
             {

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TopupService();
+            this.service = new TopupService { Client = this.StripeClient };
 
             this.createOptions = new TopupCreateOptions
             {

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransferReversalService();
+            this.service = new TransferReversalService { Client = this.StripeClient };
 
             this.createOptions = new TransferReversalCreateOptions
             {

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransferService();
+            this.service = new TransferService { Client = this.StripeClient };
 
             this.createOptions = new TransferCreateOptions
             {

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new UsageRecordSummaryService();
+            this.service = new UsageRecordSummaryService { Client = this.StripeClient };
 
             this.listOptions = new UsageRecordSummaryListOptions
             {

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new UsageRecordService();
+            this.service = new UsageRecordService { Client = this.StripeClient };
 
             this.createOptions = new UsageRecordCreateOptions
             {

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new WebhookEndpointService();
+            this.service = new WebhookEndpointService { Client = this.StripeClient };
 
             this.createOptions = new WebhookEndpointCreateOptions
             {


### PR DESCRIPTION
Since `StripeClient` can now hold its own configuration parameters instead of using the global `StripeConfiguration`, tests can now use their own `StripeClient` instance instead of modifying `StripeConfiguration`.

There are a few tests that still need to change `StripeConfiguration`, I need to make a few more changes before I can fix those.

Once all tests have been fixed, we should be able to run them in parallel!

cc @brandur-stripe @remi-stripe 
