### PR TITLE
Add setters for expandable field accessors

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountSettingsBranding.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountSettingsBranding.cs
@@ -13,13 +13,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string IconId => this.InternalIcon.Id;
+        public string IconId
+        {
+            get => this.InternalIcon.Id;
+            set => this.InternalIcon.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) An icon for the account. Must be square and at least 128px x 128px.
         /// </summary>
         [JsonIgnore]
-        public File Icon => this.InternalIcon.ExpandedObject;
+        public File Icon
+        {
+            get => this.InternalIcon.ExpandedObject;
+            set => this.InternalIcon.ExpandedObject = value;
+        }
 
         [JsonProperty("icon")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -35,14 +43,22 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string LogoId => this.InternalLogo.Id;
+        public string LogoId
+        {
+            get => this.InternalLogo.Id;
+            set => this.InternalLogo.Id = value;
+        }
 
         /// <summary>
         /// (Expanded)A logo for the account that will be used in Checkout instead of the icon and
         /// without the account’s name next to it if provided. Must be at least 128px x 128px.
         /// </summary>
         [JsonIgnore]
-        public File Logo => this.InternalLogo.ExpandedObject;
+        public File Logo
+        {
+            get => this.InternalLogo.ExpandedObject;
+            set => this.InternalLogo.ExpandedObject = value;
+        }
 
         [JsonProperty("logo")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
@@ -18,10 +18,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -37,10 +45,18 @@ namespace Stripe
 
         #region Expandable Fee
         [JsonIgnore]
-        public string FeeId => this.InternalFee.Id;
+        public string FeeId
+        {
+            get => this.InternalFee.Id;
+            set => this.InternalFee.Id = value;
+        }
 
         [JsonIgnore]
-        public ApplicationFee Fee => this.InternalFee.ExpandedObject;
+        public ApplicationFee Fee
+        {
+            get => this.InternalFee.ExpandedObject;
+            set => this.InternalFee.ExpandedObject = value;
+        }
 
         [JsonProperty("fee")]
         [JsonConverter(typeof(ExpandableFieldConverter<ApplicationFee>))]

--- a/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
+++ b/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
@@ -14,10 +14,18 @@ namespace Stripe
 
         #region Expandable Account
         [JsonIgnore]
-        public string AccountId => this.InternalAccount.Id;
+        public string AccountId
+        {
+            get => this.InternalAccount.Id;
+            set => this.InternalAccount.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Account => this.InternalAccount.ExpandedObject;
+        public Account Account
+        {
+            get => this.InternalAccount.ExpandedObject;
+            set => this.InternalAccount.ExpandedObject = value;
+        }
 
         [JsonProperty("account")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -32,10 +40,18 @@ namespace Stripe
 
         #region Expandable Application
         [JsonIgnore]
-        public string ApplicationId => this.InternalApplication.Id;
+        public string ApplicationId
+        {
+            get => this.InternalApplication.Id;
+            set => this.InternalApplication.Id = value;
+        }
 
         [JsonIgnore]
-        public Application Application => this.InternalApplication.ExpandedObject;
+        public Application Application
+        {
+            get => this.InternalApplication.ExpandedObject;
+            set => this.InternalApplication.ExpandedObject = value;
+        }
 
         [JsonProperty("application")]
         [JsonConverter(typeof(ExpandableFieldConverter<Application>))]
@@ -44,10 +60,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -56,10 +80,18 @@ namespace Stripe
 
         #region Expandable Charge
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -78,10 +110,18 @@ namespace Stripe
 
         #region Expandable Originating Transaction
         [JsonIgnore]
-        public string OriginatingTransactionId => this.InternalOriginatingTransaction.Id;
+        public string OriginatingTransactionId
+        {
+            get => this.InternalOriginatingTransaction.Id;
+            set => this.InternalOriginatingTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge OriginatingTransaction => this.InternalOriginatingTransaction.ExpandedObject;
+        public Charge OriginatingTransaction
+        {
+            get => this.InternalOriginatingTransaction.ExpandedObject;
+            set => this.InternalOriginatingTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("originating_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]

--- a/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
+++ b/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
@@ -44,10 +44,18 @@ namespace Stripe
 
         #region Expandable Source
         [JsonIgnore]
-        public string SourceId => this.InternalSource.Id;
+        public string SourceId
+        {
+            get => this.InternalSource.Id;
+            set => this.InternalSource.Id = value;
+        }
 
         [JsonIgnore]
-        public IBalanceTransactionSource Source => this.InternalSource.ExpandedObject;
+        public IBalanceTransactionSource Source
+        {
+            get => this.InternalSource.ExpandedObject;
+            set => this.InternalSource.ExpandedObject = value;
+        }
 
         [JsonProperty("source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IBalanceTransactionSource>))]

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -14,10 +14,18 @@ namespace Stripe
 
         #region Expandable Account
         [JsonIgnore]
-        public string AccountId => this.InternalAccount.Id;
+        public string AccountId
+        {
+            get => this.InternalAccount.Id;
+            set => this.InternalAccount.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Account => this.InternalAccount.ExpandedObject;
+        public Account Account
+        {
+            get => this.InternalAccount.ExpandedObject;
+            set => this.InternalAccount.ExpandedObject = value;
+        }
 
         [JsonProperty("account")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -41,10 +49,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]

--- a/src/Stripe.net/Entities/Capabilities/Capability.cs
+++ b/src/Stripe.net/Entities/Capabilities/Capability.cs
@@ -25,10 +25,18 @@ namespace Stripe
         /// ID of the account the capability is associated with.
         /// </summary>
         [JsonIgnore]
-        public string AccountId => this.InternalAccount.Id;
+        public string AccountId
+        {
+            get => this.InternalAccount.Id;
+            set => this.InternalAccount.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Account => this.InternalAccount.ExpandedObject;
+        public Account Account
+        {
+            get => this.InternalAccount.ExpandedObject;
+            set => this.InternalAccount.ExpandedObject = value;
+        }
 
         [JsonProperty("account")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -14,10 +14,18 @@ namespace Stripe
 
         #region Expandable Account
         [JsonIgnore]
-        public string AccountId => this.InternalAccount.Id;
+        public string AccountId
+        {
+            get => this.InternalAccount.Id;
+            set => this.InternalAccount.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Account => this.InternalAccount.ExpandedObject;
+        public Account Account
+        {
+            get => this.InternalAccount.ExpandedObject;
+            set => this.InternalAccount.ExpandedObject = value;
+        }
 
         [JsonProperty("account")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -62,10 +70,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -110,10 +126,18 @@ namespace Stripe
 
         #region Expandable Recipient
         [JsonIgnore]
-        public string RecipientId => this.InternalRecipient.Id;
+        public string RecipientId
+        {
+            get => this.InternalRecipient.Id;
+            set => this.InternalRecipient.Id = value;
+        }
 
         [JsonIgnore]
-        public Recipient Recipient => this.InternalRecipient.ExpandedObject;
+        public Recipient Recipient
+        {
+            get => this.InternalRecipient.ExpandedObject;
+            set => this.InternalRecipient.ExpandedObject = value;
+        }
 
         [JsonProperty("recipient")]
         [JsonConverter(typeof(ExpandableFieldConverter<Recipient>))]

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -27,10 +27,18 @@ namespace Stripe
 
         #region Expandable Application
         [JsonIgnore]
-        public string ApplicationId => this.InternalApplication.Id;
+        public string ApplicationId
+        {
+            get => this.InternalApplication.Id;
+            set => this.InternalApplication.Id = value;
+        }
 
         [JsonIgnore]
-        public Application Application => this.InternalApplication.ExpandedObject;
+        public Application Application
+        {
+            get => this.InternalApplication.ExpandedObject;
+            set => this.InternalApplication.ExpandedObject = value;
+        }
 
         [JsonProperty("application")]
         [JsonConverter(typeof(ExpandableFieldConverter<Application>))]
@@ -39,13 +47,21 @@ namespace Stripe
 
         #region Expandable Application Fee
         [JsonIgnore]
-        public string ApplicationFeeId => this.InternalApplicationFee.Id;
+        public string ApplicationFeeId
+        {
+            get => this.InternalApplicationFee.Id;
+            set => this.InternalApplicationFee.Id = value;
+        }
 
         /// <summary>
         /// The application fee (if any) for the charge. See the Connect documentation for details.
         /// </summary>
         [JsonIgnore]
-        public ApplicationFee ApplicationFee => this.InternalApplicationFee.ExpandedObject;
+        public ApplicationFee ApplicationFee
+        {
+            get => this.InternalApplicationFee.ExpandedObject;
+            set => this.InternalApplicationFee.ExpandedObject = value;
+        }
 
         [JsonProperty("application_fee")]
         [JsonConverter(typeof(ExpandableFieldConverter<ApplicationFee>))]
@@ -64,10 +80,18 @@ namespace Stripe
         /// ID of the balance transaction that describes the impact of this charge on your account balance (not including refunds or disputes).
         /// </summary>
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -102,10 +126,18 @@ namespace Stripe
         /// ID of the customer this charge is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -117,13 +149,21 @@ namespace Stripe
 
         #region Expandable Destination
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         /// <summary>
         /// The account (if any) the charge was made on behalf of, with an automatic transfer. See the Connect documentation for details.
         /// </summary>
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -132,13 +172,21 @@ namespace Stripe
 
         #region Expandable Dispute
         [JsonIgnore]
-        public string DisputeId => this.InternalDispute.Id;
+        public string DisputeId
+        {
+            get => this.InternalDispute.Id;
+            set => this.InternalDispute.Id = value;
+        }
 
         /// <summary>
         /// Details about the dispute if the charge has been disputed.
         /// </summary>
         [JsonIgnore]
-        public Dispute Dispute => this.InternalDispute.ExpandedObject;
+        public Dispute Dispute
+        {
+            get => this.InternalDispute.ExpandedObject;
+            set => this.InternalDispute.ExpandedObject = value;
+        }
 
         [JsonProperty("dispute")]
         [JsonConverter(typeof(ExpandableFieldConverter<Dispute>))]
@@ -169,10 +217,18 @@ namespace Stripe
         /// ID of the invoice this charge is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string InvoiceId => this.InternalInvoice.Id;
+        public string InvoiceId
+        {
+            get => this.InternalInvoice.Id;
+            set => this.InternalInvoice.Id = value;
+        }
 
         [JsonIgnore]
-        public Invoice Invoice => this.InternalInvoice.ExpandedObject;
+        public Invoice Invoice
+        {
+            get => this.InternalInvoice.ExpandedObject;
+            set => this.InternalInvoice.ExpandedObject = value;
+        }
 
         [JsonProperty("invoice")]
         [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]
@@ -195,10 +251,18 @@ namespace Stripe
         /// <para>To populate the OnBehalfOf entity, you need to set ExpandOnBehalfOf to true on your service before invoking a service method.</para>
         /// </summary>
         [JsonIgnore]
-        public string OnBehalfOfId => this.InternalOnBehalfOf.Id;
+        public string OnBehalfOfId
+        {
+            get => this.InternalOnBehalfOf.Id;
+            set => this.InternalOnBehalfOf.Id = value;
+        }
 
         [JsonIgnore]
-        public Account OnBehalfOf => this.InternalOnBehalfOf.ExpandedObject;
+        public Account OnBehalfOf
+        {
+            get => this.InternalOnBehalfOf.ExpandedObject;
+            set => this.InternalOnBehalfOf.ExpandedObject = value;
+        }
 
         [JsonProperty("on_behalf_of")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -211,10 +275,18 @@ namespace Stripe
         /// ID of the order this charge is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string OrderId => this.InternalOrder.Id;
+        public string OrderId
+        {
+            get => this.InternalOrder.Id;
+            set => this.InternalOrder.Id = value;
+        }
 
         [JsonIgnore]
-        public Order Order => this.InternalOrder.ExpandedObject;
+        public Order Order
+        {
+            get => this.InternalOrder.ExpandedObject;
+            set => this.InternalOrder.ExpandedObject = value;
+        }
 
         [JsonProperty("order")]
         [JsonConverter(typeof(ExpandableFieldConverter<Order>))]
@@ -246,10 +318,18 @@ namespace Stripe
         /// ID of the payment intent this charge is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string PaymentIntentId => this.InternalPaymentIntent.Id;
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent.Id;
+            set => this.InternalPaymentIntent.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentIntent PaymentIntent => this.InternalPaymentIntent.ExpandedObject;
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent.ExpandedObject;
+            set => this.InternalPaymentIntent.ExpandedObject = value;
+        }
 
         [JsonProperty("payment_intent")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
@@ -307,10 +387,18 @@ namespace Stripe
         /// ID of the review associated with this charge if one exists.
         /// </summary>
         [JsonIgnore]
-        public string ReviewId => this.InternalReview.Id;
+        public string ReviewId
+        {
+            get => this.InternalReview.Id;
+            set => this.InternalReview.Id = value;
+        }
 
         [JsonIgnore]
-        public Review Review => this.InternalReview.ExpandedObject;
+        public Review Review
+        {
+            get => this.InternalReview.ExpandedObject;
+            set => this.InternalReview.ExpandedObject = value;
+        }
 
         [JsonProperty("review")]
         [JsonConverter(typeof(ExpandableFieldConverter<Review>))]
@@ -336,10 +424,18 @@ namespace Stripe
         /// The transfer ID which created this charge. Only present if the charge came from another Stripe account. See the Connect documentation for details.
         /// </summary>
         [JsonIgnore]
-        public string SourceTransferId => this.InternalSourceTransfer.Id;
+        public string SourceTransferId
+        {
+            get => this.InternalSourceTransfer.Id;
+            set => this.InternalSourceTransfer.Id = value;
+        }
 
         [JsonIgnore]
-        public Transfer SourceTransfer => this.InternalSourceTransfer.ExpandedObject;
+        public Transfer SourceTransfer
+        {
+            get => this.InternalSourceTransfer.ExpandedObject;
+            set => this.InternalSourceTransfer.ExpandedObject = value;
+        }
 
         [JsonProperty("source_transfer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Transfer>))]
@@ -364,10 +460,18 @@ namespace Stripe
         /// ID of the transfer to the destination account (only applicable if the charge was created using the destination parameter).
         /// </summary>
         [JsonIgnore]
-        public string TransferId => this.InternalTransfer.Id;
+        public string TransferId
+        {
+            get => this.InternalTransfer.Id;
+            set => this.InternalTransfer.Id = value;
+        }
 
         [JsonIgnore]
-        public Transfer Transfer => this.InternalTransfer.ExpandedObject;
+        public Transfer Transfer
+        {
+            get => this.InternalTransfer.ExpandedObject;
+            set => this.InternalTransfer.ExpandedObject = value;
+        }
 
         [JsonProperty("transfer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Transfer>))]

--- a/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
+++ b/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
@@ -10,10 +10,18 @@ namespace Stripe
 
         #region Expandable Destination (Account)
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]

--- a/src/Stripe.net/Entities/Charges/Outcome.cs
+++ b/src/Stripe.net/Entities/Charges/Outcome.cs
@@ -35,10 +35,18 @@ namespace Stripe
         /// The ID of the Radar rule that matched the payment, if applicable.
         /// </summary>
         [JsonIgnore]
-        public string RuleId => this.InternalRule.Id;
+        public string RuleId
+        {
+            get => this.InternalRule.Id;
+            set => this.InternalRule.Id = value;
+        }
 
         [JsonIgnore]
-        public OutcomeRule Rule => this.InternalRule.ExpandedObject;
+        public OutcomeRule Rule
+        {
+            get => this.InternalRule.ExpandedObject;
+            set => this.InternalRule.ExpandedObject = value;
+        }
 
         [JsonProperty("rule")]
         [JsonConverter(typeof(ExpandableFieldConverter<OutcomeRule>))]

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -48,10 +48,18 @@ namespace Stripe.Checkout
         /// ID of the customer this Session is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -90,10 +98,18 @@ namespace Stripe.Checkout
         /// The ID of the PaymentIntent created if SKUs or line items were provided.
         /// </summary>
         [JsonIgnore]
-        public string PaymentIntentId => this.InternalPaymentIntent.Id;
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent.Id;
+            set => this.InternalPaymentIntent.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentIntent PaymentIntent => this.InternalPaymentIntent.ExpandedObject;
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent.ExpandedObject;
+            set => this.InternalPaymentIntent.ExpandedObject = value;
+        }
 
         [JsonProperty("payment_intent")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
@@ -113,10 +129,18 @@ namespace Stripe.Checkout
         /// The ID of the subscription created if one or more plans were provided.
         /// </summary>
         [JsonIgnore]
-        public string SubscriptionId => this.InternalSubscription.Id;
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription.Id;
+            set => this.InternalSubscription.Id = value;
+        }
 
         [JsonIgnore]
-        public Subscription Subscription => this.InternalSubscription.ExpandedObject;
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription.ExpandedObject;
+            set => this.InternalSubscription.ExpandedObject = value;
+        }
 
         [JsonProperty("subscription")]
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]

--- a/src/Stripe.net/Entities/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNote.cs
@@ -44,10 +44,18 @@ namespace Stripe
         /// ID of the customer associated with that credit note.
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -60,10 +68,18 @@ namespace Stripe
         /// ID of the invoice associated with that credit note.
         /// </summary>
         [JsonIgnore]
-        public string InvoiceId => this.InternalInvoice.Id;
+        public string InvoiceId
+        {
+            get => this.InternalInvoice.Id;
+            set => this.InternalInvoice.Id = value;
+        }
 
         [JsonIgnore]
-        public Invoice Invoice => this.InternalInvoice.ExpandedObject;
+        public Invoice Invoice
+        {
+            get => this.InternalInvoice.ExpandedObject;
+            set => this.InternalInvoice.ExpandedObject = value;
+        }
 
         [JsonProperty("invoice")]
         [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]
@@ -115,10 +131,18 @@ namespace Stripe
         /// ID of the refund associated with that credit note.
         /// </summary>
         [JsonIgnore]
-        public string RefundId => this.InternalRefund.Id;
+        public string RefundId
+        {
+            get => this.InternalRefund.Id;
+            set => this.InternalRefund.Id = value;
+        }
 
         [JsonIgnore]
-        public Refund Refund => this.InternalRefund.ExpandedObject;
+        public Refund Refund
+        {
+            get => this.InternalRefund.ExpandedObject;
+            set => this.InternalRefund.ExpandedObject = value;
+        }
 
         [JsonProperty("refund")]
         [JsonConverter(typeof(ExpandableFieldConverter<Refund>))]

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -53,10 +53,18 @@ namespace Stripe
         /// <para>You can expand the DefaultSource by setting the ExpandDefaultSource property on the service to true</para>
         /// </summary>
         [JsonIgnore]
-        public string DefaultSourceId => this.InternalDefaultSource.Id;
+        public string DefaultSourceId
+        {
+            get => this.InternalDefaultSource.Id;
+            set => this.InternalDefaultSource.Id = value;
+        }
 
         [JsonIgnore]
-        public IPaymentSource DefaultSource => this.InternalDefaultSource.ExpandedObject;
+        public IPaymentSource DefaultSource
+        {
+            get => this.InternalDefaultSource.ExpandedObject;
+            set => this.InternalDefaultSource.ExpandedObject = value;
+        }
 
         [JsonProperty("default_source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]

--- a/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
+++ b/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
@@ -18,10 +18,18 @@ namespace Stripe
         /// ID of the default payment method for the customer.
         /// </summary>
         [JsonIgnore]
-        public string DefaultPaymentMethodId => this.InternalDefaultPaymentMethod.Id;
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod.Id;
+            set => this.InternalDefaultPaymentMethod.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentMethod DefaultPaymentMethod => this.InternalDefaultPaymentMethod.ExpandedObject;
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+        }
 
         [JsonProperty("default_payment_method")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -14,10 +14,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -40,10 +48,18 @@ namespace Stripe
 
         #region Expandable Subscription
         [JsonIgnore]
-        public string SubscriptionId => this.InternalSubscription.Id;
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription.Id;
+            set => this.InternalSubscription.Id = value;
+        }
 
         [JsonIgnore]
-        public Subscription Subscription => this.InternalSubscription.ExpandedObject;
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription.ExpandedObject;
+            set => this.InternalSubscription.ExpandedObject = value;
+        }
 
         [JsonProperty("subscription")]
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -21,10 +21,18 @@ namespace Stripe
 
         #region Expandable Charge
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]

--- a/src/Stripe.net/Entities/Disputes/Evidence.cs
+++ b/src/Stripe.net/Entities/Disputes/Evidence.cs
@@ -19,13 +19,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string CancellationPolicyId => this.InternalCancellationPolicy.Id;
+        public string CancellationPolicyId
+        {
+            get => this.InternalCancellationPolicy.Id;
+            set => this.InternalCancellationPolicy.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Your subscription cancellation policy, as shown to the customer.
         /// </summary>
         [JsonIgnore]
-        public File CancellationPolicy => this.InternalCancellationPolicy.ExpandedObject;
+        public File CancellationPolicy
+        {
+            get => this.InternalCancellationPolicy.ExpandedObject;
+            set => this.InternalCancellationPolicy.ExpandedObject = value;
+        }
 
         [JsonProperty("cancellation_policy")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -48,7 +56,11 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string CustomerCommunicationId => this.InternalCustomerCommunication.Id;
+        public string CustomerCommunicationId
+        {
+            get => this.InternalCustomerCommunication.Id;
+            set => this.InternalCustomerCommunication.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Any communication with the customer that you feel is relevant to your case.
@@ -56,7 +68,11 @@ namespace Stripe
         /// demonstrating their use of or satisfaction with the product or service.
         /// </summary>
         [JsonIgnore]
-        public File CustomerCommunication => this.InternalCustomerCommunication.ExpandedObject;
+        public File CustomerCommunication
+        {
+            get => this.InternalCustomerCommunication.ExpandedObject;
+            set => this.InternalCustomerCommunication.ExpandedObject = value;
+        }
 
         [JsonProperty("customer_communication")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -80,13 +96,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string CustomerSignatureId => this.InternalCustomerSignature.Id;
+        public string CustomerSignatureId
+        {
+            get => this.InternalCustomerSignature.Id;
+            set => this.InternalCustomerSignature.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) A relevant document or contract showing the customer’s signature.
         /// </summary>
         [JsonIgnore]
-        public File CustomerSignature => this.InternalCustomerSignature.ExpandedObject;
+        public File CustomerSignature
+        {
+            get => this.InternalCustomerSignature.ExpandedObject;
+            set => this.InternalCustomerSignature.ExpandedObject = value;
+        }
 
         [JsonProperty("customer_signature")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -103,7 +127,11 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string DuplicateChargeDocumentationId => this.InternalDuplicateChargeDocumentation.Id;
+        public string DuplicateChargeDocumentationId
+        {
+            get => this.InternalDuplicateChargeDocumentation.Id;
+            set => this.InternalDuplicateChargeDocumentation.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Documentation for the prior charge that can uniquely  identify the charge,
@@ -111,7 +139,11 @@ namespace Stripe
         /// a similar document from the disputed payment that proves the two payments are separate.
         /// </summary>
         [JsonIgnore]
-        public File DuplicateChargeDocumentation => this.InternalDuplicateChargeDocumentation.ExpandedObject;
+        public File DuplicateChargeDocumentation
+        {
+            get => this.InternalDuplicateChargeDocumentation.ExpandedObject;
+            set => this.InternalDuplicateChargeDocumentation.ExpandedObject = value;
+        }
 
         [JsonProperty("duplicate_charge_documentation")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -135,13 +167,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string ReceiptId => this.InternalReceipt.Id;
+        public string ReceiptId
+        {
+            get => this.InternalReceipt.Id;
+            set => this.InternalReceipt.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Any receipt or message sent to the customer notifying them of the charge.
         /// </summary>
         [JsonIgnore]
-        public File Receipt => this.InternalReceipt.ExpandedObject;
+        public File Receipt
+        {
+            get => this.InternalReceipt.ExpandedObject;
+            set => this.InternalReceipt.ExpandedObject = value;
+        }
 
         [JsonProperty("receipt")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -155,13 +195,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string RefundPolicyId => this.InternalRefundPolicy.Id;
+        public string RefundPolicyId
+        {
+            get => this.InternalRefundPolicy.Id;
+            set => this.InternalRefundPolicy.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Your refund policy, as shown to the customer.
         /// </summary>
         [JsonIgnore]
-        public File RefundPolicy => this.InternalRefundPolicy.ExpandedObject;
+        public File RefundPolicy
+        {
+            get => this.InternalRefundPolicy.ExpandedObject;
+            set => this.InternalRefundPolicy.ExpandedObject = value;
+        }
 
         [JsonProperty("refund_policy")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -186,7 +234,11 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string ServiceDocumentationId => this.InternalServiceDocumentation.Id;
+        public string ServiceDocumentationId
+        {
+            get => this.InternalServiceDocumentation.Id;
+            set => this.InternalServiceDocumentation.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Documentation showing proof that a service was provided to  the customer.
@@ -194,7 +246,11 @@ namespace Stripe
         /// agreement.
         /// </summary>
         [JsonIgnore]
-        public File ServiceDocumentation => this.InternalServiceDocumentation.ExpandedObject;
+        public File ServiceDocumentation
+        {
+            get => this.InternalServiceDocumentation.ExpandedObject;
+            set => this.InternalServiceDocumentation.ExpandedObject = value;
+        }
 
         [JsonProperty("service_documentation")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -220,7 +276,11 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string ShippingDocumentationId => this.InternalShippingDocumentation.Id;
+        public string ShippingDocumentationId
+        {
+            get => this.InternalShippingDocumentation.Id;
+            set => this.InternalShippingDocumentation.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Documentation showing proof that a product was shipped to  the customer at
@@ -229,7 +289,11 @@ namespace Stripe
         /// possible.
         /// </summary>
         [JsonIgnore]
-        public File ShippingDocumentation => this.InternalShippingDocumentation.ExpandedObject;
+        public File ShippingDocumentation
+        {
+            get => this.InternalShippingDocumentation.ExpandedObject;
+            set => this.InternalShippingDocumentation.ExpandedObject = value;
+        }
 
         [JsonProperty("shipping_documentation")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -246,13 +310,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string UncategorizedFileId => this.InternalUncategorizedFile.Id;
+        public string UncategorizedFileId
+        {
+            get => this.InternalUncategorizedFile.Id;
+            set => this.InternalUncategorizedFile.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) Any additional evidence or statements.
         /// </summary>
         [JsonIgnore]
-        public File UncategorizedFile => this.InternalUncategorizedFile.ExpandedObject;
+        public File UncategorizedFile
+        {
+            get => this.InternalUncategorizedFile.ExpandedObject;
+            set => this.InternalUncategorizedFile.ExpandedObject = value;
+        }
 
         [JsonProperty("uncategorized_file")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -46,13 +46,21 @@ namespace Stripe
         /// ID of the file object this link points to.
         /// </summary>
         [JsonIgnore]
-        public string FileId => this.InternalFile.Id;
+        public string FileId
+        {
+            get => this.InternalFile.Id;
+            set => this.InternalFile.Id = value;
+        }
 
         /// <summary>
         /// The file object this link points to (if expanded).
         /// </summary>
         [JsonIgnore]
-        public File File => this.InternalFile.ExpandedObject;
+        public File File
+        {
+            get => this.InternalFile.ExpandedObject;
+            set => this.InternalFile.ExpandedObject = value;
+        }
 
         [JsonProperty("file")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -21,10 +21,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -49,10 +57,18 @@ namespace Stripe
 
         #region Expandable Invoice
         [JsonIgnore]
-        public string InvoiceId => this.InternalInvoice.Id;
+        public string InvoiceId
+        {
+            get => this.InternalInvoice.Id;
+            set => this.InternalInvoice.Id = value;
+        }
 
         [JsonIgnore]
-        public Invoice Invoice => this.InternalInvoice.ExpandedObject;
+        public Invoice Invoice
+        {
+            get => this.InternalInvoice.ExpandedObject;
+            set => this.InternalInvoice.ExpandedObject = value;
+        }
 
         [JsonProperty("invoice")]
         [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]
@@ -79,10 +95,18 @@ namespace Stripe
 
         #region Expandable Subscription
         [JsonIgnore]
-        public string SubscriptionId => this.InternalSubscription.Id;
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription.Id;
+            set => this.InternalSubscription.Id = value;
+        }
 
         [JsonIgnore]
-        public Subscription Subscription => this.InternalSubscription.ExpandedObject;
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription.ExpandedObject;
+            set => this.InternalSubscription.ExpandedObject = value;
+        }
 
         [JsonProperty("subscription")]
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -65,10 +65,18 @@ namespace Stripe
 
         #region Expandable Charge
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -87,10 +95,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -162,10 +178,18 @@ namespace Stripe
         /// method.
         /// </summary>
         [JsonIgnore]
-        public string DefaultPaymentMethodId => this.InternalDefaultPaymentMethod.Id;
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod.Id;
+            set => this.InternalDefaultPaymentMethod.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentMethod DefaultPaymentMethod => this.InternalDefaultPaymentMethod.ExpandedObject;
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+        }
 
         [JsonProperty("default_payment_method")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
@@ -174,10 +198,18 @@ namespace Stripe
 
         #region Expandable DefaultSource
         [JsonIgnore]
-        public string DefaultSourceId => this.InternalDefaultSource.Id;
+        public string DefaultSourceId
+        {
+            get => this.InternalDefaultSource.Id;
+            set => this.InternalDefaultSource.Id = value;
+        }
 
         [JsonIgnore]
-        public IPaymentSource DefaultSource => this.InternalDefaultSource.ExpandedObject;
+        public IPaymentSource DefaultSource
+        {
+            get => this.InternalDefaultSource.ExpandedObject;
+            set => this.InternalDefaultSource.ExpandedObject = value;
+        }
 
         [JsonProperty("default_source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
@@ -245,7 +277,11 @@ namespace Stripe
         /// ID of the PaymentIntent associated with this invoice.
         /// </summary>
         [JsonIgnore]
-        public string PaymentIntentId => this.InternalPaymentIntent.Id;
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent.Id;
+            set => this.InternalPaymentIntent.Id = value;
+        }
 
         /// <summary>
         /// The PaymentIntent associated with this invoice. The PaymentIntent is generated when the
@@ -253,7 +289,11 @@ namespace Stripe
         /// invoice will cancel the PaymentIntent.
         /// </summary>
         [JsonIgnore]
-        public PaymentIntent PaymentIntent => this.InternalPaymentIntent.ExpandedObject;
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent.ExpandedObject;
+            set => this.InternalPaymentIntent.ExpandedObject = value;
+        }
 
         [JsonProperty("payment_intent")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
@@ -297,10 +337,18 @@ namespace Stripe
 
         #region Expandable Subscription
         [JsonIgnore]
-        public string SubscriptionId => this.InternalSubscription.Id;
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription.Id;
+            set => this.InternalSubscription.Id = value;
+        }
 
         [JsonIgnore]
-        public Subscription Subscription => this.InternalSubscription.ExpandedObject;
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription.ExpandedObject;
+            set => this.InternalSubscription.ExpandedObject = value;
+        }
 
         [JsonProperty("subscription")]
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]

--- a/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
@@ -23,10 +23,18 @@ namespace Stripe
         /// The ID of the tax rate that was applied to get this tax amount.
         /// </summary>
         [JsonIgnore]
-        public string TaxRateId => this.InternalTaxRate.Id;
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate.Id;
+            set => this.InternalTaxRate.Id = value;
+        }
 
         [JsonIgnore]
-        public TaxRate TaxRate => this.InternalTaxRate.ExpandedObject;
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate.ExpandedObject;
+            set => this.InternalTaxRate.ExpandedObject = value;
+        }
 
         [JsonProperty("tax_rate")]
         [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]

--- a/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
@@ -7,10 +7,18 @@ namespace Stripe
     {
         #region Expandable Destination (Account)
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -33,10 +33,18 @@ namespace Stripe.Issuing
 
         #region Expandable Cardholder
         [JsonIgnore]
-        public string CardholderId => this.InternalCardholder.Id;
+        public string CardholderId
+        {
+            get => this.InternalCardholder.Id;
+            set => this.InternalCardholder.Id = value;
+        }
 
         [JsonIgnore]
-        public Cardholder Cardholder => this.InternalCardholder.ExpandedObject;
+        public Cardholder Cardholder
+        {
+            get => this.InternalCardholder.ExpandedObject;
+            set => this.InternalCardholder.ExpandedObject = value;
+        }
 
         [JsonProperty("cardholder")]
         [JsonConverter(typeof(ExpandableFieldConverter<Cardholder>))]

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -49,10 +49,18 @@ namespace Stripe.Issuing
 
         #region Expandable ReplacementFor
         [JsonIgnore]
-        public string ReplacementForId => this.InternalReplacementFor.Id;
+        public string ReplacementForId
+        {
+            get => this.InternalReplacementFor.Id;
+            set => this.InternalReplacementFor.Id = value;
+        }
 
         [JsonIgnore]
-        public Card ReplacementFor => this.InternalReplacementFor.ExpandedObject;
+        public Card ReplacementFor
+        {
+            get => this.InternalReplacementFor.ExpandedObject;
+            set => this.InternalReplacementFor.ExpandedObject = value;
+        }
 
         [JsonProperty("replacement_for")]
         [JsonConverter(typeof(ExpandableFieldConverter<Card>))]

--- a/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
@@ -11,10 +11,18 @@ namespace Stripe.Issuing
 
         #region Expandable Card
         [JsonIgnore]
-        public string CardId => this.InternalCard.Id;
+        public string CardId
+        {
+            get => this.InternalCard.Id;
+            set => this.InternalCard.Id = value;
+        }
 
         [JsonIgnore]
-        public Card Card => this.InternalCard.ExpandedObject;
+        public Card Card
+        {
+            get => this.InternalCard.ExpandedObject;
+            set => this.InternalCard.ExpandedObject = value;
+        }
 
         [JsonProperty("card")]
         [JsonConverter(typeof(ExpandableFieldConverter<Card>))]

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -37,10 +37,18 @@ namespace Stripe.Issuing
 
         #region Expandable Transaction
         [JsonIgnore]
-        public string TransactionId => this.InternalTransaction.Id;
+        public string TransactionId
+        {
+            get => this.InternalTransaction.Id;
+            set => this.InternalTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public Transaction Transaction => this.InternalTransaction.ExpandedObject;
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction.ExpandedObject;
+            set => this.InternalTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
@@ -10,10 +10,18 @@ namespace Stripe.Issuing
 
         #region Expandable UncategorizedFile
         [JsonIgnore]
-        public string UncategorizedFileId => this.InternalUncategorizedFile.Id;
+        public string UncategorizedFileId
+        {
+            get => this.InternalUncategorizedFile.Id;
+            set => this.InternalUncategorizedFile.Id = value;
+        }
 
         [JsonIgnore]
-        public File UncategorizedFile => this.InternalUncategorizedFile.ExpandedObject;
+        public File UncategorizedFile
+        {
+            get => this.InternalUncategorizedFile.ExpandedObject;
+            set => this.InternalUncategorizedFile.ExpandedObject = value;
+        }
 
         [JsonProperty("uncategorized_file")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
@@ -10,10 +10,18 @@ namespace Stripe.Issuing
 
         #region Expandable UncategorizedFile
         [JsonIgnore]
-        public string UncategorizedFileId => this.InternalUncategorizedFile.Id;
+        public string UncategorizedFileId
+        {
+            get => this.InternalUncategorizedFile.Id;
+            set => this.InternalUncategorizedFile.Id = value;
+        }
 
         [JsonIgnore]
-        public File UncategorizedFile => this.InternalUncategorizedFile.ExpandedObject;
+        public File UncategorizedFile
+        {
+            get => this.InternalUncategorizedFile.ExpandedObject;
+            set => this.InternalUncategorizedFile.ExpandedObject = value;
+        }
 
         [JsonProperty("uncategorized_file")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -18,10 +18,18 @@ namespace Stripe.Issuing
 
         #region Expandable Authorization
         [JsonIgnore]
-        public string AuthorizationId => this.InternalAuthorization.Id;
+        public string AuthorizationId
+        {
+            get => this.InternalAuthorization.Id;
+            set => this.InternalAuthorization.Id = value;
+        }
 
         [JsonIgnore]
-        public Authorization Authorization => this.InternalAuthorization.ExpandedObject;
+        public Authorization Authorization
+        {
+            get => this.InternalAuthorization.ExpandedObject;
+            set => this.InternalAuthorization.ExpandedObject = value;
+        }
 
         [JsonProperty("authorization")]
         [JsonConverter(typeof(ExpandableFieldConverter<Authorization>))]
@@ -30,10 +38,18 @@ namespace Stripe.Issuing
 
         #region Expandable BalanceTransaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -42,10 +58,18 @@ namespace Stripe.Issuing
 
         #region Expandable Card
         [JsonIgnore]
-        public string CardId => this.InternalCard.Id;
+        public string CardId
+        {
+            get => this.InternalCard.Id;
+            set => this.InternalCard.Id = value;
+        }
 
         [JsonIgnore]
-        public Card Card => this.InternalCard.ExpandedObject;
+        public Card Card
+        {
+            get => this.InternalCard.ExpandedObject;
+            set => this.InternalCard.ExpandedObject = value;
+        }
 
         [JsonProperty("card")]
         [JsonConverter(typeof(ExpandableFieldConverter<Card>))]
@@ -54,10 +78,18 @@ namespace Stripe.Issuing
 
         #region Expandable Cardholder
         [JsonIgnore]
-        public string CardholderId => this.InternalCardholder.Id;
+        public string CardholderId
+        {
+            get => this.InternalCardholder.Id;
+            set => this.InternalCardholder.Id = value;
+        }
 
         [JsonIgnore]
-        public Cardholder Cardholder => this.InternalCardholder.ExpandedObject;
+        public Cardholder Cardholder
+        {
+            get => this.InternalCardholder.ExpandedObject;
+            set => this.InternalCardholder.ExpandedObject = value;
+        }
 
         [JsonProperty("cardholder")]
         [JsonConverter(typeof(ExpandableFieldConverter<Cardholder>))]
@@ -73,10 +105,18 @@ namespace Stripe.Issuing
 
         #region Expandable Dispute
         [JsonIgnore]
-        public string DisputeId => this.InternalDispute.Id;
+        public string DisputeId
+        {
+            get => this.InternalDispute.Id;
+            set => this.InternalDispute.Id = value;
+        }
 
         [JsonIgnore]
-        public Dispute Dispute => this.InternalDispute.ExpandedObject;
+        public Dispute Dispute
+        {
+            get => this.InternalDispute.ExpandedObject;
+            set => this.InternalDispute.ExpandedObject = value;
+        }
 
         [JsonProperty("dispute")]
         [JsonConverter(typeof(ExpandableFieldConverter<Dispute>))]

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -38,10 +38,18 @@ namespace Stripe
         /// <para>Expandable</para>
         /// </summary>
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -70,7 +78,11 @@ namespace Stripe
         public string CustomerId { get; set; }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]

--- a/src/Stripe.net/Entities/Orders/OrderItem.cs
+++ b/src/Stripe.net/Entities/Orders/OrderItem.cs
@@ -32,10 +32,18 @@ namespace Stripe
         /// ID of the parent associated with this order item.
         /// </summary>
         [JsonIgnore]
-        public string ParentId => this.InternalParent.Id;
+        public string ParentId
+        {
+            get => this.InternalParent.Id;
+            set => this.InternalParent.Id = value;
+        }
 
         [JsonIgnore]
-        public Sku Parent => this.InternalParent.ExpandedObject;
+        public Sku Parent
+        {
+            get => this.InternalParent.ExpandedObject;
+            set => this.InternalParent.ExpandedObject = value;
+        }
 
         [JsonProperty("parent")]
         [JsonConverter(typeof(ExpandableFieldConverter<Sku>))]

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -45,10 +45,18 @@ namespace Stripe
         /// <para>Expandable</para>
         /// </summary>
         [JsonIgnore]
-        public string OrderId => this.InternalOrder.Id;
+        public string OrderId
+        {
+            get => this.InternalOrder.Id;
+            set => this.InternalOrder.Id = value;
+        }
 
         [JsonIgnore]
-        public Order Order => this.InternalOrder.ExpandedObject;
+        public Order Order
+        {
+            get => this.InternalOrder.ExpandedObject;
+            set => this.InternalOrder.ExpandedObject = value;
+        }
 
         [JsonProperty("order")]
         [JsonConverter(typeof(ExpandableFieldConverter<Order>))]
@@ -65,7 +73,11 @@ namespace Stripe
         public string RefundId { get; set; }
 
         [JsonIgnore]
-        public Refund Refund => this.InternalRefund.ExpandedObject;
+        public Refund Refund
+        {
+            get => this.InternalRefund.ExpandedObject;
+            set => this.InternalRefund.ExpandedObject = value;
+        }
 
         [JsonProperty("refund")]
         [JsonConverter(typeof(ExpandableFieldConverter<Refund>))]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -24,10 +24,18 @@ namespace Stripe
 
         #region Expandable Application
         [JsonIgnore]
-        public string ApplicationId => this.InternalApplication.Id;
+        public string ApplicationId
+        {
+            get => this.InternalApplication.Id;
+            set => this.InternalApplication.Id = value;
+        }
 
         [JsonIgnore]
-        public Application Application => this.InternalApplication.ExpandedObject;
+        public Application Application
+        {
+            get => this.InternalApplication.ExpandedObject;
+            set => this.InternalApplication.ExpandedObject = value;
+        }
 
         [JsonProperty("application")]
         [JsonConverter(typeof(ExpandableFieldConverter<Application>))]
@@ -65,10 +73,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -80,10 +96,18 @@ namespace Stripe
 
         #region Expandable Invoice
         [JsonIgnore]
-        public string InvoiceId => this.InternalInvoice.Id;
+        public string InvoiceId
+        {
+            get => this.InternalInvoice.Id;
+            set => this.InternalInvoice.Id = value;
+        }
 
         [JsonIgnore]
-        public Invoice Invoice => this.InternalInvoice.ExpandedObject;
+        public Invoice Invoice
+        {
+            get => this.InternalInvoice.ExpandedObject;
+            set => this.InternalInvoice.ExpandedObject = value;
+        }
 
         [JsonProperty("invoice")]
         [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]
@@ -104,10 +128,18 @@ namespace Stripe
 
         #region Expandable OnBehalfOf (Account)
         [JsonIgnore]
-        public string OnBehalfOfId => this.InternalOnBehalfOf.Id;
+        public string OnBehalfOfId
+        {
+            get => this.InternalOnBehalfOf.Id;
+            set => this.InternalOnBehalfOf.Id = value;
+        }
 
         [JsonIgnore]
-        public Account OnBehalfOf => this.InternalOnBehalfOf.ExpandedObject;
+        public Account OnBehalfOf
+        {
+            get => this.InternalOnBehalfOf.ExpandedObject;
+            set => this.InternalOnBehalfOf.ExpandedObject = value;
+        }
 
         [JsonProperty("on_behalf_of")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -116,10 +148,18 @@ namespace Stripe
 
         #region Expandable PaymentMethod
         [JsonIgnore]
-        public string PaymentMethodId => this.InternalPaymentMethod.Id;
+        public string PaymentMethodId
+        {
+            get => this.InternalPaymentMethod.Id;
+            set => this.InternalPaymentMethod.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentMethod PaymentMethod => this.InternalPaymentMethod.ExpandedObject;
+        public PaymentMethod PaymentMethod
+        {
+            get => this.InternalPaymentMethod.ExpandedObject;
+            set => this.InternalPaymentMethod.ExpandedObject = value;
+        }
 
         [JsonProperty("payment_method")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
@@ -134,10 +174,18 @@ namespace Stripe
 
         #region Expandable Review
         [JsonIgnore]
-        public string ReviewId => this.InternalReview.Id;
+        public string ReviewId
+        {
+            get => this.InternalReview.Id;
+            set => this.InternalReview.Id = value;
+        }
 
         [JsonIgnore]
-        public Review Review => this.InternalReview.ExpandedObject;
+        public Review Review
+        {
+            get => this.InternalReview.ExpandedObject;
+            set => this.InternalReview.ExpandedObject = value;
+        }
 
         [JsonProperty("review")]
         [JsonConverter(typeof(ExpandableFieldConverter<Review>))]
@@ -149,10 +197,18 @@ namespace Stripe
 
         #region Expandable Source
         [JsonIgnore]
-        public string SourceId => this.InternalSource.Id;
+        public string SourceId
+        {
+            get => this.InternalSource.Id;
+            set => this.InternalSource.Id = value;
+        }
 
         [JsonIgnore]
-        public IPaymentSource Source => this.InternalSource.ExpandedObject;
+        public IPaymentSource Source
+        {
+            get => this.InternalSource.ExpandedObject;
+            set => this.InternalSource.ExpandedObject = value;
+        }
 
         [JsonProperty("source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
@@ -8,10 +8,18 @@ namespace Stripe
     {
         #region Expandable Destination (Account)
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -32,10 +32,18 @@ namespace Stripe
         /// ID of the customer this charge is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -25,10 +25,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -47,10 +55,18 @@ namespace Stripe
 
         #region Expandable Destination
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public IExternalAccount Destination => this.InternalDestination.ExpandedObject;
+        public IExternalAccount Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<IExternalAccount>))]
@@ -63,10 +79,18 @@ namespace Stripe
         /// If the payout failed or was canceled, this will be the ID of the balance transaction that reversed the initial balance transaction, and puts the funds from the failed payout back in your balance.
         /// </summary>
         [JsonIgnore]
-        public string FailureBalanceTransactionId => this.InternalFailureBalanceTransaction.Id;
+        public string FailureBalanceTransactionId
+        {
+            get => this.InternalFailureBalanceTransaction.Id;
+            set => this.InternalFailureBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction FailureBalanceTransaction => this.InternalFailureBalanceTransaction.ExpandedObject;
+        public BalanceTransaction FailureBalanceTransaction
+        {
+            get => this.InternalFailureBalanceTransaction.ExpandedObject;
+            set => this.InternalFailureBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("failure_balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]

--- a/src/Stripe.net/Entities/Persons/PersonVerificationDocument.cs
+++ b/src/Stripe.net/Entities/Persons/PersonVerificationDocument.cs
@@ -13,14 +13,22 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string BackId => this.InternalBack.Id;
+        public string BackId
+        {
+            get => this.InternalBack.Id;
+            set => this.InternalBack.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The back of an ID returned by a file upload with a <c>purpose</c>
         /// value of <c>identity_document</c>.
         /// </summary>
         [JsonIgnore]
-        public File Back => this.InternalBack.ExpandedObject;
+        public File Back
+        {
+            get => this.InternalBack.ExpandedObject;
+            set => this.InternalBack.ExpandedObject = value;
+        }
 
         [JsonProperty("back")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
@@ -49,14 +57,22 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string FrontId => this.InternalFront.Id;
+        public string FrontId
+        {
+            get => this.InternalFront.Id;
+            set => this.InternalFront.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The front of an ID returned by a file upload with a <c>purpose</c>
         /// value of <c>identity_document</c>.
         /// </summary>
         [JsonIgnore]
-        public File Front => this.InternalFront.ExpandedObject;
+        public File Front
+        {
+            get => this.InternalFront.ExpandedObject;
+            set => this.InternalFront.ExpandedObject = value;
+        }
 
         [JsonProperty("front")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -60,10 +60,18 @@ namespace Stripe
         /// <para>You can expand the Product by setting the ExpandProduct property on the service to true</para>
         /// </summary>
         [JsonIgnore]
-        public string ProductId => this.InternalProduct.Id;
+        public string ProductId
+        {
+            get => this.InternalProduct.Id;
+            set => this.InternalProduct.Id = value;
+        }
 
         [JsonIgnore]
-        public Product Product => this.InternalProduct.ExpandedObject;
+        public Product Product
+        {
+            get => this.InternalProduct.ExpandedObject;
+            set => this.InternalProduct.ExpandedObject = value;
+        }
 
         [JsonProperty("product")]
         [JsonConverter(typeof(ExpandableFieldConverter<Product>))]

--- a/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
+++ b/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
@@ -29,10 +29,18 @@ namespace Stripe.Radar
 
         /// <summary>ID of the charge this early fraud warning is for.</summary>
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -25,10 +25,18 @@ namespace Stripe
 
         #region Expandable Default Card
         [JsonIgnore]
-        public string DefaultCardId => this.InternalDefaultCard.Id;
+        public string DefaultCardId
+        {
+            get => this.InternalDefaultCard.Id;
+            set => this.InternalDefaultCard.Id = value;
+        }
 
         [JsonIgnore]
-        public Card DefaultCard => this.InternalDefaultCard.ExpandedObject;
+        public Card DefaultCard
+        {
+            get => this.InternalDefaultCard.ExpandedObject;
+            set => this.InternalDefaultCard.ExpandedObject = value;
+        }
 
         [JsonProperty("default_card")]
         [JsonConverter(typeof(ExpandableFieldConverter<Card>))]

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -18,10 +18,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -30,10 +38,18 @@ namespace Stripe
 
         #region Expandable Charge
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -52,10 +68,18 @@ namespace Stripe
 
         #region Expandable Failure Balance Transaction
         [JsonIgnore]
-        public string FailureBalanceTransactionId => this.InternalFailureBalanceTransaction.Id;
+        public string FailureBalanceTransactionId
+        {
+            get => this.InternalFailureBalanceTransaction.Id;
+            set => this.InternalFailureBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction FailureBalanceTransaction => this.InternalFailureBalanceTransaction.ExpandedObject;
+        public BalanceTransaction FailureBalanceTransaction
+        {
+            get => this.InternalFailureBalanceTransaction.ExpandedObject;
+            set => this.InternalFailureBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("failure_balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -76,10 +100,18 @@ namespace Stripe
 
         #region Expandable Source Transfer Reversal
         [JsonIgnore]
-        public string SourceTransferReversalId => this.InternalSourceTransferReversal.Id;
+        public string SourceTransferReversalId
+        {
+            get => this.InternalSourceTransferReversal.Id;
+            set => this.InternalSourceTransferReversal.Id = value;
+        }
 
         [JsonIgnore]
-        public TransferReversal SourceTransferReversal => this.InternalSourceTransferReversal.ExpandedObject;
+        public TransferReversal SourceTransferReversal
+        {
+            get => this.InternalSourceTransferReversal.ExpandedObject;
+            set => this.InternalSourceTransferReversal.ExpandedObject = value;
+        }
 
         [JsonProperty("source_transfer_reversal")]
         [JsonConverter(typeof(ExpandableFieldConverter<TransferReversal>))]
@@ -91,10 +123,18 @@ namespace Stripe
 
         #region Expandable  Transfer Reversal
         [JsonIgnore]
-        public string TransferReversalId => this.InternalTransferReversal.Id;
+        public string TransferReversalId
+        {
+            get => this.InternalTransferReversal.Id;
+            set => this.InternalTransferReversal.Id = value;
+        }
 
         [JsonIgnore]
-        public TransferReversal TransferReversal => this.InternalTransferReversal.ExpandedObject;
+        public TransferReversal TransferReversal
+        {
+            get => this.InternalTransferReversal.ExpandedObject;
+            set => this.InternalTransferReversal.ExpandedObject = value;
+        }
 
         [JsonProperty("transfer_reversal")]
         [JsonConverter(typeof(ExpandableFieldConverter<TransferReversal>))]

--- a/src/Stripe.net/Entities/Reviews/Review.cs
+++ b/src/Stripe.net/Entities/Reviews/Review.cs
@@ -14,10 +14,18 @@ namespace Stripe
 
         #region Expandable Charge
         [JsonIgnore]
-        public string ChargeId => this.InternalCharge.Id;
+        public string ChargeId
+        {
+            get => this.InternalCharge.Id;
+            set => this.InternalCharge.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge Charge => this.InternalCharge.ExpandedObject;
+        public Charge Charge
+        {
+            get => this.InternalCharge.ExpandedObject;
+            set => this.InternalCharge.ExpandedObject = value;
+        }
 
         [JsonProperty("charge")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -36,10 +44,18 @@ namespace Stripe
 
         #region Expandable PaymentIntent
         [JsonIgnore]
-        public string PaymentIntentId => this.InternalPaymentIntent.Id;
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent.Id;
+            set => this.InternalPaymentIntent.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentIntent PaymentIntent => this.InternalPaymentIntent.ExpandedObject;
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent.ExpandedObject;
+            set => this.InternalPaymentIntent.ExpandedObject = value;
+        }
 
         [JsonProperty("payment_intent")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -86,10 +86,18 @@ namespace Stripe
         /// The ID of the product this SKU is associated with. The product must be currently active.
         /// </summary>
         [JsonIgnore]
-        public string ProductId => this.InternalProduct.Id;
+        public string ProductId
+        {
+            get => this.InternalProduct.Id;
+            set => this.InternalProduct.Id = value;
+        }
 
         [JsonIgnore]
-        public Product Product => this.InternalProduct.ExpandedObject;
+        public Product Product
+        {
+            get => this.InternalProduct.ExpandedObject;
+            set => this.InternalProduct.ExpandedObject = value;
+        }
 
         [JsonProperty("product")]
         [JsonConverter(typeof(ExpandableFieldConverter<Product>))]

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -64,10 +64,18 @@ namespace Stripe
 
         #region Expandable Customer
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -86,10 +94,18 @@ namespace Stripe
         /// ID of the default payment method for the subscription.
         /// </summary>
         [JsonIgnore]
-        public string DefaultPaymentMethodId => this.InternalDefaultPaymentMethod.Id;
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod.Id;
+            set => this.InternalDefaultPaymentMethod.Id = value;
+        }
 
         [JsonIgnore]
-        public PaymentMethod DefaultPaymentMethod => this.InternalDefaultPaymentMethod.ExpandedObject;
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+        }
 
         [JsonProperty("default_payment_method")]
         [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
@@ -98,10 +114,18 @@ namespace Stripe
 
         #region Expandable DefaultSource
         [JsonIgnore]
-        public string DefaultSourceId => this.InternalDefaultSource.Id;
+        public string DefaultSourceId
+        {
+            get => this.InternalDefaultSource.Id;
+            set => this.InternalDefaultSource.Id = value;
+        }
 
         [JsonIgnore]
-        public IPaymentSource DefaultSource => this.InternalDefaultSource.ExpandedObject;
+        public IPaymentSource DefaultSource
+        {
+            get => this.InternalDefaultSource.ExpandedObject;
+            set => this.InternalDefaultSource.ExpandedObject = value;
+        }
 
         [JsonProperty("default_source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
@@ -126,10 +150,18 @@ namespace Stripe
 
         #region Expandable LatestInvoice
         [JsonIgnore]
-        public string LatestInvoiceId => this.InternalLatestInvoice.Id;
+        public string LatestInvoiceId
+        {
+            get => this.InternalLatestInvoice.Id;
+            set => this.InternalLatestInvoice.Id = value;
+        }
 
         [JsonIgnore]
-        public Invoice LatestInvoice => this.InternalLatestInvoice.ExpandedObject;
+        public Invoice LatestInvoice
+        {
+            get => this.InternalLatestInvoice.ExpandedObject;
+            set => this.InternalLatestInvoice.ExpandedObject = value;
+        }
 
         [JsonProperty("latest_invoice")]
         [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
@@ -7,10 +7,18 @@ namespace Stripe
     {
         #region Expandable Destination (Account)
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -72,13 +72,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The <see cref="Customer"/> associated with the subscription schedule.
         /// </summary>
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
@@ -157,13 +165,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string SubscriptionId => this.InternalSubscription.Id;
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription.Id;
+            set => this.InternalSubscription.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The <see cref="Subscription"/> associated with the subscription schedule.
         /// </summary>
         [JsonIgnore]
-        public Subscription Subscription => this.InternalSubscription.ExpandedObject;
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription.ExpandedObject;
+            set => this.InternalSubscription.ExpandedObject = value;
+        }
 
         [JsonProperty("subscription")]
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
@@ -22,14 +22,22 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string CouponId => this.InternalCoupon.Id;
+        public string CouponId
+        {
+            get => this.InternalCoupon.Id;
+            set => this.InternalCoupon.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The <see cref="Coupon"/> associated with this phase for the subscription
         /// schedule.
         /// </summary>
         [JsonIgnore]
-        public Coupon Coupon => this.InternalCoupon.ExpandedObject;
+        public Coupon Coupon
+        {
+            get => this.InternalCoupon.ExpandedObject;
+            set => this.InternalCoupon.ExpandedObject = value;
+        }
 
         [JsonProperty("coupon")]
         [JsonConverter(typeof(ExpandableFieldConverter<Coupon>))]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
@@ -20,13 +20,21 @@ namespace Stripe
         /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
-        public string PlanId => this.InternalPlan.Id;
+        public string PlanId
+        {
+            get => this.InternalPlan.Id;
+            set => this.InternalPlan.Id = value;
+        }
 
         /// <summary>
         /// (Expanded) The <see cref="Plan"/> included in the phase for this subscription schedule.
         /// </summary>
         [JsonIgnore]
-        public Plan Plan => this.InternalPlan.ExpandedObject;
+        public Plan Plan
+        {
+            get => this.InternalPlan.ExpandedObject;
+            set => this.InternalPlan.ExpandedObject = value;
+        }
 
         [JsonProperty("plan")]
         [JsonConverter(typeof(ExpandableFieldConverter<Plan>))]

--- a/src/Stripe.net/Entities/TaxIds/TaxId.cs
+++ b/src/Stripe.net/Entities/TaxIds/TaxId.cs
@@ -38,10 +38,18 @@ namespace Stripe
         /// ID of the customer this tax ID is for if one exists.
         /// </summary>
         [JsonIgnore]
-        public string CustomerId => this.InternalCustomer.Id;
+        public string CustomerId
+        {
+            get => this.InternalCustomer.Id;
+            set => this.InternalCustomer.Id = value;
+        }
 
         [JsonIgnore]
-        public Customer Customer => this.InternalCustomer.ExpandedObject;
+        public Customer Customer
+        {
+            get => this.InternalCustomer.ExpandedObject;
+            set => this.InternalCustomer.ExpandedObject = value;
+        }
 
         [JsonProperty("customer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -28,7 +28,11 @@ namespace Stripe
         public string BalanceTransactionId { get; set; }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]

--- a/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
+++ b/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
@@ -18,10 +18,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -37,10 +45,18 @@ namespace Stripe
 
         #region Expandable Destination Payment Refund
         [JsonIgnore]
-        public string DestinationPaymentRefundId => this.InternalDestinationPaymentRefund.Id;
+        public string DestinationPaymentRefundId
+        {
+            get => this.InternalDestinationPaymentRefund.Id;
+            set => this.InternalDestinationPaymentRefund.Id = value;
+        }
 
         [JsonIgnore]
-        public Refund DestinationPaymentRefund => this.InternalDestinationPaymentRefund.ExpandedObject;
+        public Refund DestinationPaymentRefund
+        {
+            get => this.InternalDestinationPaymentRefund.ExpandedObject;
+            set => this.InternalDestinationPaymentRefund.ExpandedObject = value;
+        }
 
         [JsonProperty("destination_payment_refund")]
         [JsonConverter(typeof(ExpandableFieldConverter<Refund>))]
@@ -52,10 +68,18 @@ namespace Stripe
 
         #region Expandable Source Refund
         [JsonIgnore]
-        public string SourceRefundId => this.InternalSourceRefund.Id;
+        public string SourceRefundId
+        {
+            get => this.InternalSourceRefund.Id;
+            set => this.InternalSourceRefund.Id = value;
+        }
 
         [JsonIgnore]
-        public Refund SourceRefund => this.InternalSourceRefund.ExpandedObject;
+        public Refund SourceRefund
+        {
+            get => this.InternalSourceRefund.ExpandedObject;
+            set => this.InternalSourceRefund.ExpandedObject = value;
+        }
 
         [JsonProperty("source_refund")]
         [JsonConverter(typeof(ExpandableFieldConverter<Refund>))]
@@ -64,10 +88,18 @@ namespace Stripe
 
         #region Expandable Transfer
         [JsonIgnore]
-        public string TransferId => this.InternalTransfer.Id;
+        public string TransferId
+        {
+            get => this.InternalTransfer.Id;
+            set => this.InternalTransfer.Id = value;
+        }
 
         [JsonIgnore]
-        public Transfer Transfer => this.InternalTransfer.ExpandedObject;
+        public Transfer Transfer
+        {
+            get => this.InternalTransfer.ExpandedObject;
+            set => this.InternalTransfer.ExpandedObject = value;
+        }
 
         [JsonProperty("transfer")]
         [JsonConverter(typeof(ExpandableFieldConverter<Transfer>))]

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -21,10 +21,18 @@ namespace Stripe
 
         #region Expandable Balance Transaction
         [JsonIgnore]
-        public string BalanceTransactionId => this.InternalBalanceTransaction.Id;
+        public string BalanceTransactionId
+        {
+            get => this.InternalBalanceTransaction.Id;
+            set => this.InternalBalanceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public BalanceTransaction BalanceTransaction => this.InternalBalanceTransaction.ExpandedObject;
+        public BalanceTransaction BalanceTransaction
+        {
+            get => this.InternalBalanceTransaction.ExpandedObject;
+            set => this.InternalBalanceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("balance_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
@@ -43,10 +51,18 @@ namespace Stripe
 
         #region Expandable Destination
         [JsonIgnore]
-        public string DestinationId => this.InternalDestination.Id;
+        public string DestinationId
+        {
+            get => this.InternalDestination.Id;
+            set => this.InternalDestination.Id = value;
+        }
 
         [JsonIgnore]
-        public Account Destination => this.InternalDestination.ExpandedObject;
+        public Account Destination
+        {
+            get => this.InternalDestination.ExpandedObject;
+            set => this.InternalDestination.ExpandedObject = value;
+        }
 
         [JsonProperty("destination")]
         [JsonConverter(typeof(ExpandableFieldConverter<Account>))]
@@ -55,10 +71,18 @@ namespace Stripe
 
         #region Expandable Destination Payment
         [JsonIgnore]
-        public string DestinationPaymentId => this.InternalDestinationPayment.Id;
+        public string DestinationPaymentId
+        {
+            get => this.InternalDestinationPayment.Id;
+            set => this.InternalDestinationPayment.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge DestinationPayment => this.InternalDestinationPayment.ExpandedObject;
+        public Charge DestinationPayment
+        {
+            get => this.InternalDestinationPayment.ExpandedObject;
+            set => this.InternalDestinationPayment.ExpandedObject = value;
+        }
 
         [JsonProperty("destination_payment")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]
@@ -79,10 +103,18 @@ namespace Stripe
 
         #region Expandable Source Transaction
         [JsonIgnore]
-        public string SourceTransactionId => this.InternalSourceTransaction.Id;
+        public string SourceTransactionId
+        {
+            get => this.InternalSourceTransaction.Id;
+            set => this.InternalSourceTransaction.Id = value;
+        }
 
         [JsonIgnore]
-        public Charge SourceTransaction => this.InternalSourceTransaction.ExpandedObject;
+        public Charge SourceTransaction
+        {
+            get => this.InternalSourceTransaction.ExpandedObject;
+            set => this.InternalSourceTransaction.ExpandedObject = value;
+        }
 
         [JsonProperty("source_transaction")]
         [JsonConverter(typeof(ExpandableFieldConverter<Charge>))]


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

In #1481, I changed the way expandable fields are handled and removed setters for the ID and expanded properties matching these fields.

This turned out to be inconvenient for users using these setters in unit tests, so this PR adds setters back.

Fixes #1651.
