### PR TITLE
Fix duplicate expand values issue

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -296,7 +296,16 @@ namespace Stripe
             }
 
             options = options ?? new BaseOptions();
-            options.AddRangeExpand(serviceExpansions);
+
+            if (options.Expand == null)
+            {
+                options.Expand = new List<string>();
+            }
+
+            // Compute the union instead of using `AddRangeExpand` to avoid adding duplicate
+            // values in the list, in case `SetupOptions` has already been called on this options
+            // instance.
+            options.Expand = options.Expand.Union(serviceExpansions).ToList();
 
             return options;
         }

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -44,6 +44,7 @@ namespace StripeTests
 
             // Call auto-paging method
             var service = new PageableService(this.StripeClient);
+            service.ExpandFoo = true;
             var options = new ListOptions
             {
                 Limit = 2,
@@ -66,7 +67,7 @@ namespace StripeTests
                     ItExpr.Is<HttpRequestMessage>(m =>
                         m.Method == HttpMethod.Get &&
                         m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
-                        m.RequestUri.Query == "?limit=2"),
+                        m.RequestUri.Query == "?limit=2&expand[0]=data.foo"),
                     ItExpr.IsAny<CancellationToken>());
 
             this.MockHttpClientFixture.MockHandler.Protected()
@@ -76,7 +77,7 @@ namespace StripeTests
                     ItExpr.Is<HttpRequestMessage>(m =>
                         m.Method == HttpMethod.Get &&
                         m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
-                        m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_124&expand[0]=data.foo"),
                     ItExpr.IsAny<CancellationToken>());
 
             this.MockHttpClientFixture.MockHandler.Protected()
@@ -86,7 +87,7 @@ namespace StripeTests
                     ItExpr.Is<HttpRequestMessage>(m =>
                         m.Method == HttpMethod.Get &&
                         m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
-                        m.RequestUri.Query == "?limit=2&starting_after=pm_126"),
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_126&expand[0]=data.foo"),
                     ItExpr.IsAny<CancellationToken>());
         }
 
@@ -169,6 +170,8 @@ namespace StripeTests
                 : base(client)
             {
             }
+
+            public bool ExpandFoo { get; set; }
 
             public override string BasePath => "/v1/pageablemodels";
 

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -21,6 +21,7 @@ namespace StripeTests
             service.ExpandMultiWordProperty = true;
             service.Get("foo");
 
+            Assert.Equal(2, client.LastOptions.Expand.Count);
             Assert.Contains("simple", client.LastOptions.Expand);
             Assert.Contains("multi_word_property", client.LastOptions.Expand);
         }
@@ -60,8 +61,18 @@ namespace StripeTests
 
             service.ExpandSimple = true;
             service.ExpandMultiWordProperty = true;
-            service.List();
+            var options = new ListOptions();
 
+            service.List(options);
+
+            Assert.Equal(2, client.LastOptions.Expand.Count);
+            Assert.Contains("data.simple", client.LastOptions.Expand);
+            Assert.Contains("data.multi_word_property", client.LastOptions.Expand);
+
+            // Do a second request to check that expand properties are not duplicated
+            service.List(options);
+
+            Assert.Equal(2, client.LastOptions.Expand.Count);
             Assert.Contains("data.simple", client.LastOptions.Expand);
             Assert.Contains("data.multi_word_property", client.LastOptions.Expand);
         }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

When using the `ExpandX` properties on a service class, expand values in the actual HTTP request would be duplicated if the same options class instance is reused for multiple requests. This is most notable the case with auto-pagination.

This fixes the issue by only adding expand values if they're not already present in the `Expand` list of the options class instance.
