### PR TITLE
Add `ConfigureAwait(false)` to all async calls

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -116,7 +116,8 @@ namespace Stripe
         {
             var request = new StripeRequest(this, method, path, options, requestOptions);
 
-            var response = await this.HttpClient.MakeRequestAsync(request, cancellationToken);
+            var response = await this.HttpClient.MakeRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
 
             return ProcessResponse<T>(response);
         }

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -238,7 +238,7 @@ namespace Stripe
                 path,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         protected IEnumerable<T> ListRequestAutoPaging<T>(


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Some async calls were missing a `ConfigureAwait(false)`, which can cause a deadlock in applications where the main thread is busy with something else (e.g. serving HTTP requests).

I've verified that all the async calls in the library now have `ConfigureAwait(false)`, and verified that the problem described in #1653 no longer occurs with this patch.

I'll try thinking of a way to write a test for this to avoid regressions in the future, but I think it might be difficult :/

Fixes #1653.