### PR TITLE
Don't create AnyOf instances with null values

### DIFF
--- a/src/Stripe.net/Services/_base/AnyOf.cs
+++ b/src/Stripe.net/Services/_base/AnyOf.cs
@@ -18,7 +18,7 @@ namespace Stripe
 
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
-        public override string ToString() => this.Value.ToString();
+        public override string ToString() => this.Value == null ? "AnyOf(null)" : this.Value.ToString();
     }
 
     /// <summary>
@@ -103,14 +103,14 @@ namespace Stripe
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2>(T1 value) => new AnyOf<T1, T2>(value);
+        public static implicit operator AnyOf<T1, T2>(T1 value) => value == null ? null : new AnyOf<T1, T2>(value);
 
         /// <summary>
         /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2>(T2 value) => new AnyOf<T1, T2>(value);
+        public static implicit operator AnyOf<T1, T2>(T2 value) => value == null ? null : new AnyOf<T1, T2>(value);
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2}"/> object to a value of type <c>T1</c>,
@@ -236,21 +236,21 @@ namespace Stripe
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T1 value) => new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>(T1 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts a value of type <c>T2</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T2 value) => new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>(T2 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts a value of type <c>T3</c> to an <see cref="AnyOf{T1, T2, T3}"/> object.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>An <see cref="AnyOf{T1, T2, T3}"/> object that holds the value.</returns>
-        public static implicit operator AnyOf<T1, T2, T3>(T3 value) => new AnyOf<T1, T2, T3>(value);
+        public static implicit operator AnyOf<T1, T2, T3>(T3 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
         /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T1</c>,

--- a/src/StripeTests/Services/_base/AnyOfTest.cs
+++ b/src/StripeTests/Services/_base/AnyOfTest.cs
@@ -7,7 +7,7 @@ namespace StripeTests
     public class AnyOfTest : BaseStripeTest
     {
         [Fact]
-        public void Variant2Types()
+        public void Ctor_Variant2Types()
         {
             var testCases = new[]
             {
@@ -51,7 +51,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void Variant3Types()
+        public void Ctor_Variant3Types()
         {
             var someClass = new SomeClass { SomeString = "foo" };
             var testCases = new[]
@@ -107,6 +107,28 @@ namespace StripeTests
             }
         }
 
+        [Fact]
+        public void ImplicitOperator_ReturnsNullForNullValuesRegardlessOfType()
+        {
+            var testCases = new[]
+            {
+                new Container(),
+                new Container { AnyOf2 = null },
+                new Container { AnyOf2 = (AnyOf<int, string>)null },
+                new Container { AnyOf2 = (string)null },
+                new Container { AnyOf3 = null },
+                new Container { AnyOf3 = (AnyOf<int, string, SomeClass>)null },
+                new Container { AnyOf3 = (string)null },
+                new Container { AnyOf3 = (SomeClass)null },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.Null(testCase.AnyOf2);
+                Assert.Null(testCase.AnyOf3);
+            }
+        }
+
         private class TestCase
         {
             public IAnyOf AnyOf { get; set; }
@@ -119,6 +141,13 @@ namespace StripeTests
         private class SomeClass
         {
             public string SomeString { get; set; }
+        }
+
+        private class Container
+        {
+            public AnyOf<int, string> AnyOf2 { get; set; }
+
+            public AnyOf<int, string, SomeClass> AnyOf3 { get; set; }
         }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Modifies the implicit operators used to create `AnyOf<>` instances from value types to return `null` instead of creating a new `AnyOf` instance that contains `null` when the value is itself `null`,

Previous behavior:
```c#
AnyOf<int, string> anyOf = null;
anyOf = (string)null;
Assert.NotNull(anyOf);
// anyOf is now a (non-null) AnyOf<int, string> instance with `Value` set to `null`
```

New behavior:
```c#
AnyOf<int, string> anyOf = null;
anyOf = (string)null;
Assert.Null(anyOf);
// anyOf is still null
```

I've also changed `ToString()`, as previously it would crash if `Value` was null.
