### PR TITLE
Add AddRangeExpand method to BaseOptions

### DIFF
--- a/src/Stripe.net/Services/_base/BaseOptions.cs
+++ b/src/Stripe.net/Services/_base/BaseOptions.cs
@@ -36,6 +36,22 @@ namespace Stripe
         }
 
         /// <summary>
+        /// Adds a collection of <c>expand</c> values to the request, to request expansion of
+        /// specific fields in the response. When requesting expansions in a list request, don't
+        /// forget to prefix the field names with <c>data.</c>.
+        /// </summary>
+        /// <param name="values">The collection of names of the fields to expand.</param>
+        public void AddRangeExpand(IEnumerable<string> values)
+        {
+            if (this.Expand == null)
+            {
+                this.Expand = new List<string>();
+            }
+
+            this.Expand.AddRange(values);
+        }
+
+        /// <summary>
         /// Adds an extra parameter to the request. This can be useful if you need to use
         /// parameters not available in regular options classes, e.g. for beta features.
         /// </summary>

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -285,10 +285,7 @@ namespace Stripe
             }
 
             options = options ?? new BaseOptions();
-            foreach (var expansion in serviceExpansions)
-            {
-                options.AddExpand(expansion);
-            }
+            options.AddRangeExpand(serviceExpansions);
 
             return options;
         }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Just a small improvement: add an `AddRangeExpand` method to `BaseOptions` to add a list of fields at once.