### PR TITLE
Manually enable TLS 1.2 for .NET Framework 4.5

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -55,6 +55,12 @@ namespace Stripe
             int maxNetworkRetries = 0,
             AppInfo appInfo = null)
         {
+#if NET45
+            // With .NET Framework 4.5, it's necessary to manually enable support for TLS 1.2.
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol |
+                SecurityProtocolType.Tls12;
+#endif
+
             this.httpClient = httpClient ?? BuildDefaultSystemNetHttpClient();
             this.maxNetworkRetries = maxNetworkRetries;
             this.appInfo = appInfo;


### PR DESCRIPTION
r? @remi-stripe @brandur-stripe 
cc @stripe/api-libraries 

With .NET Framework 4.5, it's necessary to manually enable support for TLS 1.2, otherwise connections will use TLS 1.0 and be denied (with a very unclear error) by Stripe's servers.

The library used to do this already (https://github.com/stripe/stripe-dotnet/blob/3c470d7b8767d8cecc21a19fdc4894a4ea6959ef/src/Stripe.net/Infrastructure/Requestor.cs#L125-L127), but it was lost during the refactoring of the request infrastructure in v27.

Fixes #1667.