### PR TITLE
Fix NullReferenceException when auto-paginating without params

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -276,7 +276,9 @@ namespace Stripe
                     break;
                 }
 
+                options = options ?? new ListOptions();
                 options.StartingAfter = itemId;
+
                 page = this.Request<StripeList<T>>(
                     HttpMethod.Get,
                     url,


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Fixes an issue where the auto-pagination method would crash with a `NullReferenceException` when trying to fetch the second page if no parameters were provided.

Fixes #1717.