### PR TITLE
Properly support `OffSession` to be a bool or an enum value

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
@@ -14,7 +14,7 @@ namespace Stripe
         public string ClientSecret { get; set; }
 
         [JsonProperty("off_session")]
-        public string OffSession { get; set; }
+        public AnyOf<bool?, string> OffSession { get; set; }
 
         [JsonProperty("payment_method")]
         public string PaymentMethodId { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
         public string ConfirmationMethod { get; set; }
 
         [JsonProperty("off_session")]
-        public string OffSession { get; set; }
+        public AnyOf<bool?, string> OffSession { get; set; }
 
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
@@ -1,0 +1,27 @@
+namespace StripeTests
+{
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class PaymentIntentConfirmOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeObjectProperly()
+        {
+            var options_bool = new PaymentIntentConfirmOptions
+            {
+                OffSession = true,
+            };
+
+            Assert.Equal("off_session=True", FormEncoder.CreateQueryString(options_bool));
+
+            var options_enum = new PaymentIntentConfirmOptions
+            {
+                OffSession = "one_off",
+            };
+
+            Assert.Equal("off_session=one_off", FormEncoder.CreateQueryString(options_enum));
+        }
+    }
+}

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
@@ -1,0 +1,27 @@
+namespace StripeTests
+{
+    using Stripe;
+    using Stripe.Infrastructure.FormEncoding;
+    using Xunit;
+
+    public class PaymentIntentCreateOptionsTest : BaseStripeTest
+    {
+        [Fact]
+        public void SerializeObjectProperly()
+        {
+            var options_bool = new PaymentIntentCreateOptions
+            {
+                OffSession = true,
+            };
+
+            Assert.Equal("off_session=True", FormEncoder.CreateQueryString(options_bool));
+
+            var options_enum = new PaymentIntentCreateOptions
+            {
+                OffSession = "one_off",
+            };
+
+            Assert.Equal("off_session=one_off", FormEncoder.CreateQueryString(options_enum));
+        }
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries