### PR TITLE
Fix handling of null values with AnyOf

### DIFF
--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -101,7 +101,7 @@ namespace Stripe.Infrastructure.FormEncoding
                     break;
 
                 case IAnyOf anyOf:
-                    flatParams = FlattenParamsValue(anyOf.Value, keyPrefix);
+                    flatParams = FlattenParamsAnyOf(anyOf, keyPrefix);
                     break;
 
                 case INestedOptions options:
@@ -140,6 +140,32 @@ namespace Stripe.Infrastructure.FormEncoding
                         string.Format(CultureInfo.InvariantCulture, "{0}", value));
                     break;
             }
+
+            return flatParams;
+        }
+
+        /// <summary>
+        /// Returns a list of parameters for a given <see cref="IAnyOf"/> instance.
+        /// </summary>
+        /// <param name="anyOf">The instance for which to create the list of parameters.</param>
+        /// <param name="keyPrefix">The key under which new keys should be nested, if any.</param>
+        /// <returns>The list of parameters.</returns>
+        private static List<KeyValuePair<string, object>> FlattenParamsAnyOf(
+            IAnyOf anyOf,
+            string keyPrefix)
+        {
+            List<KeyValuePair<string, object>> flatParams = new List<KeyValuePair<string, object>>();
+
+            // If the value contained within the `AnyOf` instance is null, we don't encode it in the
+            // request. We do this to mimic the behavior of regular (non-`AnyOf`) properties in
+            // options classes, which are skipped by the encoder when they have a null value
+            // because it's the default value (cf. FlattenParamsOptions).
+            if (anyOf.Value == null)
+            {
+                return flatParams;
+            }
+
+            flatParams.AddRange(FlattenParamsValue(anyOf.Value, keyPrefix));
 
             return flatParams;
         }

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -122,6 +122,30 @@ namespace StripeTests
                     },
                     want = "any_of[foo]=bar"
                 },
+                new
+                {
+                    data = new TestOptions
+                    {
+                        AnyOf = null, // AnyOf itself is null
+                    },
+                    want = string.Empty
+                },
+                new
+                {
+                    data = new TestOptions
+                    {
+                        AnyOf = (string)null, // AnyOf is not null but AnyOf.Value is null
+                    },
+                    want = string.Empty
+                },
+                new
+                {
+                    data = new TestOptions
+                    {
+                        AnyOf = (Dictionary<string, string>)null, // same as above, AnyOf.Value is null
+                    },
+                    want = string.Empty
+                },
 
                 // Array
                 new

--- a/src/StripeTests/Services/Charges/ChargeCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeCreateOptionsTest.cs
@@ -1,0 +1,94 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class ChargeCreateOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var testCases = new[]
+            {
+                // No data
+                new
+                {
+                    data = new ChargeCreateOptions { },
+                    want = string.Empty
+                },
+
+                // Source is a non-null, non-empty string
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = "tok_visa",
+                    },
+                    want = "source=tok_visa"
+                },
+
+                // Source is a non-null, empty string
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = string.Empty,
+                    },
+                    want = "source="
+                },
+
+                // Source is a null string
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = (string)null,
+                    },
+                    want = string.Empty
+                },
+
+                // Source is a non-null CardCreateNestedOptions
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = new CardCreateNestedOptions
+                        {
+                            Number = "4242424242424242",
+                            ExpMonth = 1,
+                            ExpYear = 2030,
+                        },
+                    },
+                    want = "source[object]=card&source[exp_month]=1&source[exp_year]=2030&source[number]=4242424242424242"
+                },
+
+                // Source is a null CardCreateNestedOptions
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = (CardCreateNestedOptions)null,
+                    },
+                    want = string.Empty
+                },
+
+                // Source is null
+                new
+                {
+                    data = new ChargeCreateOptions
+                    {
+                        Source = null,
+                    },
+                    want = string.Empty
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, FormEncoder.CreateQueryString(testCase.data));
+            }
+        }
+    }
+}

--- a/src/StripeTests/Services/_base/ListOptionsWithCreatedTest.cs
+++ b/src/StripeTests/Services/_base/ListOptionsWithCreatedTest.cs
@@ -37,7 +37,7 @@ namespace StripeTests
                 Created = (DateTime?)null,
             };
 
-            Assert.Equal("created=", FormEncoder.CreateQueryString(options));
+            Assert.Equal(string.Empty, FormEncoder.CreateQueryString(options));
         }
 
         [Fact]


### PR DESCRIPTION
r? @remi-stripe @fred-stripe 
cc @stripe/api-libraries 

Fix handling of `null` values with `AnyOf` in the encoder. `null` values are now ignored, like they would be for a non-`AnyOf` property.
