### PR TITLE
Move to API version 2019-08-14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.63.0
+  STRIPE_MOCK_VERSION: 0.64.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
@@ -19,10 +19,10 @@ namespace Stripe
         public string LegacyPayments { get; set; }
 
         /// <summary>
-        /// The status of the platform payments capability of the account, or whether your platform
-        /// can process charges on behalf of the account.
+        /// The status of the transfers capability of the account, or whether your platform can
+        /// transfer funds to the account.
         /// </summary>
-        [JsonProperty("platform_payments")]
-        public string PlatformPayments { get; set; }
+        [JsonProperty("transfers")]
+        public string Transfers { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Persons/PersonRelationship.cs
+++ b/src/Stripe.net/Entities/Persons/PersonRelationship.cs
@@ -18,6 +18,13 @@ namespace Stripe
         public bool Director { get; set; }
 
         /// <summary>
+        /// Whether the person has significant responsibility to control, manage, or direct the
+        /// organization.
+        /// </summary>
+        [JsonProperty("executive")]
+        public bool Executive { get; set; }
+
+        /// <summary>
         /// Whether the person is an owner of the account’s legal entity..
         /// </summary>
         [JsonProperty("owner")]

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -30,7 +30,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-05-16";
+        public static string ApiVersion => "2019-08-14";
 
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Services/OAuth/OAuthAuthorizeUrlOptions.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthAuthorizeUrlOptions.cs
@@ -77,7 +77,7 @@ namespace Stripe
         /// <summary>
         /// If your platform is designated for one
         /// <see href="https://stripe.com/docs/connect/capabilities-overview">Capability</see>
-        /// (either <c>card_payments</c> or <c>platform_payments</c>), you won’t need to specify
+        /// (either <c>card_payments</c> or <c>transfers</c>), you won’t need to specify
         /// additional Capabilities. However, if your platform supports both, you can add a
         /// Capability to an individual Express account by including the
         /// <see cref="SuggestedCapabilities"/> parameter in your OAuth link.

--- a/src/Stripe.net/Services/OAuth/OAuthTokenCreateOptions.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenCreateOptions.cs
@@ -10,7 +10,7 @@ namespace Stripe
         /// using the <see cref="OAuthAuthorizeUrlOptions.SuggestedCapabilities"/> parameter, you
         /// can verify that Stripe applied the suggested Capability in this POST request by
         /// including <see cref="AssertCapabilities"/> and identifying that <c>card_payments</c> or
-        /// <c>platform_payments</c> match. A request error will be returned if the suggested
+        /// <c>transfers</c> match. A request error will be returned if the suggested
         /// <see href="https://stripe.com/docs/connect/capabilities-overview">Capability</see>
         /// doesn’t match the assertion: in this case, it’s recommended to end the onboarding flow
         /// with a failure.

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -51,7 +51,7 @@ namespace StripeTests
                 RequestedCapabilities = new List<string>
                 {
                     "card_payments",
-                    "platform_payments",
+                    "transfers",
                 },
                 Settings = new AccountSettingsOptions
                 {

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -12,7 +12,7 @@ namespace StripeTests
         /// <remarks>
         /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.63.0";
+        private const string MockMinimumVersion = "0.64.0";
 
         private readonly string port;
 


### PR DESCRIPTION
This introduces support for the latest API version [2019-08-14](https://stripe.com/docs/upgrades#2019-08-14)
* rename `platform_payments` to `transfers`
* introduce `executive` as a relationship on `Person`

r? @ob-stripe 
cc @stripe/api-libraries 