### PR TITLE
Add various changes to the API

### DIFF
--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -449,6 +449,15 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// The status of the payment is either succeeded, pending, or failed
         /// </summary>
         [JsonProperty("status")]

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
@@ -5,33 +5,74 @@ namespace Stripe
 
     public class ChargePaymentMethodDetailsCard : StripeEntity
     {
+        /// <summary>
+        /// Card brand. Can be <c>amex</c>, <c>diners</c>, <c>discover</c>, <c>jcb</c>,
+        /// <c>mastercard</c>, <c>unionpay</c>, <c>visa</c>, or <c>unknown</c>.
+        /// </summary>
         [JsonProperty("brand")]
         public string Brand { get; set; }
 
+        /// <summary>
+        /// Check results by Card networks on Card address and CVC at time of payment.
+        /// </summary>
         [JsonProperty("checks")]
         public ChargePaymentMethodDetailsCardChecks Checks { get; set; }
 
+        /// <summary>
+        /// Two-letter ISO code representing the country of the card. You could use this attribute
+        /// to get a sense of the international breakdown of cards you’ve collected.
+        /// </summary>
         [JsonProperty("country")]
         public string Country { get; set; }
 
+        /// <summary>
+        /// Two-digit number representing the card’s expiration month.
+        /// </summary>
         [JsonProperty("exp_month")]
         public long ExpMonth { get; set; }
 
+        /// <summary>
+        /// Four-digit number representing the card’s expiration year.
+        /// </summary>
         [JsonProperty("exp_year")]
         public long ExpYear { get; set; }
 
+        /// <summary>
+        /// Uniquely identifies this particular card number. You can use this attribute to check
+        /// whether two customers who’ve signed up with you are using the same card number, for
+        /// example.
+        /// </summary>
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
 
+        /// <summary>
+        /// Card funding type. Can be <c>credit</c>, <c>debit</c>, <c>prepaid</c>, or
+        /// <c>unknown</c>.
+        /// </summary>
         [JsonProperty("funding")]
         public string Funding { get; set; }
 
+        /// <summary>
+        /// The last four digits of the card.
+        /// </summary>
         [JsonProperty("last4")]
         public string Last4 { get; set; }
 
+        /// <summary>
+        /// True if this payment was marked as MOTO and out of scope for SCA.
+        /// </summary>
+        [JsonProperty("moto")]
+        public bool Moto { get; set; }
+
+        /// <summary>
+        /// Populated if this transaction used 3D Secure authentication.
+        /// </summary>
         [JsonProperty("three_d_secure")]
         public ChargePaymentMethodDetailsCardThreeDSecure ThreeDSecure { get; set; }
 
+        /// <summary>
+        /// If this Card is part of a card wallet, this contains the details of the card wallet.
+        /// </summary>
         [JsonProperty("wallet")]
         public ChargePaymentMethodDetailsCardWallet Wallet { get; set; }
     }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -371,6 +371,15 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// Status of this PaymentIntent, one of <c>requires_payment_method</c>,
         /// <c>requires_confirmation</c>, <c>requires_action</c>, <c>processing</c>,
         /// <c>requires_capture</c>, <c>canceled</c>, or <c>succeeded</c>. Read more about each

--- a/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
@@ -50,5 +50,14 @@ namespace Stripe
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
+
+        /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -116,6 +116,15 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
+        /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
         [JsonProperty("transfer_data")]
         public ChargeTransferDataOptions TransferData { get; set; }
     }

--- a/src/Stripe.net/Services/Checkout/SessionPaymentIntentDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionPaymentIntentDataOptions.cs
@@ -74,6 +74,15 @@ namespace Stripe.Checkout
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// The parameters used to automatically create a Transfer when the payment succeeds.
         /// </summary>
         [JsonProperty("transfer_data")]

--- a/src/Stripe.net/Services/Checkout/SessionSubscriptionDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionSubscriptionDataOptions.cs
@@ -8,6 +8,16 @@ namespace Stripe.Checkout
     public class SessionSubscriptionDataOptions : INestedOptions
     {
         /// <summary>
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner’s Stripe account. The request must be made with an OAuth key in
+        /// order to set an application fee percentage. For more information, see the application
+        /// fees <see href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</see>.
+        /// </summary>
+        [JsonProperty("application_fee_percent")]
+        public decimal? ApplicationFeePercent { get; set; }
+
+        /// <summary>
         /// List of items, each with an attached plan.
         /// </summary>
         [JsonProperty("items")]

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCaptureOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCaptureOptions.cs
@@ -30,6 +30,15 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// The parameters used to automatically create a Transfer when the payment succeeds. For
         /// more information, see the PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">
         /// use case for connected accounts</a>.

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -175,6 +175,15 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// The data with which to automatically create a Transfer when the payment is finalized.
         /// See the PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">
         /// use case for connected accounts</a> for details.

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
@@ -116,6 +116,15 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
+        /// Provides information about the charge that customers see on their statements.
+        /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set
+        /// on the account to form the complete statement descriptor. Maximum 22 characters for the
+        /// concatenated descriptor.
+        /// </summary>
+        [JsonProperty("statement_descriptor_suffix")]
+        public string StatementDescriptorSuffix { get; set; }
+
+        /// <summary>
         /// The data with which to automatically create a Transfer when the payment is finalized.
         /// See the PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">
         /// use case for connected accounts</a> for details.


### PR DESCRIPTION
* support for `payment_method_details[card][moto]` on `Charge`
* support `statement_descriptor_suffix` on `Charge` and `PaymentIntent`
* support `subscription_data[application_fee_percent]` on Checkout `Session`

r? @ob-stripe 
cc @stripe/api-libraries 