### PR TITLE
Use constants instead of static strings

### DIFF
--- a/src/Stripe.net/Constants/AccountType.cs
+++ b/src/Stripe.net/Constants/AccountType.cs
@@ -2,8 +2,8 @@ namespace Stripe
 {
     public static class AccountType
     {
-        public static string Custom => "custom";
+        public const string Custom = "custom";
 
-        public static string Standard => "standard";
+        public const string Standard = "standard";
     }
 }

--- a/src/Stripe.net/Constants/BankAccountHolderType.cs
+++ b/src/Stripe.net/Constants/BankAccountHolderType.cs
@@ -2,8 +2,8 @@ namespace Stripe
 {
     public static class BankAccountHolderType
     {
-        public static string Individual => "individual";
+        public const string Individual = "individual";
 
-        public static string Company => "company";
+        public const string Company = "company";
     }
 }

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -7,254 +7,254 @@ namespace Stripe
         /// <summary>
         /// Occurs whenever an account status or property has changed.
         /// </summary>
-        public static string AccountUpdated => "account.updated";
+        public const string AccountUpdated = "account.updated";
 
         /// <summary>
         /// Occurs whenever a user authorizes an application. Sent to the related application only.
         /// </summary>
-        public static string AccountApplicationAuthorized => "account.application.authorized";
+        public const string AccountApplicationAuthorized = "account.application.authorized";
 
         /// <summary>
         /// Occurs whenever a user deauthorizes an application. Sent to the related application only.
         /// </summary>
-        public static string AccountApplicationDeauthorized => "account.application.deauthorized";
+        public const string AccountApplicationDeauthorized = "account.application.deauthorized";
 
         /// <summary>
         /// Occurs whenever an external account is created.
         /// </summary>
-        public static string AccountExternalAccountCreated => "account.external_account.created";
+        public const string AccountExternalAccountCreated = "account.external_account.created";
 
         /// <summary>
         /// Occurs whenever an external account is deleted.
         /// </summary>
-        public static string AccountExternalAccountDeleted => "account.external_account.deleted";
+        public const string AccountExternalAccountDeleted = "account.external_account.deleted";
 
         /// <summary>
         /// Occurs whenever an external account is updated.
         /// </summary>
-        public static string AccountExternalAccountUpdated => "account.external_account.updated";
+        public const string AccountExternalAccountUpdated = "account.external_account.updated";
 
         /// <summary>
         /// Occurs whenever an application fee is created on a charge.
         /// </summary>
-        public static string ApplicationFeeCreated => "application_fee.created";
+        public const string ApplicationFeeCreated = "application_fee.created";
 
         /// <summary>
         /// Occurs whenever an application fee is refunded, whether from refunding a charge or from refunding the application fee directly, including partial refunds.
         /// </summary>
-        public static string ApplicationFeeRefunded => "application_fee.refunded";
+        public const string ApplicationFeeRefunded = "application_fee.refunded";
 
         /// <summary>
         /// Occurs whenever an application fee refund is updated.
         /// </summary>
-        public static string ApplicationFeeRefundUpdated => "application_fee.refund.updated";
+        public const string ApplicationFeeRefundUpdated = "application_fee.refund.updated";
 
         /// <summary>
         /// Occurs whenever your Stripe balance has been updated (e.g. when a charge collected is available to be paid out). By default, Stripe will automatically transfer any funds in your balance to your bank account on a daily basis.
         /// </summary>
-        public static string BalanceAvailable => "balance.available";
+        public const string BalanceAvailable = "balance.available";
 
         /// <summary>
         /// Occurs whenever a receiver has been created.
         /// </summary>
         [Obsolete]
-        public static string BitcoinReceiverCreated => "bitcoin.receiver.created";
+        public const string BitcoinReceiverCreated = "bitcoin.receiver.created";
 
         /// <summary>
         /// Occurs whenever a receiver is filled (that is, when it has received enough bitcoin to process a payment of the same amount).
         /// </summary>
         [Obsolete]
-        public static string BitcoinReceiverFilled => "bitcoin.receiver.filled";
+        public const string BitcoinReceiverFilled = "bitcoin.receiver.filled";
 
         /// <summary>
         /// Occurs whenever a receiver is updated.
         /// </summary>
         [Obsolete]
-        public static string BitcoinReceiverUpdated => "bitcoin.receiver.updated";
+        public const string BitcoinReceiverUpdated = "bitcoin.receiver.updated";
 
         /// <summary>
         /// Occurs whenever bitcoin is pushed to a receiver.
         /// </summary>
         [Obsolete]
-        public static string BitcoinReceiverTransactionUpdated => "bitcoin.receiver.transaction.created";
+        public const string BitcoinReceiverTransactionUpdated = "bitcoin.receiver.transaction.created";
 
         /// <summary>
         /// Occurs whenever a previously uncaptured charge is captured.
         /// </summary>
-        public static string ChargeCaptured => "charge.captured";
+        public const string ChargeCaptured = "charge.captured";
 
         /// <summary>
         /// Occurs whenever a previously uncaptured charge expires.
         /// </summary>
-        public static string ChargeExpired => "charge.expired";
+        public const string ChargeExpired = "charge.expired";
 
         /// <summary>
         /// Occurs whenever a failed charge attempt occurs.
         /// </summary>
-        public static string ChargeFailed => "charge.failed";
+        public const string ChargeFailed = "charge.failed";
 
         /// <summary>
         /// Occurs whenever a pending charge is created.
         /// </summary>
-        public static string ChargePending => "charge.pending";
+        public const string ChargePending = "charge.pending";
 
         /// <summary>
         /// Occurs whenever a charge is refunded, including partial refunds.
         /// </summary>
-        public static string ChargeRefunded => "charge.refunded";
+        public const string ChargeRefunded = "charge.refunded";
 
         /// <summary>
         /// Occurs whenever a new charge is created and is successful.
         /// </summary>
-        public static string ChargeSucceeded => "charge.succeeded";
+        public const string ChargeSucceeded = "charge.succeeded";
 
         /// <summary>
         /// Occurs whenever a charge description or metadata is updated.
         /// </summary>
-        public static string ChargeUpdated => "charge.updated";
+        public const string ChargeUpdated = "charge.updated";
 
         /// <summary>
         /// Occurs when the dispute is closed and the dispute status changes to
         /// <c>charge_refunded</c>, <c>lost</c>, <c>warning_closed</c>, or <c>won</c>.
         /// </summary>
-        public static string ChargeDisputeClosed => "charge.dispute.closed";
+        public const string ChargeDisputeClosed = "charge.dispute.closed";
 
         /// <summary>
         /// Occurs whenever a customer disputes a charge with their bank.
         /// </summary>
-        public static string ChargeDisputeCreated => "charge.dispute.created";
+        public const string ChargeDisputeCreated = "charge.dispute.created";
 
         /// <summary>
         /// Occurs when funds are reinstated to your account after a dispute is closed. This
         /// includes <a href="https://stripe.com/docs/disputes#disputes-on-partially-refunded-payments">partially
         /// refunded payments</a>.
         /// </summary>
-        public static string ChargeDisputeFundsReinstated => "charge.dispute.funds_reinstated";
+        public const string ChargeDisputeFundsReinstated = "charge.dispute.funds_reinstated";
 
         /// <summary>
         /// Occurs when funds are removed from your account due to a dispute.
         /// </summary>
-        public static string ChargeDisputeFundsWithdrawn => "charge.dispute.funds_withdrawn";
+        public const string ChargeDisputeFundsWithdrawn = "charge.dispute.funds_withdrawn";
 
         /// <summary>
         /// Occurs when the dispute is updated (usually with evidence).
         /// </summary>
-        public static string ChargeDisputeUpdated => "charge.dispute.updated";
+        public const string ChargeDisputeUpdated = "charge.dispute.updated";
 
         /// <summary>
         /// Occurs whenever a refund is updated on selected payment methods.
         /// </summary>
-        public static string ChargeRefundUpdated => "charge.refund.updated";
+        public const string ChargeRefundUpdated = "charge.refund.updated";
 
         /// <summary>
         /// Occurs when a Checkout Session has been successfully completed.
         /// </summary>
-        public static string CheckoutSessionCompleted => "checkout.session.completed";
+        public const string CheckoutSessionCompleted = "checkout.session.completed";
 
         /// <summary>
         /// Occurs whenever a coupon is created.
         /// </summary>
-        public static string CouponCreated => "coupon.created";
+        public const string CouponCreated = "coupon.created";
 
         /// <summary>
         /// Occurs whenever a coupon is deleted.
         /// </summary>
-        public static string CouponDeleted => "coupon.deleted";
+        public const string CouponDeleted = "coupon.deleted";
 
         /// <summary>
         /// Occurs whenever a coupon is updated.
         /// </summary>
-        public static string CouponUpdated => "coupon.updated";
+        public const string CouponUpdated = "coupon.updated";
 
         /// <summary>
         /// Occurs whenever a credit note is created.
         /// </summary>
-        public static string CreditNoteCreated => "credit_note.created";
+        public const string CreditNoteCreated = "credit_note.created";
 
         /// <summary>
         /// Occurs whenever a credit note is updated.
         /// </summary>
-        public static string CreditNoteUpdated => "credit_note.updated";
+        public const string CreditNoteUpdated = "credit_note.updated";
 
         /// <summary>
         /// Occurs whenever a credit note is voided.
         /// </summary>
-        public static string CreditNoteVoided => "credit_note.voided";
+        public const string CreditNoteVoided = "credit_note.voided";
 
         /// <summary>
         /// Occurs whenever a new customer is created.
         /// </summary>
-        public static string CustomerCreated => "customer.created";
+        public const string CustomerCreated = "customer.created";
 
         /// <summary>
         /// Occurs whenever a customer is deleted.
         /// </summary>
-        public static string CustomerDeleted => "customer.deleted";
+        public const string CustomerDeleted = "customer.deleted";
 
         /// <summary>
         /// Occurs whenever any property of a customer changes.
         /// </summary>
-        public static string CustomerUpdated => "customer.updated";
+        public const string CustomerUpdated = "customer.updated";
 
         /// <summary>
         /// Occurs whenever a coupon is attached to a customer.
         /// </summary>
-        public static string CustomerDiscountCreated => "customer.discount.created";
+        public const string CustomerDiscountCreated = "customer.discount.created";
 
         /// <summary>
         /// Occurs whenever a customer's discount is removed.
         /// </summary>
-        public static string CustomerDiscountDeleted => "customer.discount.deleted";
+        public const string CustomerDiscountDeleted = "customer.discount.deleted";
 
         /// <summary>
         /// Occurs whenever a customer is switched from one coupon to another.
         /// </summary>
-        public static string CustomerDiscountUpdated => "customer.discount.updated";
+        public const string CustomerDiscountUpdated = "customer.discount.updated";
 
         /// <summary>
         /// Occurs whenever a new source is created for the customer.
         /// </summary>
-        public static string CustomerSourceCreated => "customer.source.created";
+        public const string CustomerSourceCreated = "customer.source.created";
 
         /// <summary>
         /// Occurs whenever a source is removed from a customer.
         /// </summary>
-        public static string CustomerSourceDeleted => "customer.source.deleted";
+        public const string CustomerSourceDeleted = "customer.source.deleted";
 
         /// <summary>
         /// Occurs whenever a source will expire at the end of the month.
         /// </summary>
-        public static string CustomerSourceExpiring => "customer.source.expiring";
+        public const string CustomerSourceExpiring = "customer.source.expiring";
 
         /// <summary>
         /// Occurs whenever a source's details are changed.
         /// </summary>
-        public static string CustomerSourceUpdated => "customer.source.updated";
+        public const string CustomerSourceUpdated = "customer.source.updated";
 
         /// <summary>
         /// Occurs whenever a customer with no subscription is signed up for a plan.
         /// </summary>
-        public static string CustomerSubscriptionCreated => "customer.subscription.created";
+        public const string CustomerSubscriptionCreated = "customer.subscription.created";
 
         /// <summary>
         /// Occurs whenever a customer ends their subscription.
         /// </summary>
-        public static string CustomerSubscriptionDeleted => "customer.subscription.deleted";
+        public const string CustomerSubscriptionDeleted = "customer.subscription.deleted";
 
         /// <summary>
         /// Occurs three days before the trial period of a subscription is scheduled to end.
         /// </summary>
-        public static string CustomerSubscriptionTrialWillEnd => "customer.subscription.trial_will_end";
+        public const string CustomerSubscriptionTrialWillEnd = "customer.subscription.trial_will_end";
 
         /// <summary>
         /// Occurs three days before the trial period of a subscription is scheduled to end.
         /// </summary>
-        public static string CustomerSubscriptionUpdated => "customer.subscription.updated";
+        public const string CustomerSubscriptionUpdated = "customer.subscription.updated";
 
         /// <summary>
         /// Occurs whenever a new Stripe-generated file is available for your account.
         /// </summary>
-        public static string FileCreated => "file.created";
+        public const string FileCreated = "file.created";
 
         /// <summary>
         /// Occurs whenever a new invoice is created. To learn how webhooks can be used with this
@@ -262,43 +262,43 @@ namespace Stripe
         /// <a href="https://stripe.com/docs/subscriptions/webhooks">Using Webhooks with
         /// Subscriptions</a>.
         /// </summary>
-        public static string InvoiceCreated => "invoice.created";
+        public const string InvoiceCreated = "invoice.created";
 
         /// <summary>
         /// Occurs whenever a draft invoice is deleted.
         /// </summary>
-        public static string InvoiceDeleted => "invoice.deleted";
+        public const string InvoiceDeleted = "invoice.deleted";
 
         /// <summary>
         /// Occurs whenever a draft invoice is finalized and updated to be an open invoice.
         /// </summary>
-        public static string InvoiceFinalized => "invoice.finalized";
+        public const string InvoiceFinalized = "invoice.finalized";
 
         /// <summary>
         /// Occurs whenever an invoice is marked uncollectible.
         /// </summary>
-        public static string InvoiceMarkedUncollectible => "invoice.marked_uncollectible";
+        public const string InvoiceMarkedUncollectible = "invoice.marked_uncollectible";
 
         /// <summary>
         /// Occurs whenever an invoice payment attempt requires further user action to complete.
         /// </summary>
-        public static string InvoicePaymentActionRequired => "invoice.payment_action_required";
+        public const string InvoicePaymentActionRequired = "invoice.payment_action_required";
 
         /// <summary>
         /// Occurs whenever an invoice payment attempt fails, due either to a declined payment or
         /// to the lack of a stored payment method.
         /// </summary>
-        public static string InvoicePaymentFailed => "invoice.payment_failed";
+        public const string InvoicePaymentFailed = "invoice.payment_failed";
 
         /// <summary>
         /// Occurs whenever an invoice payment attempt succeeds.
         /// </summary>
-        public static string InvoicePaymentSucceeded => "invoice.payment_succeeded";
+        public const string InvoicePaymentSucceeded = "invoice.payment_succeeded";
 
         /// <summary>
         /// Occurs whenever an invoice email is sent out.
         /// </summary>
-        public static string InvoiceSent => "invoice.sent";
+        public const string InvoiceSent = "invoice.sent";
 
         /// <summary>
         /// Occurs X number of days before a subscription is scheduled to create an invoice that is
@@ -307,112 +307,112 @@ namespace Stripe
         /// settings</a>. Note: The received <see cref="Invoice"/> object will not have an invoice
         /// ID.
         /// </summary>
-        public static string InvoiceUpcoming => "invoice.upcoming";
+        public const string InvoiceUpcoming = "invoice.upcoming";
 
         /// <summary>
         /// Occurs whenever an invoice changes (e.g., the invoice amount).
         /// </summary>
-        public static string InvoiceUpdated => "invoice.updated";
+        public const string InvoiceUpdated = "invoice.updated";
 
         /// <summary>
         /// Occurs whenever an invoice is voided.
         /// </summary>
-        public static string InvoiceVoided => "invoice.voided";
+        public const string InvoiceVoided = "invoice.voided";
 
         /// <summary>
         /// Occurs whenever an invoice item is created.
         /// </summary>
-        public static string InvoiceItemCreated => "invoiceitem.created";
+        public const string InvoiceItemCreated = "invoiceitem.created";
 
         /// <summary>
         /// Occurs whenever an invoice item is deleted.
         /// </summary>
-        public static string InvoiceItemDeleted => "invoiceitem.deleted";
+        public const string InvoiceItemDeleted = "invoiceitem.deleted";
 
         /// <summary>
         /// Occurs whenever an invoice item is updated.
         /// </summary>
-        public static string InvoiceItemUpdated => "invoiceitem.updated";
+        public const string InvoiceItemUpdated = "invoiceitem.updated";
 
         /// <summary>
         /// Occurs whenever an issuing authorization is created.
         /// </summary>
-        public static string IssuingAuthorizationCreated => "issuing_authorization.created";
+        public const string IssuingAuthorizationCreated = "issuing_authorization.created";
 
         /// <summary>
         /// Occurs whenever an issuing authorization request is sent.
         /// </summary>
-        public static string IssuingAuthorizationRequest => "issuing_authorization.request";
+        public const string IssuingAuthorizationRequest = "issuing_authorization.request";
 
         /// <summary>
         /// Occurs whenever an issuing authorization is updated.
         /// </summary>
-        public static string IssuingAuthorizationUpdated => "issuing_authorization.updated";
+        public const string IssuingAuthorizationUpdated = "issuing_authorization.updated";
 
         /// <summary>
         /// Occurs whenever an issuing card is created.
         /// </summary>
-        public static string IssuingCardCreated => "issuing_card.created";
+        public const string IssuingCardCreated = "issuing_card.created";
 
         /// <summary>
         /// Occurs whenever an issuing card is updated.
         /// </summary>
-        public static string IssuingCardUpdated => "issuing_card.updated";
+        public const string IssuingCardUpdated = "issuing_card.updated";
 
         /// <summary>
         /// Occurs whenever an issuing cardholder is created.
         /// </summary>
-        public static string IssuingCardholderCreated => "issuing_cardholder.created";
+        public const string IssuingCardholderCreated = "issuing_cardholder.created";
 
         /// <summary>
         /// Occurs whenever an issuing cardholder is updated.
         /// </summary>
-        public static string IssuingCardholderUpdated => "issuing_cardholder.updated";
+        public const string IssuingCardholderUpdated = "issuing_cardholder.updated";
 
         /// <summary>
         /// Occurs whenever an issuing dispute is created.
         /// </summary>
-        public static string IssuingDisputeCreated => "issuing_dispute.created";
+        public const string IssuingDisputeCreated = "issuing_dispute.created";
 
         /// <summary>
         /// Occurs whenever an issuing dispute is updated.
         /// </summary>
-        public static string IssuingDisputeUpdated => "issuing_dispute.updated";
+        public const string IssuingDisputeUpdated = "issuing_dispute.updated";
 
         /// <summary>
         /// Occurs whenever an issuing transaction is created.
         /// </summary>
-        public static string IssuingTransactionCreated => "issuing_transaction.created";
+        public const string IssuingTransactionCreated = "issuing_transaction.created";
 
         /// <summary>
         /// Occurs whenever an issuing transaction is updated.
         /// </summary>
-        public static string IssuingTransactionUpdated => "issuing_transaction.updated";
+        public const string IssuingTransactionUpdated = "issuing_transaction.updated";
 
         /// <summary>
         /// Occurs whenever an order is created.
         /// </summary>
-        public static string OrderCreated => "order.created";
+        public const string OrderCreated = "order.created";
 
         /// <summary>
         /// Occurs whenever payment is attempted on an order, and the payment fails.
         /// </summary>
-        public static string OrderPaymentFailed => "order.payment_failed";
+        public const string OrderPaymentFailed = "order.payment_failed";
 
         /// <summary>
         /// Occurs whenever payment is attempted on an order, and the payment succeeds.
         /// </summary>
-        public static string OrderPaymentSucceeded => "order.payment_succeeded";
+        public const string OrderPaymentSucceeded = "order.payment_succeeded";
 
         /// <summary>
         /// Occurs whenever an order is updated.
         /// </summary>
-        public static string OrderUpdated => "order.updated";
+        public const string OrderUpdated = "order.updated";
 
         /// <summary>
         /// Occurs whenever an order return is created.
         /// </summary>
-        public static string OrderReturnCreated => "order_return.created";
+        public const string OrderReturnCreated = "order_return.created";
 
         /// <summary>
         /// Occurs when a <see cref="PaymentIntent"/> has funds to be captured. Check the
@@ -422,302 +422,302 @@ namespace Stripe
         /// amount. <a href="https://stripe.com/docs/api/payment_intents/capture">Learn more about
         /// capturing PaymentIntents.</a>
         /// </summary>
-        public static string PaymentIntentAmountCapturableUpdated => "payment_intent.amount_capturable_updated";
+        public const string PaymentIntentAmountCapturableUpdated = "payment_intent.amount_capturable_updated";
 
         /// <summary>
         /// Occurs when a new PaymentIntent is created.
         /// </summary>
-        public static string PaymentIntentCreated => "payment_intent.created";
+        public const string PaymentIntentCreated = "payment_intent.created";
 
         /// <summary>
         /// Occurs when a PaymentIntent has failed the attempt to create a source or a payment.
         /// </summary>
-        public static string PaymentIntentPaymentFailed => "payment_intent.payment_failed";
+        public const string PaymentIntentPaymentFailed = "payment_intent.payment_failed";
 
         /// <summary>
         /// Occurs when a PaymentIntent has been successfully fulfilled.
         /// </summary>
-        public static string PaymentIntentSucceeded => "payment_intent.succeeded";
+        public const string PaymentIntentSucceeded = "payment_intent.succeeded";
 
         /// <summary>
         /// Occurs whenever a new payment method is attached to a customer.
         /// </summary>
-        public static string PaymentMethodAttached => "payment_method.attached";
+        public const string PaymentMethodAttached = "payment_method.attached";
 
         /// <summary>
         /// Occurs whenever a card payment method's details are automatically updated by CAU.
         /// </summary>
-        public static string PaymentMethodCardAutomaticallyUpdated => "payment_method.card_automatically_updated";
+        public const string PaymentMethodCardAutomaticallyUpdated = "payment_method.card_automatically_updated";
 
         /// <summary>
         /// Occurs whenever a payment method is detached from a customer.
         /// </summary>
-        public static string PaymentMethodDetached => "payment_method.detached";
+        public const string PaymentMethodDetached = "payment_method.detached";
 
         /// <summary>
         /// Occurs whenever a payment method is updated via the API.
         /// </summary>
-        public static string PaymentMethodUpdated => "payment_method.updated";
+        public const string PaymentMethodUpdated = "payment_method.updated";
 
         /// <summary>
         /// Occurs whenever a payout is canceled.
         /// </summary>
-        public static string PayoutCanceled => "payout.canceled";
+        public const string PayoutCanceled = "payout.canceled";
 
         /// <summary>
         /// Occurs whenever a new payout is created.
         /// </summary>
-        public static string PayoutCreated => "payout.created";
+        public const string PayoutCreated = "payout.created";
 
         /// <summary>
         /// Occurs whenever Stripe attempts to send a payout and that transfer fails.
         /// </summary>
-        public static string PayoutFailed => "payout.failed";
+        public const string PayoutFailed = "payout.failed";
 
         /// <summary>
         /// Occurs whenever a payout is *expected* to be available in the destination account.
         /// If the payout fails, a <see cref="PayoutFailed"/> notification is also sent, at a later
         /// time.
         /// </summary>
-        public static string PayoutPaid => "payout.paid";
+        public const string PayoutPaid = "payout.paid";
 
         /// <summary>
         /// Occurs whenever a payout's metadata is updated.
         /// </summary>
-        public static string PayoutUpdated => "payout.updated";
+        public const string PayoutUpdated = "payout.updated";
 
         /// <summary>
         /// Occurs whenever a person is created.
         /// </summary>
-        public static string PersonCreated => "person.created";
+        public const string PersonCreated = "person.created";
 
         /// <summary>
         /// Occurs whenever a person is deleted.
         /// </summary>
-        public static string PersonDeleted => "person.deleted";
+        public const string PersonDeleted = "person.deleted";
 
         /// <summary>
         /// Occurs whenever a person is updated.
         /// </summary>
-        public static string PersonUpdated => "person.updated";
+        public const string PersonUpdated = "person.updated";
 
         /// <summary>
         /// Occurs whenever a plan is created.
         /// </summary>
-        public static string PlanCreated => "plan.created";
+        public const string PlanCreated = "plan.created";
 
         /// <summary>
         /// Occurs whenever a plan is deleted.
         /// </summary>
-        public static string PlanDeleted => "plan.deleted";
+        public const string PlanDeleted = "plan.deleted";
 
         /// <summary>
         /// Occurs whenever a plan is updated.
         /// </summary>
-        public static string PlanUpdated => "plan.updated";
+        public const string PlanUpdated = "plan.updated";
 
         /// <summary>
         /// Occurs whenever a product is created.
         /// </summary>
-        public static string ProductCreated => "product.created";
+        public const string ProductCreated = "product.created";
 
         /// <summary>
         /// Occurs whenever a product is deleted.
         /// </summary>
-        public static string ProductDeleted => "product.deleted";
+        public const string ProductDeleted = "product.deleted";
 
         /// <summary>
         /// Occurs whenever a product is updated.
         /// </summary>
-        public static string ProductUpdated => "product.updated";
+        public const string ProductUpdated = "product.updated";
 
         /// <summary>
         /// Occurs whenever a recipient is created.
         /// </summary>
-        public static string RecipientCreated => "recipient.created";
+        public const string RecipientCreated = "recipient.created";
 
         /// <summary>
         /// Occurs whenever a recipient is deleted.
         /// </summary>
-        public static string RecipientDeleted => "recipient.deleted";
+        public const string RecipientDeleted = "recipient.deleted";
 
         /// <summary>
         /// Occurs whenever a recipient is updated.
         /// </summary>
-        public static string RecipientUpdated => "recipient.updated";
+        public const string RecipientUpdated = "recipient.updated";
 
         /// <summary>
         /// Occurs whenever a requested <see cref="Reporting.ReportRun"/> failed to complete.
         /// </summary>
-        public static string ReportingReportRunFailed => "reporting.report_run.failed";
+        public const string ReportingReportRunFailed = "reporting.report_run.failed";
 
         /// <summary>
         /// Occurs whenever a requested <see cref="Reporting.ReportRun"/> completed succesfully.
         /// </summary>
-        public static string ReportingReportRunSucceeded => "reporting.report_run.succeeded";
+        public const string ReportingReportRunSucceeded = "reporting.report_run.succeeded";
 
         /// <summary>
         /// Occurs whenever a requested <see cref="Reporting.ReportType"/> is updated (typically to
         /// indicate that a new day's data has come available).
         /// </summary>
-        public static string ReportingReportTypeUpdated => "reporting.report_type.updated";
+        public const string ReportingReportTypeUpdated = "reporting.report_type.updated";
 
         /// <summary>
         /// Occurs whenever a review is closed. The review's reason field indicates why:
         /// <c>approved</c>, <c>disputed</c>, <c>refunded</c>, or <c>refunded_as_fraud</c>.
         /// </summary>
-        public static string ReviewClosed => "review.closed";
+        public const string ReviewClosed = "review.closed";
 
         /// <summary>
         /// Occurs whenever a review is opened.
         /// </summary>
-        public static string ReviewOpened => "review.opened";
+        public const string ReviewOpened = "review.opened";
 
         /// <summary>
         /// Occurs whenever a Sigma scheduled query run finishes.
         /// </summary>
-        public static string SigmaScheduleQueryRunCreated => "sigma.scheduled_query_run.created";
+        public const string SigmaScheduleQueryRunCreated = "sigma.scheduled_query_run.created";
 
         /// <summary>
         /// Occurs whenever a SKU is created.
         /// </summary>
-        public static string SkuCreated => "sku.created";
+        public const string SkuCreated = "sku.created";
 
         /// <summary>
         /// Occurs whenever a SKU is deleted.
         /// </summary>
-        public static string SkuDeleted => "sku.deleted";
+        public const string SkuDeleted = "sku.deleted";
 
         /// <summary>
         /// Occurs whenever a SKU is updated.
         /// </summary>
-        public static string SkuUpdated => "sku.updated";
+        public const string SkuUpdated = "sku.updated";
 
         /// <summary>
         /// Occurs whenever a source is canceled.
         /// </summary>
-        public static string SourceCanceled => "source.canceled";
+        public const string SourceCanceled = "source.canceled";
 
         /// <summary>
         /// Occurs whenever a source transitions to chargeable.
         /// </summary>
-        public static string SourceChargeable => "source.chargeable";
+        public const string SourceChargeable = "source.chargeable";
 
         /// <summary>
         /// Occurs whenever a source is failed.
         /// </summary>
-        public static string SourceFailed => "source.failed";
+        public const string SourceFailed = "source.failed";
 
         /// <summary>
         /// Occurs whenever a source mandate notification method is set to manual.
         /// </summary>
-        public static string SourceMandateNotification => "source.mandate_notification";
+        public const string SourceMandateNotification = "source.mandate_notification";
 
         /// <summary>
         /// Occurs whenever the refund attributes are required on a receiver source to process a
         /// refund or a mispayment.
         /// </summary>
-        public static string SourceRefundAttributesRequired => "source.refund_attributes_required";
+        public const string SourceRefundAttributesRequired = "source.refund_attributes_required";
 
         /// <summary>
         /// Occurs whenever a source transaction is created.
         /// </summary>
-        public static string SourceTransactionCreated => "source.transaction.created";
+        public const string SourceTransactionCreated = "source.transaction.created";
 
         /// <summary>
         /// Occurs whenever a source transaction is updated.
         /// </summary>
-        public static string SourceTransactionUpdated => "source.transaction.updated";
+        public const string SourceTransactionUpdated = "source.transaction.updated";
 
         /// <summary>
         /// Occurs whenever a subscription schedule is canceled due to the underlying subscription
         /// being canceled because of delinquency.
         /// </summary>
-        public static string SubscriptionScheduleAborted => "subscription_schedule.aborted";
+        public const string SubscriptionScheduleAborted = "subscription_schedule.aborted";
 
         /// <summary>
         /// Occurs whenever a subscription schedule is canceled.
         /// </summary>
-        public static string SubscriptionScheduleCanceled => "subscription_schedule.canceled";
+        public const string SubscriptionScheduleCanceled = "subscription_schedule.canceled";
 
         /// <summary>
         /// Occurs whenever a new subscription schedule is completed.
         /// </summary>
-        public static string SubscriptionScheduleCompleted => "subscription_schedule.completed";
+        public const string SubscriptionScheduleCompleted = "subscription_schedule.completed";
 
         /// <summary>
         /// Occurs whenever a new subscription schedule is created.
         /// </summary>
-        public static string SubscriptionScheduleCreated => "subscription_schedule.created";
+        public const string SubscriptionScheduleCreated = "subscription_schedule.created";
 
         /// <summary>
         /// Occurs 7 days before a subscription schedule will expire.
         /// </summary>
-        public static string SubscriptionScheduleExpiring => "subscription_schedule.expiring";
+        public const string SubscriptionScheduleExpiring = "subscription_schedule.expiring";
 
         /// <summary>
         /// Occurs whenever a new subscription schedule is released.
         /// </summary>
-        public static string SubscriptionScheduleReleased => "subscription_schedule.released";
+        public const string SubscriptionScheduleReleased = "subscription_schedule.released";
 
         /// <summary>
         /// Occurs whenever a subscription schedule is updated.
         /// </summary>
-        public static string SubscriptionScheduleUpdated => "subscription_schedule.updated";
+        public const string SubscriptionScheduleUpdated = "subscription_schedule.updated";
 
         /// <summary>
         /// Occurs whenever a tax rate is created.
         /// </summary>
-        public static string TaxRateCreated => "tax_rate.created";
+        public const string TaxRateCreated = "tax_rate.created";
 
         /// <summary>
         /// Occurs whenever a tax rate changes.
         /// </summary>
-        public static string TaxRateUpdated => "tax_rate.updated";
+        public const string TaxRateUpdated = "tax_rate.updated";
 
         /// <summary>
         /// Occurs whenever a top-up is canceled.
         /// </summary>
-        public static string TopupCanceled => "topup.canceled";
+        public const string TopupCanceled = "topup.canceled";
 
         /// <summary>
         /// Occurs whenever a top-up is created.
         /// </summary>
-        public static string TopupCreated => "topup.created";
+        public const string TopupCreated = "topup.created";
 
         /// <summary>
         /// Occurs whenever a top-up fails.
         /// </summary>
-        public static string TopupFailed => "topup.failed";
+        public const string TopupFailed = "topup.failed";
 
         /// <summary>
         /// Occurs whenever a top-up is reversed.
         /// </summary>
-        public static string TopupReversed => "topup.reversed";
+        public const string TopupReversed = "topup.reversed";
 
         /// <summary>
         /// Occurs whenever a top-up succeeds.
         /// </summary>
-        public static string TopupSucceeded => "topup.succeeded";
+        public const string TopupSucceeded = "topup.succeeded";
 
         /// <summary>
         /// Occurs whenever a new transfer is created.
         /// </summary>
-        public static string TransferCreated => "transfer.created";
+        public const string TransferCreated = "transfer.created";
 
         /// <summary>
         /// Occurs whenever a transfer is reversed, including partial reversals.
         /// </summary>
-        public static string TransferReversed => "transfer.reversed";
+        public const string TransferReversed = "transfer.reversed";
 
         /// <summary>
         /// Occurs whenever the description or metadata of a transfer is updated.
         /// </summary>
-        public static string TransferUpdated => "transfer.updated";
+        public const string TransferUpdated = "transfer.updated";
 
         /// <summary>
         /// May be sent by Stripe at any time to see if a provided webhook URL is working.
         /// </summary>
-        public static string Ping => "ping";
+        public const string Ping = "ping";
     }
 }

--- a/src/Stripe.net/Constants/FilePurpose.cs
+++ b/src/Stripe.net/Constants/FilePurpose.cs
@@ -2,18 +2,18 @@ namespace Stripe
 {
     public static class FilePurpose
     {
-        public static string BusinessLogo => "business_logo";
+        public const string BusinessLogo = "business_logo";
 
-        public static string DisputeEvidence => "dispute_evidence";
+        public const string DisputeEvidence = "dispute_evidence";
 
-        public static string IdentityDocument => "identity_document";
+        public const string IdentityDocument = "identity_document";
 
-        public static string IncorporationArticle => "incorporation_article";
+        public const string IncorporationArticle = "incorporation_article";
 
-        public static string IncorporationDocument => "incorporation_document";
+        public const string IncorporationDocument = "incorporation_document";
 
-        public static string PaymentProviderTransfer => "payment_provider_transfer";
+        public const string PaymentProviderTransfer = "payment_provider_transfer";
 
-        public static string ProductFeed => "product_feed";
+        public const string ProductFeed = "product_feed";
     }
 }

--- a/src/Stripe.net/Constants/PlanIntervals.cs
+++ b/src/Stripe.net/Constants/PlanIntervals.cs
@@ -2,12 +2,12 @@ namespace Stripe
 {
     public static class PlanIntervals
     {
-        public static string Day => "day";
+        public const string Day = "day";
 
-        public static string Week => "week";
+        public const string Week = "week";
 
-        public static string Month => "month";
+        public const string Month = "month";
 
-        public static string Year => "year";
+        public const string Year = "year";
     }
 }

--- a/src/Stripe.net/Constants/RefundReasons.cs
+++ b/src/Stripe.net/Constants/RefundReasons.cs
@@ -2,12 +2,12 @@ namespace Stripe
 {
     public static class RefundReasons
     {
-        public static string Unknown => null;
+        public const string Unknown = null;
 
-        public static string Duplicate => "duplicate";
+        public const string Duplicate = "duplicate";
 
-        public static string Fraudulent => "fraudulent";
+        public const string Fraudulent = "fraudulent";
 
-        public static string RequestedByCustomer => "requested_by_customer";
+        public const string RequestedByCustomer = "requested_by_customer";
     }
 }

--- a/src/Stripe.net/Constants/SourceFlow.cs
+++ b/src/Stripe.net/Constants/SourceFlow.cs
@@ -2,12 +2,12 @@ namespace Stripe
 {
     public static class SourceFlow
     {
-        public static string Redirect => "redirect";
+        public const string Redirect = "redirect";
 
-        public static string Receiver => "receiver";
+        public const string Receiver = "receiver";
 
-        public static string CodeVerification => "code_verification";
+        public const string CodeVerification = "code_verification";
 
-        public static string None => "none";
+        public const string None = "none";
     }
 }

--- a/src/Stripe.net/Constants/SourceType.cs
+++ b/src/Stripe.net/Constants/SourceType.cs
@@ -2,32 +2,32 @@ namespace Stripe
 {
     public static class SourceType
     {
-        public static string AchCreditTransfer => "ach_credit_transfer";
+        public const string AchCreditTransfer = "ach_credit_transfer";
 
-        public static string AchDebit => "ach_debit";
+        public const string AchDebit = "ach_debit";
 
-        public static string Alipay => "alipay";
+        public const string Alipay = "alipay";
 
-        public static string Bancontact => "bancontact";
+        public const string Bancontact = "bancontact";
 
-        public static string Bitcoin => "bitcoin";
+        public const string Bitcoin = "bitcoin";
 
-        public static string Card => "card";
+        public const string Card = "card";
 
-        public static string Eps => "eps";
+        public const string Eps = "eps";
 
-        public static string Giropay => "giropay";
+        public const string Giropay = "giropay";
 
-        public static string Ideal => "ideal";
+        public const string Ideal = "ideal";
 
-        public static string P24 => "p24";
+        public const string P24 = "p24";
 
-        public static string SepaCreditTransfer => "sepa_credit_transfer";
+        public const string SepaCreditTransfer = "sepa_credit_transfer";
 
-        public static string SepaDebit => "sepa_debit";
+        public const string SepaDebit = "sepa_debit";
 
-        public static string Sofort => "sofort";
+        public const string Sofort = "sofort";
 
-        public static string ThreeDSecure => "three_d_secure";
+        public const string ThreeDSecure = "three_d_secure";
     }
 }

--- a/src/Stripe.net/Constants/SourceUsage.cs
+++ b/src/Stripe.net/Constants/SourceUsage.cs
@@ -2,8 +2,8 @@ namespace Stripe
 {
     public static class SourceUsage
     {
-        public static string Reusable => "reusable";
+        public const string Reusable = "reusable";
 
-        public static string SingleUse => "single_use";
+        public const string SingleUse = "single_use";
     }
 }

--- a/src/Stripe.net/Constants/SubscriptionStatuses.cs
+++ b/src/Stripe.net/Constants/SubscriptionStatuses.cs
@@ -2,18 +2,18 @@ namespace Stripe
 {
     public static class SubscriptionStatuses
     {
-        public static string Trialing => "trialing";
+        public const string Trialing = "trialing";
 
-        public static string Active => "active";
+        public const string Active = "active";
 
-        public static string PastDue => "past_due";
+        public const string PastDue = "past_due";
 
-        public static string Canceled => "canceled";
+        public const string Canceled = "canceled";
 
-        public static string Unpaid => "unpaid";
+        public const string Unpaid = "unpaid";
 
-        public static string Incomplete => "incomplete";
+        public const string Incomplete = "incomplete";
 
-        public static string IncompleteExpired => "incomplete_expired";
+        public const string IncompleteExpired = "incomplete_expired";
     }
 }

--- a/src/Stripe.net/Constants/TransferFailureCodes.cs
+++ b/src/Stripe.net/Constants/TransferFailureCodes.cs
@@ -2,24 +2,24 @@ namespace Stripe
 {
     public static class TransferFailureCodes
     {
-        public static string InsufficientFunds => "insufficient_funds";
+        public const string InsufficientFunds = "insufficient_funds";
 
-        public static string AccountClosed => "account_closed";
+        public const string AccountClosed = "account_closed";
 
-        public static string NoAccount => "no_account";
+        public const string NoAccount = "no_account";
 
-        public static string InvalidAccountNumber => "invalid_account_number";
+        public const string InvalidAccountNumber = "invalid_account_number";
 
-        public static string DebitNotAuthorized => "debit_not_authorized";
+        public const string DebitNotAuthorized = "debit_not_authorized";
 
-        public static string BankOwnershipChanged => "bank_ownership_changed";
+        public const string BankOwnershipChanged = "bank_ownership_changed";
 
-        public static string AccountFrozen => "account_frozen";
+        public const string AccountFrozen = "account_frozen";
 
-        public static string CouldNotProcess => "could_not_process";
+        public const string CouldNotProcess = "could_not_process";
 
-        public static string BankAccountRestricted => "bank_account_restricted";
+        public const string BankAccountRestricted = "bank_account_restricted";
 
-        public static string InvalidCurrency => "invalid_currency";
+        public const string InvalidCurrency = "invalid_currency";
     }
 }

--- a/src/Stripe.net/Constants/TransferMethod.cs
+++ b/src/Stripe.net/Constants/TransferMethod.cs
@@ -5,11 +5,11 @@ namespace Stripe
         /// <summary>
         /// Standard is the default method.
         /// </summary>
-        public static string Standard => "standard";
+        public const string Standard = "standard";
 
         /// <summary>
         /// Only supported for transfers to debit cards.
         /// </summary>
-        public static string Instant => "instant";
+        public const string Instant = "instant";
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Basically a revert of #1423. Users have been complaining about the inability to use static readonly properties in `switch` blocks, so let's go back to using constants even if it's not strictly best practice.

Technically a breaking change, but in practice most users should not need to change their integration.

Fixes #1590.
