### PR TITLE
Remove formatting from Telemetry

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
+++ b/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
@@ -37,7 +37,7 @@ namespace Stripe
 
             var payload = new ClientTelemetryPayload { LastRequestMetrics = requestMetrics };
 
-            headers.Add("X-Stripe-Client-Telemetry", JsonConvert.SerializeObject(payload));
+            headers.Add("X-Stripe-Client-Telemetry", JsonConvert.SerializeObject(payload, Formatting.None));
         }
 
         /// <summary>


### PR DESCRIPTION
Remove formatting from Telemetry as this causes an error on second and subsequent requests when custom JSON.NET options are in use which specify Formatting.Indented.

Fixes: #1670 