### PR TITLE
Add support for the `SetupIntent` resource and APIs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.58.0
+  STRIPE_MOCK_VERSION: 0.60.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -579,6 +579,21 @@ namespace Stripe
         public const string ReviewOpened = "review.opened";
 
         /// <summary>
+        /// Occurs when a new SetupIntent is created.
+        /// </summary>
+        public const string SetupIntentCreated = "setup_intent.created";
+
+        /// <summary>
+        /// Occurs when a SetupIntent has failed the attempt to setup a payment method.
+        /// </summary>
+        public const string SetupIntentSetupFailed = "setup_intent.setup_failed";
+
+        /// <summary>
+        /// Occurs when a SetupIntent has successfully setup a payment method.
+        /// </summary>
+        public const string SetupIntentSucceeded = "setup_intent.succeeded";
+
+        /// <summary>
         /// Occurs whenever a Sigma scheduled query run finishes.
         /// </summary>
         public const string SigmaScheduleQueryRunCreated = "sigma.scheduled_query_run.created";

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
@@ -5,22 +5,13 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PaymentIntent : StripeEntity<PaymentIntent>, IHasId, IHasMetadata, IHasObject
+    public class SetupIntent : StripeEntity<SetupIntent>, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }
 
         [JsonProperty("object")]
         public string Object { get; set; }
-
-        [JsonProperty("amount")]
-        public long? Amount { get; set; }
-
-        [JsonProperty("amount_capturable")]
-        public long? AmountCapturable { get; set; }
-
-        [JsonProperty("amount_received")]
-        public long? AmountReceived { get; set; }
 
         #region Expandable Application
         [JsonIgnore]
@@ -42,34 +33,15 @@ namespace Stripe
         internal ExpandableField<Application> InternalApplication { get; set; }
         #endregion
 
-        [JsonProperty("application_fee_amount")]
-        public long? ApplicationFeeAmount { get; set; }
-
-        [JsonProperty("canceled_at")]
-        [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? CanceledAt { get; set; }
-
         [JsonProperty("cancellation_reason")]
         public string CancellationReason { get; set; }
-
-        [JsonProperty("capture_method")]
-        public string CaptureMethod { get; set; }
-
-        [JsonProperty("charges")]
-        public StripeList<Charge> Charges { get; set; }
 
         [JsonProperty("client_secret")]
         public string ClientSecret { get; set; }
 
-        [JsonProperty("confirmation_method")]
-        public string ConfirmationMethod { get; set; }
-
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
-
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
 
         #region Expandable Customer
         [JsonIgnore]
@@ -94,28 +66,8 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
-        #region Expandable Invoice
-        [JsonIgnore]
-        public string InvoiceId
-        {
-            get => this.InternalInvoice?.Id;
-            set => this.InternalInvoice = SetExpandableFieldId(value, this.InternalInvoice);
-        }
-
-        [JsonIgnore]
-        public Invoice Invoice
-        {
-            get => this.InternalInvoice?.ExpandedObject;
-            set => this.InternalInvoice = SetExpandableFieldObject(value, this.InternalInvoice);
-        }
-
-        [JsonProperty("invoice")]
-        [JsonConverter(typeof(ExpandableFieldConverter<Invoice>))]
-        internal ExpandableField<Invoice> InternalInvoice { get; set; }
-        #endregion
-
-        [JsonProperty("last_payment_error")]
-        public StripeError LastPaymentError { get; set; }
+        [JsonProperty("last_setup_error")]
+        public StripeError LastSetupError { get; set; }
 
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
@@ -124,7 +76,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("next_action")]
-        public PaymentIntentNextAction NextAction { get; set; }
+        public SetupIntentNextAction NextAction { get; set; }
 
         #region Expandable OnBehalfOf (Account)
         [JsonIgnore]
@@ -169,69 +121,10 @@ namespace Stripe
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
-        [JsonProperty("receipt_email")]
-        public string ReceiptEmail { get; set; }
-
-        #region Expandable Review
-        [JsonIgnore]
-        public string ReviewId
-        {
-            get => this.InternalReview?.Id;
-            set => this.InternalReview = SetExpandableFieldId(value, this.InternalReview);
-        }
-
-        [JsonIgnore]
-        public Review Review
-        {
-            get => this.InternalReview?.ExpandedObject;
-            set => this.InternalReview = SetExpandableFieldObject(value, this.InternalReview);
-        }
-
-        [JsonProperty("review")]
-        [JsonConverter(typeof(ExpandableFieldConverter<Review>))]
-        internal ExpandableField<Review> InternalReview { get; set; }
-        #endregion
-
-        [JsonProperty("setup_future_usage")]
-        public string SetupFutureUsage { get; set; }
-
-        [JsonProperty("shipping")]
-        public Shipping Shipping { get; set; }
-
-        #region Expandable Source
-        [JsonIgnore]
-        public string SourceId
-        {
-            get => this.InternalSource?.Id;
-            set => this.InternalSource = SetExpandableFieldId(value, this.InternalSource);
-        }
-
-        [JsonIgnore]
-        public IPaymentSource Source
-        {
-            get => this.InternalSource?.ExpandedObject;
-            set => this.InternalSource = SetExpandableFieldObject(value, this.InternalSource);
-        }
-
-        [JsonProperty("source")]
-        [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
-        internal ExpandableField<IPaymentSource> InternalSource { get; set; }
-        #endregion
-
-        [JsonProperty("statement_descriptor")]
-        public string StatementDescriptor { get; set; }
-
         [JsonProperty("status")]
         public string Status { get; set; }
 
-        [JsonProperty("transfer_data")]
-        public PaymentIntentTransferData TransferData { get; set; }
-
-        [JsonProperty("transfer_group")]
-        public string TransferGroup { get; set; }
-
-        [Obsolete("Use PaymentMethodTypes")]
-        [JsonProperty("allowed_source_types")]
-        public List<string> AllowedSourceTypes { get; set; }
+        [JsonProperty("usage")]
+        public string Usage { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentNextAction.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentNextAction.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentNextAction : StripeEntity<SetupIntentNextAction>
+    {
+        [JsonProperty("redirect_to_url")]
+        public SetupIntentNextActionRedirectToUrl RedirectToUrl { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionRedirectToUrl.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionRedirectToUrl.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentNextActionRedirectToUrl : StripeEntity<SetupIntentNextActionRedirectToUrl>
+    {
+        [JsonProperty("return_url")]
+        public string ReturnUrl { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -56,8 +56,19 @@ namespace Stripe
         [JsonProperty("payment_intent")]
         public PaymentIntent PaymentIntent { get; set; }
 
+        /// <summary>
+        /// The <see cref="Stripe.PaymentMethod"/> object for errors returned on a request
+        /// involving a <see cref="Stripe.PaymentMethod"/>.
+        /// </summary>
         [JsonProperty("payment_method")]
         public PaymentMethod PaymentMethod { get; set; }
+
+        /// <summary>
+        /// The <see cref="Stripe.SetupIntent"/> object for errors returned on a request
+        /// involving a <see cref="Stripe.SetupIntent"/>.
+        /// </summary>
+        [JsonProperty("setup_intent")]
+        public SetupIntent SetupIntent { get; set; }
 
         /// <summary>
         /// The source object for errors returned on a request involving a source.

--- a/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/StripeTypeRegistry.cs
@@ -65,6 +65,7 @@ namespace Stripe.Infrastructure
             { "reporting.report_run", typeof(Reporting.ReportRun) },
             { "reporting.report_type", typeof(Reporting.ReportType) },
             { "scheduled_query_run", typeof(Sigma.ScheduledQueryRun) },
+            { "setup_intent", typeof(SetupIntent) },
             { "sku", typeof(Sku) },
             { "source", typeof(Source) },
             { "source_mandate_notification", typeof(SourceMandateNotification) },

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
 
+        [JsonProperty("setup_future_usage")]
+        public string SetupFutureUsage { get; set; }
+
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
     }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCancelOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCancelOptions.cs
@@ -1,0 +1,11 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SetupIntentCancelOptions : BaseOptions
+    {
+        [JsonProperty("cancellation_reason")]
+        public string CancellationReason { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
@@ -1,0 +1,22 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SetupIntentConfirmOptions : BaseOptions
+    {
+        /// <summary>
+        /// The client secret of the SetupIntent. Required if a publishable key is used to
+        /// confirm the setup intent.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+
+        [JsonProperty("payment_method")]
+        public string PaymentMethodId { get; set; }
+
+        [JsonProperty("return_url")]
+        public string ReturnUrl { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
@@ -1,0 +1,29 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SetupIntentCreateOptions : BaseOptions
+    {
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("on_behalf_of")]
+        public string OnBehalfOf { get; set; }
+
+        [JsonProperty("payment_method")]
+        public string PaymentMethodId { get; set; }
+
+        [JsonProperty("payment_method_types")]
+        public List<string> PaymentMethodTypes { get; set; }
+
+        [JsonProperty("usage")]
+        public string Usage { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentGetOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentGetOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentGetOptions : BaseOptions
+    {
+        /// <summary>
+        /// The client secret of the SetupIntent. Required if a publishable key is used to
+        /// retrieve the setup intent.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentListOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentListOptions.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentListOptions : ListOptionsWithCreated
+    {
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        [JsonProperty("payment_method")]
+        public string PaymentMethodId { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -1,0 +1,92 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class SetupIntentService : Service<SetupIntent>,
+        ICreatable<SetupIntent, SetupIntentCreateOptions>,
+        IListable<SetupIntent, SetupIntentListOptions>,
+        IRetrievable<SetupIntent, SetupIntentGetOptions>,
+        IUpdatable<SetupIntent, SetupIntentUpdateOptions>
+    {
+        public SetupIntentService()
+            : base(null)
+        {
+        }
+
+        public SetupIntentService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/setup_intents";
+
+        public virtual SetupIntent Cancel(string paymentIntentId, SetupIntentCancelOptions options, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions);
+        }
+
+        public virtual Task<SetupIntent> CancelAsync(string paymentIntentId, SetupIntentCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/cancel", options, requestOptions, cancellationToken);
+        }
+
+        public virtual SetupIntent Confirm(string paymentIntentId, SetupIntentConfirmOptions options, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions);
+        }
+
+        public virtual Task<SetupIntent> ConfirmAsync(string paymentIntentId, SetupIntentConfirmOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(paymentIntentId)}/confirm", options, requestOptions, cancellationToken);
+        }
+
+        public virtual SetupIntent Create(SetupIntentCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<SetupIntent> CreateAsync(SetupIntentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual SetupIntent Get(string paymentIntentId, SetupIntentGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(paymentIntentId, options, requestOptions);
+        }
+
+        public virtual Task<SetupIntent> GetAsync(string paymentIntentId, SetupIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.GetEntityAsync(paymentIntentId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<SetupIntent> List(SetupIntentListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<SetupIntent>> ListAsync(SetupIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<SetupIntent> ListAutoPaging(SetupIntentListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual SetupIntent Update(string paymentIntentId, SetupIntentUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(paymentIntentId, options, requestOptions);
+        }
+
+        public virtual Task<SetupIntent> UpdateAsync(string paymentIntentId, SetupIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.UpdateEntityAsync(paymentIntentId, options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
@@ -1,0 +1,26 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SetupIntentUpdateOptions : BaseOptions
+    {
+        [JsonProperty("customer")]
+        public string CustomerId { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("payment_method")]
+        public string PaymentMethodId { get; set; }
+
+        [JsonProperty("payment_method_types")]
+        public List<string> PaymentMethodTypes { get; set; }
+
+        [JsonProperty("usage")]
+        public string Usage { get; set; }
+    }
+}

--- a/src/StripeTests/Entities/SetupIntents/SetupIntentTest.cs
+++ b/src/StripeTests/Entities/SetupIntents/SetupIntentTest.cs
@@ -1,0 +1,58 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class SetupIntentTest : BaseStripeTest
+    {
+        public SetupIntentTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            string json = this.GetFixture("/v1/setup_intents/seti_123");
+            var intent = JsonConvert.DeserializeObject<SetupIntent>(json);
+            Assert.NotNull(intent);
+            Assert.IsType<SetupIntent>(intent);
+            Assert.NotNull(intent.Id);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void DeserializeWithExpansions()
+        {
+            // Do not test expanding `source` as it is not supported by stripe-mock
+            // and will be auto-expanded in a future API version.
+            string[] expansions =
+            {
+              "application",
+              "customer",
+              "on_behalf_of",
+              "payment_method",
+            };
+
+            string json = this.GetFixture("/v1/setup_intents/seti_123", expansions);
+            var intent = JsonConvert.DeserializeObject<SetupIntent>(json);
+            Assert.NotNull(intent);
+            Assert.IsType<SetupIntent>(intent);
+            Assert.NotNull(intent.Id);
+            Assert.Equal("setup_intent", intent.Object);
+
+            Assert.NotNull(intent.Application);
+            Assert.Equal("application", intent.Application.Object);
+
+            Assert.NotNull(intent.Customer);
+            Assert.Equal("customer", intent.Customer.Object);
+
+            Assert.NotNull(intent.OnBehalfOf);
+            Assert.Equal("account", intent.OnBehalfOf.Object);
+
+            Assert.NotNull(intent.PaymentMethod);
+            Assert.Equal("payment_method", intent.PaymentMethod.Object);
+        }
+    }
+}

--- a/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
+++ b/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
@@ -1,0 +1,192 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class SetupIntentServiceTest : BaseStripeTest
+    {
+        private const string SetupIntentId = "seti_123";
+
+        private readonly SetupIntentService service;
+        private readonly SetupIntentCancelOptions cancelOptions;
+        private readonly SetupIntentConfirmOptions confirmOptions;
+        private readonly SetupIntentCreateOptions createOptions;
+        private readonly SetupIntentListOptions listOptions;
+        private readonly SetupIntentUpdateOptions updateOptions;
+
+        public SetupIntentServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+        {
+            this.service = new SetupIntentService(this.StripeClient);
+
+            this.cancelOptions = new SetupIntentCancelOptions
+            {
+            };
+
+            this.confirmOptions = new SetupIntentConfirmOptions
+            {
+            };
+
+            this.createOptions = new SetupIntentCreateOptions
+            {
+                PaymentMethodTypes = new List<string>
+                {
+                    "card",
+                },
+            };
+
+            this.listOptions = new SetupIntentListOptions
+            {
+                Limit = 1,
+            };
+
+            this.updateOptions = new SetupIntentUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
+            };
+        }
+
+        [Fact]
+        public void Cancel()
+        {
+            var intent = this.service.Cancel(SetupIntentId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123/cancel");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public async Task CancelAsync()
+        {
+            var intent = await this.service.CancelAsync(SetupIntentId, this.cancelOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123/cancel");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void Confirm()
+        {
+            var intent = this.service.Confirm(SetupIntentId, this.confirmOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123/confirm");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public async Task ConfirmAsync()
+        {
+            var intent = await this.service.ConfirmAsync(SetupIntentId, this.confirmOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123/confirm");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var intent = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var intent = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var intent = this.service.Get(SetupIntentId);
+            this.AssertRequest(HttpMethod.Get, "/v1/setup_intents/seti_123");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var intent = await this.service.GetAsync(SetupIntentId);
+            this.AssertRequest(HttpMethod.Get, "/v1/setup_intents/seti_123");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void GetWithClientSecret()
+        {
+            var options = new SetupIntentGetOptions
+            {
+                ClientSecret = "seti_client_secret_123",
+            };
+            var intent = this.service.Get(SetupIntentId, options);
+            this.AssertRequest(HttpMethod.Get, "/v1/setup_intents/seti_123");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var intents = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/setup_intents");
+            Assert.NotNull(intents);
+            Assert.Equal("list", intents.Object);
+            Assert.Single(intents.Data);
+            Assert.Equal("setup_intent", intents.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var intents = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/setup_intents");
+            Assert.NotNull(intents);
+            Assert.Equal("list", intents.Object);
+            Assert.Single(intents.Data);
+            Assert.Equal("setup_intent", intents.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(intents);
+            Assert.Equal("setup_intent", intents[0].Object);
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var intent = this.service.Update(SetupIntentId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+
+        [Fact]
+        public async Task UpdateAsync()
+        {
+            var intent = await this.service.UpdateAsync(SetupIntentId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/setup_intents/seti_123");
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+    }
+}

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -12,7 +12,7 @@ namespace StripeTests
         /// <remarks>
         /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.58.0";
+        private const string MockMinimumVersion = "0.60.0";
 
         private readonly string port;
 


### PR DESCRIPTION
This PR does not add the docs because the strings are not finalized. I will commit to fixing those (and the PaymentIntent ones) after the API is public. We would like to merge ahead of that though.

r? @ob-stripe 
cc @stripe/api-libraries @danwang-stripe 