### PR TITLE
Deprecate Expand properties on services

### DIFF
--- a/src/Stripe.net/Services/Account/AccountService.cs
+++ b/src/Stripe.net/Services/Account/AccountService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -24,6 +25,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/accounts";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBusinessLogo { get; set; }
 
         public virtual Account Create(AccountCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,8 +23,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/application_fees/{PARENT_ID}/refunds";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandFee { get; set; }
 
         public virtual ApplicationFeeRefund Create(string applicationFeeId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -20,14 +21,19 @@ namespace Stripe
 
         public override string BasePath => "/v1/application_fees";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandAccount { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandApplication { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCharge { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandOriginatingTransaction { get; set; }
 
         public virtual ApplicationFee Get(string applicationFeeId, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -20,6 +21,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/balance/history";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSource { get; set; }
 
         public virtual BalanceTransaction Get(string balanceTransactionId, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -24,6 +25,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/customers/{PARENT_ID}/sources";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
         public virtual BankAccount Create(string customerId, BankAccountCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -21,6 +22,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/accounts/{PARENT_ID}/capabilities";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandAccount { get; set; }
 
         public virtual Capability Get(string accountId, string capabilityId, CapabilityGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,8 +24,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/customers/{PARENT_ID}/sources";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandRecipient { get; set; }
 
         public virtual Card Create(string customerId, CardCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,30 +24,43 @@ namespace Stripe
 
         public override string BasePath => "/v1/charges";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandApplication { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandApplicationFee { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDestination { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDispute { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandInvoice { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandOnBehalfOf { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandOrder { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandReview { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSourceTransfer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandTransfer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBusinessLogo { get; set; }
 
         public virtual Charge Capture(string chargeId, ChargeCaptureOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/customers";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDefaultSource { get; set; }
 
         public bool ExpandDefaultCustomerBankAccount { get; set; } // TODO: remove in next major version

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -22,6 +23,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/disputes";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCharge { get; set; }
 
         public virtual Dispute Close(string disputeId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,10 +24,13 @@ namespace Stripe
 
         public override string BasePath => "/v1/invoiceitems";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandInvoice { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSubscription { get; set; }
 
         public virtual InvoiceItem Create(InvoiceItemCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,12 +24,16 @@ namespace Stripe
 
         public override string BasePath => "/v1/invoices";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCharge { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDefaultPaymentMethod { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSubscription { get; set; }
 
         public virtual Invoice Create(InvoiceCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,8 +24,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/orders";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCharge { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
         public virtual Order Create(OrderCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,16 +24,22 @@ namespace Stripe
 
         public override string BasePath => "/v1/payment_intents";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandApplication { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandOnBehalfOf { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandPaymentMethod { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandReview { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSource { get; set; }
 
         public virtual PaymentIntent Cancel(string paymentIntentId, PaymentIntentCancelOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,6 +24,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/payment_methods";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
         public virtual PaymentMethod Attach(string paymentMethodId, PaymentMethodAttachOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,10 +24,13 @@ namespace Stripe
 
         public override string BasePath => "/v1/payouts";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDestination { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandFailureBalanceTransaction { get; set; }
 
         public virtual Payout Cancel(string payoutId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,8 +23,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/accounts/{PARENT_ID}/persons";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandTransfer { get; set; }
 
         public virtual Person Create(string accountId, PersonCreateOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/plans";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandProduct { get; set; }
 
         public virtual Plan Create(PlanCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,10 +23,13 @@ namespace Stripe
 
         public override string BasePath => "/v1/refunds";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCharge { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandFailureBalanceTransaction { get; set; }
 
         public virtual Refund Create(RefundCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/skus";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandProduct { get; set; }
 
         public virtual Sku Create(SkuCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,12 +23,16 @@ namespace Stripe
 
         public override string BasePath => "/v1/subscriptions";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDefaultPaymentMethod { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDefaultSource { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandLatestInvoice { get; set; }
 
         public virtual Subscription Cancel(string subscriptionId, SubscriptionCancelOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -21,6 +22,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/customers/{PARENT_ID}/tax_ids";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
         public virtual TaxId Create(string customerId, TaxIdCreateOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,6 +23,7 @@ namespace Stripe
 
         public override string BasePath => "/v1/tax_rates";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandCustomer { get; set; }
 
         public virtual TaxRate Create(TaxRateCreateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
@@ -23,8 +24,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/topups";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSource { get; set; }
 
         public virtual Topup Cancel(string topupId, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,8 +23,10 @@ namespace Stripe
 
         public override string BasePath => "/v1/transfers/{PARENT_ID}/reversals";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandTransfer { get; set; }
 
         public virtual TransferReversal Create(string transferId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,12 +23,16 @@ namespace Stripe
 
         public override string BasePath => "/v1/transfers";
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandBalanceTransaction { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDestination { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandDestinationPayment { get; set; }
 
+        [Obsolete("Use BaseOptions.AddExpand instead.")]
         public bool ExpandSourceTransaction { get; set; }
 
         public virtual Transfer Create(TransferCreateOptions options, RequestOptions requestOptions = null)


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Mark all `ExpandFoo` properties on services as obsolete in favor of using `BaseOptions.AddExpand`.