### PR TITLE
Add support for VoidedAt on CreditNote

### DIFF
--- a/src/Stripe.net/Entities/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNote.cs
@@ -184,5 +184,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        /// <summary>
+        /// The time that the credit note was voided.
+        /// </summary>
+        [JsonProperty("voided_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime VoidedAt { get; set; }
     }
 }


### PR DESCRIPTION
This adds `VoidedAt` on `CreditNote`

r? @ob-stripe 
cc @stripe/api-libraries 