### PR TITLE
Add support for SCA features for Billing

### DIFF
--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -183,6 +183,33 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        #region Expandable PendingSetupIntent
+
+        /// <summary>
+        /// ID of the pending SetupIntent associated with this subscription.
+        /// </summary>
+        [JsonIgnore]
+        public string PendingSetupIntentId
+        {
+            get => this.InternalPendingSetupIntent?.Id;
+            set => this.InternalPendingSetupIntent = SetExpandableFieldId(value, this.InternalPendingSetupIntent);
+        }
+
+        /// <summary>
+        /// The pending SetupIntent associated with this subscription if any.
+        /// </summary>
+        [JsonIgnore]
+        public SetupIntent PendingSetupIntent
+        {
+            get => this.InternalPendingSetupIntent?.ExpandedObject;
+            set => this.InternalPendingSetupIntent = SetExpandableFieldObject(value, this.InternalPendingSetupIntent);
+        }
+
+        [JsonProperty("pending_setup_intent")]
+        [JsonConverter(typeof(ExpandableFieldConverter<SetupIntent>))]
+        internal ExpandableField<SetupIntent> InternalPendingSetupIntent { get; set; }
+        #endregion
+
         [JsonProperty("plan")]
         public Plan Plan { get; set; }
 

--- a/src/Stripe.net/Services/Invoices/InvoicePayOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoicePayOptions.cs
@@ -18,6 +18,12 @@ namespace Stripe
         public bool? PaidOutOfBand { get; set; }
 
         /// <summary>
+        /// Indicates if a customer is on session while an invoice payment is attempted.
+        /// </summary>
+        [JsonProperty("off_session")]
+        public bool? OffSession { get; set; }
+
+        /// <summary>
         /// ID of the payment method to use for paying the invoice.
         /// </summary>
         [JsonProperty("payment_method")]

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
@@ -5,7 +5,17 @@ namespace Stripe
 
     public class SubscriptionItemUpdateOptions : SubscriptionItemSharedOptions
     {
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if
+        /// the invoice caused by the update cannot be paid. Otherwise use <c>allow_incomplete</c>.
+        /// </summary>
+        [JsonProperty("payment_behavior")]
+        public string PaymentBehavior { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -85,6 +85,33 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
+        /// Indicates if a customer is on session while an invoice payment is attempted.
+        /// </summary>
+        [JsonProperty("off_session")]
+        public bool? OffSession { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// Use <c>allow_incomplete</c> to create subscriptions with <c>status=incomplete</c> if its
+        /// first invoice cannot be paid. Creating subscriptions with this status allows you to
+        /// manage scenarios where additional user actions are needed to pay a subscription's
+        /// invoice. For example, SCA regulation may require 3DS authentication to complete payment.
+        /// See the <a href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration Guide</a>
+        /// for Billing to learn more. This is the default behavior.
+        /// </para>
+        /// <para>
+        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if
+        /// a subscription's first invoice cannot be paid. For example, if a payment method requires
+        /// 3DS authentication due to SCA regulation and further user action is needed, this
+        /// parameter does not create a subscription and returns an error instead. This was the
+        /// default behavior for API versions prior to 2019-03-14. See the <a href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a>
+        /// to learn more.
+        /// </para>
+        /// </summary>
+        [JsonProperty("payment_behavior")]
+        public string PaymentBehavior { get; set; }
+
+        /// <summary>
         /// Boolean (default <c>true</c>). Use with a <c>billing_cycle_anchor</c> timestamp to determine whether the customer will be invoiced a prorated amount until the anchor date. If <c>false</c>, the anchor period will be free (similar to a trial).
         /// </summary>
         [JsonProperty("prorate")]

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -25,6 +25,7 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
+            // TODO: Add support for expanding pending_setup_intent in the future.
             string[] expansions =
             {
               "customer",


### PR DESCRIPTION
Those features are shipping on Monday 7/15 to support SCA for Billing
* Add `payment_behavior` and `off_session` when creating or updating a `Subscription`
* Add `off_session` when paying an `Invoice`.
* Add `pending_setup_intent` on `Subscription.

r? @ob-stripe 
cc @stripe/api-libraries 

Do not review yet as there might be more fields after all