### PR TITLE
[wip] Add EmptyValue enum for unsettable values

### DIFF
--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -63,7 +63,7 @@ namespace Stripe
         public List<string> PreferredLocales { get; set; }
 
         [JsonProperty("shipping")]
-        public ShippingOptions Shipping { get; set; }
+        public AnyOf<ShippingOptions, EmptyValue> Shipping { get; set; }
 
         /// <summary>
         /// A Token’s or a Source’s ID, as returned by

--- a/src/Stripe.net/Services/_common/EmptyValue.cs
+++ b/src/Stripe.net/Services/_common/EmptyValue.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    public class EmptyValue : StringEnum
+    {
+        /// <summary>Empties the value.</summary>
+        public static readonly EmptyValue Empty = new EmptyValue(string.Empty);
+
+        private EmptyValue(string value)
+            : base(value)
+        {
+        }
+    }
+}

--- a/src/StripeTests/Services/Customers/CustomerUpdateOptionsTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerUpdateOptionsTest.cs
@@ -1,0 +1,42 @@
+namespace StripeTests
+{
+    using System;
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class CustomerUpdateOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeShipping()
+        {
+            var testCases = new[]
+            {
+                new
+                {
+                    options = new CustomerUpdateOptions
+                    {
+                        Shipping = new ShippingOptions
+                        {
+                            Name = "Jenny Rosen",
+                        }
+                    },
+                    want = "shipping[name]=Jenny+Rosen",
+                },
+                new
+                {
+                    options = new CustomerUpdateOptions
+                    {
+                        Shipping = EmptyValue.Empty,
+                    },
+                    want = "shipping=",
+                },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Equal(testCase.want, FormEncoder.CreateQueryString(testCase.options));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just a quick proof of concept to add support for sending empty strings to unset values, similar to stripe-java's `EmptyParam`.
