### PR TITLE
Add missing IHas* interfaces everywhere

### DIFF
--- a/src/Stripe.net/Entities/EphemeralKeys/EphemeralkeyAssociatedObject.cs
+++ b/src/Stripe.net/Entities/EphemeralKeys/EphemeralkeyAssociatedObject.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class EphemeralKeyAssociatedObject : StripeEntity<EphemeralKeyAssociatedObject>
+    public class EphemeralKeyAssociatedObject : StripeEntity<EphemeralKeyAssociatedObject>, IHasId
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Events/EventRequest.cs
+++ b/src/Stripe.net/Entities/Events/EventRequest.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class EventRequest : StripeEntity<EventRequest>
+    public class EventRequest : StripeEntity<EventRequest>, IHasId
     {
         /// <summary>
         /// ID of the API request that caused the event. If null, the event was automatic (e.g.,

--- a/src/Stripe.net/Entities/Orders/ShippingMethod.cs
+++ b/src/Stripe.net/Entities/Orders/ShippingMethod.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class ShippingMethod : StripeEntity<ShippingMethod>
+    public class ShippingMethod : StripeEntity<ShippingMethod>, IHasId
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Entities/Persons/Person.cs
+++ b/src/Stripe.net/Entities/Persons/Person.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Person : StripeEntity<Person>, IHasId, IHasObject
+    public class Person : StripeEntity<Person>, IHasId, IHasObject, IHasMetadata
     {
         /// <summary>
         /// Unique identifier for the object.

--- a/src/Stripe.net/Services/Account/AccountCardOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountCardOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class AccountCardOptions : INestedOptions
+    public class AccountCardOptions : INestedOptions, IHasMetadata
     {
         [JsonProperty("object")]
         internal string Object => "card";

--- a/src/Stripe.net/Services/Account/AccountSharedOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountSharedOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public abstract class AccountSharedOptions : BaseOptions
+    public abstract class AccountSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("account_token")]
         public string AccountToken { get; set; }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ApplicationFeeRefundCreateOptions : BaseOptions
+    public class ApplicationFeeRefundCreateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundUpdateOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ApplicationFeeRefundUpdateOptions : BaseOptions
+    public class ApplicationFeeRefundUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountUpdateOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class BankAccountUpdateOptions : BaseOptions
+    public class BankAccountUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("account_holder_name")]
         public string AccountHolderName { get; set; }

--- a/src/Stripe.net/Services/Cards/CardCreateOptions.cs
+++ b/src/Stripe.net/Services/Cards/CardCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CardCreateOptions : BaseOptions
+    public class CardCreateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("default_for_currency")]
         public bool? DefaultForCurrency { get; set; }

--- a/src/Stripe.net/Services/Cards/CardUpdateOptions.cs
+++ b/src/Stripe.net/Services/Cards/CardUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CardUpdateOptions : BaseOptions
+    public class CardUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("address_city")]
         public string AddressCity { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class ChargeCreateOptions : BaseOptions
+    public class ChargeCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A positive integer in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a 0-decimal currency) representing how much to charge the card. The minimum amount is $0.50 US or equivalent in charge currency.

--- a/src/Stripe.net/Services/Charges/ChargeSourceListOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeSourceListOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class ChargeSourceListOptions : INestedOptions
+    public class ChargeSourceListOptions : INestedOptions, IHasObject
     {
         [JsonProperty("object")]
         public string Object { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ChargeUpdateOptions : BaseOptions
+    public class ChargeUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/Checkout/SessionPaymentIntentDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionPaymentIntentDataOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Checkout
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SessionPaymentIntentDataOptions : INestedOptions
+    public class SessionPaymentIntentDataOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// The amount of the application fee (if any) that will be applied to the payment and

--- a/src/Stripe.net/Services/Checkout/SessionSubscriptionDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionSubscriptionDataOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe.Checkout
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class SessionSubscriptionDataOptions : INestedOptions
+    public class SessionSubscriptionDataOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// List of items, each with an attached plan.

--- a/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CouponCreateOptions : BaseOptions
+    public class CouponCreateOptions : BaseOptions, IHasId
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CouponCreateOptions : BaseOptions, IHasId
+    public class CouponCreateOptions : BaseOptions, IHasId, IHasMetadata
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Coupons/CouponUpdateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CouponUpdateOptions : BaseOptions
+    public class CouponUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteCreateOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CreditNoteCreateOptions : BaseOptions
+    public class CreditNoteCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Credit note amount.

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteUpdateOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteUpdateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CreditNoteUpdateOptions : BaseOptions
+    public class CreditNoteUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Credit note memo.

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionCreateOptions.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CustomerBalanceTransactionCreateOptions : BaseOptions
+    public class CustomerBalanceTransactionCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// The amount to apply to the customer’s balance. Pass a negative amount to credit the

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionUpdateOptions.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CustomerBalanceTransactionUpdateOptions : BaseOptions
+    public class CustomerBalanceTransactionUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// An arbitrary string attached to the object. Often useful for displaying to users.

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CustomerCreateOptions : BaseOptions
+    public class CustomerCreateOptions : BaseOptions, IHasMetadata
     {
         [Obsolete("Use Balance")]
         [JsonProperty("account_balance")]

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class CustomerUpdateOptions : BaseOptions
+    public class CustomerUpdateOptions : BaseOptions, IHasMetadata
     {
         [Obsolete("Use Balance")]
         [JsonProperty("account_balance")]

--- a/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class DisputeEvidenceOptions : INestedOptions
+    public class DisputeEvidenceOptions : INestedOptions, IHasMetadata
     {
         [JsonProperty("access_activity_log")]
         public string AccessActivityLog { get; set; }
@@ -43,6 +43,9 @@ namespace Stripe
 
         [JsonProperty("duplicate_charge_id")]
         public string DuplicateChargeFileId { get; set; }
+
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("product_description")]
         public string ProductDescription { get; set; }
@@ -85,8 +88,5 @@ namespace Stripe
 
         [JsonProperty("uncategorized_text")]
         public string UncategorizedText { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Disputes/DisputeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class DisputeUpdateOptions : BaseOptions
+    public class DisputeUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Evidence to upload, to respond to a dispute. Updating any field in the hash will submit

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardUpdateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ExternalAccountCardUpdateOptions : INestedOptions
+    public class ExternalAccountCardUpdateOptions : INestedOptions, IHasMetadata
     {
         [JsonProperty("default_for_currency")]
         public bool? DefaultForCurrency { get; set; }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class ExternalAccountCreateOptions : BaseOptions
+    public class ExternalAccountCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// REQUIRED. Either a token, like the ones returned by

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountUpdateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ExternalAccountUpdateOptions : BaseOptions
+    public class ExternalAccountUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/FileLinks/FileLinkSharedOptions.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkSharedOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class FileLinkSharedOptions : BaseOptions
+    public class FileLinkSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A future timestamp after which the link will no longer be usable.

--- a/src/Stripe.net/Services/Files/FileLinkDataOptions.cs
+++ b/src/Stripe.net/Services/Files/FileLinkDataOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class FileLinkDataOptions : BaseOptions
+    public class FileLinkDataOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Set this to <c>true</c> to create a file link for the newly created file. Creating a

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class InvoiceItemCreateOptions : BaseOptions
+    public class InvoiceItemCreateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class InvoiceItemUpdateOptions : BaseOptions
+    public class InvoiceItemUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class InvoiceCreateOptions : BaseOptions
+    public class InvoiceCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A fee in cents that will be applied to the invoice and transferred to the application

--- a/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class InvoiceSubscriptionItemOptions : BaseOptions
+    public class InvoiceSubscriptionItemOptions : BaseOptions, IHasId
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class InvoiceUpcomingInvoiceItemOption : INestedOptions
+    public class InvoiceUpcomingInvoiceItemOption : INestedOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class InvoiceUpdateOptions : BaseOptions
+    public class InvoiceUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A fee in cents that will be applied to the invoice and transferred to the application

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationUpdateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class AuthorizationUpdateOptions : BaseOptions
+    public class AuthorizationUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderSharedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CardholderSharedOptions : BaseOptions
+    public class CardholderSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("billing")]
         public BillingOptions Billing { get; set; }

--- a/src/Stripe.net/Services/Issuing/Cards/CardSharedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CardSharedOptions : BaseOptions
+    public class CardSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("authorization_controls")]
         public AuthorizationControlsOptions AuthorizationControls { get; set; }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeSharedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class DisputeSharedOptions : BaseOptions
+    public class DisputeSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TransactionUpdateOptions : BaseOptions
+    public class TransactionUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Orders/OrderCreateOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class OrderCreateOptions : BaseOptions
+    public class OrderCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// REQUIRED: Three-letter ISO currency code, in lowercase. Must be a supported currency.

--- a/src/Stripe.net/Services/Orders/OrderPayOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderPayOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class OrderPayOptions : BaseOptions
+    public class OrderPayOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// The ID of an existing customer that will be charged in this request.

--- a/src/Stripe.net/Services/Orders/OrderUpdateOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class OrderUpdateOptions : BaseOptions
+    public class OrderUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A coupon code that represents a discount to be applied to this order. Must be one-time duration and in tbe same currency as the order.

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PaymentIntentCreateOptions : BaseOptions
+    public class PaymentIntentCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A positive integer representing how much to charge in the smallest currency unit (e.g.,

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PaymentIntentUpdateOptions : BaseOptions
+    public class PaymentIntentUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A positive integer representing how much to charge in the smallest currency unit (e.g.,

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PaymentMethodCreateOptions : BaseOptions
+    public class PaymentMethodCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Billing information associated with the PaymentMethod that may be used or required by

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodUpdateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PaymentMethodUpdateOptions : BaseOptions
+    public class PaymentMethodUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Billing information associated with the PaymentMethod that may be used or required by

--- a/src/Stripe.net/Services/Payouts/PayoutCreateOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PayoutCreateOptions : BaseOptions
+    public class PayoutCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// REQUIRED. A positive integer in cents representing how much to payout.

--- a/src/Stripe.net/Services/Payouts/PayoutUpdateOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PayoutUpdateOptions : BaseOptions
+    public class PayoutUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A set of key-value pairs that you can attach to a payout object. It can be useful for

--- a/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public abstract class PersonSharedOptions : BaseOptions
+    public abstract class PersonSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("address")]
         public AddressOptions Address { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PlanCreateOptions : BaseOptions, IHasId
+    public class PlanCreateOptions : BaseOptions, IHasId, IHasMetadata
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class PlanCreateOptions : BaseOptions
+    public class PlanCreateOptions : BaseOptions, IHasId
     {
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/src/Stripe.net/Services/Plans/PlanUpdateOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PlanUpdateOptions : BaseOptions
+    public class PlanUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("active")]
         public bool? Active { get; set; }

--- a/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PlanProductCreateOptions : INestedOptions, IHasId
+    public class PlanProductCreateOptions : INestedOptions, IHasId, IHasMetadata
     {
         [JsonProperty("active")]
         public bool? Active { get; set; }

--- a/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/PlanProductCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class PlanProductCreateOptions : INestedOptions
+    public class PlanProductCreateOptions : INestedOptions, IHasId
     {
         [JsonProperty("active")]
         public bool? Active { get; set; }

--- a/src/Stripe.net/Services/Products/ProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductCreateOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class ProductCreateOptions : ProductSharedOptions
+    public class ProductCreateOptions : ProductSharedOptions, IHasId
     {
         /// <summary>
         /// The identifier for the product. Must be unique. If not provided, an identifier will be randomly generated.

--- a/src/Stripe.net/Services/Products/ProductSharedOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public abstract class ProductSharedOptions : BaseOptions
+    public abstract class ProductSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Whether or not the product is currently available for purchase. Defaults to true.

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListSharedOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.Radar
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class ValueListSharedOptions : BaseOptions
+    public class ValueListSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("alias")]
         public string Alias { get; set; }

--- a/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class RefundCreateOptions : BaseOptions
+    public class RefundCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A positive integer in cents representing how much of this charge to refund. Can refund

--- a/src/Stripe.net/Services/Refunds/RefundUpdateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class RefundUpdateOptions : BaseOptions
+    public class RefundUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SetupIntentCreateOptions : BaseOptions
+    public class SetupIntentCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Set to <c>true</c> to attempt to confirm this SetupIntent immediately. This parameter

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SetupIntentUpdateOptions : BaseOptions
+    public class SetupIntentUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// <para>

--- a/src/Stripe.net/Services/Skus/SkuCreateOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuCreateOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class SkuCreateOptions : SkuSharedOptions
+    public class SkuCreateOptions : SkuSharedOptions, IHasId
     {
         /// <summary>
         /// The identifier for the SKU. Must be unique. If not provided, an identifier will be randomly generated.

--- a/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public abstract class SkuSharedOptions : BaseOptions
+    public abstract class SkuSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Whether or not the SKU is currently available for purchase. Defaults to true.

--- a/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class SourceCreateOptions : BaseOptions
+    public class SourceCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// REQUIRED: The type of the source to create. One of type <see cref="SourceType"/>

--- a/src/Stripe.net/Services/Sources/SourceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceUpdateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SourceUpdateOptions : BaseOptions
+    public class SourceUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Information about a mandate possiblity attached to a source object (generally for bank debits) as well as its acceptance status.

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemCreateOptions : SubscriptionItemSharedOptions
+    public class SubscriptionItemCreateOptions : SubscriptionItemSharedOptions, IHasMetadata
     {
         /// <summary>
         /// REQUIRED: The identifier of the subscription to modify.

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemUpdateOptions : SubscriptionItemSharedOptions
+    public class SubscriptionItemUpdateOptions : SubscriptionItemSharedOptions, IHasMetadata
     {
         /// <summary>
         /// A set of key/value pairs that you can attach to a subscription object. It can be useful for storing additional information about the subscription in a structured format.

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public abstract class SubscriptionScheduleSharedOptions : BaseOptions
+    public abstract class SubscriptionScheduleSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// This field has been renamed to <c>CollectionMethod</c> and will be removed

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemOption.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemOption : INestedOptions
+    public class SubscriptionItemOption : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// A set of key/value pairs that you can attach to a charge object. It can be useful for

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemUpdateOption.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemUpdateOption.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemUpdateOption : INestedOptions, IHasId
+    public class SubscriptionItemUpdateOption : INestedOptions, IHasId, IHasMetadata
     {
         /// <summary>
         /// SubscriptionItem to update.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemUpdateOption.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemUpdateOption.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemUpdateOption : INestedOptions
+    public class SubscriptionItemUpdateOption : INestedOptions, IHasId
     {
         /// <summary>
         /// SubscriptionItem to update.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionSharedOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public abstract class SubscriptionSharedOptions : BaseOptions
+    public abstract class SubscriptionSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner’s Stripe account. The request must be made with an OAuth key in order to set an application fee percentage. For more information, see the application fees <see href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</see>.

--- a/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class TaxRateCreateOptions : BaseOptions
+    public class TaxRateCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Whether the tax rate is currently available for new subscriptions.

--- a/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
@@ -5,7 +5,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class TaxRateUpdateOptions : BaseOptions
+    public class TaxRateUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// Whether the tax rate is currently available for new subscriptions.

--- a/src/Stripe.net/Services/Topups/TopupCreateOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TopupCreateOptions : BaseOptions
+    public class TopupCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
         /// A positive integer in the smallest currency unit (e.g., 100 cents to top up $1.00 or 100 to top up ¥100, a 0-decimal currency) representing how much to top up your Stripe balance.

--- a/src/Stripe.net/Services/Topups/TopupUpdateOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TopupUpdateOptions : BaseOptions
+    public class TopupUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalCreateOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TransferReversalCreateOptions : BaseOptions
+    public class TransferReversalCreateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalUpdateOptions.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TransferReversalUpdateOptions : BaseOptions
+    public class TransferReversalUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/Transfers/TransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/TransferCreateOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TransferCreateOptions : BaseOptions
+    public class TransferCreateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/Transfers/TransferUpdateOptions.cs
+++ b/src/Stripe.net/Services/Transfers/TransferUpdateOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class TransferUpdateOptions : BaseOptions
+    public class TransferUpdateOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("description")]
         public string Description { get; set; }

--- a/src/Stripe.net/Services/_refactor/CardCreateNestedOptions.cs
+++ b/src/Stripe.net/Services/_refactor/CardCreateNestedOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CardCreateNestedOptions : INestedOptions
+    public class CardCreateNestedOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// The type of payment source. Should be "card".

--- a/src/Stripe.net/Services/_refactor/SourceBankAccount.cs
+++ b/src/Stripe.net/Services/_refactor/SourceBankAccount.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SourceBankAccount : INestedOptions
+    public class SourceBankAccount : INestedOptions, IHasMetadata
     {
         [JsonProperty("object")]
         internal string Object => "bank_account";

--- a/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
+++ b/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
@@ -23,8 +23,9 @@ namespace StripeTests
         {
             List<string> results = new List<string>();
 
-            // Get all classes that implement IHasObject
-            var modelClasses = GetClassesWithInterface(typeof(IHasObject));
+            // Get all StripeEntity subclasses that implement IHasObject
+            var modelClasses = GetSubclassesOf(typeof(StripeEntity))
+                .Intersect(GetClassesWithInterface(typeof(IHasObject)));
 
             foreach (Type modelClass in modelClasses)
             {

--- a/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
+++ b/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
@@ -1,0 +1,68 @@
+#if NETCOREAPP
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Stripe;
+    using Xunit;
+
+    /// <summary>
+    /// This wholesome test ensures that all Stripe entity and options classes implement the
+    /// <c>IHasX</c> interfaces when they have matching properties.
+    /// </summary>
+    public class DontForgetIHasInterfaces : WholesomeTest
+    {
+        private const string AssertionMessage =
+            "Found at least one missing interface.";
+
+        [Fact]
+        public void Check()
+        {
+            List<string> results = new List<string>();
+
+            // Get all classes that derive from StripeEntity or implement INestedOptions
+            var stripeClasses = GetSubclassesOf(typeof(StripeEntity));
+            stripeClasses.AddRange(GetClassesWithInterface(typeof(INestedOptions)));
+
+            foreach (Type stripeClass in stripeClasses)
+            {
+                var interfaces = stripeClass.GetInterfaces();
+
+                foreach (PropertyInfo property in stripeClass.GetProperties())
+                {
+                    // Check for IHasId
+                    if ((property.Name == "Id") && (property.PropertyType == typeof(string)))
+                    {
+                        if (!interfaces.Contains(typeof(IHasId)))
+                        {
+                            results.Add($"{stripeClass.Name} is missing IHasId");
+                        }
+                    }
+
+                    // Check for IHasObject
+                    if ((property.Name == "Object") && (property.PropertyType == typeof(string)))
+                    {
+                        if (!interfaces.Contains(typeof(IHasObject)))
+                        {
+                            results.Add($"{stripeClass.Name} is missing IHasObject");
+                        }
+                    }
+
+                    // Check for IHasMetadata
+                    if ((property.Name == "Metadata") && (property.PropertyType == typeof(Dictionary<string, string>)))
+                    {
+                        if (!interfaces.Contains(typeof(IHasMetadata)))
+                        {
+                            results.Add($"{stripeClass.Name} is missing IHasMetadata");
+                        }
+                    }
+                }
+            }
+
+            AssertEmpty(results, AssertionMessage);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

This PR:
- adds a wholesome test to check that Stripe entities and options classes that can implement a specific `IHas*` interface do inherit the interface
- adds the interfaces to all options classes (previously they were only applied to entities classes)
