### PR TITLE
Allow null API key in StripeClient

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -34,24 +34,19 @@ namespace Stripe
         /// if <c>apiKey</c> is empty or contains whitespace
         /// </exception>
         public StripeClient(
-            string apiKey,
+            string apiKey = null,
             string clientId = null,
             IHttpClient httpClient = null,
             string apiBase = null,
             string connectBase = null,
             string filesBase = null)
         {
-            if (apiKey == null)
-            {
-                throw new ArgumentNullException(nameof(apiKey));
-            }
-
-            if (apiKey.Length == 0)
+            if (apiKey != null && apiKey.Length == 0)
             {
                 throw new ArgumentException("API key cannot be the empty string.", nameof(apiKey));
             }
 
-            if (StringUtils.ContainsWhitespace(apiKey))
+            if (apiKey != null && StringUtils.ContainsWhitespace(apiKey))
             {
                 throw new ArgumentException("API key cannot contain whitespace.", nameof(apiKey));
             }

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -5,6 +5,9 @@ namespace Stripe
     using System.Reflection;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
+#if NET45 || NETSTANDARD2_0
+    using System.Configuration;
+#endif
 
     /// <summary>
     /// Global configuration class for Stripe.net settings.
@@ -43,9 +46,10 @@ namespace Stripe
             get
             {
 #if NET45 || NETSTANDARD2_0
-                if (string.IsNullOrEmpty(apiKey))
+                if (string.IsNullOrEmpty(apiKey) &&
+                    !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeApiKey"]))
                 {
-                    apiKey = System.Configuration.ConfigurationManager.AppSettings["StripeApiKey"];
+                    apiKey = ConfigurationManager.AppSettings["StripeApiKey"];
                 }
 #endif
                 return apiKey;
@@ -76,9 +80,10 @@ namespace Stripe
             get
             {
 #if NET45 || NETSTANDARD2_0
-                if (string.IsNullOrEmpty(apiKey))
+                if (string.IsNullOrEmpty(apiKey) &&
+                    !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeClientId"]))
                 {
-                    clientId = System.Configuration.ConfigurationManager.AppSettings["StripeClientId"];
+                    clientId = ConfigurationManager.AppSettings["StripeClientId"];
                 }
 #endif
                 return clientId;
@@ -213,17 +218,16 @@ namespace Stripe
 
         private static StripeClient BuildDefaultStripeClient()
         {
-            if (string.IsNullOrEmpty(ApiKey))
+            if (ApiKey != null && ApiKey.Length == 0)
             {
-                var message = "No API key provided. Set your API key using "
-                    + "`StripeConfiguration.ApiKey = \"<API-KEY>\"`. You can generate API keys "
-                    + "from the Stripe Dashboard. See "
+                var message = "Your API key is invalid, as it is an empty string. You can "
+                    + "double-check your API key from the Stripe Dashboard. See "
                     + "https://stripe.com/docs/api/authentication for details or contact support "
                     + "at https://support.stripe.com/email if you have any questions.";
                 throw new StripeException(message);
             }
 
-            if (StringUtils.ContainsWhitespace(ApiKey))
+            if (ApiKey != null && StringUtils.ContainsWhitespace(ApiKey))
             {
                 var message = "Your API key is invalid, as it contains whitespace. You can "
                     + "double-check your API key from the Stripe Dashboard. See "

--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -111,6 +111,17 @@ namespace Stripe
             RequestOptions requestOptions)
         {
             string apiKey = requestOptions?.ApiKey ?? client.ApiKey;
+
+            if (apiKey == null)
+            {
+                var message = "No API key provided. Set your API key using "
+                    + "`StripeConfiguration.ApiKey = \"<API-KEY>\"`. You can generate API keys "
+                    + "from the Stripe Dashboard. See "
+                    + "https://stripe.com/docs/api/authentication for details or contact support "
+                    + "at https://support.stripe.com/email if you have any questions.";
+                throw new StripeException(message);
+            }
+
             return new AuthenticationHeaderValue("Bearer", apiKey);
         }
 

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -31,9 +31,11 @@ namespace StripeTests
         }
 
         [Fact]
-        public void Ctor_ThrowsIfApiKeyIsNull()
+        public void Ctor_DoesNotThrowsIfApiKeyIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new StripeClient(null));
+            var client = new StripeClient(null);
+            Assert.NotNull(client);
+            Assert.Null(client.ApiKey);
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -11,7 +11,7 @@ namespace StripeTests
     public class StripeConfigurationTest : BaseStripeTest
     {
         [Fact]
-        public void StripeClient_Getter_CreatesNewStripeClientIfNull()
+        public void StripeClient_Getter_CreatesNewStripeClientIfNullAndApiKeyIsSet()
         {
             var origApiKey = StripeConfiguration.ApiKey;
             var origClientId = StripeConfiguration.ClientId;
@@ -35,7 +35,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void StripeClient_Getter_ThrowsIfClientIsNullAndApiKeyIsNull()
+        public void StripeClient_Getter_CreatesNewStripeClientIfNullAndApiKeyIsNull()
         {
             var origApiKey = StripeConfiguration.ApiKey;
 
@@ -44,9 +44,9 @@ namespace StripeTests
                 StripeConfiguration.ApiKey = null;
                 StripeConfiguration.StripeClient = null;
 
-                var exception = Assert.Throws<StripeException>(() =>
-                    StripeConfiguration.StripeClient);
-                Assert.Contains("No API key provided.", exception.Message);
+                var client = StripeConfiguration.StripeClient;
+                Assert.NotNull(client);
+                Assert.Null(client.ApiKey);
             }
             finally
             {
@@ -66,7 +66,7 @@ namespace StripeTests
 
                 var exception = Assert.Throws<StripeException>(() =>
                     StripeConfiguration.StripeClient);
-                Assert.Contains("No API key provided.", exception.Message);
+                Assert.Contains("Your API key is invalid, as it is an empty string.", exception.Message);
             }
             finally
             {

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -117,5 +117,17 @@ namespace StripeTests
             Assert.Equal("acct_456", request.StripeHeaders["Stripe-Account"]);
             Assert.Null(request.Content);
         }
+
+        [Fact]
+        public void Ctor_ThrowsIfApiKeyIsNull()
+        {
+            var client = new StripeClient(null);
+            var requestOptions = new RequestOptions();
+
+            var exception = Assert.Throws<StripeException>(() =>
+                new StripeRequest(client, HttpMethod.Get, "/get", null, requestOptions));
+
+            Assert.Contains("No API key provided.", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries-releasers 

Don't enforce an API key when creating `StripeClient`, so that users can create clients without API keys and pass the key only via `RequestOptions` on a per-request basis.

We still check for empty strings or whitespace, and we do check that an API key was provided (either by `RequestOptions` or by the client) when creating an actual API request.

Fixes #1650.