### PR TITLE
Fix file creation requests

### DIFF
--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -31,7 +31,7 @@ namespace Stripe
         /// </summary>
         [JsonProperty("expires_at")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime ExpiresAt { get; set; }
+        public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value

--- a/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
@@ -66,6 +66,11 @@ namespace Stripe.Infrastructure.FormEncoding
             return content;
         }
 
+        private static string QuoteString(string value)
+        {
+            return "\"" + value + "\"";
+        }
+
         private void ProcessParameters(IEnumerable<KeyValuePair<string, object>> nameValueCollection)
         {
             foreach (var kvp in nameValueCollection)
@@ -73,11 +78,11 @@ namespace Stripe.Infrastructure.FormEncoding
                 switch (kvp.Value)
                 {
                     case string s:
-                        this.Add(CreateStringContent(s), kvp.Key);
+                        this.Add(CreateStringContent(s), QuoteString(kvp.Key));
                         break;
 
                     case Stream s:
-                        this.Add(CreateStreamContent(s, kvp.Key));
+                        this.Add(CreateStreamContent(s, QuoteString(kvp.Key)));
                         break;
 
                     default:

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -23,15 +23,13 @@ namespace Stripe
 
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
-            requestOptions = this.SetupRequestOptions(requestOptions);
-            requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.Client.FilesBase;
+            requestOptions = this.SetupRequestOptionsForFilesRequest(requestOptions);
             return this.CreateEntity(options, requestOptions);
         }
 
         public virtual Task<File> CreateAsync(FileCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            requestOptions = this.SetupRequestOptions(requestOptions);
-            requestOptions.BaseUrl = requestOptions.BaseUrl ?? this.Client.FilesBase;
+            requestOptions = this.SetupRequestOptionsForFilesRequest(requestOptions);
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
@@ -58,6 +56,21 @@ namespace Stripe
         public virtual IEnumerable<File> ListAutoPaging(FileListOptions options = null, RequestOptions requestOptions = null)
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        private RequestOptions SetupRequestOptionsForFilesRequest(RequestOptions requestOptions)
+        {
+            if (requestOptions == null)
+            {
+                requestOptions = new RequestOptions();
+            }
+
+            if (requestOptions.BaseUrl == null)
+            {
+                requestOptions.BaseUrl = this.Client.FilesBase;
+            }
+
+            return requestOptions;
         }
     }
 }

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -71,7 +71,7 @@ namespace StripeTests
             Assert.Equal(1, content.Headers.ContentType.Parameters.Count);
 
             var stream = await content.ReadAsStreamAsync();
-            Assert.Equal(760, stream.Length);
+            Assert.Equal(764, stream.Length);
             var result = new StreamReader(stream).ReadToEnd();
 
             // The boundary will be a random GUID, so we just check for substrings.
@@ -86,10 +86,10 @@ namespace StripeTests
                 "Content-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"list[2]\"\r\n\r\n3\r\n",
                 result);
             Assert.Contains(
-                "Content-Disposition: form-data; name=stream; filename=blob; filename*=utf-8''blob\r\nContent-Type: application/octet-stream\r\n\r\nHello World!\r\n",
+                "Content-Disposition: form-data; name=\"stream\"; filename=blob; filename*=utf-8''blob\r\nContent-Type: application/octet-stream\r\n\r\nHello World!\r\n",
                 result);
             Assert.Contains(
-                "Content-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=string\r\n\r\nString!\r\n",
+                "Content-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"string\"\r\n\r\nString!\r\n",
                 result);
         }
 

--- a/src/StripeTests/Infrastructure/FormEncoding/MultipartFormDataContentTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/MultipartFormDataContentTest.cs
@@ -43,11 +43,11 @@ namespace StripeTests
             var content = new MultipartFormDataContent(source, "test-boundary");
 
             var stream = await content.ReadAsStreamAsync();
-            Assert.Equal(131, stream.Length);
+            Assert.Equal(133, stream.Length);
             var result = new StreamReader(stream).ReadToEnd();
             Assert.Equal(
                 "--test-boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
-                + "Content-Disposition: form-data; name=key\r\n\r\nvalueク\r\n--test-boundary--\r\n",
+                + "Content-Disposition: form-data; name=\"key\"\r\n\r\nvalueク\r\n--test-boundary--\r\n",
                 result);
         }
 
@@ -61,11 +61,11 @@ namespace StripeTests
             var content = new MultipartFormDataContent(source, "test-boundary");
 
             var stream = await content.ReadAsStreamAsync();
-            Assert.Equal(172, stream.Length);
+            Assert.Equal(174, stream.Length);
             var result = new StreamReader(stream).ReadToEnd();
             Assert.Equal(
                 "--test-boundary\r\n"
-                + "Content-Disposition: form-data; name=key; filename=blob; filename*=utf-8''blob\r\n"
+                + "Content-Disposition: form-data; name=\"key\"; filename=blob; filename*=utf-8''blob\r\n"
                 + "Content-Type: application/octet-stream\r\n\r\nHello World!\r\n"
                 + "--test-boundary--\r\n",
                 result);
@@ -82,14 +82,14 @@ namespace StripeTests
             var content = new MultipartFormDataContent(source, "test-boundary");
 
             var stream = await content.ReadAsStreamAsync();
-            Assert.Equal(295, stream.Length);
+            Assert.Equal(299, stream.Length);
             var result = new StreamReader(stream).ReadToEnd();
             Assert.Equal(
                 "--test-boundary\r\n"
-                + "Content-Disposition: form-data; name=stream; filename=blob; filename*=utf-8''blob\r\n"
+                + "Content-Disposition: form-data; name=\"stream\"; filename=blob; filename*=utf-8''blob\r\n"
                 + "Content-Type: application/octet-stream\r\n\r\nHello クWorld!\r\n"
                 + "--test-boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
-                + "Content-Disposition: form-data; name=string\r\n\r\nString!ク\r\n--test-boundary--\r\n",
+                + "Content-Disposition: form-data; name=\"string\"\r\n\r\nString!ク\r\n--test-boundary--\r\n",
                 result);
         }
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

So there were actually three different issues 🤦‍♂ 

1. File creation requests were sent to `api.stripe.com` instead of `files.stripe.com`
2. Field names in multipart requests must be quoted
3. `FileLink.ExpiresAt` is nullable

Fixes #1654.
