### PR TITLE
Add confirm property to SetupIntentCreateOptions

### DIFF
--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class SetupIntentCreateOptions : BaseOptions
     {
+        [JsonProperty("confirm")]
+        public bool? Confirm { get; set; }
+
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
@@ -22,6 +25,9 @@ namespace Stripe
 
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
+
+        [JsonProperty("return_url")]
+        public string ReturnUrl { get; set; }
 
         [JsonProperty("usage")]
         public string Usage { get; set; }


### PR DESCRIPTION
https://stripe.com/docs/api/setup_intents/create lists a `confirm` property which was not present in the `SetupIntentCreateOptions`.