### PR TITLE
Add support for Authenticated on 3DS Charges

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
@@ -5,9 +5,22 @@ namespace Stripe
 
     public class ChargePaymentMethodDetailsCardThreeDSecure : StripeEntity
     {
+        /// <summary>
+        /// Whether or not authentication was performed. 3D Secure will succeed without
+        /// authentication when the card is not enrolled.
+        /// </summary>
+        [JsonProperty("authenticated")]
+        public bool Authenticated { get; set; }
+
+        /// <summary>
+        /// Whether or not 3D Secure succeeded.
+        /// </summary>
         [JsonProperty("succeeded")]
         public bool Succeeded { get; set; }
 
+        /// <summary>
+        /// The version of 3D Secure that was used for this payment.
+        /// </summary>
         [JsonProperty("version")]
         public string Version { get; set; }
     }


### PR DESCRIPTION
Add support for the missing `Authenticated` field for 3DS `Charge`.

r? @brandur-stripe 
cc @stripe/api-libraries 