### PR TITLE
Make client in services readonly

### DIFF
--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -17,8 +17,8 @@ namespace Stripe
         {
         }
 
-        public AccountService(string apiKey)
-            : base(apiKey)
+        public AccountService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public AccountLinkService(string apiKey)
-            : base(apiKey)
+        public AccountLinkService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public ApplePayDomainService(string apiKey)
-            : base(apiKey)
+        public ApplePayDomainService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public ApplicationFeeRefundService(string apiKey)
-            : base(apiKey)
+        public ApplicationFeeRefundService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public ApplicationFeeService(string apiKey)
-            : base(apiKey)
+        public ApplicationFeeService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Balance/BalanceService.cs
+++ b/src/Stripe.net/Services/Balance/BalanceService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public BalanceService(string apiKey)
-            : base(apiKey)
+        public BalanceService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public BalanceTransactionService(string apiKey)
-            : base(apiKey)
+        public BalanceTransactionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -17,8 +17,8 @@ namespace Stripe
         {
         }
 
-        public BankAccountService(string apiKey)
-            : base(apiKey)
+        public BankAccountService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public CapabilityService(string apiKey)
-            : base(apiKey)
+        public CapabilityService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public CardService(string apiKey)
-            : base(apiKey)
+        public CardService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public ChargeService(string apiKey)
-            : base(apiKey)
+        public ChargeService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Checkout/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/SessionService.cs
@@ -14,8 +14,8 @@ namespace Stripe.Checkout
         {
         }
 
-        public SessionService(string apiKey)
-            : base(apiKey)
+        public SessionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public CountrySpecService(string apiKey)
-            : base(apiKey)
+        public CountrySpecService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public CouponService(string apiKey)
-            : base(apiKey)
+        public CouponService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public CreditNoteService(string apiKey)
-            : base(apiKey)
+        public CreditNoteService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public CustomerService(string apiKey)
-            : base(apiKey)
+        public CustomerService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Discounts/DiscountService.cs
+++ b/src/Stripe.net/Services/Discounts/DiscountService.cs
@@ -11,8 +11,8 @@ namespace Stripe
         {
         }
 
-        public DiscountService(string apiKey)
-            : base(apiKey)
+        public DiscountService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public DisputeService(string apiKey)
-            : base(apiKey)
+        public DisputeService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public EphemeralKeyService(string apiKey)
-            : base(apiKey)
+        public EphemeralKeyService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public EventService(string apiKey)
-            : base(apiKey)
+        public EventService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public ExchangeRateService(string apiKey)
-            : base(apiKey)
+        public ExchangeRateService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public ExternalAccountService(string apiKey)
-            : base(apiKey)
+        public ExternalAccountService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public FileLinkService(string apiKey)
-            : base(apiKey)
+        public FileLinkService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public FileService(string apiKey)
-            : base(apiKey)
+        public FileService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public InvoiceItemService(string apiKey)
-            : base(apiKey)
+        public InvoiceItemService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public InvoiceService(string apiKey)
-            : base(apiKey)
+        public InvoiceService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -15,8 +15,8 @@ namespace Stripe.Issuing
         {
         }
 
-        public AuthorizationService(string apiKey)
-            : base(apiKey)
+        public AuthorizationService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -15,8 +15,8 @@ namespace Stripe.Issuing
         {
         }
 
-        public CardholderService(string apiKey)
-            : base(apiKey)
+        public CardholderService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -16,8 +16,8 @@ namespace Stripe.Issuing
         {
         }
 
-        public CardService(string apiKey)
-            : base(apiKey)
+        public CardService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -15,8 +15,8 @@ namespace Stripe.Issuing
         {
         }
 
-        public DisputeService(string apiKey)
-            : base(apiKey)
+        public DisputeService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -14,8 +14,8 @@ namespace Stripe.Issuing
         {
         }
 
-        public TransactionService(string apiKey)
-            : base(apiKey)
+        public TransactionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/LoginLink/LoginLinkService.cs
+++ b/src/Stripe.net/Services/LoginLink/LoginLinkService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public LoginLinkService(string apiKey)
-            : base(apiKey)
+        public LoginLinkService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public OAuthTokenService(string apiKey)
-            : base(apiKey)
+        public OAuthTokenService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public OrderService(string apiKey)
-            : base(apiKey)
+        public OrderService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public PaymentIntentService(string apiKey)
-            : base(apiKey)
+        public PaymentIntentService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public PaymentMethodService(string apiKey)
-            : base(apiKey)
+        public PaymentMethodService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public PayoutService(string apiKey)
-            : base(apiKey)
+        public PayoutService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public PersonService(string apiKey)
-            : base(apiKey)
+        public PersonService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public PlanService(string apiKey)
-            : base(apiKey)
+        public PlanService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public ProductService(string apiKey)
-            : base(apiKey)
+        public ProductService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Radar
         {
         }
 
-        public EarlyFraudWarningService(string apiKey)
-            : base(apiKey)
+        public EarlyFraudWarningService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -14,8 +14,8 @@ namespace Stripe.Radar
         {
         }
 
-        public ValueListItemService(string apiKey)
-            : base(apiKey)
+        public ValueListItemService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -14,8 +14,8 @@ namespace Stripe.Radar
         {
         }
 
-        public ValueListService(string apiKey)
-            : base(apiKey)
+        public ValueListService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public RefundService(string apiKey)
-            : base(apiKey)
+        public RefundService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -14,8 +14,8 @@ namespace Stripe.Reporting
         {
         }
 
-        public ReportRunService(string apiKey)
-            : base(apiKey)
+        public ReportRunService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Reporting
         {
         }
 
-        public ReportTypeService(string apiKey)
-            : base(apiKey)
+        public ReportTypeService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public ReviewService(string apiKey)
-            : base(apiKey)
+        public ReviewService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Sigma
         {
         }
 
-        public ScheduledQueryRunService(string apiKey)
-            : base(apiKey)
+        public ScheduledQueryRunService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public SkuService(string apiKey)
-            : base(apiKey)
+        public SkuService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -12,8 +12,8 @@ namespace Stripe
         {
         }
 
-        public SourceTransactionService(string apiKey)
-            : base(apiKey)
+        public SourceTransactionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -17,8 +17,8 @@ namespace Stripe
         {
         }
 
-        public SourceService(string apiKey)
-            : base(apiKey)
+        public SourceService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public SubscriptionItemService(string apiKey)
-            : base(apiKey)
+        public SubscriptionItemService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public SubscriptionScheduleRevisionService(string apiKey)
-            : base(apiKey)
+        public SubscriptionScheduleRevisionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public SubscriptionScheduleService(string apiKey)
-            : base(apiKey)
+        public SubscriptionScheduleService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public SubscriptionService(string apiKey)
-            : base(apiKey)
+        public SubscriptionService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public TaxIdService(string apiKey)
-            : base(apiKey)
+        public TaxIdService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public TaxRateService(string apiKey)
-            : base(apiKey)
+        public TaxRateService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
+++ b/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Terminal
         {
         }
 
-        public ConnectionTokenService(string apiKey)
-            : base(apiKey)
+        public ConnectionTokenService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Terminal
         {
         }
 
-        public LocationService(string apiKey)
-            : base(apiKey)
+        public LocationService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -13,8 +13,8 @@ namespace Stripe.Terminal
         {
         }
 
-        public ReaderService(string apiKey)
-            : base(apiKey)
+        public ReaderService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureService.cs
+++ b/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureService.cs
@@ -14,8 +14,8 @@ namespace Stripe
         {
         }
 
-        public ThreeDSecureService(string apiKey)
-            : base(apiKey)
+        public ThreeDSecureService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public TokenService(string apiKey)
-            : base(apiKey)
+        public TokenService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public TopupService(string apiKey)
-            : base(apiKey)
+        public TopupService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public TransferReversalService(string apiKey)
-            : base(apiKey)
+        public TransferReversalService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        public TransferService(string apiKey)
-            : base(apiKey)
+        public TransferService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -12,8 +12,8 @@ namespace Stripe
         {
         }
 
-        public UsageRecordSummaryService(string apiKey)
-            : base(apiKey)
+        public UsageRecordSummaryService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
@@ -13,8 +13,8 @@ namespace Stripe
         {
         }
 
-        public UsageRecordService(string apiKey)
-            : base(apiKey)
+        public UsageRecordService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -16,8 +16,8 @@ namespace Stripe
         {
         }
 
-        public WebhookEndpointService(string apiKey)
-            : base(apiKey)
+        public WebhookEndpointService(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -10,34 +10,44 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure;
 
+    /// <summary>Abstract base class for all services.</summary>
+    /// <typeparam name="EntityReturned">
+    /// The type of <see cref="IStripeEntity"/> that this service returns.
+    /// </typeparam>
     public abstract class Service<EntityReturned>
         where EntityReturned : IStripeEntity
     {
         private IStripeClient client;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Service{EntityReturned}"/> class.
+        /// </summary>
         protected Service()
         {
         }
 
-        protected Service(string apiKey)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Service{EntityReturned}"/> class with a
+        /// custom <see cref="IStripeClient"/>.
+        /// </summary>
+        /// <param name="client">The client used by the service to send requests.</param>
+        protected Service(IStripeClient client)
         {
-            this.ApiKey = apiKey;
+            this.client = client;
         }
-
-        public string ApiKey { get; set; }
 
         public abstract string BasePath { get; }
 
         public virtual string BaseUrl => this.Client.ApiBase;
 
         /// <summary>
-        /// Gets or sets the client used by this service to send requests. If <c>null</c>, then the
-        /// default client in <see cref="StripeConfiguration.StripeClient"/> is used instead.
+        /// Gets the client used by this service to send requests. If no client was set when the
+        /// service instance was created, then the default client in
+        /// <see cref="StripeConfiguration.StripeClient"/> is used instead.
         /// </summary>
         public IStripeClient Client
         {
             get => this.client ?? StripeConfiguration.StripeClient;
-            set => this.client = value;
         }
 
         protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
@@ -288,11 +298,6 @@ namespace Stripe
             if (requestOptions == null)
             {
                 requestOptions = new RequestOptions();
-            }
-
-            if (string.IsNullOrEmpty(requestOptions.ApiKey) && !string.IsNullOrEmpty(this.ApiKey))
-            {
-                requestOptions.ApiKey = this.ApiKey;
             }
 
             requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.BaseUrl;

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -15,8 +15,8 @@ namespace Stripe
         {
         }
 
-        protected ServiceNested(string apiKey)
-            : base(apiKey)
+        protected ServiceNested(IStripeClient client)
+            : base(client)
         {
         }
 

--- a/src/StripeTests/Functional/NetworkRetriesTest.cs
+++ b/src/StripeTests/Functional/NetworkRetriesTest.cs
@@ -47,7 +47,7 @@ namespace StripeTests
                     }))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var balance = service.Get();
 
             Assert.NotNull(balance);
@@ -74,7 +74,7 @@ namespace StripeTests
                     }))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var balance = service.Get();
 
             Assert.NotNull(balance);
@@ -101,7 +101,7 @@ namespace StripeTests
                     }))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var balance = service.Get();
 
             Assert.NotNull(balance);
@@ -128,7 +128,7 @@ namespace StripeTests
                     })
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new CustomerService { Client = this.StripeClient };
+            var service = new CustomerService(this.StripeClient);
             Assert.Throws<StripeException>(() => service.Create(null));
 
             Assert.Equal(1, requestCount);
@@ -150,7 +150,7 @@ namespace StripeTests
                     }))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var balance = service.Get();
 
             Assert.NotNull(balance);
@@ -170,7 +170,7 @@ namespace StripeTests
                 .Throws(new HttpRequestException("Connection error 3"))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var exception = Assert.Throws<HttpRequestException>(() => service.Get());
 
             Assert.NotNull(exception);
@@ -193,7 +193,7 @@ namespace StripeTests
                     }))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var balance = service.Get();
 
             Assert.NotNull(balance);
@@ -213,7 +213,7 @@ namespace StripeTests
                 .Throws(new TaskCanceledException("Timeout 3"))
                 .Throws(new StripeTestException("Unexpected invocation"));
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var exception = Assert.Throws<TaskCanceledException>(() => service.Get());
 
             Assert.NotNull(exception);
@@ -239,7 +239,7 @@ namespace StripeTests
                         };
                     });
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             var source = new CancellationTokenSource();
             source.CancelAfter(TimeSpan.FromMilliseconds(10));
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -28,7 +28,7 @@ namespace StripeTests
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
             fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
             service.Get();
             fakeServer.Delay = TimeSpan.FromMilliseconds(40);
             service.Get();
@@ -72,7 +72,7 @@ namespace StripeTests
             var fakeServer = FakeServer.ForMockHandler(this.MockHttpClientFixture.MockHandler);
             fakeServer.Delay = TimeSpan.FromMilliseconds(20);
 
-            var service = new BalanceService { Client = this.StripeClient };
+            var service = new BalanceService(this.StripeClient);
 
             // the first 2 requests will not contain telemetry
             await Task.WhenAll(service.GetAsync(), service.GetAsync());

--- a/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeResponseTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
         [Fact]
         public void Date()
         {
-            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
+            var response = new AccountService(this.StripeClient).GetSelf().StripeResponse;
 
             Assert.NotNull(response.Date);
         }
@@ -31,7 +31,7 @@ namespace StripeTests
         public void IdempotencyKey_Present()
         {
             var requestOptions = new RequestOptions { IdempotencyKey = "idempotency_key" };
-            var response = new AccountService { Client = this.StripeClient }.GetSelf(requestOptions).StripeResponse;
+            var response = new AccountService(this.StripeClient).GetSelf(requestOptions).StripeResponse;
 
             Assert.Equal("idempotency_key", response.IdempotencyKey);
         }
@@ -39,7 +39,7 @@ namespace StripeTests
         [Fact]
         public void IdempotencyKey_Absent()
         {
-            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
+            var response = new AccountService(this.StripeClient).GetSelf().StripeResponse;
 
             Assert.Null(response.IdempotencyKey);
         }
@@ -47,7 +47,7 @@ namespace StripeTests
         [Fact]
         public void RequestId()
         {
-            var response = new AccountService { Client = this.StripeClient }.GetSelf().StripeResponse;
+            var response = new AccountService(this.StripeClient).GetSelf().StripeResponse;
 
             Assert.NotNull(response.RequestId);
         }

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
         {
             var exception = await Assert.ThrowsAsync<StripeException>(async () =>
             {
-                await new CouponService { Client = this.StripeClient }
+                await new CouponService(this.StripeClient)
                     .CreateAsync(new CouponCreateOptions());
             });
 

--- a/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
+++ b/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AccountLinkService { Client = this.StripeClient };
+            this.service = new AccountLinkService(this.StripeClient);
 
             this.createOptions = new AccountLinkCreateOptions
             {

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AccountService { Client = this.StripeClient };
+            this.service = new AccountService(this.StripeClient);
 
             this.createOptions = new AccountCreateOptions
             {

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplePayDomainService { Client = this.StripeClient };
+            this.service = new ApplePayDomainService(this.StripeClient);
 
             this.createOptions = new ApplePayDomainCreateOptions
             {

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplicationFeeRefundService { Client = this.StripeClient };
+            this.service = new ApplicationFeeRefundService(this.StripeClient);
 
             this.createOptions = new ApplicationFeeRefundCreateOptions
             {

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ApplicationFeeService { Client = this.StripeClient };
+            this.service = new ApplicationFeeService(this.StripeClient);
 
             this.listOptions = new ApplicationFeeListOptions
             {

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -43,7 +43,7 @@ namespace StripeTests
                 .Throws(new StripeTestException("Unexpected invocation!"));
 
             // Call auto-paging method
-            var service = new PageableService { Client = this.StripeClient };
+            var service = new PageableService(this.StripeClient);
             var options = new ListOptions
             {
                 Limit = 2,
@@ -98,6 +98,11 @@ namespace StripeTests
 
         public class PageableService : Service<PageableModel>
         {
+            public PageableService(IStripeClient client)
+                : base(client)
+            {
+            }
+
             public override string BasePath => "/v1/pageablemodels";
 
             public IEnumerable<PageableModel> ListAutoPaging(ListOptions options)

--- a/src/StripeTests/Services/Balance/BalanceServiceTest.cs
+++ b/src/StripeTests/Services/Balance/BalanceServiceTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BalanceService { Client = this.StripeClient };
+            this.service = new BalanceService(this.StripeClient);
         }
 
         [Fact]

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BalanceTransactionService { Client = this.StripeClient };
+            this.service = new BalanceTransactionService(this.StripeClient);
 
             this.listOptions = new BalanceTransactionListOptions
             {

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new BankAccountService { Client = this.StripeClient };
+            this.service = new BankAccountService(this.StripeClient);
 
             this.createOptions = new BankAccountCreateOptions
             {

--- a/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CapabilityService { Client = this.StripeClient };
+            this.service = new CapabilityService(this.StripeClient);
 
             this.updateOptions = new CapabilityUpdateOptions
             {

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -27,7 +27,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardService { Client = this.StripeClient };
+            this.service = new CardService(this.StripeClient);
 
             this.createOptions = new CardCreateOptions
             {

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ChargeService { Client = this.StripeClient };
+            this.service = new ChargeService(this.StripeClient);
 
             this.captureOptions = new ChargeCaptureOptions
             {

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests.Checkout
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SessionService { Client = this.StripeClient };
+            this.service = new SessionService(this.StripeClient);
 
             this.createOptions = new SessionCreateOptions
             {

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CountrySpecService { Client = this.StripeClient };
+            this.service = new CountrySpecService(this.StripeClient);
 
             this.listOptions = new CountrySpecListOptions
             {

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CouponService { Client = this.StripeClient };
+            this.service = new CouponService(this.StripeClient);
 
             this.createOptions = new CouponCreateOptions
             {

--- a/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
+++ b/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CreditNoteService { Client = this.StripeClient };
+            this.service = new CreditNoteService(this.StripeClient);
 
             this.createOptions = new CreditNoteCreateOptions
             {

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CustomerService { Client = this.StripeClient };
+            this.service = new CustomerService(this.StripeClient);
 
             this.createOptions = new CustomerCreateOptions
             {

--- a/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
+++ b/src/StripeTests/Services/Discounts/DiscountServiceTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DiscountService { Client = this.StripeClient };
+            this.service = new DiscountService(this.StripeClient);
         }
 
         [Fact]

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DisputeService { Client = this.StripeClient };
+            this.service = new DisputeService(this.StripeClient);
 
             this.updateOptions = new DisputeUpdateOptions
             {

--- a/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
+++ b/src/StripeTests/Services/EphemeralKeys/EphemeralKeyServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EphemeralKeyService { Client = this.StripeClient };
+            this.service = new EphemeralKeyService(this.StripeClient);
 
             this.createOptions = new EphemeralKeyCreateOptions
             {

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EventService { Client = this.StripeClient };
+            this.service = new EventService(this.StripeClient);
 
             this.listOptions = new EventListOptions
             {

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ExchangeRateService { Client = this.StripeClient };
+            this.service = new ExchangeRateService(this.StripeClient);
 
             this.listOptions = new ExchangeRateListOptions
             {

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ExternalAccountService { Client = this.StripeClient };
+            this.service = new ExternalAccountService(this.StripeClient);
 
             this.createOptions = new ExternalAccountCreateOptions
             {

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new FileLinkService { Client = this.StripeClient };
+            this.service = new FileLinkService(this.StripeClient);
 
             this.createOptions = new FileLinkCreateOptions
             {

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new FileService { Client = this.StripeClient };
+            this.service = new FileService(this.StripeClient);
 
             this.createOptions = new FileCreateOptions
             {

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new InvoiceItemService { Client = this.StripeClient };
+            this.service = new InvoiceItemService(this.StripeClient);
 
             this.createOptions = new InvoiceItemCreateOptions
             {

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -30,7 +30,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new InvoiceService { Client = this.StripeClient };
+            this.service = new InvoiceService(this.StripeClient);
 
             this.createOptions = new InvoiceCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new AuthorizationService { Client = this.StripeClient };
+            this.service = new AuthorizationService(this.StripeClient);
 
             this.updateOptions = new AuthorizationUpdateOptions
             {

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardholderService { Client = this.StripeClient };
+            this.service = new CardholderService(this.StripeClient);
 
             this.createOptions = new CardholderCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new CardService { Client = this.StripeClient };
+            this.service = new CardService(this.StripeClient);
 
             this.createOptions = new CardCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new DisputeService { Client = this.StripeClient };
+            this.service = new DisputeService(this.StripeClient);
 
             this.createOptions = new DisputeCreateOptions
             {

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Issuing
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransactionService { Client = this.StripeClient };
+            this.service = new TransactionService(this.StripeClient);
 
             this.updateOptions = new TransactionUpdateOptions
             {

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new LoginLinkService { Client = this.StripeClient };
+            this.service = new LoginLinkService(this.StripeClient);
 
             this.createOptions = new LoginLinkCreateOptions
             {

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new OAuthTokenService { Client = this.StripeClient };
+            this.service = new OAuthTokenService(this.StripeClient);
 
             this.createOptions = new OAuthTokenCreateOptions
             {

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new OrderService { Client = this.StripeClient };
+            this.service = new OrderService(this.StripeClient);
 
             this.createOptions = new OrderCreateOptions
             {

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PaymentIntentService { Client = this.StripeClient };
+            this.service = new PaymentIntentService(this.StripeClient);
 
             this.cancelOptions = new PaymentIntentCancelOptions
             {

--- a/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
+++ b/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PaymentMethodService { Client = this.StripeClient };
+            this.service = new PaymentMethodService(this.StripeClient);
 
             this.attachOptions = new PaymentMethodAttachOptions
             {

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PayoutService { Client = this.StripeClient };
+            this.service = new PayoutService(this.StripeClient);
 
             this.createOptions = new PayoutCreateOptions
             {

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PersonService { Client = this.StripeClient };
+            this.service = new PersonService(this.StripeClient);
 
             this.createOptions = new PersonCreateOptions
             {

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new PlanService { Client = this.StripeClient };
+            this.service = new PlanService(this.StripeClient);
 
             this.createOptions = new PlanCreateOptions
             {

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ProductService { Client = this.StripeClient };
+            this.service = new ProductService(this.StripeClient);
 
             this.createOptions = new ProductCreateOptions
             {

--- a/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
+++ b/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new EarlyFraudWarningService { Client = this.StripeClient };
+            this.service = new EarlyFraudWarningService(this.StripeClient);
 
             this.listOptions = new EarlyFraudWarningListOptions
             {

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ValueListItemService { Client = this.StripeClient };
+            this.service = new ValueListItemService(this.StripeClient);
 
             this.createOptions = new ValueListItemCreateOptions
             {

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Radar
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ValueListService { Client = this.StripeClient };
+            this.service = new ValueListService(this.StripeClient);
 
             this.createOptions = new ValueListCreateOptions
             {

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
        {
-            this.service = new RefundService { Client = this.StripeClient };
+            this.service = new RefundService(this.StripeClient);
 
             this.createOptions = new RefundCreateOptions
             {

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests.Reporting
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
        {
-            this.service = new ReportRunService { Client = this.StripeClient };
+            this.service = new ReportRunService(this.StripeClient);
 
             this.createOptions = new ReportRunCreateOptions
             {

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests.Reporting
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReportTypeService { Client = this.StripeClient };
+            this.service = new ReportTypeService(this.StripeClient);
 
             this.listOptions = new ReportTypeListOptions
             {

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReviewService { Client = this.StripeClient };
+            this.service = new ReviewService(this.StripeClient);
 
             this.approveOptions = new ReviewApproveOptions
             {

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ScheduledQueryRunService { Client = this.StripeClient };
+            this.service = new ScheduledQueryRunService(this.StripeClient);
 
             this.listOptions = new ScheduledQueryRunListOptions
             {

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SkuService { Client = this.StripeClient };
+            this.service = new SkuService(this.StripeClient);
 
             this.createOptions = new SkuCreateOptions
             {

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -19,7 +19,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SourceTransactionService { Client = this.StripeClient };
+            this.service = new SourceTransactionService(this.StripeClient);
 
             this.listOptions = new SourceTransactionsListOptions
             {

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -26,7 +26,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SourceService { Client = this.StripeClient };
+            this.service = new SourceService(this.StripeClient);
 
             this.attachOptions = new SourceAttachOptions
             {

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionItemService { Client = this.StripeClient };
+            this.service = new SubscriptionItemService(this.StripeClient);
 
             this.createOptions = new SubscriptionItemCreateOptions
             {

--- a/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionScheduleRevisions.cs/SubscriptionScheduleRevisionServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionScheduleRevisionService { Client = this.StripeClient };
+            this.service = new SubscriptionScheduleRevisionService(this.StripeClient);
 
             this.listOptions = new SubscriptionScheduleRevisionListOptions
             {

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionScheduleService { Client = this.StripeClient };
+            this.service = new SubscriptionScheduleService(this.StripeClient);
 
             this.cancelOptions = new SubscriptionScheduleCancelOptions
             {

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new SubscriptionService { Client = this.StripeClient };
+            this.service = new SubscriptionService(this.StripeClient);
 
             this.cancelOptions = new SubscriptionCancelOptions
             {

--- a/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
+++ b/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
@@ -21,7 +21,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TaxIdService { Client = this.StripeClient };
+            this.service = new TaxIdService(this.StripeClient);
 
             this.createOptions = new TaxIdCreateOptions
             {

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TaxRateService { Client = this.StripeClient };
+            this.service = new TaxRateService(this.StripeClient);
 
             this.createOptions = new TaxRateCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/ConnectionTokens/ConnectionTokenServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ConnectionTokenService { Client = this.StripeClient };
+            this.service = new ConnectionTokenService(this.StripeClient);
 
             this.createOptions = new ConnectionTokenCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new LocationService { Client = this.StripeClient };
+            this.service = new LocationService(this.StripeClient);
 
             this.createOptions = new LocationCreateOptions
             {

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests.Terminal
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ReaderService { Client = this.StripeClient };
+            this.service = new ReaderService(this.StripeClient);
 
             this.createOptions = new ReaderCreateOptions
             {

--- a/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
+++ b/src/StripeTests/Services/ThreeDSecure/ThreeDSecureServiceTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new ThreeDSecureService { Client = this.StripeClient };
+            this.service = new ThreeDSecureService(this.StripeClient);
 
             this.createOptions = new ThreeDSecureCreateOptions
             {

--- a/src/StripeTests/Services/Tokens/TokenServiceTest.cs
+++ b/src/StripeTests/Services/Tokens/TokenServiceTest.cs
@@ -20,7 +20,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TokenService { Client = this.StripeClient };
+            this.service = new TokenService(this.StripeClient);
 
             this.createOptions = new TokenCreateOptions
             {

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TopupService { Client = this.StripeClient };
+            this.service = new TopupService(this.StripeClient);
 
             this.createOptions = new TopupCreateOptions
             {

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransferReversalService { Client = this.StripeClient };
+            this.service = new TransferReversalService(this.StripeClient);
 
             this.createOptions = new TransferReversalCreateOptions
             {

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new TransferService { Client = this.StripeClient };
+            this.service = new TransferService(this.StripeClient);
 
             this.createOptions = new TransferCreateOptions
             {

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new UsageRecordSummaryService { Client = this.StripeClient };
+            this.service = new UsageRecordSummaryService(this.StripeClient);
 
             this.listOptions = new UsageRecordSummaryListOptions
             {

--- a/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecords/UsageRecordServiceTest.cs
@@ -18,7 +18,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new UsageRecordService { Client = this.StripeClient };
+            this.service = new UsageRecordService(this.StripeClient);
 
             this.createOptions = new UsageRecordCreateOptions
             {

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -22,7 +22,7 @@ namespace StripeTests
             MockHttpClientFixture mockHttpClientFixture)
             : base(stripeMockFixture, mockHttpClientFixture)
         {
-            this.service = new WebhookEndpointService { Client = this.StripeClient };
+            this.service = new WebhookEndpointService(this.StripeClient);
 
             this.createOptions = new WebhookEndpointCreateOptions
             {

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -15,7 +15,7 @@ namespace StripeTests
         public void Get_ExpandProperties()
         {
             var client = new TestClient();
-            var service = new TestService { Client = client };
+            var service = new TestService(client);
 
             service.ExpandSimple = true;
             service.ExpandMultiWordProperty = true;
@@ -29,7 +29,7 @@ namespace StripeTests
         public void Get_ThrowsIfIdIsNull()
         {
             var client = new TestClient();
-            var service = new TestService { Client = client };
+            var service = new TestService(client);
 
             Assert.Throws<ArgumentException>(() => service.Get(null));
         }
@@ -38,7 +38,7 @@ namespace StripeTests
         public void Get_ThrowsIfIdIsEmpty()
         {
             var client = new TestClient();
-            var service = new TestService { Client = client };
+            var service = new TestService(client);
 
             Assert.Throws<ArgumentException>(() => service.Get(string.Empty));
         }
@@ -47,7 +47,7 @@ namespace StripeTests
         public void Get_ThrowsIfIdIsWhitespace()
         {
             var client = new TestClient();
-            var service = new TestService { Client = client };
+            var service = new TestService(client);
 
             Assert.Throws<ArgumentException>(() => service.Get(" "));
         }
@@ -56,7 +56,7 @@ namespace StripeTests
         public void List_ExpandProperties()
         {
             var client = new TestClient();
-            var service = new TestService { Client = client };
+            var service = new TestService(client);
 
             service.ExpandSimple = true;
             service.ExpandMultiWordProperty = true;
@@ -103,6 +103,11 @@ namespace StripeTests
             IListable<TestEntity, ListOptions>,
             IRetrievable<TestEntity>
         {
+            public TestService(IStripeClient client)
+                : base(client)
+            {
+            }
+
             public override string BasePath => "/v1/test_entities";
 
             public bool ExpandSimple { get; set; }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Make the `IStripeClient` property in `Service` readonly, i.e. it can only be set when the service is created.

Also remove the ability to pass an API key when creating a service. Users who need this can now pass a client instead, i.e. they'd replace:
```c#
var fooService = new FooService(apiKey);
```
with:
```c#
var fooService = new FooService(new StripeClient(apiKey));
```
