### PR TITLE
Add support for setting MaxNetworkRetries and AppInfo in SystemNetHttpClient

### DIFF
--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
@@ -10,7 +10,7 @@ namespace Stripe
         /// <summary>
         /// Events sent to this endpoint will be generated with this API version instead of your
         /// account's default API version. We recommend that you set this to the API version that
-        /// the library is pinned to in <c>StripeConfiguration.stripeApiVersion</c>
+        /// the library is pinned to in <see cref="StripeConfiguration.ApiVersion"/>.
         /// </summary>
         [JsonProperty("api_version")]
         public string ApiVersion { get; set; }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This PR is similar to #1633. Here we allow for setting `MaxNetworkRetries` and `AppInfo` directly when constructing a new instance of `SystemNetHttpClient`.

This fixes the last remaining tests that need to set global properties in `StripeConfiguration`. Now the only test that changes anything in `StripeConfiguration` is `StripeConfigurationTest` \o/

Unfortunately, I don't think I'll be able to enable running tests in parallel. xUnit does not have global setup/teardown hooks, we can only rely on collection fixtures for this, and all tests in the same collection are executed serially. Given that the test suite only takes ~10 seconds to run, I think I'll just leave things as is and be content in the knowledge that tests are now isolated.