### PR TITLE
Make autopagination a bit safer

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -258,7 +258,7 @@ namespace Stripe
                 string itemId = null;
                 foreach (var item in page)
                 {
-                    itemId = ((IHasId)item).Id;
+                    itemId = (item as IHasId)?.Id;
                     yield return item;
                 }
 


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Make autopagination a bit safer by using the `as` keyword to cast page items to `IHasId`, and using the safe navigation operator to get the ID. If for some reason the cast fails, `itemId` will be `null` and the iterator will stop per the condition on line 265.

In practice, this should never happen as listable resources should always have IDs, but I ran into this in a test, probably because of a weird stripe-mock fixture.
