### PR TITLE
Add DefaultSource and DefaultPaymentMethod on SubscriptionSchedule

### DIFF
--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -93,6 +93,54 @@ namespace Stripe
         internal ExpandableField<Customer> InternalCustomer { get; set; }
         #endregion
 
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonProperty("default_payment_method")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
+        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
+        #endregion
+
+        #region Expandable DefaultSource
+
+        /// <summary>
+        /// ID of the default source for the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultSourceId
+        {
+            get => this.InternalDefaultSource?.Id;
+            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
+        }
+
+        [JsonIgnore]
+        public IPaymentSource DefaultSource
+        {
+            get => this.InternalDefaultSource?.ExpandedObject;
+            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
+        }
+
+        [JsonProperty("default_source")]
+        [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
+        internal ExpandableField<IPaymentSource> InternalDefaultSource { get; set; }
+        #endregion
+
         /// <summary>
         /// The schedule's default invoice settings.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
@@ -24,6 +24,18 @@ namespace Stripe
         public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
 
         /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
+
+        /// <summary>
+        /// ID of the default source for the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_source")]
+        public string DefaultSourceId { get; set; }
+
+        /// <summary>
         /// Define the default settings applied to invoices created by this subscription schedule.
         /// </summary>
         [JsonProperty("invoice_settings")]


### PR DESCRIPTION
This just shipped though SubscriptionSchedule are still gated all new users have access to it.

r? @ob-stripe 
cc @stripe/api-libraries