### PR TITLE
Ignore null elements when autopaginating

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -258,6 +258,15 @@ namespace Stripe
                 string itemId = null;
                 foreach (var item in page)
                 {
+                    // Elements in `StripeList` instances are decoded by `StripeObjectConverter`,
+                    // which returns `null` for objects it doesn't know how to decode.
+                    // When auto-paginating, we simply ignore these null elements but still return
+                    // other elements.
+                    if (item == null)
+                    {
+                        continue;
+                    }
+
                     itemId = ((IHasId)item).Id;
                     yield return item;
                 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Okay, so the bug here is a bit convoluted:
- list elements in the `data` attribute of a list object are decoded using `StripeObjectConverter`: https://github.com/stripe/stripe-dotnet/blob/c879198aed61573638953126b3fdb78b536c055f/src/Stripe.net/Entities/StripeList.cs#L20-L21
- when encountering an object it doesn't know how to decode, `StripeObjectConverter` returns `null`: https://github.com/stripe/stripe-dotnet/blob/c879198aed61573638953126b3fdb78b536c055f/src/Stripe.net/Infrastructure/JsonConverters/StripeObjectConverter.cs#L57-L58
    (This was a deliberate design decision, because new object types may be added to the API and older versions of the library should not crash upon encountering them.)
- the two above points mean that the `Data` list can contain `null` elements. It would be better if those null values were not added to the list at all, but unfortunately I don't think Newtonsoft.Json's `ItemConverterType` attribute lets us do that
- when autopaginating, we cast elements to `IHasId` to extract the ID
- of course, trying to access the ID on a `null` instance fails and throws a `NullReferenceException`

The fix is fairly simple: just skip over null elements in a page when autopaginating.

Also, for full context, I ran into this because stripe-mock returns a list element with `object=alipay_account` and the library does not have a model for this object type.