### PR TITLE
Remove Equals and GetHashCode methods from AnyOf

### DIFF
--- a/src/Stripe.net/Services/_base/AnyOf.cs
+++ b/src/Stripe.net/Services/_base/AnyOf.cs
@@ -16,10 +16,8 @@ namespace Stripe
         /// <returns>The type of the current <see cref="AnyOf"/> object.</returns>
         public abstract Type Type { get; }
 
-        public override bool Equals(object other) => this.Value.Equals(other);
-
-        public override int GetHashCode() => this.Value.GetHashCode();
-
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
         public override string ToString() => this.Value.ToString();
     }
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Remove the `Equals` and `GetHashCode` methods from the `AnyOf` wrapper class.

In C#, `Equals` and `GetHashCode` should be overridden to give value semantics to a reference type (cf. https://docs.microsoft.com/en-us/dotnet/api/system.object.equals?view=netframework-4.8).

The type held by an `AnyOf` instance may be either a value type (e.g. `int`, `bool`, etc.) or a reference type (e.g. `DateRangeOptions`, `CardCreateNestedOptions`, etc.). By delegating `Equals` to the value held within the `AnyOf` instance, we're implying that the value has value semantics even when that's not the case.

This breaks assumptions in some testing frameworks like [Fluent Assertions](https://github.com/fluentassertions/fluentassertions), as they use reflection to see if a type overrides `Equals` and assume that it has value semantics if that's the case (cf. https://www.continuousimprover.com/2018/02/fluent-assertions-50-best-unit-test.html).

The library itself doesn't rely on `AnyOf` overriding `Equals` anywhere, so let's just remove it.

I did leave the `ToString` method that delegates to the held value since that seems useful for debugging (e.g. to log the values of request parameters).
