### PR TITLE
Add support for PaymentMethodOptions on PaymentIntent and SetupIntent

### DIFF
--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -275,6 +275,12 @@ namespace Stripe
         #endregion
 
         /// <summary>
+        /// Payment-method-specific configuration for this PaymentIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public PaymentIntentPaymentMethodOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
         /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
         /// </summary>
         [JsonProperty("payment_method_types")]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -1,0 +1,16 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentPaymentMethodOptions : StripeEntity<PaymentIntentPaymentMethodOptions>
+    {
+        /// <summary>
+        /// If the PaymentIntent’s supported payment method types include <c>card</c>, this hash
+        /// contains the configurations that will be applied to each payment attempt of that type.
+        /// </summary>
+        [JsonProperty("card")]
+        public PaymentIntentPaymentMethodOptionsCard Card { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -1,0 +1,19 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentPaymentMethodOptionsCard : StripeEntity<PaymentIntentPaymentMethodOptionsCard>
+    {
+        /// <summary>
+        /// We strongly recommend that you rely on our SCA engine to automatically prompt your
+        /// customers for authentication based on risk level and other requirements. However, if
+        /// you wish to request authentication based on logic from your own fraud engine, provide
+        /// this option. Permitted values include: <c>automatic</c>, <c>any</c>, or
+        /// <c>challenge_only</c>.
+        /// </summary>
+        [JsonProperty("request_three_d_secure")]
+        public string RequestThreeDSecure { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
@@ -7,13 +7,23 @@ namespace Stripe
 
     public class SetupIntent : StripeEntity<SetupIntent>, IHasId, IHasMetadata, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
         #region Expandable Application
+
+        /// <summary>
+        /// ID of the Connect application that created the SetupIntent.
+        /// </summary>
         [JsonIgnore]
         public string ApplicationId
         {
@@ -33,17 +43,41 @@ namespace Stripe
         internal ExpandableField<Application> InternalApplication { get; set; }
         #endregion
 
+        /// <summary>
+        /// Reason for canceling this SetupIntent. Possible values are <c>abandoned</c>,
+        /// <c>requested_by_customer</c>, or <c>duplicate</c>.
+        /// </summary>
         [JsonProperty("cancellation_reason")]
         public string CancellationReason { get; set; }
 
+        /// <summary>
+        /// <para>
+        /// The client secret of this SetupIntent. Used for client-side retrieval using a
+        /// publishable key.
+        /// </para>
+        /// <para>
+        /// The client secret can be used to complete payment setup from your frontend. It should
+        /// not be stored, logged, embedded in URLs, or exposed to anyone other than the customer.
+        /// Make sure that you have TLS enabled on any page that includes the client secret.
+        /// </para>
+        /// </summary>
         [JsonProperty("client_secret")]
         public string ClientSecret { get; set; }
 
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
         #region Expandable Customer
+
+        /// <summary>
+        /// ID of the Customer this SetupIntent belongs to, if one exists. If present, payment
+        /// methods used with this SetupIntent can only be attached to this Customer, and payment
+        /// methods attached to other Customers cannot be used with this SetupIntent.
+        /// </summary>
         [JsonIgnore]
         public string CustomerId
         {
@@ -63,22 +97,44 @@ namespace Stripe
         internal ExpandableField<Customer> InternalCustomer { get; set; }
         #endregion
 
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <summary>
+        /// The error encountered in the previous SetupIntent confirmation.
+        /// </summary>
         [JsonProperty("last_setup_error")]
         public StripeError LastSetupError { get; set; }
 
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value
+        /// <c>false</c> if the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
+        /// <summary>
+        /// A set of key/value pairs that you can attach to an order object. It can be useful for
+        /// storing additional information about the order in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// If present, this property tells you what actions you need to take in order for your
+        /// customer to continue payment setup.
+        /// </summary>
         [JsonProperty("next_action")]
         public SetupIntentNextAction NextAction { get; set; }
 
         #region Expandable OnBehalfOf (Account)
+
+        /// <summary>
+        /// ID of the account (if any) for which the setup is intended.
+        /// </summary>
         [JsonIgnore]
         public string OnBehalfOfId
         {
@@ -99,6 +155,10 @@ namespace Stripe
         #endregion
 
         #region Expandable PaymentMethod
+
+        /// <summary>
+        /// ID of the payment method used with this SetupIntent.
+        /// </summary>
         [JsonIgnore]
         public string PaymentMethodId
         {
@@ -118,12 +178,32 @@ namespace Stripe
         internal ExpandableField<PaymentMethod> InternalPaymentMethod { get; set; }
         #endregion
 
+        /// <summary>
+        /// Payment-method-specific configuration for this SetupIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public SetupIntentPaymentMethodOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
+        /// The list of payment method types (e.g. card) that this SetupIntent is allowed to set up.
+        /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
+        /// <summary>
+        /// Status of this SetupIntent, one of <c>requires_payment_method</c>,
+        /// <c>requires_confirmation</c>, <c>requires_action</c>, <c>processing</c>,
+        /// <c>canceled</c>, or <c>succeeded</c>.
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        /// <summary>
+        /// Indicates how the payment method is intended to be used in the future. Use
+        /// <c>on_session</c> if you intend to only reuse the payment method when the customer is in
+        /// your checkout flow. Use <c>off_session</c> if your customer may or may not be in your
+        /// checkout flow. If not provided, this value defaults to <c>off_session</c>.
+        /// </summary>
         [JsonProperty("usage")]
         public string Usage { get; set; }
     }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
@@ -1,0 +1,16 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SetupIntentPaymentMethodOptions : StripeEntity<SetupIntentPaymentMethodOptions>
+    {
+        /// <summary>
+        /// If the SetupIntent’s payment method types include <c>card</c>, this hash contains the
+        /// configurations that will be applied to each setup attempt of that type.
+        /// </summary>
+        [JsonProperty("card")]
+        public SetupIntentPaymentMethodOptionsCard Card { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCard.cs
@@ -1,0 +1,19 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SetupIntentPaymentMethodOptionsCard : StripeEntity<SetupIntentPaymentMethodOptionsCard>
+    {
+        /// <summary>
+        /// We strongly recommend that you rely on our SCA engine to automatically prompt your
+        /// customers for authentication based on risk level and other requirements. However, if
+        /// you wish to request authentication based on logic from your own fraud engine, provide
+        /// this option. Permitted values include: <c>automatic</c>, <c>any</c>, or
+        /// <c>challenge_only</c>.
+        /// </summary>
+        [JsonProperty("request_three_d_secure")]
+        public string RequestThreeDSecure { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
@@ -30,6 +30,12 @@ namespace Stripe
         public string PaymentMethodId { get; set; }
 
         /// <summary>
+        /// Payment-method-specific configuration for this PaymentIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public PaymentIntentPaymentMethodOptionsOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
         /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
         /// </summary>
         [JsonProperty("payment_method_types")]

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -105,6 +105,12 @@ namespace Stripe
         public string PaymentMethodId { get; set; }
 
         /// <summary>
+        /// Payment-method-specific configuration for this PaymentIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public PaymentIntentPaymentMethodOptionsOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
         /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
         /// </summary>
         [JsonProperty("payment_method_types")]

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
@@ -1,0 +1,21 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsCardOptions : INestedOptions
+    {
+        /// <summary>
+        /// When specified, this parameter indicates that a transaction will be marked as MOTO
+        /// (Mail Order Telephone Order) and thus out of scope for SCA.
+        /// </summary>
+        [JsonProperty("moto")]
+        public bool? Moto { get; set; }
+
+        /// <summary>
+        /// Control when to request 3D Secure on this PaymentIntent.
+        /// </summary>
+        [JsonProperty("request_three_d_secure")]
+        public string RequestThreeDSecure { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Configuration for any card payments attempted on this PaymentIntent.
+        /// </summary>
+        [JsonProperty("card")]
+        public PaymentIntentPaymentMethodOptionsCardOptions Card { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCancelOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCancelOptions.cs
@@ -5,6 +5,10 @@ namespace Stripe
 
     public class SetupIntentCancelOptions : BaseOptions
     {
+        /// <summary>
+        /// Reason for canceling this SetupIntent. Possible values are <c>abandoned</c>,
+        /// <c>requested_by_customer</c>, or <c>duplicate</c>.
+        /// </summary>
         [JsonProperty("cancellation_reason")]
         public string CancellationReason { get; set; }
     }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
@@ -13,9 +13,25 @@ namespace Stripe
         [JsonProperty("client_secret")]
         public string ClientSecret { get; set; }
 
+        /// <summary>
+        /// ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
+        /// attach to this SetupIntent
+        /// </summary>
         [JsonProperty("payment_method")]
         public string PaymentMethodId { get; set; }
 
+        /// <summary>
+        /// Payment-method-specific configuration for this SetupIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public SetupIntentPaymentMethodOptionsOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
+        /// The URL to redirect your customer back to after they authenticate on the payment
+        /// method’s app or site. If you’d prefer to redirect to a mobile application, you can
+        /// alternatively supply an application URI scheme. This parameter is only used for cards
+        /// and other redirect-based payment methods.
+        /// </summary>
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
     }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
@@ -5,30 +5,82 @@ namespace Stripe
 
     public class SetupIntentCreateOptions : BaseOptions
     {
+        /// <summary>
+        /// Set to <c>true</c> to attempt to confirm this SetupIntent immediately. This parameter
+        /// defaults to <c>false</c>. If the payment method attached is a card, a <c>ReturnUrl</c>
+        /// may be provided in case additional authentication is required.
+        /// </summary>
         [JsonProperty("confirm")]
         public bool? Confirm { get; set; }
 
+        /// <summary>
+        /// <para>
+        /// ID of the Customer this SetupIntent belongs to, if one exists.
+        /// </para>
+        /// <para>
+        /// If present, payment methods used with this SetupIntent can only be attached to this
+        /// Customer, and payment methods attached to other Customers cannot be used with this
+        /// SetupIntent.
+        /// </para>
+        /// </summary>
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users. This
+        /// can be unset by updating the value to null and then saving.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <summary>
+        /// A set of key/value pairs that you can attach to an order object. It can be useful for
+        /// storing additional information about the order in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// The Stripe account ID for which this SetupIntent is created.
+        /// </summary>
         [JsonProperty("on_behalf_of")]
         public string OnBehalfOf { get; set; }
 
+        /// <summary>
+        /// ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
+        /// attach to this SetupIntent.
+        /// </summary>
         [JsonProperty("payment_method")]
         public string PaymentMethodId { get; set; }
 
+        /// <summary>
+        /// Payment-method-specific configuration for this SetupIntent.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public SetupIntentPaymentMethodOptionsOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
+        /// The list of payment method types that this SetupIntent is allowed to set up. If this is
+        /// not provided, defaults to card.
+        /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
+        /// <summary>
+        /// The URL to redirect your customer back to after they authenticate on the payment
+        /// method’s app or site. If you’d prefer to redirect to a mobile application, you can
+        /// alternatively supply an application URI scheme. This parameter is only used for cards
+        /// and other redirect-based payment methods.
+        /// </summary>
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
 
+        /// <summary>
+        /// Indicates how the payment method is intended to be used in the future. Use
+        /// <c>on_session</c> if you intend to only reuse the payment method when the customer is in
+        /// your checkout flow. Use <c>off_session</c> if your customer may or may not be in your
+        /// checkout flow. If not provided, this value defaults to <c>off_session</c>.
+        /// </summary>
         [JsonProperty("usage")]
         public string Usage { get; set; }
     }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardOptions.cs
@@ -1,0 +1,21 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsCardOptions : INestedOptions
+    {
+        /// <summary>
+        /// When specified, this parameter signals that a card has been collected as MOTO (Mail
+        /// Order Telephone Order) and is thus out of scope for SCA.
+        /// </summary>
+        [JsonProperty("moto")]
+        public bool? Moto { get; set; }
+
+        /// <summary>
+        /// Control when to request 3D Secure on this SetupIntent.
+        /// </summary>
+        [JsonProperty("request_three_d_secure")]
+        public string RequestThreeDSecure { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Configuration for any card payments attempted on this SetupIntent.
+        /// </summary>
+        [JsonProperty("card")]
+        public PaymentIntentPaymentMethodOptionsCardOptions Card { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
@@ -5,21 +5,50 @@ namespace Stripe
 
     public class SetupIntentUpdateOptions : BaseOptions
     {
+        /// <summary>
+        /// <para>
+        /// ID of the Customer this SetupIntent belongs to, if one exists.
+        /// </para>
+        /// <para>
+        /// If present, payment methods used with this SetupIntent can only be attached to this
+        /// Customer, and payment methods attached to other Customers cannot be used with this
+        /// SetupIntent.
+        /// </para>
+        /// </summary>
         [JsonProperty("customer")]
         public string CustomerId { get; set; }
 
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users. This
+        /// can be unset by updating the value to null and then saving.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <summary>
+        /// A set of key/value pairs that you can attach to an order object. It can be useful for
+        /// storing additional information about the order in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
+        /// attach to this SetupIntent.
+        /// </summary>
         [JsonProperty("payment_method")]
         public string PaymentMethodId { get; set; }
 
+        /// <summary>
+        /// The list of payment method types that this SetupIntent is allowed to set up. If this is
+        /// not provided, defaults to card.
+        /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
+        /// <summary>
+        /// This feature is not yet available in the API.
+        /// </summary>
         [JsonProperty("usage")]
         public string Usage { get; set; }
     }


### PR DESCRIPTION
This PR adds support for `payment_method_options` on `PaymentIntent` and `SetupIntent`. This also adds missing documentation.

r? @ob-stripe 
cc @stripe/api-libraries 