### PR TITLE
Add support for undeclared fields in StripeEntity

### DIFF
--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -1,13 +1,19 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     [JsonObject(MemberSerialization.OptIn)]
     public abstract class StripeEntity : IStripeEntity
     {
+        /// <summary>Dictionary containing extra resource fields.</summary>
+        [JsonExtensionData]
+        public IDictionary<string, JToken> ExtraFields { get; set; }
+
         [JsonIgnore]
         public StripeResponse StripeResponse { get; set; }
 

--- a/src/StripeTests/Entities/_base/StripeEntityTest.cs
+++ b/src/StripeTests/Entities/_base/StripeEntityTest.cs
@@ -141,6 +141,18 @@ namespace StripeTests
             Assert.Equal(42, o.Nested.Bar);
         }
 
+        [Fact]
+        public void ExtraFields()
+        {
+            var json = "{\"integer\": 234, \"string\": \"String!\", \"extra_string\": \"Hello!\", \"extra_object\": {\"array\": [{\"foo\": \"Foo!\"}]}}";
+
+            var o = StripeEntity.FromJson<TestEntity>(json);
+
+            Assert.NotNull(o);
+            Assert.Equal("Hello!", o.ExtraFields["extra_string"]);
+            Assert.Equal("Foo!", o.ExtraFields["extra_object"]["array"][0]["foo"]);
+        }
+
         private class TestEntity : StripeEntity<TestEntity>
         {
             [JsonProperty("integer")]


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Similar to https://github.com/stripe/stripe-java/pull/799, this lets users access fields that don't have a matching property in the Stripe.net model class.

This relies on Newtonsoft.Json's [`JsonExtensionData`](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonExtensionDataAttribute.htm) attribute. Like the Java PR, this feature leaks the underlying JSON library to users. However, unlike the Java PR, I don't think we need an extended warning here:
1. Unlike Java, `ExtraFields` will contain _only_ fields that don't have a matching property, so it cannot be use to access "normal" declared fields.
2. We're unlikely to change the JSON library used by Stripe.net

Happy to add a comment if you think it's preferable though!
