### PR TITLE
Add options classes for Get/GetAsync methods

### DIFF
--- a/src/Stripe.net/Services/Account/AccountGetOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class AccountGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -9,7 +9,7 @@ namespace Stripe
         ICreatable<Account, AccountCreateOptions>,
         IDeletable<Account>,
         IListable<Account, AccountListOptions>,
-        IRetrievable<Account>,
+        IRetrievable<Account, AccountGetOptions>,
         IUpdatable<Account, AccountUpdateOptions>
     {
         public AccountService()
@@ -46,14 +46,14 @@ namespace Stripe
             return this.DeleteEntityAsync(accountId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Account Get(string accountId, RequestOptions requestOptions = null)
+        public virtual Account Get(string accountId, AccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(accountId, null, requestOptions);
+            return this.GetEntity(accountId, options, requestOptions);
         }
 
-        public virtual Task<Account> GetAsync(string accountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Account> GetAsync(string accountId, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(accountId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainGetOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ApplePayDomainGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<ApplePayDomain, ApplePayDomainCreateOptions>,
         IDeletable<ApplePayDomain>,
         IListable<ApplePayDomain, ApplePayDomainListOptions>,
-        IRetrievable<ApplePayDomain>
+        IRetrievable<ApplePayDomain, ApplePayDomainGetOptions>
     {
         public ApplePayDomainService()
             : base(null)
@@ -42,14 +42,14 @@ namespace Stripe
             return this.DeleteEntityAsync(domainId, null, requestOptions, cancellationToken);
         }
 
-        public virtual ApplePayDomain Get(string domainId, RequestOptions requestOptions = null)
+        public virtual ApplePayDomain Get(string domainId, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(domainId, null, requestOptions);
+            return this.GetEntity(domainId, options, requestOptions);
         }
 
-        public virtual Task<ApplePayDomain> GetAsync(string domainId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplePayDomain> GetAsync(string domainId, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(domainId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(domainId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplePayDomain> List(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundGetOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ApplicationFeeRefundGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundListOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class ApplicationFeeRefundListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class ApplicationFeeRefundService : ServiceNested<ApplicationFeeRefund>,
         INestedCreatable<ApplicationFeeRefund, ApplicationFeeRefundCreateOptions>,
         INestedListable<ApplicationFeeRefund, ApplicationFeeRefundListOptions>,
-        INestedRetrievable<ApplicationFeeRefund>,
+        INestedRetrievable<ApplicationFeeRefund, ApplicationFeeRefundGetOptions>,
         INestedUpdatable<ApplicationFeeRefund, ApplicationFeeRefundUpdateOptions>
     {
         public ApplicationFeeRefundService()
@@ -36,14 +36,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(applicationFeeId, options, requestOptions, cancellationToken);
         }
 
-        public virtual ApplicationFeeRefund Get(string applicationFeeId, string refundId, RequestOptions requestOptions = null)
+        public virtual ApplicationFeeRefund Get(string applicationFeeId, string refundId, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(applicationFeeId, refundId, null, requestOptions);
+            return this.GetNestedEntity(applicationFeeId, refundId, options, requestOptions);
         }
 
-        public virtual Task<ApplicationFeeRefund> GetAsync(string applicationFeeId, string refundId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplicationFeeRefund> GetAsync(string applicationFeeId, string refundId, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(applicationFeeId, refundId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(applicationFeeId, refundId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplicationFeeRefund> List(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeGetOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ApplicationFeeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class ApplicationFeeService : Service<ApplicationFee>,
         IListable<ApplicationFee, ApplicationFeeListOptions>,
-        IRetrievable<ApplicationFee>
+        IRetrievable<ApplicationFee, ApplicationFeeGetOptions>
     {
         public ApplicationFeeService()
             : base(null)
@@ -30,14 +30,14 @@ namespace Stripe
 
         public bool ExpandOriginatingTransaction { get; set; }
 
-        public virtual ApplicationFee Get(string applicationFeeId, RequestOptions requestOptions = null)
+        public virtual ApplicationFee Get(string applicationFeeId, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(applicationFeeId, null, requestOptions);
+            return this.GetEntity(applicationFeeId, options, requestOptions);
         }
 
-        public virtual Task<ApplicationFee> GetAsync(string applicationFeeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplicationFee> GetAsync(string applicationFeeId, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(applicationFeeId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(applicationFeeId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplicationFee> List(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionGetOptions.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class BalanceTransactionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class BalanceTransactionService : Service<BalanceTransaction>,
         IListable<BalanceTransaction, BalanceTransactionListOptions>,
-        IRetrievable<BalanceTransaction>
+        IRetrievable<BalanceTransaction, BalanceTransactionGetOptions>
     {
         public BalanceTransactionService()
             : base(null)
@@ -22,14 +22,14 @@ namespace Stripe
 
         public bool ExpandSource { get; set; }
 
-        public virtual BalanceTransaction Get(string balanceTransactionId, RequestOptions requestOptions = null)
+        public virtual BalanceTransaction Get(string balanceTransactionId, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(balanceTransactionId, null, requestOptions);
+            return this.GetEntity(balanceTransactionId, options, requestOptions);
         }
 
-        public virtual Task<BalanceTransaction> GetAsync(string balanceTransactionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<BalanceTransaction> GetAsync(string balanceTransactionId, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(balanceTransactionId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(balanceTransactionId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<BalanceTransaction> List(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/BankAccounts/BankAccountGetOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class BankAccountGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -9,7 +9,7 @@ namespace Stripe
         INestedCreatable<BankAccount, BankAccountCreateOptions>,
         INestedDeletable<BankAccount>,
         INestedListable<BankAccount, BankAccountListOptions>,
-        INestedRetrievable<BankAccount>,
+        INestedRetrievable<BankAccount, BankAccountGetOptions>,
         INestedUpdatable<BankAccount, BankAccountUpdateOptions>
     {
         public BankAccountService()
@@ -46,14 +46,14 @@ namespace Stripe
             return this.DeleteNestedEntityAsync(customerId, bankAccountId, null, requestOptions, cancellationToken);
         }
 
-        public virtual BankAccount Get(string customerId, string bankAccountId, RequestOptions requestOptions = null)
+        public virtual BankAccount Get(string customerId, string bankAccountId, BankAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(customerId, bankAccountId, null, requestOptions);
+            return this.GetNestedEntity(customerId, bankAccountId, options, requestOptions);
         }
 
-        public virtual Task<BankAccount> GetAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<BankAccount> GetAsync(string customerId, string bankAccountId, BankAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(customerId, bankAccountId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(customerId, bankAccountId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<BankAccount> List(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Capabilities/CapabilityGetOptions.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CapabilityGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Capabilities/CapabilityListOptions.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class CapabilityListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class CapabilityService : ServiceNested<Capability>,
         INestedListable<Capability, CapabilityListOptions>,
-        INestedRetrievable<Capability>,
+        INestedRetrievable<Capability, CapabilityGetOptions>,
         INestedUpdatable<Capability, CapabilityUpdateOptions>
     {
         public CapabilityService()
@@ -23,14 +23,14 @@ namespace Stripe
 
         public bool ExpandAccount { get; set; }
 
-        public virtual Capability Get(string accountId, string capabilityId, RequestOptions requestOptions = null)
+        public virtual Capability Get(string accountId, string capabilityId, CapabilityGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(accountId, capabilityId, null, requestOptions);
+            return this.GetNestedEntity(accountId, capabilityId, options, requestOptions);
         }
 
-        public virtual Task<Capability> GetAsync(string accountId, string capabilityId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Capability> GetAsync(string accountId, string capabilityId, CapabilityGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(accountId, capabilityId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(accountId, capabilityId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Capability> List(string accountId, CapabilityListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Cards/CardGetOptions.cs
+++ b/src/Stripe.net/Services/Cards/CardGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CardGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         INestedCreatable<Card, CardCreateOptions>,
         INestedDeletable<Card>,
         INestedListable<Card, CardListOptions>,
-        INestedRetrievable<Card>,
+        INestedRetrievable<Card, CardGetOptions>,
         INestedUpdatable<Card, CardUpdateOptions>
     {
         public CardService()
@@ -47,14 +47,14 @@ namespace Stripe
             return this.DeleteNestedEntityAsync(customerId, cardId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Card Get(string customerId, string cardId, RequestOptions requestOptions = null)
+        public virtual Card Get(string customerId, string cardId, CardGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(customerId, cardId, null, requestOptions);
+            return this.GetNestedEntity(customerId, cardId, options, requestOptions);
         }
 
-        public virtual Task<Card> GetAsync(string customerId, string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> GetAsync(string customerId, string cardId, CardGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(customerId, cardId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(customerId, cardId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(string customerId, CardListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Charges/ChargeGetOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ChargeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class ChargeService : Service<Charge>,
         ICreatable<Charge, ChargeCreateOptions>,
         IListable<Charge, ChargeListOptions>,
-        IRetrievable<Charge>,
+        IRetrievable<Charge, ChargeGetOptions>,
         IUpdatable<Charge, ChargeUpdateOptions>
     {
         public ChargeService()
@@ -69,14 +69,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Charge Get(string chargeId, RequestOptions requestOptions = null)
+        public virtual Charge Get(string chargeId, ChargeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(chargeId, null, requestOptions);
+            return this.GetEntity(chargeId, options, requestOptions);
         }
 
-        public virtual Task<Charge> GetAsync(string chargeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Charge> GetAsync(string chargeId, ChargeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(chargeId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(chargeId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Charge> List(ChargeListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Checkout/SessionGetOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Checkout
+{
+    public class SessionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Checkout/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/SessionService.cs
@@ -31,14 +31,14 @@ namespace Stripe.Checkout
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Session Get(string sessionId, RequestOptions requestOptions = null)
+        public virtual Session Get(string sessionId, SessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(sessionId, null, requestOptions);
+            return this.GetEntity(sessionId, options, requestOptions);
         }
 
-        public virtual Task<Session> GetAsync(string sessionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Session> GetAsync(string sessionId, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(sessionId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(sessionId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecGetOptions.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CountrySpecGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class CountrySpecService : Service<CountrySpec>,
         IListable<CountrySpec, CountrySpecListOptions>,
-        IRetrievable<CountrySpec>
+        IRetrievable<CountrySpec, CountrySpecGetOptions>
     {
         public CountrySpecService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe
 
         public override string BasePath => "/v1/country_specs";
 
-        public virtual CountrySpec Get(string country, RequestOptions requestOptions = null)
+        public virtual CountrySpec Get(string country, CountrySpecGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(country, null, requestOptions);
+            return this.GetEntity(country, options, requestOptions);
         }
 
-        public virtual Task<CountrySpec> GetAsync(string country, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<CountrySpec> GetAsync(string country, CountrySpecGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(country, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(country, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CountrySpec> List(CountrySpecListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Coupons/CouponGetOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CouponGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<Coupon, CouponCreateOptions>,
         IDeletable<Coupon>,
         IListable<Coupon, CouponListOptions>,
-        IRetrievable<Coupon>,
+        IRetrievable<Coupon, CouponGetOptions>,
         IUpdatable<Coupon, CouponUpdateOptions>
     {
         public CouponService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteEntityAsync(couponId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Coupon Get(string couponId, RequestOptions requestOptions = null)
+        public virtual Coupon Get(string couponId, CouponGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(couponId, null, requestOptions);
+            return this.GetEntity(couponId, options, requestOptions);
         }
 
-        public virtual Task<Coupon> GetAsync(string couponId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Coupon> GetAsync(string couponId, CouponGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(couponId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(couponId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Coupon> List(CouponListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteCreateOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteCreateOptions.cs
@@ -1,9 +1,7 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class CreditNoteCreateOptions : BaseOptions
     {

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteGetOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CreditNoteGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteListOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteListOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
 
     public class CreditNoteListOptions : ListOptions

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class CreditNoteService : Service<CreditNote>,
         ICreatable<CreditNote, CreditNoteCreateOptions>,
         IListable<CreditNote, CreditNoteListOptions>,
-        IRetrievable<CreditNote>,
+        IRetrievable<CreditNote, CreditNoteGetOptions>,
         IUpdatable<CreditNote, CreditNoteUpdateOptions>
     {
         public CreditNoteService()
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual CreditNote Get(string creditNoteId, RequestOptions requestOptions = null)
+        public virtual CreditNote Get(string creditNoteId, CreditNoteGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(creditNoteId, null, requestOptions);
+            return this.GetEntity(creditNoteId, options, requestOptions);
         }
 
-        public virtual Task<CreditNote> GetAsync(string creditNoteId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<CreditNote> GetAsync(string creditNoteId, CreditNoteGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(creditNoteId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(creditNoteId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditNote> List(CreditNoteListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Customers/CustomerGetOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CustomerGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<Customer, CustomerCreateOptions>,
         IDeletable<Customer>,
         IListable<Customer, CustomerListOptions>,
-        IRetrievable<Customer>,
+        IRetrievable<Customer, CustomerGetOptions>,
         IUpdatable<Customer, CustomerUpdateOptions>
     {
         public CustomerService()
@@ -47,14 +47,14 @@ namespace Stripe
             return this.DeleteEntityAsync(customerId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Customer Get(string customerId, RequestOptions requestOptions = null)
+        public virtual Customer Get(string customerId, CustomerGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(customerId, null, requestOptions);
+            return this.GetEntity(customerId, options, requestOptions);
         }
 
-        public virtual Task<Customer> GetAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Customer> GetAsync(string customerId, CustomerGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(customerId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Customer> List(CustomerListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Disputes/DisputeGetOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class DisputeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class DisputeService : Service<Dispute>,
         IListable<Dispute, DisputeListOptions>,
-        IRetrievable<Dispute>,
+        IRetrievable<Dispute, DisputeGetOptions>,
         IUpdatable<Dispute, DisputeUpdateOptions>
     {
         public DisputeService()
@@ -34,14 +34,14 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(disputeId)}/close", null, requestOptions, cancellationToken);
         }
 
-        public virtual Dispute Get(string disputeId, RequestOptions requestOptions = null)
+        public virtual Dispute Get(string disputeId, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(disputeId, null, requestOptions);
+            return this.GetEntity(disputeId, options, requestOptions);
         }
 
-        public virtual Task<Dispute> GetAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Dispute> GetAsync(string disputeId, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(disputeId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(disputeId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Events/EventGetOptions.cs
+++ b/src/Stripe.net/Services/Events/EventGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class EventGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class EventService : Service<Event>,
         IListable<Event, EventListOptions>,
-        IRetrievable<Event>
+        IRetrievable<Event, EventGetOptions>
     {
         public EventService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe
 
         public override string BasePath => "/v1/events";
 
-        public virtual Event Get(string eventId, RequestOptions requestOptions = null)
+        public virtual Event Get(string eventId, EventGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(eventId, null, requestOptions);
+            return this.GetEntity(eventId, options, requestOptions);
         }
 
-        public virtual Task<Event> GetAsync(string eventId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Event> GetAsync(string eventId, EventGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(eventId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(eventId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Event> List(EventListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateGetOptions.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ExchangeRateGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateListOptions.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class ExchangeRateListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class ExchangeRateService : Service<ExchangeRate>,
         IListable<ExchangeRate, ExchangeRateListOptions>,
-        IRetrievable<ExchangeRate>
+        IRetrievable<ExchangeRate, ExchangeRateGetOptions>
     {
         public ExchangeRateService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe
 
         public override string BasePath => "/v1/exchange_rates";
 
-        public virtual ExchangeRate Get(string currency, RequestOptions requestOptions = null)
+        public virtual ExchangeRate Get(string currency, ExchangeRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(currency, null, requestOptions);
+            return this.GetEntity(currency, options, requestOptions);
         }
 
-        public virtual Task<ExchangeRate> GetAsync(string currency, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ExchangeRate> GetAsync(string currency, ExchangeRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(currency, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(currency, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ExchangeRate> List(ExchangeRateListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountGetOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ExternalAccountGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountListOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class ExternalAccountListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         INestedCreatable<IExternalAccount, ExternalAccountCreateOptions>,
         INestedDeletable<IExternalAccount>,
         INestedListable<IExternalAccount, ExternalAccountListOptions>,
-        INestedRetrievable<IExternalAccount>,
+        INestedRetrievable<IExternalAccount, ExternalAccountGetOptions>,
         INestedUpdatable<IExternalAccount, ExternalAccountUpdateOptions>
     {
         public ExternalAccountService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteNestedEntityAsync(accountId, externalAccountId, null, requestOptions, cancellationToken);
         }
 
-        public virtual IExternalAccount Get(string accountId, string externalAccountId, RequestOptions requestOptions = null)
+        public virtual IExternalAccount Get(string accountId, string externalAccountId, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(accountId, externalAccountId, null, requestOptions);
+            return this.GetNestedEntity(accountId, externalAccountId, options, requestOptions);
         }
 
-        public virtual Task<IExternalAccount> GetAsync(string accountId, string externalAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<IExternalAccount> GetAsync(string accountId, string externalAccountId, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(accountId, externalAccountId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(accountId, externalAccountId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<IExternalAccount> List(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/FileLinks/FileLinkGetOptions.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class FileLinkGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class FileLinkService : Service<FileLink>,
         ICreatable<FileLink, FileLinkCreateOptions>,
         IListable<FileLink, FileLinkListOptions>,
-        IRetrievable<FileLink>,
+        IRetrievable<FileLink, FileLinkGetOptions>,
         IUpdatable<FileLink, FileLinkUpdateOptions>
     {
         public FileLinkService()
@@ -32,14 +32,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual FileLink Get(string fileLinkId, RequestOptions requestOptions = null)
+        public virtual FileLink Get(string fileLinkId, FileLinkGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(fileLinkId, null, requestOptions);
+            return this.GetEntity(fileLinkId, options, requestOptions);
         }
 
-        public virtual Task<FileLink> GetAsync(string fileLinkId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<FileLink> GetAsync(string fileLinkId, FileLinkGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(fileLinkId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(fileLinkId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<FileLink> List(FileLinkListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Files/FileGetOptions.cs
+++ b/src/Stripe.net/Services/Files/FileGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class FileGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class FileService : Service<File>,
         ICreatable<File, FileCreateOptions>,
         IListable<File, FileListOptions>,
-        IRetrievable<File>
+        IRetrievable<File, FileGetOptions>
     {
         public FileService()
             : base(null)
@@ -35,14 +35,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual File Get(string fileId, RequestOptions requestOptions = null)
+        public virtual File Get(string fileId, FileGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(fileId, null, requestOptions);
+            return this.GetEntity(fileId, options, requestOptions);
         }
 
-        public virtual Task<File> GetAsync(string fileId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<File> GetAsync(string fileId, FileGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(fileId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(fileId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<File> List(FileListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemGetOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class InvoiceItemGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<InvoiceItem, InvoiceItemCreateOptions>,
         IDeletable<InvoiceItem>,
         IListable<InvoiceItem, InvoiceItemListOptions>,
-        IRetrievable<InvoiceItem>,
+        IRetrievable<InvoiceItem, InvoiceItemGetOptions>,
         IUpdatable<InvoiceItem, InvoiceItemUpdateOptions>
     {
         public InvoiceItemService()
@@ -49,14 +49,14 @@ namespace Stripe
             return this.DeleteEntityAsync(invoiceitemId, null, requestOptions, cancellationToken);
         }
 
-        public virtual InvoiceItem Get(string invoiceitemId, RequestOptions requestOptions = null)
+        public virtual InvoiceItem Get(string invoiceitemId, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(invoiceitemId, null, requestOptions);
+            return this.GetEntity(invoiceitemId, options, requestOptions);
         }
 
-        public virtual Task<InvoiceItem> GetAsync(string invoiceitemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<InvoiceItem> GetAsync(string invoiceitemId, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(invoiceitemId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(invoiceitemId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InvoiceItem> List(InvoiceItemListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceGetOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class InvoiceGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class InvoiceService : Service<Invoice>,
         ICreatable<Invoice, InvoiceCreateOptions>,
         IListable<Invoice, InvoiceListOptions>,
-        IRetrievable<Invoice>,
+        IRetrievable<Invoice, InvoiceGetOptions>,
         IUpdatable<Invoice, InvoiceUpdateOptions>
     {
         public InvoiceService()
@@ -61,14 +61,14 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(invoiceId)}/finalize", options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice Get(string invoiceId, RequestOptions requestOptions = null)
+        public virtual Invoice Get(string invoiceId, InvoiceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(invoiceId, null, requestOptions);
+            return this.GetEntity(invoiceId, options, requestOptions);
         }
 
-        public virtual Task<Invoice> GetAsync(string invoiceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Invoice> GetAsync(string invoiceId, InvoiceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(invoiceId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(invoiceId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Invoice> List(InvoiceListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationGetOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Issuing
+{
+    public class AuthorizationGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Issuing
 
     public class AuthorizationService : Service<Authorization>,
         IListable<Authorization, AuthorizationListOptions>,
-        IRetrievable<Authorization>,
+        IRetrievable<Authorization, AuthorizationGetOptions>,
         IUpdatable<Authorization, AuthorizationUpdateOptions>
     {
         public AuthorizationService()
@@ -42,14 +42,14 @@ namespace Stripe.Issuing
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(authorizationId)}/decline", options, requestOptions, cancellationToken);
         }
 
-        public virtual Authorization Get(string authorizationId, RequestOptions requestOptions = null)
+        public virtual Authorization Get(string authorizationId, AuthorizationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(authorizationId, null, requestOptions);
+            return this.GetEntity(authorizationId, options, requestOptions);
         }
 
-        public virtual Task<Authorization> GetAsync(string authorizationId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Authorization> GetAsync(string authorizationId, AuthorizationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(authorizationId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(authorizationId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Authorization> List(AuthorizationListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderGetOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Issuing
+{
+    public class CardholderGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Issuing
     public class CardholderService : Service<Cardholder>,
         ICreatable<Cardholder, CardholderCreateOptions>,
         IListable<Cardholder, CardholderListOptions>,
-        IRetrievable<Cardholder>,
+        IRetrievable<Cardholder, CardholderGetOptions>,
         IUpdatable<Cardholder, CardholderUpdateOptions>
     {
         public CardholderService()
@@ -32,14 +32,14 @@ namespace Stripe.Issuing
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Cardholder Get(string cardholderId, RequestOptions requestOptions = null)
+        public virtual Cardholder Get(string cardholderId, CardholderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(cardholderId, null, requestOptions);
+            return this.GetEntity(cardholderId, options, requestOptions);
         }
 
-        public virtual Task<Cardholder> GetAsync(string cardholderId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Cardholder> GetAsync(string cardholderId, CardholderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(cardholderId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(cardholderId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Cardholder> List(CardholderListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/CardGetOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Issuing
+{
+    public class CardGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     public class CardService : Service<Card>,
         ICreatable<Card, CardCreateOptions>,
         IListable<Card, CardListOptions>,
-        IRetrievable<Card>,
+        IRetrievable<Card, CardGetOptions>,
         IUpdatable<Card, CardUpdateOptions>
     {
         public CardService()
@@ -43,14 +43,14 @@ namespace Stripe.Issuing
             return this.RequestAsync<CardDetails>(HttpMethod.Get, $"{this.InstanceUrl(cardId)}/details", null, requestOptions, cancellationToken);
         }
 
-        public virtual Card Get(string cardId, RequestOptions requestOptions = null)
+        public virtual Card Get(string cardId, CardGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(cardId, null, requestOptions);
+            return this.GetEntity(cardId, options, requestOptions);
         }
 
-        public virtual Task<Card> GetAsync(string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> GetAsync(string cardId, CardGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(cardId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(cardId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(CardListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeGetOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Issuing
+{
+    public class DisputeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Issuing
     public class DisputeService : Service<Dispute>,
         ICreatable<Dispute, DisputeCreateOptions>,
         IListable<Dispute, DisputeListOptions>,
-        IRetrievable<Dispute>,
+        IRetrievable<Dispute, DisputeGetOptions>,
         IUpdatable<Dispute, DisputeUpdateOptions>
     {
         public DisputeService()
@@ -32,14 +32,14 @@ namespace Stripe.Issuing
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Dispute Get(string disputeId, RequestOptions requestOptions = null)
+        public virtual Dispute Get(string disputeId, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(disputeId, null, requestOptions);
+            return this.GetEntity(disputeId, options, requestOptions);
         }
 
-        public virtual Task<Dispute> GetAsync(string disputeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Dispute> GetAsync(string disputeId, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(disputeId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(disputeId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionGetOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Issuing
+{
+    public class TransactionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Issuing
 
     public class TransactionService : Service<Transaction>,
         IListable<Transaction, TransactionListOptions>,
-        IRetrievable<Transaction>,
+        IRetrievable<Transaction, TransactionGetOptions>,
         IUpdatable<Transaction, TransactionUpdateOptions>
     {
         public TransactionService()
@@ -21,14 +21,14 @@ namespace Stripe.Issuing
 
         public override string BasePath => "/v1/issuing/transactions";
 
-        public virtual Transaction Get(string transactionId, RequestOptions requestOptions = null)
+        public virtual Transaction Get(string transactionId, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(transactionId, null, requestOptions);
+            return this.GetEntity(transactionId, options, requestOptions);
         }
 
-        public virtual Task<Transaction> GetAsync(string transactionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Transaction> GetAsync(string transactionId, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(transactionId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(transactionId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transaction> List(TransactionListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Orders/OrderGetOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class OrderGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class OrderService : Service<Order>,
         ICreatable<Order, OrderCreateOptions>,
         IListable<Order, OrderListOptions>,
-        IRetrievable<Order>,
+        IRetrievable<Order, OrderGetOptions>,
         IUpdatable<Order, OrderUpdateOptions>
     {
         public OrderService()
@@ -37,14 +37,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Order Get(string orderId, RequestOptions requestOptions = null)
+        public virtual Order Get(string orderId, OrderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(orderId, null, requestOptions);
+            return this.GetEntity(orderId, options, requestOptions);
         }
 
-        public virtual Task<Order> GetAsync(string orderId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Order> GetAsync(string orderId, OrderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(orderId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(orderId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Order> List(OrderListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentGetOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentGetOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class PaymentIntentGetOptions : BaseOptions

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentListOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentListOptions.cs
@@ -1,8 +1,6 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class PaymentIntentListOptions : ListOptionsWithCreated
     {

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class PaymentIntentService : Service<PaymentIntent>,
         ICreatable<PaymentIntent, PaymentIntentCreateOptions>,
         IListable<PaymentIntent, PaymentIntentListOptions>,
-        IRetrievable<PaymentIntent>,
+        IRetrievable<PaymentIntent, PaymentIntentGetOptions>,
         IUpdatable<PaymentIntent, PaymentIntentUpdateOptions>
     {
         public PaymentIntentService()
@@ -75,22 +75,12 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual PaymentIntent Get(string paymentIntentId, RequestOptions requestOptions = null)
-        {
-            return this.Get(paymentIntentId, null, requestOptions);
-        }
-
-        public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.GetAsync(paymentIntentId, null, requestOptions, cancellationToken);
-        }
-
-        public virtual PaymentIntent Get(string paymentIntentId, PaymentIntentGetOptions options, RequestOptions requestOptions = null)
+        public virtual PaymentIntent Get(string paymentIntentId, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null)
         {
             return this.GetEntity(paymentIntentId, options, requestOptions);
         }
 
-        public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, PaymentIntentGetOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<PaymentIntent> GetAsync(string paymentIntentId, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetEntityAsync(paymentIntentId, options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodGetOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PaymentMethodGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodListOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodListOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
 
     public class PaymentMethodListOptions : ListOptions

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class PaymentMethodService : Service<PaymentMethod>,
         ICreatable<PaymentMethod, PaymentMethodCreateOptions>,
         IListable<PaymentMethod, PaymentMethodListOptions>,
-        IRetrievable<PaymentMethod>,
+        IRetrievable<PaymentMethod, PaymentMethodGetOptions>,
         IUpdatable<PaymentMethod, PaymentMethodUpdateOptions>
     {
         public PaymentMethodService()
@@ -55,14 +55,14 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentMethodId)}/detach", options, requestOptions, cancellationToken);
         }
 
-        public virtual PaymentMethod Get(string paymentMethodId, RequestOptions requestOptions = null)
+        public virtual PaymentMethod Get(string paymentMethodId, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(paymentMethodId, null, requestOptions);
+            return this.GetEntity(paymentMethodId, options, requestOptions);
         }
 
-        public virtual Task<PaymentMethod> GetAsync(string paymentMethodId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<PaymentMethod> GetAsync(string paymentMethodId, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(paymentMethodId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(paymentMethodId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentMethod> List(PaymentMethodListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Payouts/PayoutGetOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PayoutGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class PayoutService : Service<Payout>,
         ICreatable<Payout, PayoutCreateOptions>,
         IListable<Payout, PayoutListOptions>,
-        IRetrievable<Payout>,
+        IRetrievable<Payout, PayoutGetOptions>,
         IUpdatable<Payout, PayoutUpdateOptions>
     {
         public PayoutService()
@@ -49,14 +49,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Payout Get(string payoutId, RequestOptions requestOptions = null)
+        public virtual Payout Get(string payoutId, PayoutGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(payoutId, null, requestOptions);
+            return this.GetEntity(payoutId, options, requestOptions);
         }
 
-        public virtual Task<Payout> GetAsync(string payoutId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Payout> GetAsync(string payoutId, PayoutGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(payoutId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(payoutId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Payout> List(PayoutListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Persons/PersonGetOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PersonGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class PersonService : ServiceNested<Person>,
         INestedCreatable<Person, PersonCreateOptions>,
         INestedListable<Person, PersonListOptions>,
-        INestedRetrievable<Person>,
+        INestedRetrievable<Person, PersonGetOptions>,
         INestedUpdatable<Person, PersonUpdateOptions>
     {
         public PersonService()
@@ -46,14 +46,14 @@ namespace Stripe
             return this.DeleteNestedEntityAsync(accountId, personId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Person Get(string accountId, string personId, RequestOptions requestOptions = null)
+        public virtual Person Get(string accountId, string personId, PersonGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(accountId, personId, null, requestOptions);
+            return this.GetNestedEntity(accountId, personId, options, requestOptions);
         }
 
-        public virtual Task<Person> GetAsync(string accountId, string personId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Person> GetAsync(string accountId, string personId, PersonGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(accountId, personId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(accountId, personId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Person> List(string accountId, PersonListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Plans/PlanGetOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PlanGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<Plan, PlanCreateOptions>,
         IDeletable<Plan>,
         IListable<Plan, PlanListOptions>,
-        IRetrievable<Plan>,
+        IRetrievable<Plan, PlanGetOptions>,
         IUpdatable<Plan, PlanUpdateOptions>
     {
         public PlanService()
@@ -45,14 +45,14 @@ namespace Stripe
             return this.DeleteEntityAsync(planId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Plan Get(string planId, RequestOptions requestOptions = null)
+        public virtual Plan Get(string planId, PlanGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(planId, null, requestOptions);
+            return this.GetEntity(planId, options, requestOptions);
         }
 
-        public virtual Task<Plan> GetAsync(string planId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Plan> GetAsync(string planId, PlanGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(planId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(planId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Plan> List(PlanListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Products/ProductGetOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ProductGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<Product, ProductCreateOptions>,
         IDeletable<Product>,
         IListable<Product, ProductListOptions>,
-        IRetrievable<Product>,
+        IRetrievable<Product, ProductGetOptions>,
         IUpdatable<Product, ProductUpdateOptions>
     {
         public ProductService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteEntityAsync(productId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Product Get(string productId, RequestOptions requestOptions = null)
+        public virtual Product Get(string productId, ProductGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(productId, null, requestOptions);
+            return this.GetEntity(productId, options, requestOptions);
         }
 
-        public virtual Task<Product> GetAsync(string productId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Product> GetAsync(string productId, ProductGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(productId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(productId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Product> List(ProductListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningGetOptions.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Radar
+{
+    public class EarlyFraudWarningGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Radar
 
     public class EarlyFraudWarningService : Service<EarlyFraudWarning>,
         IListable<EarlyFraudWarning, EarlyFraudWarningListOptions>,
-        IRetrievable<EarlyFraudWarning>
+        IRetrievable<EarlyFraudWarning, EarlyFraudWarningGetOptions>
     {
         public EarlyFraudWarningService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe.Radar
 
         public override string BasePath => "/v1/radar/early_fraud_warnings";
 
-        public virtual EarlyFraudWarning Get(string earlyFraudWarningId, RequestOptions requestOptions = null)
+        public virtual EarlyFraudWarning Get(string earlyFraudWarningId, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(earlyFraudWarningId, null, requestOptions);
+            return this.GetEntity(earlyFraudWarningId, options, requestOptions);
         }
 
-        public virtual Task<EarlyFraudWarning> GetAsync(string earlyFraudWarningId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<EarlyFraudWarning> GetAsync(string earlyFraudWarningId, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(earlyFraudWarningId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(earlyFraudWarningId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<EarlyFraudWarning> List(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemGetOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Radar
+{
+    public class ValueListItemGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Radar
     public class ValueListItemService : Service<ValueListItem>,
         ICreatable<ValueListItem, ValueListItemCreateOptions>,
         IListable<ValueListItem, ValueListItemListOptions>,
-        IRetrievable<ValueListItem>
+        IRetrievable<ValueListItem, ValueListItemGetOptions>
     {
         public ValueListItemService()
             : base(null)
@@ -41,14 +41,14 @@ namespace Stripe.Radar
             return this.DeleteEntityAsync(valueListItemId, null, requestOptions, cancellationToken);
         }
 
-        public virtual ValueListItem Get(string valueListItemId, RequestOptions requestOptions = null)
+        public virtual ValueListItem Get(string valueListItemId, ValueListItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(valueListItemId, null, requestOptions);
+            return this.GetEntity(valueListItemId, options, requestOptions);
         }
 
-        public virtual Task<ValueListItem> GetAsync(string valueListItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ValueListItem> GetAsync(string valueListItemId, ValueListItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(valueListItemId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(valueListItemId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ValueListItem> List(ValueListItemListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListGetOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Radar
+{
+    public class ValueListGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Radar
     public class ValueListService : Service<ValueList>,
         ICreatable<ValueList, ValueListCreateOptions>,
         IListable<ValueList, ValueListListOptions>,
-        IRetrievable<ValueList>
+        IRetrievable<ValueList, ValueListGetOptions>
     {
         public ValueListService()
             : base(null)
@@ -41,14 +41,14 @@ namespace Stripe.Radar
             return this.DeleteEntityAsync(valueListId, null, requestOptions, cancellationToken);
         }
 
-        public virtual ValueList Get(string valueListId, RequestOptions requestOptions = null)
+        public virtual ValueList Get(string valueListId, ValueListGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(valueListId, null, requestOptions);
+            return this.GetEntity(valueListId, options, requestOptions);
         }
 
-        public virtual Task<ValueList> GetAsync(string valueListId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ValueList> GetAsync(string valueListId, ValueListGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(valueListId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(valueListId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ValueList> List(ValueListListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Refunds/RefundGetOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class RefundGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class RefundService : Service<Refund>,
         ICreatable<Refund, RefundCreateOptions>,
         IListable<Refund, RefundListOptions>,
-        IRetrievable<Refund>,
+        IRetrievable<Refund, RefundGetOptions>,
         IUpdatable<Refund, RefundUpdateOptions>
     {
         public RefundService()
@@ -38,14 +38,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Refund Get(string refundId, RequestOptions requestOptions = null)
+        public virtual Refund Get(string refundId, RefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(refundId, null, requestOptions);
+            return this.GetEntity(refundId, options, requestOptions);
         }
 
-        public virtual Task<Refund> GetAsync(string refundId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Refund> GetAsync(string refundId, RefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(refundId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(refundId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Refund> List(RefundListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunGetOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Reporting
+{
+    public class ReportRunGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Reporting
     public class ReportRunService : Service<ReportRun>,
         ICreatable<ReportRun, ReportRunCreateOptions>,
         IListable<ReportRun, ReportRunListOptions>,
-        IRetrievable<ReportRun>
+        IRetrievable<ReportRun, ReportRunGetOptions>
     {
         public ReportRunService()
             : base(null)
@@ -31,14 +31,14 @@ namespace Stripe.Reporting
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual ReportRun Get(string reportRunId, RequestOptions requestOptions = null)
+        public virtual ReportRun Get(string reportRunId, ReportRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(reportRunId, null, requestOptions);
+            return this.GetEntity(reportRunId, options, requestOptions);
         }
 
-        public virtual Task<ReportRun> GetAsync(string reportRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ReportRun> GetAsync(string reportRunId, ReportRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(reportRunId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(reportRunId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportRun> List(ReportRunListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeGetOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Reporting
+{
+    public class ReportTypeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeListOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe.Reporting
 {
-    using Newtonsoft.Json;
-
     public class ReportTypeListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Reporting
 
     public class ReportTypeService : Service<ReportType>,
         IListable<ReportType, ReportTypeListOptions>,
-        IRetrievable<ReportType>
+        IRetrievable<ReportType, ReportTypeGetOptions>
     {
         public ReportTypeService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe.Reporting
 
         public override string BasePath => "/v1/reporting/report_types";
 
-        public virtual ReportType Get(string reportTypeId, RequestOptions requestOptions = null)
+        public virtual ReportType Get(string reportTypeId, ReportTypeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(reportTypeId, null, requestOptions);
+            return this.GetEntity(reportTypeId, options, requestOptions);
         }
 
-        public virtual Task<ReportType> GetAsync(string reportTypeId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ReportType> GetAsync(string reportTypeId, ReportTypeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(reportTypeId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(reportTypeId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportType> List(ReportTypeListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Reviews/ReviewGetOptions.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ReviewGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Reviews/ReviewListOptions.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class ReviewListOptions : ListOptionsWithCreated
     {
     }

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class ReviewService : Service<Review>,
         IListable<Review, ReviewListOptions>,
-        IRetrievable<Review>
+        IRetrievable<Review, ReviewGetOptions>
     {
         public ReviewService()
             : base(null)
@@ -31,14 +31,14 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(reviewId)}/approve", options, requestOptions, cancellationToken);
         }
 
-        public virtual Review Get(string reviewId, RequestOptions requestOptions = null)
+        public virtual Review Get(string reviewId, ReviewGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(reviewId, null, requestOptions);
+            return this.GetEntity(reviewId, options, requestOptions);
         }
 
-        public virtual Task<Review> GetAsync(string reviewId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Review> GetAsync(string reviewId, ReviewGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(reviewId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(reviewId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Review> List(ReviewListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunGetOptions.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Sigma
+{
+    public class ScheduledQueryRunGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunListOptions.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunListOptions.cs
@@ -1,9 +1,5 @@
 namespace Stripe.Sigma
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
     public class ScheduledQueryRunListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Sigma
 
     public class ScheduledQueryRunService : Service<ScheduledQueryRun>,
         IListable<ScheduledQueryRun, ScheduledQueryRunListOptions>,
-        IRetrievable<ScheduledQueryRun>
+        IRetrievable<ScheduledQueryRun, ScheduledQueryRunGetOptions>
     {
         public ScheduledQueryRunService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe.Sigma
 
         public override string BasePath => "/v1/sigma/scheduled_query_runs";
 
-        public virtual ScheduledQueryRun Get(string queryRunId, RequestOptions requestOptions = null)
+        public virtual ScheduledQueryRun Get(string queryRunId, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(queryRunId, null, requestOptions);
+            return this.GetEntity(queryRunId, options, requestOptions);
         }
 
-        public virtual Task<ScheduledQueryRun> GetAsync(string queryRunId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ScheduledQueryRun> GetAsync(string queryRunId, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(queryRunId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(queryRunId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Skus/SkuGetOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SkuGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<Sku, SkuCreateOptions>,
         IDeletable<Sku>,
         IListable<Sku, SkuListOptions>,
-        IRetrievable<Sku>,
+        IRetrievable<Sku, SkuGetOptions>,
         IUpdatable<Sku, SkuUpdateOptions>
     {
         public SkuService()
@@ -45,14 +45,14 @@ namespace Stripe
             return this.DeleteEntityAsync(skuId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Sku Get(string skuId, RequestOptions requestOptions = null)
+        public virtual Sku Get(string skuId, SkuGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(skuId, null, requestOptions);
+            return this.GetEntity(skuId, options, requestOptions);
         }
 
-        public virtual Task<Sku> GetAsync(string skuId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Sku> GetAsync(string skuId, SkuGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(skuId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(skuId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Sku> List(SkuListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SourceTransactionsGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -8,7 +8,7 @@ namespace Stripe
 
     public class SourceService : Service<Source>,
         ICreatable<Source, SourceCreateOptions>,
-        IRetrievable<Source>,
+        IRetrievable<Source, SourceGetOptions>,
         IUpdatable<Source, SourceUpdateOptions>,
         INestedListable<Source, SourceListOptions>
     {
@@ -54,22 +54,12 @@ namespace Stripe
             return this.RequestAsync<Source>(HttpMethod.Delete, $"/v1/customers/{customerId}/sources/{sourceId}", null, requestOptions, cancellationToken);
         }
 
-        public virtual Source Get(string sourceId, RequestOptions requestOptions = null)
-        {
-            return this.Get(sourceId, null, requestOptions);
-        }
-
-        public virtual Task<Source> GetAsync(string sourceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.GetAsync(sourceId, null, requestOptions, cancellationToken);
-        }
-
-        public virtual Source Get(string sourceId, SourceGetOptions options, RequestOptions requestOptions = null)
+        public virtual Source Get(string sourceId, SourceGetOptions options = null, RequestOptions requestOptions = null)
         {
             return this.GetEntity(sourceId, options, requestOptions);
         }
 
-        public virtual Task<Source> GetAsync(string sourceId, SourceGetOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Source> GetAsync(string sourceId, SourceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetEntityAsync(sourceId, options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemGetOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SubscriptionItemGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<SubscriptionItem, SubscriptionItemCreateOptions>,
         IDeletable<SubscriptionItem>,
         IListable<SubscriptionItem, SubscriptionItemListOptions>,
-        IRetrievable<SubscriptionItem>,
+        IRetrievable<SubscriptionItem, SubscriptionItemGetOptions>,
         IUpdatable<SubscriptionItem, SubscriptionItemUpdateOptions>
     {
         public SubscriptionItemService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteEntityAsync(subscriptionItemId, null, requestOptions, cancellationToken);
         }
 
-        public virtual SubscriptionItem Get(string subscriptionItemId, RequestOptions requestOptions = null)
+        public virtual SubscriptionItem Get(string subscriptionItemId, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(subscriptionItemId, null, requestOptions);
+            return this.GetEntity(subscriptionItemId, options, requestOptions);
         }
 
-        public virtual Task<SubscriptionItem> GetAsync(string subscriptionItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<SubscriptionItem> GetAsync(string subscriptionItemId, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(subscriptionItemId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(subscriptionItemId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionItem> List(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionGetOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SubscriptionScheduleRevisionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionListOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class SubscriptionScheduleRevisionListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
+++ b/src/Stripe.net/Services/SubscriptionScheduleRevisions/SubscriptionScheduleRevisionService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class SubscriptionScheduleRevisionService : ServiceNested<SubscriptionScheduleRevision>,
         INestedListable<SubscriptionScheduleRevision, SubscriptionScheduleRevisionListOptions>,
-        INestedRetrievable<SubscriptionScheduleRevision>
+        INestedRetrievable<SubscriptionScheduleRevision, SubscriptionScheduleRevisionGetOptions>
     {
         public SubscriptionScheduleRevisionService()
             : base(null)
@@ -20,14 +20,14 @@ namespace Stripe
 
         public override string BasePath => "/v1/subscription_schedules/{PARENT_ID}/revisions";
 
-        public virtual SubscriptionScheduleRevision Get(string scheduleId, string revisionId, RequestOptions requestOptions = null)
+        public virtual SubscriptionScheduleRevision Get(string scheduleId, string revisionId, SubscriptionScheduleRevisionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(scheduleId, revisionId, null, requestOptions);
+            return this.GetNestedEntity(scheduleId, revisionId, options, requestOptions);
         }
 
-        public virtual Task<SubscriptionScheduleRevision> GetAsync(string scheduleId, string revisionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<SubscriptionScheduleRevision> GetAsync(string scheduleId, string revisionId, SubscriptionScheduleRevisionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(scheduleId, revisionId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(scheduleId, revisionId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionScheduleRevision> List(string scheduleId, SubscriptionScheduleRevisionListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleGetOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SubscriptionScheduleGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class SubscriptionScheduleService : Service<SubscriptionSchedule>,
         ICreatable<SubscriptionSchedule, SubscriptionScheduleCreateOptions>,
         IListable<SubscriptionSchedule, SubscriptionScheduleListOptions>,
-        IRetrievable<SubscriptionSchedule>,
+        IRetrievable<SubscriptionSchedule, SubscriptionScheduleGetOptions>,
         IUpdatable<SubscriptionSchedule, SubscriptionScheduleUpdateOptions>
     {
         public SubscriptionScheduleService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual SubscriptionSchedule Get(string scheduleId, RequestOptions requestOptions = null)
+        public virtual SubscriptionSchedule Get(string scheduleId, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(scheduleId, null, requestOptions);
+            return this.GetEntity(scheduleId, options, requestOptions);
         }
 
-        public virtual Task<SubscriptionSchedule> GetAsync(string scheduleId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<SubscriptionSchedule> GetAsync(string scheduleId, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(scheduleId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(scheduleId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionSchedule> List(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionGetOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SubscriptionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class SubscriptionService : Service<Subscription>,
         ICreatable<Subscription, SubscriptionCreateOptions>,
         IListable<Subscription, SubscriptionListOptions>,
-        IRetrievable<Subscription>,
+        IRetrievable<Subscription, SubscriptionGetOptions>,
         IUpdatable<Subscription, SubscriptionUpdateOptions>
     {
         public SubscriptionService()
@@ -50,14 +50,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Subscription Get(string subscriptionId, RequestOptions requestOptions = null)
+        public virtual Subscription Get(string subscriptionId, SubscriptionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(subscriptionId, null, requestOptions);
+            return this.GetEntity(subscriptionId, options, requestOptions);
         }
 
-        public virtual Task<Subscription> GetAsync(string subscriptionId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Subscription> GetAsync(string subscriptionId, SubscriptionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(subscriptionId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(subscriptionId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Subscription> List(SubscriptionListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TaxIds/TaxIdGetOptions.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TaxIdGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TaxIds/TaxIdListOptions.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class TaxIdListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class TaxIdService : ServiceNested<TaxId>,
         INestedCreatable<TaxId, TaxIdCreateOptions>,
         INestedListable<TaxId, TaxIdListOptions>,
-        INestedRetrievable<TaxId>
+        INestedRetrievable<TaxId, TaxIdGetOptions>
     {
         public TaxIdService()
             : base(null)
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteNestedEntityAsync(customerId, taxIdId, null, requestOptions, cancellationToken);
         }
 
-        public virtual TaxId Get(string customerId, string taxIdId, RequestOptions requestOptions = null)
+        public virtual TaxId Get(string customerId, string taxIdId, TaxIdGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(customerId, taxIdId, null, requestOptions);
+            return this.GetNestedEntity(customerId, taxIdId, options, requestOptions);
         }
 
-        public virtual Task<TaxId> GetAsync(string customerId, string taxIdId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<TaxId> GetAsync(string customerId, string taxIdId, TaxIdGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(customerId, taxIdId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(customerId, taxIdId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TaxId> List(string customerId, TaxIdListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TaxRates/TaxRateGetOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TaxRateGetOptions : ListOptionsWithCreated
+    {
+    }
+}

--- a/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class TaxRateService : Service<TaxRate>,
         ICreatable<TaxRate, TaxRateCreateOptions>,
         IListable<TaxRate, TaxRateListOptions>,
-        IRetrievable<TaxRate>,
+        IRetrievable<TaxRate, TaxRateGetOptions>,
         IUpdatable<TaxRate, TaxRateUpdateOptions>
     {
         public TaxRateService()
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual TaxRate Get(string taxRateId, RequestOptions requestOptions = null)
+        public virtual TaxRate Get(string taxRateId, TaxRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(taxRateId, null, requestOptions);
+            return this.GetEntity(taxRateId, options, requestOptions);
         }
 
-        public virtual Task<TaxRate> GetAsync(string taxRateId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<TaxRate> GetAsync(string taxRateId, TaxRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(taxRateId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(taxRateId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TaxRate> List(TaxRateListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Terminal/Locations/LocationGetOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Terminal
+{
+    public class LocationGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -40,14 +40,14 @@ namespace Stripe.Terminal
             return this.DeleteEntityAsync(locationId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Location Get(string locationId, RequestOptions requestOptions = null)
+        public virtual Location Get(string locationId, LocationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(locationId, null, requestOptions);
+            return this.GetEntity(locationId, options, requestOptions);
         }
 
-        public virtual Task<Location> GetAsync(string locationId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Location> GetAsync(string locationId, LocationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(locationId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(locationId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Location> List(LocationListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderGetOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Terminal
+{
+    public class ReaderGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -40,14 +40,14 @@ namespace Stripe.Terminal
             return this.DeleteEntityAsync(readerId, null, requestOptions, cancellationToken);
         }
 
-        public virtual Reader Get(string readerId, RequestOptions requestOptions = null)
+        public virtual Reader Get(string readerId, ReaderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(readerId, null, requestOptions);
+            return this.GetEntity(readerId, options, requestOptions);
         }
 
-        public virtual Task<Reader> GetAsync(string readerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Reader> GetAsync(string readerId, ReaderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(readerId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(readerId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Reader> List(ReaderListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Tokens/TokenGetOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TokenGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class TokenService : Service<Token>,
         ICreatable<Token, TokenCreateOptions>,
-        IRetrievable<Token>
+        IRetrievable<Token, TokenGetOptions>
     {
         public TokenService()
             : base(null)
@@ -30,14 +30,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Token Get(string tokenId, RequestOptions requestOptions = null)
+        public virtual Token Get(string tokenId, TokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(tokenId, null, requestOptions);
+            return this.GetEntity(tokenId, options, requestOptions);
         }
 
-        public virtual Task<Token> GetAsync(string tokenId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Token> GetAsync(string tokenId, TokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(tokenId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(tokenId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupGetOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TopupGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Topups/TopupListOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class TopupListOptions : ListOptionsWithCreated
     {
     }

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     public class TopupService : Service<Topup>,
         ICreatable<Topup, TopupCreateOptions>,
         IListable<Topup, TopupListOptions>,
-        IRetrievable<Topup>,
+        IRetrievable<Topup, TopupGetOptions>,
         IUpdatable<Topup, TopupUpdateOptions>
     {
         public TopupService()
@@ -47,14 +47,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Topup Get(string topupId, RequestOptions requestOptions = null)
+        public virtual Topup Get(string topupId, TopupGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(topupId, null, requestOptions);
+            return this.GetEntity(topupId, options, requestOptions);
         }
 
-        public virtual Task<Topup> GetAsync(string topupId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Topup> GetAsync(string topupId, TopupGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(topupId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(topupId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Topup> List(TopupListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalGetOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TransferReversalGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalListOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class TransferReversalListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class TransferReversalService : ServiceNested<TransferReversal>,
         INestedCreatable<TransferReversal, TransferReversalCreateOptions>,
         INestedListable<TransferReversal, TransferReversalListOptions>,
-        INestedRetrievable<TransferReversal>,
+        INestedRetrievable<TransferReversal, TransferReversalGetOptions>,
         INestedUpdatable<TransferReversal, TransferReversalUpdateOptions>
     {
         public TransferReversalService()
@@ -36,14 +36,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(transferId, options, requestOptions, cancellationToken);
         }
 
-        public virtual TransferReversal Get(string transferId, string reversalId, RequestOptions requestOptions = null)
+        public virtual TransferReversal Get(string transferId, string reversalId, TransferReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(transferId, reversalId, null, requestOptions);
+            return this.GetNestedEntity(transferId, reversalId, options, requestOptions);
         }
 
-        public virtual Task<TransferReversal> GetAsync(string transferId, string reversalId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<TransferReversal> GetAsync(string transferId, string reversalId, TransferReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetNestedEntityAsync(transferId, reversalId, null, requestOptions, cancellationToken);
+            return this.GetNestedEntityAsync(transferId, reversalId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TransferReversal> List(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Transfers/TransferGetOptions.cs
+++ b/src/Stripe.net/Services/Transfers/TransferGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TransferGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class TransferService : Service<Transfer>,
         ICreatable<Transfer, TransferCreateOptions>,
         IListable<Transfer, TransferListOptions>,
-        IRetrievable<Transfer>,
+        IRetrievable<Transfer, TransferGetOptions>,
         IUpdatable<Transfer, TransferUpdateOptions>
     {
         public TransferService()
@@ -40,14 +40,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Transfer Get(string transferId, RequestOptions requestOptions = null)
+        public virtual Transfer Get(string transferId, TransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(transferId, null, requestOptions);
+            return this.GetEntity(transferId, options, requestOptions);
         }
 
-        public virtual Task<Transfer> GetAsync(string transferId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Transfer> GetAsync(string transferId, TransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(transferId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(transferId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transfer> List(TransferListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointGetOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class WebhookEndpointGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointListOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class WebhookEndpointListOptions : ListOptionsWithCreated
     {
     }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -8,7 +8,7 @@ namespace Stripe
         ICreatable<WebhookEndpoint, WebhookEndpointCreateOptions>,
         IDeletable<WebhookEndpoint>,
         IListable<WebhookEndpoint, WebhookEndpointListOptions>,
-        IRetrievable<WebhookEndpoint>,
+        IRetrievable<WebhookEndpoint, WebhookEndpointGetOptions>,
         IUpdatable<WebhookEndpoint, WebhookEndpointUpdateOptions>
     {
         public WebhookEndpointService()
@@ -43,14 +43,14 @@ namespace Stripe
             return this.DeleteEntityAsync(endpointId, null, requestOptions, cancellationToken);
         }
 
-        public virtual WebhookEndpoint Get(string endpointId, RequestOptions requestOptions = null)
+        public virtual WebhookEndpoint Get(string endpointId, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(endpointId, null, requestOptions);
+            return this.GetEntity(endpointId, options, requestOptions);
         }
 
-        public virtual Task<WebhookEndpoint> GetAsync(string endpointId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<WebhookEndpoint> GetAsync(string endpointId, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetEntityAsync(endpointId, null, requestOptions, cancellationToken);
+            return this.GetEntityAsync(endpointId, options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<WebhookEndpoint> List(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
@@ -3,11 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedRetrievable<T>
+    public interface INestedRetrievable<T, O>
         where T : IStripeEntity, IHasId
+        where O : BaseOptions
     {
-        T Get(string parentId, string id, RequestOptions requestOptions = null);
+        T Get(string parentId, string id, O retrieveOptions, RequestOptions requestOptions = null);
 
-        Task<T> GetAsync(string parentId, string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<T> GetAsync(string parentId, string id, O retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/IRetrievable.cs
@@ -3,11 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IRetrievable<T>
+    public interface IRetrievable<T, O>
         where T : IStripeEntity, IHasId
+        where O : BaseOptions
     {
-        T Get(string id, RequestOptions requestOptions = null);
+        T Get(string id, O retrieveOptions, RequestOptions requestOptions = null);
 
-        Task<T> GetAsync(string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<T> GetAsync(string id, O retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -101,7 +101,7 @@ namespace StripeTests
 
         private class TestService : Service<TestEntity>,
             IListable<TestEntity, ListOptions>,
-            IRetrievable<TestEntity>
+            IRetrievable<TestEntity, BaseOptions>
         {
             public TestService(IStripeClient client)
                 : base(client)
@@ -114,14 +114,14 @@ namespace StripeTests
 
             public bool ExpandMultiWordProperty { get; set; }
 
-            public virtual TestEntity Get(string id, RequestOptions requestOptions = null)
+            public virtual TestEntity Get(string id, BaseOptions options = null, RequestOptions requestOptions = null)
             {
-                return this.GetEntity(id, null, requestOptions);
+                return this.GetEntity(id, options, requestOptions);
             }
 
-            public virtual Task<TestEntity> GetAsync(string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+            public virtual Task<TestEntity> GetAsync(string id, BaseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
             {
-                return this.GetEntityAsync(id, null, requestOptions, cancellationToken);
+                return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
             }
 
             public virtual StripeList<TestEntity> List(ListOptions options = null, RequestOptions requestOptions = null)


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add options classes for all `Get` and `GetAsync` methods.

Most of these simply derive from `BaseOptions` and don't have any properties of their own, but this allows users to expand nested fields in retrieve requests.

Fixes #1630.