### PR TITLE
Fix possible NRE in expandable field accessors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
+  "window.title": "${rootName}${separator}${activeEditorMedium}",
   "[csharp]": {
     "editor.detectIndentation": false,
     "editor.insertSpaces": true,

--- a/src/Stripe.net/Entities/Accounts/AccountSettingsBranding.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountSettingsBranding.cs
@@ -15,8 +15,8 @@ namespace Stripe
         [JsonIgnore]
         public string IconId
         {
-            get => this.InternalIcon.Id;
-            set => this.InternalIcon.Id = value;
+            get => this.InternalIcon?.Id;
+            set => this.InternalIcon = SetExpandableFieldId(value, this.InternalIcon);
         }
 
         /// <summary>
@@ -25,8 +25,8 @@ namespace Stripe
         [JsonIgnore]
         public File Icon
         {
-            get => this.InternalIcon.ExpandedObject;
-            set => this.InternalIcon.ExpandedObject = value;
+            get => this.InternalIcon?.ExpandedObject;
+            set => this.InternalIcon = SetExpandableFieldObject(value, this.InternalIcon);
         }
 
         [JsonProperty("icon")]
@@ -45,8 +45,8 @@ namespace Stripe
         [JsonIgnore]
         public string LogoId
         {
-            get => this.InternalLogo.Id;
-            set => this.InternalLogo.Id = value;
+            get => this.InternalLogo?.Id;
+            set => this.InternalLogo = SetExpandableFieldId(value, this.InternalLogo);
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace Stripe
         [JsonIgnore]
         public File Logo
         {
-            get => this.InternalLogo.ExpandedObject;
-            set => this.InternalLogo.ExpandedObject = value;
+            get => this.InternalLogo?.ExpandedObject;
+            set => this.InternalLogo = SetExpandableFieldObject(value, this.InternalLogo);
         }
 
         [JsonProperty("logo")]

--- a/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
+++ b/src/Stripe.net/Entities/ApplicationFeeRefunds/ApplicationFeeRefund.cs
@@ -20,15 +20,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -47,15 +47,15 @@ namespace Stripe
         [JsonIgnore]
         public string FeeId
         {
-            get => this.InternalFee.Id;
-            set => this.InternalFee.Id = value;
+            get => this.InternalFee?.Id;
+            set => this.InternalFee = SetExpandableFieldId(value, this.InternalFee);
         }
 
         [JsonIgnore]
         public ApplicationFee Fee
         {
-            get => this.InternalFee.ExpandedObject;
-            set => this.InternalFee.ExpandedObject = value;
+            get => this.InternalFee?.ExpandedObject;
+            set => this.InternalFee = SetExpandableFieldObject(value, this.InternalFee);
         }
 
         [JsonProperty("fee")]

--- a/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
+++ b/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
@@ -16,15 +16,15 @@ namespace Stripe
         [JsonIgnore]
         public string AccountId
         {
-            get => this.InternalAccount.Id;
-            set => this.InternalAccount.Id = value;
+            get => this.InternalAccount?.Id;
+            set => this.InternalAccount = SetExpandableFieldId(value, this.InternalAccount);
         }
 
         [JsonIgnore]
         public Account Account
         {
-            get => this.InternalAccount.ExpandedObject;
-            set => this.InternalAccount.ExpandedObject = value;
+            get => this.InternalAccount?.ExpandedObject;
+            set => this.InternalAccount = SetExpandableFieldObject(value, this.InternalAccount);
         }
 
         [JsonProperty("account")]
@@ -42,15 +42,15 @@ namespace Stripe
         [JsonIgnore]
         public string ApplicationId
         {
-            get => this.InternalApplication.Id;
-            set => this.InternalApplication.Id = value;
+            get => this.InternalApplication?.Id;
+            set => this.InternalApplication = SetExpandableFieldId(value, this.InternalApplication);
         }
 
         [JsonIgnore]
         public Application Application
         {
-            get => this.InternalApplication.ExpandedObject;
-            set => this.InternalApplication.ExpandedObject = value;
+            get => this.InternalApplication?.ExpandedObject;
+            set => this.InternalApplication = SetExpandableFieldObject(value, this.InternalApplication);
         }
 
         [JsonProperty("application")]
@@ -62,15 +62,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -82,15 +82,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]
@@ -112,15 +112,15 @@ namespace Stripe
         [JsonIgnore]
         public string OriginatingTransactionId
         {
-            get => this.InternalOriginatingTransaction.Id;
-            set => this.InternalOriginatingTransaction.Id = value;
+            get => this.InternalOriginatingTransaction?.Id;
+            set => this.InternalOriginatingTransaction = SetExpandableFieldId(value, this.InternalOriginatingTransaction);
         }
 
         [JsonIgnore]
         public Charge OriginatingTransaction
         {
-            get => this.InternalOriginatingTransaction.ExpandedObject;
-            set => this.InternalOriginatingTransaction.ExpandedObject = value;
+            get => this.InternalOriginatingTransaction?.ExpandedObject;
+            set => this.InternalOriginatingTransaction = SetExpandableFieldObject(value, this.InternalOriginatingTransaction);
         }
 
         [JsonProperty("originating_transaction")]

--- a/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
+++ b/src/Stripe.net/Entities/BalanceTransactions/BalanceTransaction.cs
@@ -46,15 +46,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceId
         {
-            get => this.InternalSource.Id;
-            set => this.InternalSource.Id = value;
+            get => this.InternalSource?.Id;
+            set => this.InternalSource = SetExpandableFieldId(value, this.InternalSource);
         }
 
         [JsonIgnore]
         public IBalanceTransactionSource Source
         {
-            get => this.InternalSource.ExpandedObject;
-            set => this.InternalSource.ExpandedObject = value;
+            get => this.InternalSource?.ExpandedObject;
+            set => this.InternalSource = SetExpandableFieldObject(value, this.InternalSource);
         }
 
         [JsonProperty("source")]

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -16,15 +16,15 @@ namespace Stripe
         [JsonIgnore]
         public string AccountId
         {
-            get => this.InternalAccount.Id;
-            set => this.InternalAccount.Id = value;
+            get => this.InternalAccount?.Id;
+            set => this.InternalAccount = SetExpandableFieldId(value, this.InternalAccount);
         }
 
         [JsonIgnore]
         public Account Account
         {
-            get => this.InternalAccount.ExpandedObject;
-            set => this.InternalAccount.ExpandedObject = value;
+            get => this.InternalAccount?.ExpandedObject;
+            set => this.InternalAccount = SetExpandableFieldObject(value, this.InternalAccount);
         }
 
         [JsonProperty("account")]
@@ -51,15 +51,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]

--- a/src/Stripe.net/Entities/Capabilities/Capability.cs
+++ b/src/Stripe.net/Entities/Capabilities/Capability.cs
@@ -27,15 +27,15 @@ namespace Stripe
         [JsonIgnore]
         public string AccountId
         {
-            get => this.InternalAccount.Id;
-            set => this.InternalAccount.Id = value;
+            get => this.InternalAccount?.Id;
+            set => this.InternalAccount = SetExpandableFieldId(value, this.InternalAccount);
         }
 
         [JsonIgnore]
         public Account Account
         {
-            get => this.InternalAccount.ExpandedObject;
-            set => this.InternalAccount.ExpandedObject = value;
+            get => this.InternalAccount?.ExpandedObject;
+            set => this.InternalAccount = SetExpandableFieldObject(value, this.InternalAccount);
         }
 
         [JsonProperty("account")]

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -16,15 +16,15 @@ namespace Stripe
         [JsonIgnore]
         public string AccountId
         {
-            get => this.InternalAccount.Id;
-            set => this.InternalAccount.Id = value;
+            get => this.InternalAccount?.Id;
+            set => this.InternalAccount = SetExpandableFieldId(value, this.InternalAccount);
         }
 
         [JsonIgnore]
         public Account Account
         {
-            get => this.InternalAccount.ExpandedObject;
-            set => this.InternalAccount.ExpandedObject = value;
+            get => this.InternalAccount?.ExpandedObject;
+            set => this.InternalAccount = SetExpandableFieldObject(value, this.InternalAccount);
         }
 
         [JsonProperty("account")]
@@ -72,15 +72,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -128,15 +128,15 @@ namespace Stripe
         [JsonIgnore]
         public string RecipientId
         {
-            get => this.InternalRecipient.Id;
-            set => this.InternalRecipient.Id = value;
+            get => this.InternalRecipient?.Id;
+            set => this.InternalRecipient = SetExpandableFieldId(value, this.InternalRecipient);
         }
 
         [JsonIgnore]
         public Recipient Recipient
         {
-            get => this.InternalRecipient.ExpandedObject;
-            set => this.InternalRecipient.ExpandedObject = value;
+            get => this.InternalRecipient?.ExpandedObject;
+            set => this.InternalRecipient = SetExpandableFieldObject(value, this.InternalRecipient);
         }
 
         [JsonProperty("recipient")]

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -29,15 +29,15 @@ namespace Stripe
         [JsonIgnore]
         public string ApplicationId
         {
-            get => this.InternalApplication.Id;
-            set => this.InternalApplication.Id = value;
+            get => this.InternalApplication?.Id;
+            set => this.InternalApplication = SetExpandableFieldId(value, this.InternalApplication);
         }
 
         [JsonIgnore]
         public Application Application
         {
-            get => this.InternalApplication.ExpandedObject;
-            set => this.InternalApplication.ExpandedObject = value;
+            get => this.InternalApplication?.ExpandedObject;
+            set => this.InternalApplication = SetExpandableFieldObject(value, this.InternalApplication);
         }
 
         [JsonProperty("application")]
@@ -49,8 +49,8 @@ namespace Stripe
         [JsonIgnore]
         public string ApplicationFeeId
         {
-            get => this.InternalApplicationFee.Id;
-            set => this.InternalApplicationFee.Id = value;
+            get => this.InternalApplicationFee?.Id;
+            set => this.InternalApplicationFee = SetExpandableFieldId(value, this.InternalApplicationFee);
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace Stripe
         [JsonIgnore]
         public ApplicationFee ApplicationFee
         {
-            get => this.InternalApplicationFee.ExpandedObject;
-            set => this.InternalApplicationFee.ExpandedObject = value;
+            get => this.InternalApplicationFee?.ExpandedObject;
+            set => this.InternalApplicationFee = SetExpandableFieldObject(value, this.InternalApplicationFee);
         }
 
         [JsonProperty("application_fee")]
@@ -82,15 +82,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -128,15 +128,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -151,8 +151,8 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         /// <summary>
@@ -161,8 +161,8 @@ namespace Stripe
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]
@@ -174,8 +174,8 @@ namespace Stripe
         [JsonIgnore]
         public string DisputeId
         {
-            get => this.InternalDispute.Id;
-            set => this.InternalDispute.Id = value;
+            get => this.InternalDispute?.Id;
+            set => this.InternalDispute = SetExpandableFieldId(value, this.InternalDispute);
         }
 
         /// <summary>
@@ -184,8 +184,8 @@ namespace Stripe
         [JsonIgnore]
         public Dispute Dispute
         {
-            get => this.InternalDispute.ExpandedObject;
-            set => this.InternalDispute.ExpandedObject = value;
+            get => this.InternalDispute?.ExpandedObject;
+            set => this.InternalDispute = SetExpandableFieldObject(value, this.InternalDispute);
         }
 
         [JsonProperty("dispute")]
@@ -219,15 +219,15 @@ namespace Stripe
         [JsonIgnore]
         public string InvoiceId
         {
-            get => this.InternalInvoice.Id;
-            set => this.InternalInvoice.Id = value;
+            get => this.InternalInvoice?.Id;
+            set => this.InternalInvoice = SetExpandableFieldId(value, this.InternalInvoice);
         }
 
         [JsonIgnore]
         public Invoice Invoice
         {
-            get => this.InternalInvoice.ExpandedObject;
-            set => this.InternalInvoice.ExpandedObject = value;
+            get => this.InternalInvoice?.ExpandedObject;
+            set => this.InternalInvoice = SetExpandableFieldObject(value, this.InternalInvoice);
         }
 
         [JsonProperty("invoice")]
@@ -253,15 +253,15 @@ namespace Stripe
         [JsonIgnore]
         public string OnBehalfOfId
         {
-            get => this.InternalOnBehalfOf.Id;
-            set => this.InternalOnBehalfOf.Id = value;
+            get => this.InternalOnBehalfOf?.Id;
+            set => this.InternalOnBehalfOf = SetExpandableFieldId(value, this.InternalOnBehalfOf);
         }
 
         [JsonIgnore]
         public Account OnBehalfOf
         {
-            get => this.InternalOnBehalfOf.ExpandedObject;
-            set => this.InternalOnBehalfOf.ExpandedObject = value;
+            get => this.InternalOnBehalfOf?.ExpandedObject;
+            set => this.InternalOnBehalfOf = SetExpandableFieldObject(value, this.InternalOnBehalfOf);
         }
 
         [JsonProperty("on_behalf_of")]
@@ -277,15 +277,15 @@ namespace Stripe
         [JsonIgnore]
         public string OrderId
         {
-            get => this.InternalOrder.Id;
-            set => this.InternalOrder.Id = value;
+            get => this.InternalOrder?.Id;
+            set => this.InternalOrder = SetExpandableFieldId(value, this.InternalOrder);
         }
 
         [JsonIgnore]
         public Order Order
         {
-            get => this.InternalOrder.ExpandedObject;
-            set => this.InternalOrder.ExpandedObject = value;
+            get => this.InternalOrder?.ExpandedObject;
+            set => this.InternalOrder = SetExpandableFieldObject(value, this.InternalOrder);
         }
 
         [JsonProperty("order")]
@@ -320,15 +320,15 @@ namespace Stripe
         [JsonIgnore]
         public string PaymentIntentId
         {
-            get => this.InternalPaymentIntent.Id;
-            set => this.InternalPaymentIntent.Id = value;
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
         }
 
         [JsonIgnore]
         public PaymentIntent PaymentIntent
         {
-            get => this.InternalPaymentIntent.ExpandedObject;
-            set => this.InternalPaymentIntent.ExpandedObject = value;
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
         }
 
         [JsonProperty("payment_intent")]
@@ -389,15 +389,15 @@ namespace Stripe
         [JsonIgnore]
         public string ReviewId
         {
-            get => this.InternalReview.Id;
-            set => this.InternalReview.Id = value;
+            get => this.InternalReview?.Id;
+            set => this.InternalReview = SetExpandableFieldId(value, this.InternalReview);
         }
 
         [JsonIgnore]
         public Review Review
         {
-            get => this.InternalReview.ExpandedObject;
-            set => this.InternalReview.ExpandedObject = value;
+            get => this.InternalReview?.ExpandedObject;
+            set => this.InternalReview = SetExpandableFieldObject(value, this.InternalReview);
         }
 
         [JsonProperty("review")]
@@ -426,15 +426,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceTransferId
         {
-            get => this.InternalSourceTransfer.Id;
-            set => this.InternalSourceTransfer.Id = value;
+            get => this.InternalSourceTransfer?.Id;
+            set => this.InternalSourceTransfer = SetExpandableFieldId(value, this.InternalSourceTransfer);
         }
 
         [JsonIgnore]
         public Transfer SourceTransfer
         {
-            get => this.InternalSourceTransfer.ExpandedObject;
-            set => this.InternalSourceTransfer.ExpandedObject = value;
+            get => this.InternalSourceTransfer?.ExpandedObject;
+            set => this.InternalSourceTransfer = SetExpandableFieldObject(value, this.InternalSourceTransfer);
         }
 
         [JsonProperty("source_transfer")]
@@ -462,15 +462,15 @@ namespace Stripe
         [JsonIgnore]
         public string TransferId
         {
-            get => this.InternalTransfer.Id;
-            set => this.InternalTransfer.Id = value;
+            get => this.InternalTransfer?.Id;
+            set => this.InternalTransfer = SetExpandableFieldId(value, this.InternalTransfer);
         }
 
         [JsonIgnore]
         public Transfer Transfer
         {
-            get => this.InternalTransfer.ExpandedObject;
-            set => this.InternalTransfer.ExpandedObject = value;
+            get => this.InternalTransfer?.ExpandedObject;
+            set => this.InternalTransfer = SetExpandableFieldObject(value, this.InternalTransfer);
         }
 
         [JsonProperty("transfer")]

--- a/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
+++ b/src/Stripe.net/Entities/Charges/ChargeTransferData.cs
@@ -12,15 +12,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]

--- a/src/Stripe.net/Entities/Charges/Outcome.cs
+++ b/src/Stripe.net/Entities/Charges/Outcome.cs
@@ -37,15 +37,15 @@ namespace Stripe
         [JsonIgnore]
         public string RuleId
         {
-            get => this.InternalRule.Id;
-            set => this.InternalRule.Id = value;
+            get => this.InternalRule?.Id;
+            set => this.InternalRule = SetExpandableFieldId(value, this.InternalRule);
         }
 
         [JsonIgnore]
         public OutcomeRule Rule
         {
-            get => this.InternalRule.ExpandedObject;
-            set => this.InternalRule.ExpandedObject = value;
+            get => this.InternalRule?.ExpandedObject;
+            set => this.InternalRule = SetExpandableFieldObject(value, this.InternalRule);
         }
 
         [JsonProperty("rule")]

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -50,15 +50,15 @@ namespace Stripe.Checkout
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -100,15 +100,15 @@ namespace Stripe.Checkout
         [JsonIgnore]
         public string PaymentIntentId
         {
-            get => this.InternalPaymentIntent.Id;
-            set => this.InternalPaymentIntent.Id = value;
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
         }
 
         [JsonIgnore]
         public PaymentIntent PaymentIntent
         {
-            get => this.InternalPaymentIntent.ExpandedObject;
-            set => this.InternalPaymentIntent.ExpandedObject = value;
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
         }
 
         [JsonProperty("payment_intent")]
@@ -131,15 +131,15 @@ namespace Stripe.Checkout
         [JsonIgnore]
         public string SubscriptionId
         {
-            get => this.InternalSubscription.Id;
-            set => this.InternalSubscription.Id = value;
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
         [JsonIgnore]
         public Subscription Subscription
         {
-            get => this.InternalSubscription.ExpandedObject;
-            set => this.InternalSubscription.ExpandedObject = value;
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
         }
 
         [JsonProperty("subscription")]

--- a/src/Stripe.net/Entities/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNote.cs
@@ -46,15 +46,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -70,15 +70,15 @@ namespace Stripe
         [JsonIgnore]
         public string InvoiceId
         {
-            get => this.InternalInvoice.Id;
-            set => this.InternalInvoice.Id = value;
+            get => this.InternalInvoice?.Id;
+            set => this.InternalInvoice = SetExpandableFieldId(value, this.InternalInvoice);
         }
 
         [JsonIgnore]
         public Invoice Invoice
         {
-            get => this.InternalInvoice.ExpandedObject;
-            set => this.InternalInvoice.ExpandedObject = value;
+            get => this.InternalInvoice?.ExpandedObject;
+            set => this.InternalInvoice = SetExpandableFieldObject(value, this.InternalInvoice);
         }
 
         [JsonProperty("invoice")]
@@ -133,15 +133,15 @@ namespace Stripe
         [JsonIgnore]
         public string RefundId
         {
-            get => this.InternalRefund.Id;
-            set => this.InternalRefund.Id = value;
+            get => this.InternalRefund?.Id;
+            set => this.InternalRefund = SetExpandableFieldId(value, this.InternalRefund);
         }
 
         [JsonIgnore]
         public Refund Refund
         {
-            get => this.InternalRefund.ExpandedObject;
-            set => this.InternalRefund.ExpandedObject = value;
+            get => this.InternalRefund?.ExpandedObject;
+            set => this.InternalRefund = SetExpandableFieldObject(value, this.InternalRefund);
         }
 
         [JsonProperty("refund")]

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -50,20 +50,19 @@ namespace Stripe
 
         /// <summary>
         /// ID of the default source attached to this customer
-        /// <para>You can expand the DefaultSource by setting the ExpandDefaultSource property on the service to true</para>
         /// </summary>
         [JsonIgnore]
         public string DefaultSourceId
         {
-            get => this.InternalDefaultSource.Id;
-            set => this.InternalDefaultSource.Id = value;
+            get => this.InternalDefaultSource?.Id;
+            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
         }
 
         [JsonIgnore]
         public IPaymentSource DefaultSource
         {
-            get => this.InternalDefaultSource.ExpandedObject;
-            set => this.InternalDefaultSource.ExpandedObject = value;
+            get => this.InternalDefaultSource?.ExpandedObject;
+            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
         }
 
         [JsonProperty("default_source")]

--- a/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
+++ b/src/Stripe.net/Entities/Customers/CustomerInvoiceSettings.cs
@@ -20,15 +20,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultPaymentMethodId
         {
-            get => this.InternalDefaultPaymentMethod.Id;
-            set => this.InternalDefaultPaymentMethod.Id = value;
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonIgnore]
         public PaymentMethod DefaultPaymentMethod
         {
-            get => this.InternalDefaultPaymentMethod.ExpandedObject;
-            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonProperty("default_payment_method")]

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -16,15 +16,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -50,15 +50,15 @@ namespace Stripe
         [JsonIgnore]
         public string SubscriptionId
         {
-            get => this.InternalSubscription.Id;
-            set => this.InternalSubscription.Id = value;
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
         [JsonIgnore]
         public Subscription Subscription
         {
-            get => this.InternalSubscription.ExpandedObject;
-            set => this.InternalSubscription.ExpandedObject = value;
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
         }
 
         [JsonProperty("subscription")]

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -23,15 +23,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]

--- a/src/Stripe.net/Entities/Disputes/Evidence.cs
+++ b/src/Stripe.net/Entities/Disputes/Evidence.cs
@@ -21,8 +21,8 @@ namespace Stripe
         [JsonIgnore]
         public string CancellationPolicyId
         {
-            get => this.InternalCancellationPolicy.Id;
-            set => this.InternalCancellationPolicy.Id = value;
+            get => this.InternalCancellationPolicy?.Id;
+            set => this.InternalCancellationPolicy = SetExpandableFieldId(value, this.InternalCancellationPolicy);
         }
 
         /// <summary>
@@ -31,8 +31,8 @@ namespace Stripe
         [JsonIgnore]
         public File CancellationPolicy
         {
-            get => this.InternalCancellationPolicy.ExpandedObject;
-            set => this.InternalCancellationPolicy.ExpandedObject = value;
+            get => this.InternalCancellationPolicy?.ExpandedObject;
+            set => this.InternalCancellationPolicy = SetExpandableFieldObject(value, this.InternalCancellationPolicy);
         }
 
         [JsonProperty("cancellation_policy")]
@@ -58,8 +58,8 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerCommunicationId
         {
-            get => this.InternalCustomerCommunication.Id;
-            set => this.InternalCustomerCommunication.Id = value;
+            get => this.InternalCustomerCommunication?.Id;
+            set => this.InternalCustomerCommunication = SetExpandableFieldId(value, this.InternalCustomerCommunication);
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace Stripe
         [JsonIgnore]
         public File CustomerCommunication
         {
-            get => this.InternalCustomerCommunication.ExpandedObject;
-            set => this.InternalCustomerCommunication.ExpandedObject = value;
+            get => this.InternalCustomerCommunication?.ExpandedObject;
+            set => this.InternalCustomerCommunication = SetExpandableFieldObject(value, this.InternalCustomerCommunication);
         }
 
         [JsonProperty("customer_communication")]
@@ -98,8 +98,8 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerSignatureId
         {
-            get => this.InternalCustomerSignature.Id;
-            set => this.InternalCustomerSignature.Id = value;
+            get => this.InternalCustomerSignature?.Id;
+            set => this.InternalCustomerSignature = SetExpandableFieldId(value, this.InternalCustomerSignature);
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace Stripe
         [JsonIgnore]
         public File CustomerSignature
         {
-            get => this.InternalCustomerSignature.ExpandedObject;
-            set => this.InternalCustomerSignature.ExpandedObject = value;
+            get => this.InternalCustomerSignature?.ExpandedObject;
+            set => this.InternalCustomerSignature = SetExpandableFieldObject(value, this.InternalCustomerSignature);
         }
 
         [JsonProperty("customer_signature")]
@@ -129,8 +129,8 @@ namespace Stripe
         [JsonIgnore]
         public string DuplicateChargeDocumentationId
         {
-            get => this.InternalDuplicateChargeDocumentation.Id;
-            set => this.InternalDuplicateChargeDocumentation.Id = value;
+            get => this.InternalDuplicateChargeDocumentation?.Id;
+            set => this.InternalDuplicateChargeDocumentation = SetExpandableFieldId(value, this.InternalDuplicateChargeDocumentation);
         }
 
         /// <summary>
@@ -141,8 +141,8 @@ namespace Stripe
         [JsonIgnore]
         public File DuplicateChargeDocumentation
         {
-            get => this.InternalDuplicateChargeDocumentation.ExpandedObject;
-            set => this.InternalDuplicateChargeDocumentation.ExpandedObject = value;
+            get => this.InternalDuplicateChargeDocumentation?.ExpandedObject;
+            set => this.InternalDuplicateChargeDocumentation = SetExpandableFieldObject(value, this.InternalDuplicateChargeDocumentation);
         }
 
         [JsonProperty("duplicate_charge_documentation")]
@@ -169,8 +169,8 @@ namespace Stripe
         [JsonIgnore]
         public string ReceiptId
         {
-            get => this.InternalReceipt.Id;
-            set => this.InternalReceipt.Id = value;
+            get => this.InternalReceipt?.Id;
+            set => this.InternalReceipt = SetExpandableFieldId(value, this.InternalReceipt);
         }
 
         /// <summary>
@@ -179,8 +179,8 @@ namespace Stripe
         [JsonIgnore]
         public File Receipt
         {
-            get => this.InternalReceipt.ExpandedObject;
-            set => this.InternalReceipt.ExpandedObject = value;
+            get => this.InternalReceipt?.ExpandedObject;
+            set => this.InternalReceipt = SetExpandableFieldObject(value, this.InternalReceipt);
         }
 
         [JsonProperty("receipt")]
@@ -197,8 +197,8 @@ namespace Stripe
         [JsonIgnore]
         public string RefundPolicyId
         {
-            get => this.InternalRefundPolicy.Id;
-            set => this.InternalRefundPolicy.Id = value;
+            get => this.InternalRefundPolicy?.Id;
+            set => this.InternalRefundPolicy = SetExpandableFieldId(value, this.InternalRefundPolicy);
         }
 
         /// <summary>
@@ -207,8 +207,8 @@ namespace Stripe
         [JsonIgnore]
         public File RefundPolicy
         {
-            get => this.InternalRefundPolicy.ExpandedObject;
-            set => this.InternalRefundPolicy.ExpandedObject = value;
+            get => this.InternalRefundPolicy?.ExpandedObject;
+            set => this.InternalRefundPolicy = SetExpandableFieldObject(value, this.InternalRefundPolicy);
         }
 
         [JsonProperty("refund_policy")]
@@ -236,8 +236,8 @@ namespace Stripe
         [JsonIgnore]
         public string ServiceDocumentationId
         {
-            get => this.InternalServiceDocumentation.Id;
-            set => this.InternalServiceDocumentation.Id = value;
+            get => this.InternalServiceDocumentation?.Id;
+            set => this.InternalServiceDocumentation = SetExpandableFieldId(value, this.InternalServiceDocumentation);
         }
 
         /// <summary>
@@ -248,8 +248,8 @@ namespace Stripe
         [JsonIgnore]
         public File ServiceDocumentation
         {
-            get => this.InternalServiceDocumentation.ExpandedObject;
-            set => this.InternalServiceDocumentation.ExpandedObject = value;
+            get => this.InternalServiceDocumentation?.ExpandedObject;
+            set => this.InternalServiceDocumentation = SetExpandableFieldObject(value, this.InternalServiceDocumentation);
         }
 
         [JsonProperty("service_documentation")]
@@ -278,8 +278,8 @@ namespace Stripe
         [JsonIgnore]
         public string ShippingDocumentationId
         {
-            get => this.InternalShippingDocumentation.Id;
-            set => this.InternalShippingDocumentation.Id = value;
+            get => this.InternalShippingDocumentation?.Id;
+            set => this.InternalShippingDocumentation = SetExpandableFieldId(value, this.InternalShippingDocumentation);
         }
 
         /// <summary>
@@ -291,8 +291,8 @@ namespace Stripe
         [JsonIgnore]
         public File ShippingDocumentation
         {
-            get => this.InternalShippingDocumentation.ExpandedObject;
-            set => this.InternalShippingDocumentation.ExpandedObject = value;
+            get => this.InternalShippingDocumentation?.ExpandedObject;
+            set => this.InternalShippingDocumentation = SetExpandableFieldObject(value, this.InternalShippingDocumentation);
         }
 
         [JsonProperty("shipping_documentation")]
@@ -312,8 +312,8 @@ namespace Stripe
         [JsonIgnore]
         public string UncategorizedFileId
         {
-            get => this.InternalUncategorizedFile.Id;
-            set => this.InternalUncategorizedFile.Id = value;
+            get => this.InternalUncategorizedFile?.Id;
+            set => this.InternalUncategorizedFile = SetExpandableFieldId(value, this.InternalUncategorizedFile);
         }
 
         /// <summary>
@@ -322,8 +322,8 @@ namespace Stripe
         [JsonIgnore]
         public File UncategorizedFile
         {
-            get => this.InternalUncategorizedFile.ExpandedObject;
-            set => this.InternalUncategorizedFile.ExpandedObject = value;
+            get => this.InternalUncategorizedFile?.ExpandedObject;
+            set => this.InternalUncategorizedFile = SetExpandableFieldObject(value, this.InternalUncategorizedFile);
         }
 
         [JsonProperty("uncategorized_file")]

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -48,8 +48,8 @@ namespace Stripe
         [JsonIgnore]
         public string FileId
         {
-            get => this.InternalFile.Id;
-            set => this.InternalFile.Id = value;
+            get => this.InternalFile?.Id;
+            set => this.InternalFile = SetExpandableFieldId(value, this.InternalFile);
         }
 
         /// <summary>
@@ -58,8 +58,8 @@ namespace Stripe
         [JsonIgnore]
         public File File
         {
-            get => this.InternalFile.ExpandedObject;
-            set => this.InternalFile.ExpandedObject = value;
+            get => this.InternalFile?.ExpandedObject;
+            set => this.InternalFile = SetExpandableFieldObject(value, this.InternalFile);
         }
 
         [JsonProperty("file")]

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -23,15 +23,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -59,15 +59,15 @@ namespace Stripe
         [JsonIgnore]
         public string InvoiceId
         {
-            get => this.InternalInvoice.Id;
-            set => this.InternalInvoice.Id = value;
+            get => this.InternalInvoice?.Id;
+            set => this.InternalInvoice = SetExpandableFieldId(value, this.InternalInvoice);
         }
 
         [JsonIgnore]
         public Invoice Invoice
         {
-            get => this.InternalInvoice.ExpandedObject;
-            set => this.InternalInvoice.ExpandedObject = value;
+            get => this.InternalInvoice?.ExpandedObject;
+            set => this.InternalInvoice = SetExpandableFieldObject(value, this.InternalInvoice);
         }
 
         [JsonProperty("invoice")]
@@ -97,15 +97,15 @@ namespace Stripe
         [JsonIgnore]
         public string SubscriptionId
         {
-            get => this.InternalSubscription.Id;
-            set => this.InternalSubscription.Id = value;
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
         [JsonIgnore]
         public Subscription Subscription
         {
-            get => this.InternalSubscription.ExpandedObject;
-            set => this.InternalSubscription.ExpandedObject = value;
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
         }
 
         [JsonProperty("subscription")]

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -67,15 +67,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]
@@ -97,15 +97,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -180,15 +180,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultPaymentMethodId
         {
-            get => this.InternalDefaultPaymentMethod.Id;
-            set => this.InternalDefaultPaymentMethod.Id = value;
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonIgnore]
         public PaymentMethod DefaultPaymentMethod
         {
-            get => this.InternalDefaultPaymentMethod.ExpandedObject;
-            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonProperty("default_payment_method")]
@@ -200,15 +200,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultSourceId
         {
-            get => this.InternalDefaultSource.Id;
-            set => this.InternalDefaultSource.Id = value;
+            get => this.InternalDefaultSource?.Id;
+            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
         }
 
         [JsonIgnore]
         public IPaymentSource DefaultSource
         {
-            get => this.InternalDefaultSource.ExpandedObject;
-            set => this.InternalDefaultSource.ExpandedObject = value;
+            get => this.InternalDefaultSource?.ExpandedObject;
+            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
         }
 
         [JsonProperty("default_source")]
@@ -279,8 +279,8 @@ namespace Stripe
         [JsonIgnore]
         public string PaymentIntentId
         {
-            get => this.InternalPaymentIntent.Id;
-            set => this.InternalPaymentIntent.Id = value;
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
         }
 
         /// <summary>
@@ -291,8 +291,8 @@ namespace Stripe
         [JsonIgnore]
         public PaymentIntent PaymentIntent
         {
-            get => this.InternalPaymentIntent.ExpandedObject;
-            set => this.InternalPaymentIntent.ExpandedObject = value;
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
         }
 
         [JsonProperty("payment_intent")]
@@ -339,15 +339,15 @@ namespace Stripe
         [JsonIgnore]
         public string SubscriptionId
         {
-            get => this.InternalSubscription.Id;
-            set => this.InternalSubscription.Id = value;
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
         [JsonIgnore]
         public Subscription Subscription
         {
-            get => this.InternalSubscription.ExpandedObject;
-            set => this.InternalSubscription.ExpandedObject = value;
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
         }
 
         [JsonProperty("subscription")]

--- a/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTaxAmount.cs
@@ -25,15 +25,15 @@ namespace Stripe
         [JsonIgnore]
         public string TaxRateId
         {
-            get => this.InternalTaxRate.Id;
-            set => this.InternalTaxRate.Id = value;
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
         }
 
         [JsonIgnore]
         public TaxRate TaxRate
         {
-            get => this.InternalTaxRate.ExpandedObject;
-            set => this.InternalTaxRate.ExpandedObject = value;
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
         }
 
         [JsonProperty("tax_rate")]

--- a/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTransferData.cs
@@ -9,15 +9,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -35,15 +35,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string CardholderId
         {
-            get => this.InternalCardholder.Id;
-            set => this.InternalCardholder.Id = value;
+            get => this.InternalCardholder?.Id;
+            set => this.InternalCardholder = SetExpandableFieldId(value, this.InternalCardholder);
         }
 
         [JsonIgnore]
         public Cardholder Cardholder
         {
-            get => this.InternalCardholder.ExpandedObject;
-            set => this.InternalCardholder.ExpandedObject = value;
+            get => this.InternalCardholder?.ExpandedObject;
+            set => this.InternalCardholder = SetExpandableFieldObject(value, this.InternalCardholder);
         }
 
         [JsonProperty("cardholder")]

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -51,15 +51,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string ReplacementForId
         {
-            get => this.InternalReplacementFor.Id;
-            set => this.InternalReplacementFor.Id = value;
+            get => this.InternalReplacementFor?.Id;
+            set => this.InternalReplacementFor = SetExpandableFieldId(value, this.InternalReplacementFor);
         }
 
         [JsonIgnore]
         public Card ReplacementFor
         {
-            get => this.InternalReplacementFor.ExpandedObject;
-            set => this.InternalReplacementFor.ExpandedObject = value;
+            get => this.InternalReplacementFor?.ExpandedObject;
+            set => this.InternalReplacementFor = SetExpandableFieldObject(value, this.InternalReplacementFor);
         }
 
         [JsonProperty("replacement_for")]

--- a/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardDetails.cs
@@ -13,15 +13,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string CardId
         {
-            get => this.InternalCard.Id;
-            set => this.InternalCard.Id = value;
+            get => this.InternalCard?.Id;
+            set => this.InternalCard = SetExpandableFieldId(value, this.InternalCard);
         }
 
         [JsonIgnore]
         public Card Card
         {
-            get => this.InternalCard.ExpandedObject;
-            set => this.InternalCard.ExpandedObject = value;
+            get => this.InternalCard?.ExpandedObject;
+            set => this.InternalCard = SetExpandableFieldObject(value, this.InternalCard);
         }
 
         [JsonProperty("card")]

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -39,15 +39,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string TransactionId
         {
-            get => this.InternalTransaction.Id;
-            set => this.InternalTransaction.Id = value;
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
         }
 
         [JsonIgnore]
         public Transaction Transaction
         {
-            get => this.InternalTransaction.ExpandedObject;
-            set => this.InternalTransaction.ExpandedObject = value;
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
         }
 
         [JsonProperty("transaction")]

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceFraudulent.cs
@@ -12,15 +12,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string UncategorizedFileId
         {
-            get => this.InternalUncategorizedFile.Id;
-            set => this.InternalUncategorizedFile.Id = value;
+            get => this.InternalUncategorizedFile?.Id;
+            set => this.InternalUncategorizedFile = SetExpandableFieldId(value, this.InternalUncategorizedFile);
         }
 
         [JsonIgnore]
         public File UncategorizedFile
         {
-            get => this.InternalUncategorizedFile.ExpandedObject;
-            set => this.InternalUncategorizedFile.ExpandedObject = value;
+            get => this.InternalUncategorizedFile?.ExpandedObject;
+            set => this.InternalUncategorizedFile = SetExpandableFieldObject(value, this.InternalUncategorizedFile);
         }
 
         [JsonProperty("uncategorized_file")]

--- a/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/EvidenceOther.cs
@@ -12,15 +12,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string UncategorizedFileId
         {
-            get => this.InternalUncategorizedFile.Id;
-            set => this.InternalUncategorizedFile.Id = value;
+            get => this.InternalUncategorizedFile?.Id;
+            set => this.InternalUncategorizedFile = SetExpandableFieldId(value, this.InternalUncategorizedFile);
         }
 
         [JsonIgnore]
         public File UncategorizedFile
         {
-            get => this.InternalUncategorizedFile.ExpandedObject;
-            set => this.InternalUncategorizedFile.ExpandedObject = value;
+            get => this.InternalUncategorizedFile?.ExpandedObject;
+            set => this.InternalUncategorizedFile = SetExpandableFieldObject(value, this.InternalUncategorizedFile);
         }
 
         [JsonProperty("uncategorized_file")]

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -20,15 +20,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string AuthorizationId
         {
-            get => this.InternalAuthorization.Id;
-            set => this.InternalAuthorization.Id = value;
+            get => this.InternalAuthorization?.Id;
+            set => this.InternalAuthorization = SetExpandableFieldId(value, this.InternalAuthorization);
         }
 
         [JsonIgnore]
         public Authorization Authorization
         {
-            get => this.InternalAuthorization.ExpandedObject;
-            set => this.InternalAuthorization.ExpandedObject = value;
+            get => this.InternalAuthorization?.ExpandedObject;
+            set => this.InternalAuthorization = SetExpandableFieldObject(value, this.InternalAuthorization);
         }
 
         [JsonProperty("authorization")]
@@ -40,15 +40,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -60,15 +60,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string CardId
         {
-            get => this.InternalCard.Id;
-            set => this.InternalCard.Id = value;
+            get => this.InternalCard?.Id;
+            set => this.InternalCard = SetExpandableFieldId(value, this.InternalCard);
         }
 
         [JsonIgnore]
         public Card Card
         {
-            get => this.InternalCard.ExpandedObject;
-            set => this.InternalCard.ExpandedObject = value;
+            get => this.InternalCard?.ExpandedObject;
+            set => this.InternalCard = SetExpandableFieldObject(value, this.InternalCard);
         }
 
         [JsonProperty("card")]
@@ -80,15 +80,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string CardholderId
         {
-            get => this.InternalCardholder.Id;
-            set => this.InternalCardholder.Id = value;
+            get => this.InternalCardholder?.Id;
+            set => this.InternalCardholder = SetExpandableFieldId(value, this.InternalCardholder);
         }
 
         [JsonIgnore]
         public Cardholder Cardholder
         {
-            get => this.InternalCardholder.ExpandedObject;
-            set => this.InternalCardholder.ExpandedObject = value;
+            get => this.InternalCardholder?.ExpandedObject;
+            set => this.InternalCardholder = SetExpandableFieldObject(value, this.InternalCardholder);
         }
 
         [JsonProperty("cardholder")]
@@ -107,15 +107,15 @@ namespace Stripe.Issuing
         [JsonIgnore]
         public string DisputeId
         {
-            get => this.InternalDispute.Id;
-            set => this.InternalDispute.Id = value;
+            get => this.InternalDispute?.Id;
+            set => this.InternalDispute = SetExpandableFieldId(value, this.InternalDispute);
         }
 
         [JsonIgnore]
         public Dispute Dispute
         {
-            get => this.InternalDispute.ExpandedObject;
-            set => this.InternalDispute.ExpandedObject = value;
+            get => this.InternalDispute?.ExpandedObject;
+            set => this.InternalDispute = SetExpandableFieldObject(value, this.InternalDispute);
         }
 
         [JsonProperty("dispute")]

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -40,15 +40,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]
@@ -80,8 +80,8 @@ namespace Stripe
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]

--- a/src/Stripe.net/Entities/Orders/OrderItem.cs
+++ b/src/Stripe.net/Entities/Orders/OrderItem.cs
@@ -34,15 +34,15 @@ namespace Stripe
         [JsonIgnore]
         public string ParentId
         {
-            get => this.InternalParent.Id;
-            set => this.InternalParent.Id = value;
+            get => this.InternalParent?.Id;
+            set => this.InternalParent = SetExpandableFieldId(value, this.InternalParent);
         }
 
         [JsonIgnore]
         public Sku Parent
         {
-            get => this.InternalParent.ExpandedObject;
-            set => this.InternalParent.ExpandedObject = value;
+            get => this.InternalParent?.ExpandedObject;
+            set => this.InternalParent = SetExpandableFieldObject(value, this.InternalParent);
         }
 
         [JsonProperty("parent")]

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -47,15 +47,15 @@ namespace Stripe
         [JsonIgnore]
         public string OrderId
         {
-            get => this.InternalOrder.Id;
-            set => this.InternalOrder.Id = value;
+            get => this.InternalOrder?.Id;
+            set => this.InternalOrder = SetExpandableFieldId(value, this.InternalOrder);
         }
 
         [JsonIgnore]
         public Order Order
         {
-            get => this.InternalOrder.ExpandedObject;
-            set => this.InternalOrder.ExpandedObject = value;
+            get => this.InternalOrder?.ExpandedObject;
+            set => this.InternalOrder = SetExpandableFieldObject(value, this.InternalOrder);
         }
 
         [JsonProperty("order")]
@@ -75,8 +75,8 @@ namespace Stripe
         [JsonIgnore]
         public Refund Refund
         {
-            get => this.InternalRefund.ExpandedObject;
-            set => this.InternalRefund.ExpandedObject = value;
+            get => this.InternalRefund?.ExpandedObject;
+            set => this.InternalRefund = SetExpandableFieldObject(value, this.InternalRefund);
         }
 
         [JsonProperty("refund")]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -26,15 +26,15 @@ namespace Stripe
         [JsonIgnore]
         public string ApplicationId
         {
-            get => this.InternalApplication.Id;
-            set => this.InternalApplication.Id = value;
+            get => this.InternalApplication?.Id;
+            set => this.InternalApplication = SetExpandableFieldId(value, this.InternalApplication);
         }
 
         [JsonIgnore]
         public Application Application
         {
-            get => this.InternalApplication.ExpandedObject;
-            set => this.InternalApplication.ExpandedObject = value;
+            get => this.InternalApplication?.ExpandedObject;
+            set => this.InternalApplication = SetExpandableFieldObject(value, this.InternalApplication);
         }
 
         [JsonProperty("application")]
@@ -75,15 +75,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -98,15 +98,15 @@ namespace Stripe
         [JsonIgnore]
         public string InvoiceId
         {
-            get => this.InternalInvoice.Id;
-            set => this.InternalInvoice.Id = value;
+            get => this.InternalInvoice?.Id;
+            set => this.InternalInvoice = SetExpandableFieldId(value, this.InternalInvoice);
         }
 
         [JsonIgnore]
         public Invoice Invoice
         {
-            get => this.InternalInvoice.ExpandedObject;
-            set => this.InternalInvoice.ExpandedObject = value;
+            get => this.InternalInvoice?.ExpandedObject;
+            set => this.InternalInvoice = SetExpandableFieldObject(value, this.InternalInvoice);
         }
 
         [JsonProperty("invoice")]
@@ -130,15 +130,15 @@ namespace Stripe
         [JsonIgnore]
         public string OnBehalfOfId
         {
-            get => this.InternalOnBehalfOf.Id;
-            set => this.InternalOnBehalfOf.Id = value;
+            get => this.InternalOnBehalfOf?.Id;
+            set => this.InternalOnBehalfOf = SetExpandableFieldId(value, this.InternalOnBehalfOf);
         }
 
         [JsonIgnore]
         public Account OnBehalfOf
         {
-            get => this.InternalOnBehalfOf.ExpandedObject;
-            set => this.InternalOnBehalfOf.ExpandedObject = value;
+            get => this.InternalOnBehalfOf?.ExpandedObject;
+            set => this.InternalOnBehalfOf = SetExpandableFieldObject(value, this.InternalOnBehalfOf);
         }
 
         [JsonProperty("on_behalf_of")]
@@ -150,15 +150,15 @@ namespace Stripe
         [JsonIgnore]
         public string PaymentMethodId
         {
-            get => this.InternalPaymentMethod.Id;
-            set => this.InternalPaymentMethod.Id = value;
+            get => this.InternalPaymentMethod?.Id;
+            set => this.InternalPaymentMethod = SetExpandableFieldId(value, this.InternalPaymentMethod);
         }
 
         [JsonIgnore]
         public PaymentMethod PaymentMethod
         {
-            get => this.InternalPaymentMethod.ExpandedObject;
-            set => this.InternalPaymentMethod.ExpandedObject = value;
+            get => this.InternalPaymentMethod?.ExpandedObject;
+            set => this.InternalPaymentMethod = SetExpandableFieldObject(value, this.InternalPaymentMethod);
         }
 
         [JsonProperty("payment_method")]
@@ -176,15 +176,15 @@ namespace Stripe
         [JsonIgnore]
         public string ReviewId
         {
-            get => this.InternalReview.Id;
-            set => this.InternalReview.Id = value;
+            get => this.InternalReview?.Id;
+            set => this.InternalReview = SetExpandableFieldId(value, this.InternalReview);
         }
 
         [JsonIgnore]
         public Review Review
         {
-            get => this.InternalReview.ExpandedObject;
-            set => this.InternalReview.ExpandedObject = value;
+            get => this.InternalReview?.ExpandedObject;
+            set => this.InternalReview = SetExpandableFieldObject(value, this.InternalReview);
         }
 
         [JsonProperty("review")]
@@ -199,15 +199,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceId
         {
-            get => this.InternalSource.Id;
-            set => this.InternalSource.Id = value;
+            get => this.InternalSource?.Id;
+            set => this.InternalSource = SetExpandableFieldId(value, this.InternalSource);
         }
 
         [JsonIgnore]
         public IPaymentSource Source
         {
-            get => this.InternalSource.ExpandedObject;
-            set => this.InternalSource.ExpandedObject = value;
+            get => this.InternalSource?.ExpandedObject;
+            set => this.InternalSource = SetExpandableFieldObject(value, this.InternalSource);
         }
 
         [JsonProperty("source")]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
@@ -10,15 +10,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -34,15 +34,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -27,15 +27,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -57,15 +57,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public IExternalAccount Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]
@@ -81,15 +81,15 @@ namespace Stripe
         [JsonIgnore]
         public string FailureBalanceTransactionId
         {
-            get => this.InternalFailureBalanceTransaction.Id;
-            set => this.InternalFailureBalanceTransaction.Id = value;
+            get => this.InternalFailureBalanceTransaction?.Id;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldId(value, this.InternalFailureBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction FailureBalanceTransaction
         {
-            get => this.InternalFailureBalanceTransaction.ExpandedObject;
-            set => this.InternalFailureBalanceTransaction.ExpandedObject = value;
+            get => this.InternalFailureBalanceTransaction?.ExpandedObject;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldObject(value, this.InternalFailureBalanceTransaction);
         }
 
         [JsonProperty("failure_balance_transaction")]

--- a/src/Stripe.net/Entities/Persons/PersonVerificationDocument.cs
+++ b/src/Stripe.net/Entities/Persons/PersonVerificationDocument.cs
@@ -15,8 +15,8 @@ namespace Stripe
         [JsonIgnore]
         public string BackId
         {
-            get => this.InternalBack.Id;
-            set => this.InternalBack.Id = value;
+            get => this.InternalBack?.Id;
+            set => this.InternalBack = SetExpandableFieldId(value, this.InternalBack);
         }
 
         /// <summary>
@@ -26,8 +26,8 @@ namespace Stripe
         [JsonIgnore]
         public File Back
         {
-            get => this.InternalBack.ExpandedObject;
-            set => this.InternalBack.ExpandedObject = value;
+            get => this.InternalBack?.ExpandedObject;
+            set => this.InternalBack = SetExpandableFieldObject(value, this.InternalBack);
         }
 
         [JsonProperty("back")]
@@ -59,8 +59,8 @@ namespace Stripe
         [JsonIgnore]
         public string FrontId
         {
-            get => this.InternalFront.Id;
-            set => this.InternalFront.Id = value;
+            get => this.InternalFront?.Id;
+            set => this.InternalFront = SetExpandableFieldId(value, this.InternalFront);
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace Stripe
         [JsonIgnore]
         public File Front
         {
-            get => this.InternalFront.ExpandedObject;
-            set => this.InternalFront.ExpandedObject = value;
+            get => this.InternalFront?.ExpandedObject;
+            set => this.InternalFront = SetExpandableFieldObject(value, this.InternalFront);
         }
 
         [JsonProperty("front")]

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -62,15 +62,15 @@ namespace Stripe
         [JsonIgnore]
         public string ProductId
         {
-            get => this.InternalProduct.Id;
-            set => this.InternalProduct.Id = value;
+            get => this.InternalProduct?.Id;
+            set => this.InternalProduct = SetExpandableFieldId(value, this.InternalProduct);
         }
 
         [JsonIgnore]
         public Product Product
         {
-            get => this.InternalProduct.ExpandedObject;
-            set => this.InternalProduct.ExpandedObject = value;
+            get => this.InternalProduct?.ExpandedObject;
+            set => this.InternalProduct = SetExpandableFieldObject(value, this.InternalProduct);
         }
 
         [JsonProperty("product")]

--- a/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
+++ b/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
@@ -31,15 +31,15 @@ namespace Stripe.Radar
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -27,15 +27,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultCardId
         {
-            get => this.InternalDefaultCard.Id;
-            set => this.InternalDefaultCard.Id = value;
+            get => this.InternalDefaultCard?.Id;
+            set => this.InternalDefaultCard = SetExpandableFieldId(value, this.InternalDefaultCard);
         }
 
         [JsonIgnore]
         public Card DefaultCard
         {
-            get => this.InternalDefaultCard.ExpandedObject;
-            set => this.InternalDefaultCard.ExpandedObject = value;
+            get => this.InternalDefaultCard?.ExpandedObject;
+            set => this.InternalDefaultCard = SetExpandableFieldObject(value, this.InternalDefaultCard);
         }
 
         [JsonProperty("default_card")]

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -20,15 +20,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -40,15 +40,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]
@@ -70,15 +70,15 @@ namespace Stripe
         [JsonIgnore]
         public string FailureBalanceTransactionId
         {
-            get => this.InternalFailureBalanceTransaction.Id;
-            set => this.InternalFailureBalanceTransaction.Id = value;
+            get => this.InternalFailureBalanceTransaction?.Id;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldId(value, this.InternalFailureBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction FailureBalanceTransaction
         {
-            get => this.InternalFailureBalanceTransaction.ExpandedObject;
-            set => this.InternalFailureBalanceTransaction.ExpandedObject = value;
+            get => this.InternalFailureBalanceTransaction?.ExpandedObject;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldObject(value, this.InternalFailureBalanceTransaction);
         }
 
         [JsonProperty("failure_balance_transaction")]
@@ -102,15 +102,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceTransferReversalId
         {
-            get => this.InternalSourceTransferReversal.Id;
-            set => this.InternalSourceTransferReversal.Id = value;
+            get => this.InternalSourceTransferReversal?.Id;
+            set => this.InternalSourceTransferReversal = SetExpandableFieldId(value, this.InternalSourceTransferReversal);
         }
 
         [JsonIgnore]
         public TransferReversal SourceTransferReversal
         {
-            get => this.InternalSourceTransferReversal.ExpandedObject;
-            set => this.InternalSourceTransferReversal.ExpandedObject = value;
+            get => this.InternalSourceTransferReversal?.ExpandedObject;
+            set => this.InternalSourceTransferReversal = SetExpandableFieldObject(value, this.InternalSourceTransferReversal);
         }
 
         [JsonProperty("source_transfer_reversal")]
@@ -125,15 +125,15 @@ namespace Stripe
         [JsonIgnore]
         public string TransferReversalId
         {
-            get => this.InternalTransferReversal.Id;
-            set => this.InternalTransferReversal.Id = value;
+            get => this.InternalTransferReversal?.Id;
+            set => this.InternalTransferReversal = SetExpandableFieldId(value, this.InternalTransferReversal);
         }
 
         [JsonIgnore]
         public TransferReversal TransferReversal
         {
-            get => this.InternalTransferReversal.ExpandedObject;
-            set => this.InternalTransferReversal.ExpandedObject = value;
+            get => this.InternalTransferReversal?.ExpandedObject;
+            set => this.InternalTransferReversal = SetExpandableFieldObject(value, this.InternalTransferReversal);
         }
 
         [JsonProperty("transfer_reversal")]

--- a/src/Stripe.net/Entities/Reviews/Review.cs
+++ b/src/Stripe.net/Entities/Reviews/Review.cs
@@ -16,15 +16,15 @@ namespace Stripe
         [JsonIgnore]
         public string ChargeId
         {
-            get => this.InternalCharge.Id;
-            set => this.InternalCharge.Id = value;
+            get => this.InternalCharge?.Id;
+            set => this.InternalCharge = SetExpandableFieldId(value, this.InternalCharge);
         }
 
         [JsonIgnore]
         public Charge Charge
         {
-            get => this.InternalCharge.ExpandedObject;
-            set => this.InternalCharge.ExpandedObject = value;
+            get => this.InternalCharge?.ExpandedObject;
+            set => this.InternalCharge = SetExpandableFieldObject(value, this.InternalCharge);
         }
 
         [JsonProperty("charge")]
@@ -46,15 +46,15 @@ namespace Stripe
         [JsonIgnore]
         public string PaymentIntentId
         {
-            get => this.InternalPaymentIntent.Id;
-            set => this.InternalPaymentIntent.Id = value;
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
         }
 
         [JsonIgnore]
         public PaymentIntent PaymentIntent
         {
-            get => this.InternalPaymentIntent.ExpandedObject;
-            set => this.InternalPaymentIntent.ExpandedObject = value;
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
         }
 
         [JsonProperty("payment_intent")]

--- a/src/Stripe.net/Entities/Skus/Sku.cs
+++ b/src/Stripe.net/Entities/Skus/Sku.cs
@@ -88,15 +88,15 @@ namespace Stripe
         [JsonIgnore]
         public string ProductId
         {
-            get => this.InternalProduct.Id;
-            set => this.InternalProduct.Id = value;
+            get => this.InternalProduct?.Id;
+            set => this.InternalProduct = SetExpandableFieldId(value, this.InternalProduct);
         }
 
         [JsonIgnore]
         public Product Product
         {
-            get => this.InternalProduct.ExpandedObject;
-            set => this.InternalProduct.ExpandedObject = value;
+            get => this.InternalProduct?.ExpandedObject;
+            set => this.InternalProduct = SetExpandableFieldObject(value, this.InternalProduct);
         }
 
         [JsonProperty("product")]

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -66,15 +66,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -96,15 +96,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultPaymentMethodId
         {
-            get => this.InternalDefaultPaymentMethod.Id;
-            set => this.InternalDefaultPaymentMethod.Id = value;
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonIgnore]
         public PaymentMethod DefaultPaymentMethod
         {
-            get => this.InternalDefaultPaymentMethod.ExpandedObject;
-            set => this.InternalDefaultPaymentMethod.ExpandedObject = value;
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
         }
 
         [JsonProperty("default_payment_method")]
@@ -116,15 +116,15 @@ namespace Stripe
         [JsonIgnore]
         public string DefaultSourceId
         {
-            get => this.InternalDefaultSource.Id;
-            set => this.InternalDefaultSource.Id = value;
+            get => this.InternalDefaultSource?.Id;
+            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
         }
 
         [JsonIgnore]
         public IPaymentSource DefaultSource
         {
-            get => this.InternalDefaultSource.ExpandedObject;
-            set => this.InternalDefaultSource.ExpandedObject = value;
+            get => this.InternalDefaultSource?.ExpandedObject;
+            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
         }
 
         [JsonProperty("default_source")]
@@ -152,15 +152,15 @@ namespace Stripe
         [JsonIgnore]
         public string LatestInvoiceId
         {
-            get => this.InternalLatestInvoice.Id;
-            set => this.InternalLatestInvoice.Id = value;
+            get => this.InternalLatestInvoice?.Id;
+            set => this.InternalLatestInvoice = SetExpandableFieldId(value, this.InternalLatestInvoice);
         }
 
         [JsonIgnore]
         public Invoice LatestInvoice
         {
-            get => this.InternalLatestInvoice.ExpandedObject;
-            set => this.InternalLatestInvoice.ExpandedObject = value;
+            get => this.InternalLatestInvoice?.ExpandedObject;
+            set => this.InternalLatestInvoice = SetExpandableFieldObject(value, this.InternalLatestInvoice);
         }
 
         [JsonProperty("latest_invoice")]

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionTransferData.cs
@@ -9,15 +9,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -74,8 +74,8 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         /// <summary>
@@ -84,8 +84,8 @@ namespace Stripe
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]
@@ -167,8 +167,8 @@ namespace Stripe
         [JsonIgnore]
         public string SubscriptionId
         {
-            get => this.InternalSubscription.Id;
-            set => this.InternalSubscription.Id = value;
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
         /// <summary>
@@ -177,8 +177,8 @@ namespace Stripe
         [JsonIgnore]
         public Subscription Subscription
         {
-            get => this.InternalSubscription.ExpandedObject;
-            set => this.InternalSubscription.ExpandedObject = value;
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
         }
 
         [JsonProperty("subscription")]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
@@ -24,8 +24,8 @@ namespace Stripe
         [JsonIgnore]
         public string CouponId
         {
-            get => this.InternalCoupon.Id;
-            set => this.InternalCoupon.Id = value;
+            get => this.InternalCoupon?.Id;
+            set => this.InternalCoupon = SetExpandableFieldId(value, this.InternalCoupon);
         }
 
         /// <summary>
@@ -35,8 +35,8 @@ namespace Stripe
         [JsonIgnore]
         public Coupon Coupon
         {
-            get => this.InternalCoupon.ExpandedObject;
-            set => this.InternalCoupon.ExpandedObject = value;
+            get => this.InternalCoupon?.ExpandedObject;
+            set => this.InternalCoupon = SetExpandableFieldObject(value, this.InternalCoupon);
         }
 
         [JsonProperty("coupon")]

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
@@ -22,8 +22,8 @@ namespace Stripe
         [JsonIgnore]
         public string PlanId
         {
-            get => this.InternalPlan.Id;
-            set => this.InternalPlan.Id = value;
+            get => this.InternalPlan?.Id;
+            set => this.InternalPlan = SetExpandableFieldId(value, this.InternalPlan);
         }
 
         /// <summary>
@@ -32,8 +32,8 @@ namespace Stripe
         [JsonIgnore]
         public Plan Plan
         {
-            get => this.InternalPlan.ExpandedObject;
-            set => this.InternalPlan.ExpandedObject = value;
+            get => this.InternalPlan?.ExpandedObject;
+            set => this.InternalPlan = SetExpandableFieldObject(value, this.InternalPlan);
         }
 
         [JsonProperty("plan")]

--- a/src/Stripe.net/Entities/TaxIds/TaxId.cs
+++ b/src/Stripe.net/Entities/TaxIds/TaxId.cs
@@ -40,15 +40,15 @@ namespace Stripe
         [JsonIgnore]
         public string CustomerId
         {
-            get => this.InternalCustomer.Id;
-            set => this.InternalCustomer.Id = value;
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
         [JsonIgnore]
         public Customer Customer
         {
-            get => this.InternalCustomer.ExpandedObject;
-            set => this.InternalCustomer.ExpandedObject = value;
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
         }
 
         [JsonProperty("customer")]

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -30,8 +30,8 @@ namespace Stripe
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]

--- a/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
+++ b/src/Stripe.net/Entities/TransferReversals/TransferReversal.cs
@@ -20,15 +20,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -47,15 +47,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationPaymentRefundId
         {
-            get => this.InternalDestinationPaymentRefund.Id;
-            set => this.InternalDestinationPaymentRefund.Id = value;
+            get => this.InternalDestinationPaymentRefund?.Id;
+            set => this.InternalDestinationPaymentRefund = SetExpandableFieldId(value, this.InternalDestinationPaymentRefund);
         }
 
         [JsonIgnore]
         public Refund DestinationPaymentRefund
         {
-            get => this.InternalDestinationPaymentRefund.ExpandedObject;
-            set => this.InternalDestinationPaymentRefund.ExpandedObject = value;
+            get => this.InternalDestinationPaymentRefund?.ExpandedObject;
+            set => this.InternalDestinationPaymentRefund = SetExpandableFieldObject(value, this.InternalDestinationPaymentRefund);
         }
 
         [JsonProperty("destination_payment_refund")]
@@ -70,15 +70,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceRefundId
         {
-            get => this.InternalSourceRefund.Id;
-            set => this.InternalSourceRefund.Id = value;
+            get => this.InternalSourceRefund?.Id;
+            set => this.InternalSourceRefund = SetExpandableFieldId(value, this.InternalSourceRefund);
         }
 
         [JsonIgnore]
         public Refund SourceRefund
         {
-            get => this.InternalSourceRefund.ExpandedObject;
-            set => this.InternalSourceRefund.ExpandedObject = value;
+            get => this.InternalSourceRefund?.ExpandedObject;
+            set => this.InternalSourceRefund = SetExpandableFieldObject(value, this.InternalSourceRefund);
         }
 
         [JsonProperty("source_refund")]
@@ -90,15 +90,15 @@ namespace Stripe
         [JsonIgnore]
         public string TransferId
         {
-            get => this.InternalTransfer.Id;
-            set => this.InternalTransfer.Id = value;
+            get => this.InternalTransfer?.Id;
+            set => this.InternalTransfer = SetExpandableFieldId(value, this.InternalTransfer);
         }
 
         [JsonIgnore]
         public Transfer Transfer
         {
-            get => this.InternalTransfer.ExpandedObject;
-            set => this.InternalTransfer.ExpandedObject = value;
+            get => this.InternalTransfer?.ExpandedObject;
+            set => this.InternalTransfer = SetExpandableFieldObject(value, this.InternalTransfer);
         }
 
         [JsonProperty("transfer")]

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -23,15 +23,15 @@ namespace Stripe
         [JsonIgnore]
         public string BalanceTransactionId
         {
-            get => this.InternalBalanceTransaction.Id;
-            set => this.InternalBalanceTransaction.Id = value;
+            get => this.InternalBalanceTransaction?.Id;
+            set => this.InternalBalanceTransaction = SetExpandableFieldId(value, this.InternalBalanceTransaction);
         }
 
         [JsonIgnore]
         public BalanceTransaction BalanceTransaction
         {
-            get => this.InternalBalanceTransaction.ExpandedObject;
-            set => this.InternalBalanceTransaction.ExpandedObject = value;
+            get => this.InternalBalanceTransaction?.ExpandedObject;
+            set => this.InternalBalanceTransaction = SetExpandableFieldObject(value, this.InternalBalanceTransaction);
         }
 
         [JsonProperty("balance_transaction")]
@@ -53,15 +53,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationId
         {
-            get => this.InternalDestination.Id;
-            set => this.InternalDestination.Id = value;
+            get => this.InternalDestination?.Id;
+            set => this.InternalDestination = SetExpandableFieldId(value, this.InternalDestination);
         }
 
         [JsonIgnore]
         public Account Destination
         {
-            get => this.InternalDestination.ExpandedObject;
-            set => this.InternalDestination.ExpandedObject = value;
+            get => this.InternalDestination?.ExpandedObject;
+            set => this.InternalDestination = SetExpandableFieldObject(value, this.InternalDestination);
         }
 
         [JsonProperty("destination")]
@@ -73,15 +73,15 @@ namespace Stripe
         [JsonIgnore]
         public string DestinationPaymentId
         {
-            get => this.InternalDestinationPayment.Id;
-            set => this.InternalDestinationPayment.Id = value;
+            get => this.InternalDestinationPayment?.Id;
+            set => this.InternalDestinationPayment = SetExpandableFieldId(value, this.InternalDestinationPayment);
         }
 
         [JsonIgnore]
         public Charge DestinationPayment
         {
-            get => this.InternalDestinationPayment.ExpandedObject;
-            set => this.InternalDestinationPayment.ExpandedObject = value;
+            get => this.InternalDestinationPayment?.ExpandedObject;
+            set => this.InternalDestinationPayment = SetExpandableFieldObject(value, this.InternalDestinationPayment);
         }
 
         [JsonProperty("destination_payment")]
@@ -105,15 +105,15 @@ namespace Stripe
         [JsonIgnore]
         public string SourceTransactionId
         {
-            get => this.InternalSourceTransaction.Id;
-            set => this.InternalSourceTransaction.Id = value;
+            get => this.InternalSourceTransaction?.Id;
+            set => this.InternalSourceTransaction = SetExpandableFieldId(value, this.InternalSourceTransaction);
         }
 
         [JsonIgnore]
         public Charge SourceTransaction
         {
-            get => this.InternalSourceTransaction.ExpandedObject;
-            set => this.InternalSourceTransaction.ExpandedObject = value;
+            get => this.InternalSourceTransaction?.ExpandedObject;
+            set => this.InternalSourceTransaction = SetExpandableFieldObject(value, this.InternalSourceTransaction);
         }
 
         [JsonProperty("source_transaction")]

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -57,6 +57,60 @@ namespace Stripe
                 StripeConfiguration.SerializerSettings);
         }
 
+        /// <summary>
+        /// Sets a string ID on an expandable field. If the expandable field does not exist,
+        /// a new one is initialized. If the expandable field exists and already contains an
+        /// expanded object, and the ID within the expanded object does not match the new string ID,
+        /// expanded object is discarded.
+        /// </summary>
+        /// <typeparam name="T">Type of the expanded object.</typeparam>
+        /// <param name="id">The string ID.</param>
+        /// <param name="expandable">The expandable field.</param>
+        /// <returns>The expandable field with its ID set to the provided string ID.</returns>
+        protected static ExpandableField<T> SetExpandableFieldId<T>(
+            string id,
+            ExpandableField<T> expandable)
+            where T : IHasId
+        {
+            if (expandable == null)
+            {
+                expandable = new ExpandableField<T>();
+                expandable.Id = id;
+            }
+            else if (expandable.Id != id)
+            {
+                expandable.ExpandedObject = default(T);
+                expandable.Id = id;
+            }
+
+            return expandable;
+        }
+
+        /// <summary>
+        /// Sets an expanded object on an expandable field. If the expandable field does not exist,
+        /// a new one is initialized.
+        /// </summary>
+        /// <typeparam name="T">Type of the expanded object.</typeparam>
+        /// <param name="obj">The expanded object.</param>
+        /// <param name="expandable">The expandable field.</param>
+        /// <returns>
+        /// The expandable field with its expanded object set to the provided object.
+        /// </returns>
+        protected static ExpandableField<T> SetExpandableFieldObject<T>(
+            T obj,
+            ExpandableField<T> expandable)
+            where T : IHasId
+        {
+            if (expandable == null)
+            {
+                expandable = new ExpandableField<T>();
+            }
+
+            expandable.ExpandedObject = obj;
+
+            return expandable;
+        }
+
         private object GetIdString()
         {
             foreach (var property in this.GetType().GetTypeInfo().DeclaredProperties)

--- a/src/StripeTests/Entities/Customers/CustomerTest.cs
+++ b/src/StripeTests/Entities/Customers/CustomerTest.cs
@@ -58,5 +58,31 @@ namespace StripeTests
             Assert.IsType<Card>(customer.DefaultSource);
             Assert.Equal("card", customer.DefaultSource.Object);
         }
+
+        [Fact]
+        public void DefaultSourceId_Setter()
+        {
+            var customer = new Customer
+            {
+                DefaultSourceId = "card_123",
+            };
+
+            Assert.Equal("card_123", customer.DefaultSourceId);
+            Assert.Null(customer.DefaultSource);
+        }
+
+        [Fact]
+        public void DefaultSource_Setter()
+        {
+            var customer = new Customer
+            {
+                DefaultSource = new Card { Id = "card_123", Object = "card" },
+            };
+
+            Assert.Equal("card_123", customer.DefaultSourceId);
+            Assert.NotNull(customer.DefaultSource);
+            Assert.Equal("card_123", customer.DefaultSource.Id);
+            Assert.Equal("card", customer.DefaultSource.Object);
+        }
     }
 }

--- a/src/StripeTests/Entities/_base/StripeEntityTest.cs
+++ b/src/StripeTests/Entities/_base/StripeEntityTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using Newtonsoft.Json;
     using Stripe;
+    using Stripe.Infrastructure;
     using Xunit;
 
     public class StripeEntityTest
@@ -73,8 +74,71 @@ namespace StripeTests
 
             var json = o.ToJson().Replace("\r\n", "\n");
 
-            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\"\n}";
+            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\",\n  \"nested\": null\n}";
             Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void ExpandableAccessors_Id()
+        {
+            var o = new TestEntity
+            {
+                NestedId = "id_unexpanded",
+            };
+
+            Assert.Equal("id_unexpanded", o.NestedId);
+            Assert.Null(o.Nested);
+        }
+
+        [Fact]
+        public void ExpandableAccessors_ExpandedObject()
+        {
+            var o = new TestEntity
+            {
+                Nested = new TestNestedEntity { Id = "id_expanded", Bar = 42 },
+            };
+
+            Assert.Equal("id_expanded", o.NestedId);
+            Assert.NotNull(o.Nested);
+            Assert.Equal("id_expanded", o.Nested.Id);
+            Assert.Equal(42, o.Nested.Bar);
+        }
+
+        [Fact]
+        public void ExpandableAccessors_Null()
+        {
+            var o = new TestEntity();
+
+            Assert.Null(o.NestedId);
+            Assert.Null(o.Nested);
+        }
+
+        [Fact]
+        public void ExpandableAccessors_Id_ResetsExistingExpandedObjectIfIdIsDifferent()
+        {
+            var o = new TestEntity
+            {
+                Nested = new TestNestedEntity { Id = "id_expanded", Bar = 42 },
+            };
+            o.NestedId = "id_new";
+
+            Assert.Equal("id_new", o.NestedId);
+            Assert.Null(o.Nested);
+        }
+
+        [Fact]
+        public void ExpandableAccessors_Id_DoesNotResetExistingExpandedObjectIfIdIsSame()
+        {
+            var o = new TestEntity
+            {
+                Nested = new TestNestedEntity { Id = "id_expanded", Bar = 42 },
+            };
+            o.NestedId = "id_expanded";
+
+            Assert.Equal("id_expanded", o.NestedId);
+            Assert.NotNull(o.Nested);
+            Assert.Equal("id_expanded", o.Nested.Id);
+            Assert.Equal(42, o.Nested.Bar);
         }
 
         private class TestEntity : StripeEntity<TestEntity>
@@ -84,6 +148,33 @@ namespace StripeTests
 
             [JsonProperty("string")]
             public string String { get; set; }
+
+            [JsonIgnore]
+            public string NestedId
+            {
+                get => this.InternalNested?.Id;
+                set => this.InternalNested = SetExpandableFieldId(value, this.InternalNested);
+            }
+
+            [JsonIgnore]
+            public TestNestedEntity Nested
+            {
+                get => this.InternalNested?.ExpandedObject;
+                set => this.InternalNested = SetExpandableFieldObject(value, this.InternalNested);
+            }
+
+            [JsonProperty("nested")]
+            [JsonConverter(typeof(ExpandableFieldConverter<TestNestedEntity>))]
+            internal ExpandableField<TestNestedEntity> InternalNested { get; set; }
+        }
+
+        private class TestNestedEntity : StripeEntity<TestNestedEntity>, IHasId
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("bar")]
+            public int Bar { get; set; }
         }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

A few changes to avoid possible `NullReferenceException`s when using accessors for expandable fields:
- add safe navigation operator to all getters
- use new helper methods for all setters:
    - when setting the ID, `SetExpandableFieldId` will create the `ExpandableField<T>` instance if it doesn't exist already, and resets the expanded object if the IDs don't match
    - when setting the expanded object, `SetExpandableFieldObject` will create the `ExpandableField<T>` instance if it doesn't exist already.

I've written some generic tests for `StripeEntity` to test the helper methods, and also a few tests for `Customer.DefaultSource` so that we test at least one "real" expandable field. It doesn't seem realistic to write tests for every single expandable field accessor, so I guess we'll just have to be careful with copy/paste when adding new expandable fields.

(I have a vague idea for simplifying the expandable field accessor mess, but I'll keep that for a future major version.)

(Also, I think the entity classes should not have public setters at all and should be implemented as immutable [value objects](https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects), but that would require writing very long constructor methods, so not going to do that until we can codegen .NET.)

Fixes #1659.
