### PR TITLE
Only run Coveralls if $COVERALLS_REPO_TOKEN is available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,12 @@ test_script:
 after_test:
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
   - dotnet test -c Debug -f netcoreapp2.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-  - .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.opencover.xml --useRelativePaths
+  - sh: |
+      # Secure env vars are not available on all branches, so make sure the
+      # token is available before invoking Coveralls.
+      if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
+        .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.opencover.xml --useRelativePaths
+      fi
 
 artifacts:
   - path: 'src\Stripe.net\bin\Release\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,12 +57,12 @@ test_script:
 after_test:
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
   - dotnet test -c Debug -f netcoreapp2.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-  - sh: |
+  - ps: |
       # Secure env vars are not available on all branches, so make sure the
       # token is available before invoking Coveralls.
-      if [ ! -z "$COVERALLS_REPO_TOKEN" ]; then
+      if (Test-Path env:COVERALLS_REPO_TOKEN) {
         .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.opencover.xml --useRelativePaths
-      fi
+      }
 
 artifacts:
   - path: 'src\Stripe.net\bin\Release\*.nupkg'


### PR DESCRIPTION
I noticed that builds from third party contributors apparently fail
because no Coveralls key is available (`$COVERALLS_REPO_TOKEN` is a
secure token and AppVeyor won't put it in all build environments). Here
we still run coverage, but only invoke the Coveralls step if a key is
available for it.