### PR TITLE
Bump Stylecop.Analyzers to latest version

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -130,7 +130,7 @@ namespace Stripe
         public AccountSettings Settings { get; set; }
 
         /// <summary>
-        /// Details on the acceptance of the Stripe Services Agreement
+        /// Details on the acceptance of the Stripe Services Agreement.
         /// </summary>
         [JsonProperty("tos_acceptance")]
         public AccountTosAcceptance TosAcceptance { get; set; }

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -457,7 +457,7 @@ namespace Stripe
         public string StatementDescriptorSuffix { get; set; }
 
         /// <summary>
-        /// The status of the payment is either succeeded, pending, or failed
+        /// The status of the payment is either <c>succeeded</c>, <c>pending</c>, or <c>failed</c>.
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -37,7 +37,7 @@ namespace Stripe
         public DateTime Created { get; set; }
 
         /// <summary>
-        /// The currency the customer can be charged in for recurring billing purposes
+        /// The currency the customer can be charged in for recurring billing purposes.
         /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }
@@ -45,7 +45,7 @@ namespace Stripe
         #region Expandable DefaultSource
 
         /// <summary>
-        /// ID of the default source attached to this customer
+        /// ID of the default source attached to this customer.
         /// </summary>
         [JsonIgnore]
         public string DefaultSourceId
@@ -67,7 +67,7 @@ namespace Stripe
         #endregion
 
         /// <summary>
-        /// Warning: this is not in the documentation
+        /// Warning: this is not in the documentation.
         /// </summary>
         [JsonProperty("default_source_type")]
         public string DefaultSourceType { get; set; }
@@ -79,7 +79,7 @@ namespace Stripe
         public bool? Deleted { get; set; }
 
         /// <summary>
-        /// Whether or not the latest charge for the customer’s latest invoice has failed
+        /// Whether or not the latest charge for the customer’s latest invoice has failed.
         /// </summary>
         [JsonProperty("delinquent")]
         public bool Delinquent { get; set; }
@@ -91,7 +91,7 @@ namespace Stripe
         public string Description { get; set; }
 
         /// <summary>
-        /// Describes the current discount active on the customer, if there is one
+        /// Describes the current discount active on the customer, if there is one.
         /// </summary>
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
@@ -123,7 +123,7 @@ namespace Stripe
 
         /// <summary>
         /// A set of key/value pairs that you can attach to a customer object. It can be useful for
-        /// storing additional information about the customer in a structured format
+        /// storing additional information about the customer in a structured format.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
@@ -154,13 +154,13 @@ namespace Stripe
         public Shipping Shipping { get; set; }
 
         /// <summary>
-        /// The customer’s payment sources, if any
+        /// The customer’s payment sources, if any.
         /// </summary>
         [JsonProperty("sources")]
         public StripeList<IPaymentSource> Sources { get; set; }
 
         /// <summary>
-        /// The customer’s current subscriptions, if any
+    /// The customer’s current subscriptions, if any.
         /// </summary>
         [JsonProperty("subscriptions")]
         public StripeList<Subscription> Subscriptions { get; set; }

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -22,7 +22,7 @@ namespace Stripe
 
         /// <summary>
         /// The public name of the business associated with this invoice, most often the business
-        /// creating the invoice
+        /// creating the invoice.
         /// </summary>
         [JsonProperty("account_name")]
         public string AccountName { get; set; }

--- a/src/Stripe.net/Entities/Orders/DeliveryEstimate.cs
+++ b/src/Stripe.net/Entities/Orders/DeliveryEstimate.cs
@@ -17,7 +17,7 @@ namespace Stripe
         public string Earliest { get; set; }
 
         /// <summary>
-        /// If type is "range", latest will be the latest delivery date in the format YYYY-MM-DD
+        /// If type is "range", latest will be the latest delivery date in the format YYYY-MM-DD.
         /// </summary>
         [JsonProperty("latest")]
         public string Latest { get; set; }

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -35,7 +35,7 @@ namespace Stripe
 
         /// <summary>
         /// <para>The ID of the payment used to pay for the order. Present if the order status is paid, fulfilled, or refunded.</para>
-        /// <para>Expandable</para>
+        /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
         public string ChargeId

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -42,7 +42,7 @@ namespace Stripe
 
         /// <summary>
         /// <para>The order that this return includes items from.</para>
-        /// <para>Expandable</para>
+        /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
         public string OrderId
@@ -67,7 +67,7 @@ namespace Stripe
 
         /// <summary>
         /// <para>The ID of the refund issued for this return.</para>
-        /// <para>Expandable</para>
+        /// <para>Expandable.</para>
         /// </summary>
         [JsonIgnore]
         public string RefundId { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -365,7 +365,7 @@ namespace Stripe
 
         /// <summary>
         /// Extra information about a PaymentIntent. This will appear on your customer’s statement
-        /// when this PaymentIntent succeeds in creating a charge
+        /// when this PaymentIntent succeeds in creating a charge.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -56,7 +56,7 @@ namespace Stripe
         #region Expandable Product
 
         /// <summary>
-        /// ID of the product linked to this plan
+        /// ID of the product linked to this plan.
         /// </summary>
         [JsonIgnore]
         public string ProductId

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -23,7 +23,7 @@ namespace Stripe
         /// <summary>
         /// For card errors resulting from a card issuer decline, a short string indicating the
         /// <a href="https://stripe.com//docs/declines#issuer-declines">card issuer's reason for the
-        /// decline</a>
+        /// decline</a>.
         /// </summary>
         [JsonProperty("decline_code")]
         public string DeclineCode { get; set; }
@@ -80,7 +80,7 @@ namespace Stripe
         /// <summary>
         /// The type of error returned. One of <c>api_connection_error</c>, <c>api_error</c>,
         /// <c>authentication_error</c>, <c>card_error</c>, <c>idempotency_error</c>,
-        /// <c>invalid_request_error</c>, or <c>rate_limit_error</c>
+        /// <c>invalid_request_error</c>, or <c>rate_limit_error</c>.
         /// </summary>
         [JsonProperty("type")]
         public string ErrorType { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -22,7 +22,7 @@ namespace Stripe
 
         /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period
+        /// new billing period.
         /// </summary>
         [JsonProperty("billing_thresholds")]
         public SubscriptionBillingThresholds BillingThresholds { get; set; }

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -21,7 +21,7 @@ namespace Stripe
 
         /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period
+        /// new billing period.
         /// </summary>
         [JsonProperty("billing_thresholds")]
         public SubscriptionBillingThresholds BillingThresholds { get; set; }

--- a/src/Stripe.net/Entities/TaxIds/TaxId.cs
+++ b/src/Stripe.net/Entities/TaxIds/TaxId.cs
@@ -71,7 +71,7 @@ namespace Stripe
 
         /// <summary>
         /// Type of the tax ID, one of <c>au_abn</c>, <c>eu_vat</c>, <c>in_gst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, or <c>unknown</c>
+        /// <c>nz_gst</c>, or <c>unknown</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -90,7 +90,8 @@ namespace Stripe
         public string StatementDescriptor { get; set; }
 
         /// <summary>
-        /// The status of the payment is either succeeded, pending, or failed
+        /// The status of the top-up is either <c>canceled</c>, <c>failed</c>, <c>pending</c>,
+        /// <c>reversed</c>, or <c>succeeded</c>.
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -89,7 +89,7 @@ namespace Stripe.Infrastructure.FormEncoding
         /// </summary>
         /// <param name="value">The value for which to create the list of parameters.</param>
         /// <param name="keyPrefix">The key under which new keys should be nested, if any.</param>
-        /// <returns>The list of parameters</returns>
+        /// <returns>The list of parameters.</returns>
         private static List<KeyValuePair<string, object>> FlattenParamsValue(object value, string keyPrefix)
         {
             List<KeyValuePair<string, object>> flatParams = null;
@@ -178,7 +178,7 @@ namespace Stripe.Infrastructure.FormEncoding
         /// </summary>
         /// <param name="options">The options class for which to create the list of parameters.</param>
         /// <param name="keyPrefix">The key under which new keys should be nested, if any.</param>
-        /// <returns>The list of parameters</returns>
+        /// <returns>The list of parameters.</returns>
         private static List<KeyValuePair<string, object>> FlattenParamsOptions(
             INestedOptions options,
             string keyPrefix)
@@ -235,7 +235,7 @@ namespace Stripe.Infrastructure.FormEncoding
         /// </summary>
         /// <param name="dictionary">The dictionary for which to create the list of parameters.</param>
         /// <param name="keyPrefix">The key under which new keys should be nested, if any.</param>
-        /// <returns>The list of parameters</returns>
+        /// <returns>The list of parameters.</returns>
         private static List<KeyValuePair<string, object>> FlattenParamsDictionary(
             IDictionary dictionary,
             string keyPrefix)
@@ -266,7 +266,7 @@ namespace Stripe.Infrastructure.FormEncoding
         /// </summary>
         /// <param name="list">The list for which to create the list of parameters.</param>
         /// <param name="keyPrefix">The key under which new keys should be nested.</param>
-        /// <returns>The list of parameters</returns>
+        /// <returns>The list of parameters.</returns>
         private static List<KeyValuePair<string, object>> FlattenParamsList(
             IEnumerable list,
             string keyPrefix)

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -21,17 +21,17 @@ namespace Stripe
         /// created with default parameters.
         /// </param>
         /// <param name="apiBase">
-        /// The base URL for Stripe's API. Defaults to <see cref="DefaultApiBase"/>
+        /// The base URL for Stripe's API. Defaults to <see cref="DefaultApiBase"/>.
         /// </param>
         /// <param name="connectBase">
-        /// The base URL for Stripe's OAuth API. Defaults to <see cref="DefaultConnectBase"/>
+        /// The base URL for Stripe's OAuth API. Defaults to <see cref="DefaultConnectBase"/>.
         /// </param>
         /// <param name="filesBase">
-        /// The base URL for Stripe's Files API. Defaults to <see cref="DefaultFilesBase"/>
+        /// The base URL for Stripe's Files API. Defaults to <see cref="DefaultFilesBase"/>.
         /// </param>
-        /// <exception cref="ArgumentNullException">if <c>apiKey</c> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException">if <c>apiKey</c> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
-        /// if <c>apiKey</c> is empty or contains whitespace
+        /// if <c>apiKey</c> is empty or contains whitespace.
         /// </exception>
         public StripeClient(
             string apiKey = null,

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -44,7 +44,7 @@ namespace Stripe
         /// </param>
         /// <param name="maxNetworkRetries">
         /// The maximum number of times the client will retry requests that fail due to an
-        /// intermittent problem
+        /// intermittent problem.
         /// </param>
         /// <param name="appInfo">
         /// Information about the "app" which this integration belongs to. This should be reserved

--- a/src/Stripe.net/Services/Account/AccountCreateOptions.cs
+++ b/src/Stripe.net/Services/Account/AccountCreateOptions.cs
@@ -11,7 +11,7 @@ namespace Stripe
         public PersonCreateOptions Individual { get; set; }
 
         /// <summary>
-        /// One of <see cref="AccountType"/>
+        /// One of <see cref="AccountType"/>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainCreateOptions.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class ApplePayDomainCreateOptions : BaseOptions
     {
         /// <summary>
-        /// Domain to add as an Apple Pay Domain
+        /// Domain to add as an Apple Pay Domain.
         /// </summary>
         [JsonProperty("domain_name")]
         public string DomainName { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe
     public class ChargeCaptureOptions : BaseOptions
     {
         /// <summary>
-        /// Amount to capture on the authorization
+        /// Amount to capture on the authorization.
         /// </summary>
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -47,7 +47,7 @@ namespace Stripe
         public decimal? ExchangeRate { get; set; }
 
         /// <summary>
-        /// Extra information about the charge passing level III data to card networks
+        /// Extra information about the charge passing level III data to card networks.
         /// </summary>
         [JsonProperty("level3")]
         public ChargeLevel3Options Level3 { get; set; }

--- a/src/Stripe.net/Services/Checkout/SessionLineItemOptions.cs
+++ b/src/Stripe.net/Services/Checkout/SessionLineItemOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe.Checkout
     public class SessionLineItemOptions : INestedOptions
     {
         /// <summary>
-        /// Per item amount to be collected
+        /// The amount to be collected per unit of the line item.
         /// </summary>
         [JsonProperty("amount")]
         public long? Amount { get; set; }

--- a/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using Newtonsoft.Json;
 
     /// <summary>
-    /// The optional arguments you can pass. <see href="https://stripe.com/docs/api#list_disputes">Stripe Documentation</see>
+    /// The optional arguments you can pass. <a href="https://stripe.com/docs/api#list_disputes">Stripe Documentation</a>.
     /// </summary>
     public class DisputeListOptions : ListOptionsWithCreated
     {

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
@@ -28,7 +28,7 @@ namespace Stripe
         /// useful for storing additional information about the external account in a structured
         /// format.
         /// </summary>
-         [JsonProperty("metadata")]
+        [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
    }
 }

--- a/src/Stripe.net/Services/Files/FileCreateOptions.cs
+++ b/src/Stripe.net/Services/Files/FileCreateOptions.cs
@@ -22,7 +22,7 @@ namespace Stripe
         /// <summary>
         /// REQUIRED. The purpose of the uploaded file. Possible values are <c>business_logo</c>,
         /// <c>customer_signature</c>, <c>dispute_evidence</c>, <c>identity_document</c>,
-        /// <c>pci_document</c>, or <c>tax_document_user_upload</c>
+        /// <c>pci_document</c>, or <c>tax_document_user_upload</c>.
         /// </summary>
         [JsonProperty("purpose")]
         public string Purpose { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -36,7 +36,7 @@ namespace Stripe
         public List<InvoiceCustomFieldOptions> CustomFields { get; set; }
 
         /// <summary>
-        /// REQUIRED
+        /// REQUIRED.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -18,7 +18,7 @@ namespace Stripe
         public string Coupon { get; set; }
 
         /// <summary>
-        /// REQUIRED
+        /// REQUIRED.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -18,7 +18,7 @@ namespace Stripe
         public string Coupon { get; set; }
 
         /// <summary>
-        /// REQUIRED
+        /// REQUIRED.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCaptureOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCaptureOptions.cs
@@ -16,8 +16,8 @@ namespace Stripe
         /// <summary>
         /// The amount of the application fee (if any) that will be applied to the payment and
         /// transferred to the application owner’s Stripe account. For more information, see the
-        /// PaymentIntents \<a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
-        /// case for connected accounts</a>/
+        /// PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
+        /// case for connected accounts</a>.
         /// </summary>
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -16,8 +16,8 @@ namespace Stripe
         /// <summary>
         /// The amount of the application fee (if any) that will be applied to the payment and
         /// transferred to the application owner’s Stripe account. For more information, see the
-        /// PaymentIntents \<a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
-        /// case for connected accounts</a>/
+        /// PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
+        /// case for connected accounts</a>.
         /// </summary>
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
@@ -16,8 +16,8 @@ namespace Stripe
         /// <summary>
         /// The amount of the application fee (if any) that will be applied to the payment and
         /// transferred to the application owner’s Stripe account. For more information, see the
-        /// PaymentIntents \<a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
-        /// case for connected accounts</a>/
+        /// PaymentIntents <a href="https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts">use
+        /// case for connected accounts</a>.
         /// </summary>
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }

--- a/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
@@ -22,7 +22,7 @@ namespace Stripe
         /// A set of key-value pairs that you can attach to a <c>Refund</c> object. This can be
         /// useful for storing additional information about the refund in a structured format. You
         /// can unset individual keys if you POST an empty value for that key. You can clear all
-        /// keys if you POST an empty value for <c>metadata</c>
+        /// keys if you POST an empty value for <c>metadata</c>.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentConfirmOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
 
         /// <summary>
         /// ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-        /// attach to this SetupIntent
+        /// attach to this SetupIntent.
         /// </summary>
         [JsonProperty("payment_method")]
         public string PaymentMethod { get; set; }

--- a/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuSharedOptions.cs
@@ -12,8 +12,9 @@ namespace Stripe
         public bool? Active { get; set; }
 
         /// <summary>
-        /// A dictionary of attributes and values for the attributes defined by the product. If, for example, a product’s attributes are ["size", "gender"], a valid SKU has the following dictionary of attributes: {"size": "Medium", "gender": "Unisex"}.
-        /// This dictionary encoding is handled in a custom parser in DictionaryPlugin.cs
+        /// A dictionary of attributes and values for the attributes defined by the product. If, for
+        /// example, a product’s attributes are <c>["size", "gender"]</c>, a valid SKU has the
+        /// following dictionary of attributes: <c>{"size": "Medium", "gender": "Unisex"}</c>.
         /// </summary>
         [JsonProperty("attributes")]
         public Dictionary<string, string> Attributes { get; set; }

--- a/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceCreateOptions.cs
@@ -7,7 +7,7 @@ namespace Stripe
     public class SourceCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// REQUIRED: The type of the source to create. One of type <see cref="SourceType"/>
+        /// REQUIRED: The type of the source to create. One of type <see cref="SourceType"/>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
@@ -29,7 +29,7 @@ namespace Stripe
 
         /// <summary>
         /// The customer associated with the Source that you are trying to share with a Connected account.
-        /// This only works with Stripe Connect as documented here: https://stripe.com/docs/sources/connect#shared-card-sources
+        /// This only works with Stripe Connect as documented <a href="https://stripe.com/docs/sources/connect#shared-card-sources">here</a>.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
@@ -54,7 +54,7 @@ namespace Stripe
 
         /// <summary>
         /// The id of the Source that you are trying to share with a Connected account.
-        /// This only works with Stripe Connect as documented here: https://stripe.com/docs/sources/connect#shared-card-sources
+        /// This only works with Stripe Connect as documented <a href="https://stripe.com/docs/sources/connect#shared-card-sources">here</a>.
         /// </summary>
         [JsonProperty("original_source")]
         public string OriginalSource { get; set; }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseItemOptions.cs
@@ -13,7 +13,7 @@ namespace Stripe
 
         /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period
+        /// new billing period.
         /// </summary>
         [JsonProperty("billing_thresholds")]
         public SubscriptionItemBillingThresholdsOptions BillingThresholds { get; set; }

--- a/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
+++ b/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
@@ -14,7 +14,7 @@ namespace Stripe
         public string ReturnUrl { get; set; }
 
         /// <summary>
-        /// If you pass a card id, you must also pass the customer id
+        /// If you pass a card id, you must also pass the customer id.
         /// </summary>
         [JsonProperty("card")]
         public string CardTokenOrCardId { get; set; }

--- a/src/Stripe.net/Services/_base/AnyOf.cs
+++ b/src/Stripe.net/Services/_base/AnyOf.cs
@@ -113,7 +113,7 @@ namespace Stripe
         public static implicit operator AnyOf<T1, T2>(T2 value) => value == null ? null : new AnyOf<T1, T2>(value);
 
         /// <summary>
-        /// Converts an <see cref="AnyOf{T1, T2}"/> object to a value of type <c>T1</c>,
+        /// Converts an <see cref="AnyOf{T1, T2}"/> object to a value of type <c>T1</c>.
         /// </summary>
         /// <param name="anyOf">The <see cref="AnyOf{T1, T2}"/> object to convert.</param>
         /// <returns>
@@ -253,7 +253,7 @@ namespace Stripe
         public static implicit operator AnyOf<T1, T2, T3>(T3 value) => value == null ? null : new AnyOf<T1, T2, T3>(value);
 
         /// <summary>
-        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T1</c>,
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T1</c>.
         /// </summary>
         /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
         /// <returns>
@@ -263,7 +263,7 @@ namespace Stripe
         public static implicit operator T1(AnyOf<T1, T2, T3> anyOf) => anyOf.value1;
 
         /// <summary>
-        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T2</c>,
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T2</c>.
         /// </summary>
         /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
         /// <returns>
@@ -273,7 +273,7 @@ namespace Stripe
         public static implicit operator T2(AnyOf<T1, T2, T3> anyOf) => anyOf.value2;
 
         /// <summary>
-        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T3</c>,
+        /// Converts an <see cref="AnyOf{T1, T2, T3}"/> object to a value of type <c>T3</c>.
         /// </summary>
         /// <param name="anyOf">The <see cref="AnyOf{T1, T2, T3}"/> object to convert.</param>
         /// <returns>

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -11,11 +11,11 @@ namespace Stripe
     using Stripe.Infrastructure;
 
     /// <summary>Abstract base class for all services.</summary>
-    /// <typeparam name="EntityReturned">
+    /// <typeparam name="TEntityReturned">
     /// The type of <see cref="IStripeEntity"/> that this service returns.
     /// </typeparam>
-    public abstract class Service<EntityReturned>
-        where EntityReturned : IStripeEntity
+    public abstract class Service<TEntityReturned>
+        where TEntityReturned : IStripeEntity
     {
         private IStripeClient client;
 
@@ -50,7 +50,7 @@ namespace Stripe
             get => this.client ?? StripeConfiguration.StripeClient;
         }
 
-        protected EntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
+        protected TEntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
             return this.Request(
                 HttpMethod.Post,
@@ -59,7 +59,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> CreateEntityAsync(
+        protected Task<TEntityReturned> CreateEntityAsync(
             BaseOptions options,
             RequestOptions requestOptions,
             CancellationToken cancellationToken)
@@ -72,7 +72,7 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected EntityReturned DeleteEntity(
+        protected TEntityReturned DeleteEntity(
             string id,
             BaseOptions options,
             RequestOptions requestOptions)
@@ -84,7 +84,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> DeleteEntityAsync(
+        protected Task<TEntityReturned> DeleteEntityAsync(
             string id,
             BaseOptions options,
             RequestOptions requestOptions,
@@ -98,7 +98,7 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected EntityReturned GetEntity(
+        protected TEntityReturned GetEntity(
             string id,
             BaseOptions options,
             RequestOptions requestOptions)
@@ -110,7 +110,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> GetEntityAsync(
+        protected Task<TEntityReturned> GetEntityAsync(
             string id,
             BaseOptions options,
             RequestOptions requestOptions,
@@ -124,23 +124,23 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected StripeList<EntityReturned> ListEntities(
+        protected StripeList<TEntityReturned> ListEntities(
             ListOptions options,
             RequestOptions requestOptions)
         {
-            return this.Request<StripeList<EntityReturned>>(
+            return this.Request<StripeList<TEntityReturned>>(
                 HttpMethod.Get,
                 this.ClassUrl(),
                 options,
                 requestOptions);
         }
 
-        protected Task<StripeList<EntityReturned>> ListEntitiesAsync(
+        protected Task<StripeList<TEntityReturned>> ListEntitiesAsync(
             ListOptions options,
             RequestOptions requestOptions,
             CancellationToken cancellationToken)
         {
-            return this.RequestAsync<StripeList<EntityReturned>>(
+            return this.RequestAsync<StripeList<TEntityReturned>>(
                 HttpMethod.Get,
                 this.ClassUrl(),
                 options,
@@ -148,17 +148,17 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected IEnumerable<EntityReturned> ListEntitiesAutoPaging(
+        protected IEnumerable<TEntityReturned> ListEntitiesAutoPaging(
             ListOptions options,
             RequestOptions requestOptions)
         {
-            return this.ListRequestAutoPaging<EntityReturned>(
+            return this.ListRequestAutoPaging<TEntityReturned>(
                 this.ClassUrl(),
                 options,
                 requestOptions);
         }
 
-        protected EntityReturned UpdateEntity(
+        protected TEntityReturned UpdateEntity(
             string id,
             BaseOptions options,
             RequestOptions requestOptions)
@@ -170,7 +170,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> UpdateEntityAsync(
+        protected Task<TEntityReturned> UpdateEntityAsync(
             string id,
             BaseOptions options,
             RequestOptions requestOptions,
@@ -184,27 +184,27 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected EntityReturned Request(
+        protected TEntityReturned Request(
             HttpMethod method,
             string path,
             BaseOptions options,
             RequestOptions requestOptions)
         {
-            return this.Request<EntityReturned>(
+            return this.Request<TEntityReturned>(
                 method,
                 path,
                 options,
                 requestOptions);
         }
 
-        protected Task<EntityReturned> RequestAsync(
+        protected Task<TEntityReturned> RequestAsync(
             HttpMethod method,
             string path,
             BaseOptions options,
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.RequestAsync<EntityReturned>(
+            return this.RequestAsync<TEntityReturned>(
                 method,
                 path,
                 options,

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -7,8 +7,8 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public abstract class ServiceNested<EntityReturned> : Service<EntityReturned>
-        where EntityReturned : IStripeEntity
+    public abstract class ServiceNested<TEntityReturned> : Service<TEntityReturned>
+        where TEntityReturned : IStripeEntity
     {
         protected ServiceNested()
             : base(null)
@@ -20,7 +20,7 @@ namespace Stripe
         {
         }
 
-        protected EntityReturned CreateNestedEntity(
+        protected TEntityReturned CreateNestedEntity(
             string parentId,
             BaseOptions options,
             RequestOptions requestOptions)
@@ -32,7 +32,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> CreateNestedEntityAsync(
+        protected Task<TEntityReturned> CreateNestedEntityAsync(
             string parentId,
             BaseOptions options,
             RequestOptions requestOptions,
@@ -46,7 +46,7 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected EntityReturned DeleteNestedEntity(
+        protected TEntityReturned DeleteNestedEntity(
             string parentId,
             string id,
             BaseOptions options,
@@ -59,7 +59,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> DeleteNestedEntityAsync(
+        protected Task<TEntityReturned> DeleteNestedEntityAsync(
             string parentId,
             string id,
             BaseOptions options,
@@ -74,7 +74,7 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected EntityReturned GetNestedEntity(
+        protected TEntityReturned GetNestedEntity(
             string parentId,
             string id,
             BaseOptions options,
@@ -87,7 +87,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> GetNestedEntityAsync(
+        protected Task<TEntityReturned> GetNestedEntityAsync(
             string parentId,
             string id,
             BaseOptions options,
@@ -102,25 +102,25 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected StripeList<EntityReturned> ListNestedEntities(
+        protected StripeList<TEntityReturned> ListNestedEntities(
             string parentId,
             ListOptions options,
             RequestOptions requestOptions)
         {
-            return this.Request<StripeList<EntityReturned>>(
+            return this.Request<StripeList<TEntityReturned>>(
                 HttpMethod.Get,
                 this.ClassUrl(parentId),
                 options,
                 requestOptions);
         }
 
-        protected Task<StripeList<EntityReturned>> ListNestedEntitiesAsync(
+        protected Task<StripeList<TEntityReturned>> ListNestedEntitiesAsync(
             string parentId,
             ListOptions options,
             RequestOptions requestOptions,
             CancellationToken cancellationToken)
         {
-            return this.RequestAsync<StripeList<EntityReturned>>(
+            return this.RequestAsync<StripeList<TEntityReturned>>(
                 HttpMethod.Get,
                 this.ClassUrl(parentId),
                 options,
@@ -128,18 +128,18 @@ namespace Stripe
                 cancellationToken);
         }
 
-        protected IEnumerable<EntityReturned> ListNestedEntitiesAutoPaging(
+        protected IEnumerable<TEntityReturned> ListNestedEntitiesAutoPaging(
             string parentId,
             ListOptions options,
             RequestOptions requestOptions)
         {
-            return this.ListRequestAutoPaging<EntityReturned>(
+            return this.ListRequestAutoPaging<TEntityReturned>(
                 this.ClassUrl(parentId),
                 options,
                 requestOptions);
         }
 
-        protected EntityReturned UpdateNestedEntity(
+        protected TEntityReturned UpdateNestedEntity(
             string parentId,
             string id,
             BaseOptions options,
@@ -152,7 +152,7 @@ namespace Stripe
                 requestOptions);
         }
 
-        protected Task<EntityReturned> UpdateNestedEntityAsync(
+        protected Task<TEntityReturned> UpdateNestedEntityAsync(
             string parentId,
             string id,
             BaseOptions options,

--- a/src/Stripe.net/Services/_interfaces/ICreatable.cs
+++ b/src/Stripe.net/Services/_interfaces/ICreatable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface ICreatable<T, O>
-        where T : IStripeEntity
-        where O : BaseOptions
+    public interface ICreatable<TEntity, TOptions>
+        where TEntity : IStripeEntity
+        where TOptions : BaseOptions
     {
-        T Create(O createOptions, RequestOptions requestOptions = null);
+        TEntity Create(TOptions createOptions, RequestOptions requestOptions = null);
 
-        Task<T> CreateAsync(O createOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> CreateAsync(TOptions createOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/IDeletable.cs
@@ -3,11 +3,11 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IDeletable<T>
-        where T : IStripeEntity, IHasId
+    public interface IDeletable<TEntity>
+        where TEntity : IStripeEntity, IHasId
     {
-        T Delete(string id, RequestOptions requestOptions = null);
+        TEntity Delete(string id, RequestOptions requestOptions = null);
 
-        Task<T> DeleteAsync(string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> DeleteAsync(string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IListable.cs
+++ b/src/Stripe.net/Services/_interfaces/IListable.cs
@@ -4,14 +4,14 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IListable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : ListOptions
+    public interface IListable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : ListOptions
     {
-        StripeList<T> List(O listOptions = null, RequestOptions requestOptions = null);
+        StripeList<TEntity> List(TOptions listOptions = null, RequestOptions requestOptions = null);
 
-        Task<StripeList<T>> ListAsync(O listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<StripeList<TEntity>> ListAsync(TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
 
-        IEnumerable<T> ListAutoPaging(O listOptions = null, RequestOptions requestOptions = null);
+        IEnumerable<TEntity> ListAutoPaging(TOptions listOptions = null, RequestOptions requestOptions = null);
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedCreatable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedCreatable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedCreatable<T, O>
-        where T : IStripeEntity
-        where O : BaseOptions
+    public interface INestedCreatable<TEntity, TOptions>
+        where TEntity : IStripeEntity
+        where TOptions : BaseOptions
     {
-        T Create(string parentId, O createOptions, RequestOptions requestOptions = null);
+        TEntity Create(string parentId, TOptions createOptions, RequestOptions requestOptions = null);
 
-        Task<T> CreateAsync(string parentId, O createOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> CreateAsync(string parentId, TOptions createOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
@@ -3,11 +3,11 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedDeletable<T>
-        where T : IStripeEntity, IHasId
+    public interface INestedDeletable<TEntity>
+        where TEntity : IStripeEntity, IHasId
     {
-        T Delete(string parentId, string id, RequestOptions requestOptions = null);
+        TEntity Delete(string parentId, string id, RequestOptions requestOptions = null);
 
-        Task<T> DeleteAsync(string parentId, string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> DeleteAsync(string parentId, string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedListable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedListable.cs
@@ -4,14 +4,14 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedListable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : ListOptions
+    public interface INestedListable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : ListOptions
     {
-        StripeList<T> List(string parentId, O listOptions = null, RequestOptions requestOptions = null);
+        StripeList<TEntity> List(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null);
 
-        Task<StripeList<T>> ListAsync(string parentId, O listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<StripeList<TEntity>> ListAsync(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
 
-        IEnumerable<T> ListAutoPaging(string parentId, O listOptions = null, RequestOptions requestOptions = null);
+        IEnumerable<TEntity> ListAutoPaging(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null);
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedRetrievable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : BaseOptions
+    public interface INestedRetrievable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions
     {
-        T Get(string parentId, string id, O retrieveOptions, RequestOptions requestOptions = null);
+        TEntity Get(string parentId, string id, TOptions retrieveOptions, RequestOptions requestOptions = null);
 
-        Task<T> GetAsync(string parentId, string id, O retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> GetAsync(string parentId, string id, TOptions retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedUpdatable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedUpdatable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedUpdatable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : BaseOptions
+    public interface INestedUpdatable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions
     {
-        T Update(string parentId, string id, O updateOptions, RequestOptions requestOptions = null);
+        TEntity Update(string parentId, string id, TOptions updateOptions, RequestOptions requestOptions = null);
 
-        Task<T> UpdateAsync(string parentId, string id, O updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> UpdateAsync(string parentId, string id, TOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/IRetrievable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IRetrievable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : BaseOptions
+    public interface IRetrievable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions
     {
-        T Get(string id, O retrieveOptions, RequestOptions requestOptions = null);
+        TEntity Get(string id, TOptions retrieveOptions, RequestOptions requestOptions = null);
 
-        Task<T> GetAsync(string id, O retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> GetAsync(string id, TOptions retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/ISingletonRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/ISingletonRetrievable.cs
@@ -3,11 +3,11 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface ISingletonRetrievable<T>
-        where T : IStripeEntity
+    public interface ISingletonRetrievable<TEntity>
+        where TEntity : IStripeEntity
     {
-        T Get(RequestOptions requestOptions = null);
+        TEntity Get(RequestOptions requestOptions = null);
 
-        Task<T> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IUpdatable.cs
+++ b/src/Stripe.net/Services/_interfaces/IUpdatable.cs
@@ -3,12 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IUpdatable<T, O>
-        where T : IStripeEntity, IHasId
-        where O : BaseOptions
+    public interface IUpdatable<TEntity, TOptions>
+        where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions
     {
-        T Update(string id, O updateOptions, RequestOptions requestOptions = null);
+        TEntity Update(string id, TOptions updateOptions, RequestOptions requestOptions = null);
 
-        Task<T> UpdateAsync(string id, O updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> UpdateAsync(string id, TOptions updateOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
+    <PackageReference Include="Stylecop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -12,7 +12,7 @@ namespace StripeTests
     public class BaseStripeTest
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseStripeTest"/> with no fixtures.
+        /// Initializes a new instance of the <see cref="BaseStripeTest"/> class with no fixtures.
         /// </summary>
         public BaseStripeTest()
             : this(null, null)
@@ -20,33 +20,45 @@ namespace StripeTests
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseStripeTest"/> with the
+        /// Initializes a new instance of the <see cref="BaseStripeTest"/> class with the
         /// <see cref="StripeMockFixture"/> fixture. Use this constructor for tests that need to
         /// send requests to stripe-mock, but don't need mocking capabilities (i.e. don't need to
         /// assert or stub HTTP requests).
         /// </summary>
+        /// <param name="stripeMockFixture">
+        /// The <see cref="StripeMockFixture"/> fixture.
+        /// </param>
         public BaseStripeTest(StripeMockFixture stripeMockFixture)
             : this(stripeMockFixture, null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseStripeTest"/> with the
+        /// Initializes a new instance of the <see cref="BaseStripeTest"/> class with the
         /// <see cref="MockHttpClientFixture"/> fixture. Use this constructor for tests that need
         /// mocking capabilities (i.e. need to assert or stub HTTP requests) but don't need to send
         /// requests to stripe-mock.
         /// </summary>
+        /// <param name="mockHttpClientFixture">
+        /// The <see cref="MockHttpClientFixture"/> fixture.
+        /// </param>
         public BaseStripeTest(MockHttpClientFixture mockHttpClientFixture)
             : this(null, mockHttpClientFixture)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseStripeTest"/> with both the
+        /// Initializes a new instance of the <see cref="BaseStripeTest"/> class with both the
         /// <see cref="StripeMockFixture"/> and the <see cref="MockHttpClientFixture"/> fixtures.
         /// Use this constructor for tests that need to send requests to stripe-mock and also need
         /// mocking capabilities (i.e. need to assert or stub HTTP requests).
         /// </summary>
+        /// <param name="stripeMockFixture">
+        /// The <see cref="StripeMockFixture"/> fixture.
+        /// </param>
+        /// <param name="mockHttpClientFixture">
+        /// The <see cref="MockHttpClientFixture"/> fixture.
+        /// </param>
         public BaseStripeTest(
             StripeMockFixture stripeMockFixture,
             MockHttpClientFixture mockHttpClientFixture)
@@ -98,8 +110,8 @@ namespace StripeTests
         /// <summary>
         /// Gets a resource file and returns its contents in a string.
         /// </summary>
-        /// <param name="path">Path to the resource file</param>
-        /// <returns>File contents</returns>
+        /// <param name="path">Path to the resource file.</param>
+        /// <returns>The file contents.</returns>
         protected static string GetResourceAsString(string path)
         {
             var fullpath = "StripeTests.Resources." + path;
@@ -113,6 +125,8 @@ namespace StripeTests
         /// <summary>
         /// Asserts that a single HTTP request was made with the specified method and path.
         /// </summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The HTTP path.</param>
         protected void AssertRequest(HttpMethod method, string path)
         {
             if (this.MockHttpClientFixture == null)
@@ -131,6 +145,10 @@ namespace StripeTests
         /// Stubs an HTTP request with the specified method and path to return the specified status
         /// code and response body.
         /// </summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The HTTP path.</param>
+        /// <param name="status">The status code to return.</param>
+        /// <param name="response">The response body to return.</param>
         protected void StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
         {
             if (this.MockHttpClientFixture == null)
@@ -151,9 +169,9 @@ namespace StripeTests
         /// Use the special <c>*</c> character to specify that all fields should be
         /// expanded.
         /// </summary>
-        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
-        /// <param name="expansions">Set of expansions that should be applied</param>
-        /// <returns>Fixture data encoded as JSON</returns>
+        /// <param name="path">API path to use to get a fixture for stripe-mock.</param>
+        /// <param name="expansions">Set of expansions that should be applied.</param>
+        /// <returns>Fixture data encoded as JSON.</returns>
         protected string GetFixture(string path, string[] expansions = null)
         {
             if (this.StripeMockFixture == null)

--- a/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
+++ b/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
@@ -30,7 +30,7 @@ namespace StripeTests
             {
               "customer",
               "phases.plans.plan",
-              "subscription"
+              "subscription",
             };
 
             string json = this.GetFixture("/v1/subscription_schedules/sub_sched_123", expansions);

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -102,7 +102,7 @@ namespace StripeTests
                 new
                 {
                     data = new TestOptions { },
-                    want = string.Empty
+                    want = string.Empty,
                 },
 
                 // AnyOf
@@ -112,7 +112,7 @@ namespace StripeTests
                     {
                         AnyOf = "foo",
                     },
-                    want = "any_of=foo"
+                    want = "any_of=foo",
                 },
                 new
                 {
@@ -120,7 +120,7 @@ namespace StripeTests
                     {
                         AnyOf = new Dictionary<string, string> { { "foo", "bar" } },
                     },
-                    want = "any_of[foo]=bar"
+                    want = "any_of[foo]=bar",
                 },
                 new
                 {
@@ -128,7 +128,7 @@ namespace StripeTests
                     {
                         AnyOf = null, // AnyOf itself is null
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
                 new
                 {
@@ -136,7 +136,7 @@ namespace StripeTests
                     {
                         AnyOf = (string)null, // AnyOf is not null but AnyOf.Value is null
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
                 new
                 {
@@ -144,7 +144,7 @@ namespace StripeTests
                     {
                         AnyOf = (Dictionary<string, string>)null, // same as above, AnyOf.Value is null
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
 
                 // Array
@@ -154,7 +154,7 @@ namespace StripeTests
                     {
                             Array = new[] { "1", "2", "3" },
                     },
-                    want = "array[0]=1&array[1]=2&array[2]=3"
+                    want = "array[0]=1&array[1]=2&array[2]=3",
                 },
                 new
                 {
@@ -162,7 +162,7 @@ namespace StripeTests
                     {
                             Array = new string[] { },
                     },
-                    want = "array="
+                    want = "array=",
                 },
 
                 // Bool
@@ -172,7 +172,7 @@ namespace StripeTests
                     {
                         Bool = false,
                     },
-                    want = "bool=False"
+                    want = "bool=False",
                 },
                 new
                 {
@@ -180,7 +180,7 @@ namespace StripeTests
                     {
                         Bool = true,
                     },
-                    want = "bool=True"
+                    want = "bool=True",
                 },
 
                 // DateRangeOptions
@@ -192,9 +192,9 @@ namespace StripeTests
                         {
                             LessThan = DateTime.Parse("Sat, 01 Jan 2000 05:00:00Z"),
                             GreaterThanOrEqual = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
-                        }
+                        },
                     },
-                    want = "date_filter[gte]=946684800&date_filter[lt]=946702800"
+                    want = "date_filter[gte]=946684800&date_filter[lt]=946702800",
                 },
 
                 // DateTime
@@ -204,7 +204,7 @@ namespace StripeTests
                     {
                         DateTime = DateTime.Parse("Sat, 01 Jan 2000 00:00:00Z"),
                     },
-                    want = "datetime=946684800"
+                    want = "datetime=946684800",
                 },
 
                 // Decimal
@@ -214,7 +214,7 @@ namespace StripeTests
                     {
                         Decimal = 1.2345m,
                     },
-                    want = "decimal=1.2345"
+                    want = "decimal=1.2345",
                 },
                 new
                 {
@@ -222,7 +222,7 @@ namespace StripeTests
                     {
                         Decimal = 0.0m,
                     },
-                    want = "decimal=0.0"
+                    want = "decimal=0.0",
                 },
 
                 // Dictionary
@@ -232,7 +232,7 @@ namespace StripeTests
                     {
                         Dictionary = new Dictionary<string, object> { { "foo", "bar" } },
                     },
-                    want = "dictionary[foo]=bar"
+                    want = "dictionary[foo]=bar",
                 },
                 new
                 {
@@ -240,7 +240,7 @@ namespace StripeTests
                     {
                         Dictionary = new Dictionary<string, object> { { "empty", string.Empty } },
                     },
-                    want = "dictionary[empty]="
+                    want = "dictionary[empty]=",
                 },
                 new
                 {
@@ -248,7 +248,7 @@ namespace StripeTests
                     {
                         Dictionary = new Dictionary<string, object> { { "null", null } },
                     },
-                    want = "dictionary[null]="
+                    want = "dictionary[null]=",
                 },
                 new
                 {
@@ -259,7 +259,7 @@ namespace StripeTests
                             { "foo", new Dictionary<string, object> { { "bar", "baz" } } },
                         },
                     },
-                    want = "dictionary[foo][bar]=baz"
+                    want = "dictionary[foo][bar]=baz",
                 },
 
                 // Enum
@@ -269,7 +269,7 @@ namespace StripeTests
                     {
                         Enum = TestOptions.TestEnum.TestOne,
                     },
-                    want = "enum=test_one"
+                    want = "enum=test_one",
                 },
                 new
                 {
@@ -277,7 +277,7 @@ namespace StripeTests
                     {
                         Enum = TestOptions.TestEnum.TestTwo,
                     },
-                    want = "enum=TestTwo"
+                    want = "enum=TestTwo",
                 },
 
                 // List
@@ -287,7 +287,7 @@ namespace StripeTests
                     {
                         List = new List<object> { "foo", "bar" },
                     },
-                    want = "list[0]=foo&list[1]=bar"
+                    want = "list[0]=foo&list[1]=bar",
                 },
                 new
                 {
@@ -295,7 +295,7 @@ namespace StripeTests
                     {
                         List = new List<object> { string.Empty, 0 },
                     },
-                    want = "list[0]=&list[1]=0"
+                    want = "list[0]=&list[1]=0",
                 },
                 new
                 {
@@ -303,7 +303,7 @@ namespace StripeTests
                     {
                         List = new List<object> { },
                     },
-                    want = "list="
+                    want = "list=",
                 },
                 new
                 {
@@ -315,7 +315,7 @@ namespace StripeTests
                             new Dictionary<string, object> { { "foo", "baz" } },
                         },
                     },
-                    want = "list[0][foo]=bar&list[1][foo]=baz"
+                    want = "list[0][foo]=bar&list[1][foo]=baz",
                 },
 
                 // Long
@@ -325,7 +325,7 @@ namespace StripeTests
                     {
                         Long = 123,
                     },
-                    want = "long=123"
+                    want = "long=123",
                 },
                 new
                 {
@@ -333,7 +333,7 @@ namespace StripeTests
                     {
                         Long = 0,
                     },
-                    want = "long=0"
+                    want = "long=0",
                 },
 
                 // String
@@ -343,7 +343,7 @@ namespace StripeTests
                     {
                         String = "foo",
                     },
-                    want = "string=foo"
+                    want = "string=foo",
                 },
                 new
                 {
@@ -351,7 +351,7 @@ namespace StripeTests
                     {
                         String = string.Empty,
                     },
-                    want = "string="
+                    want = "string=",
                 },
 
                 // StringEnum
@@ -361,7 +361,7 @@ namespace StripeTests
                     {
                         StringEnum = TestOptions.TestStringEnum.Foo,
                     },
-                    want = "string_enum=foo"
+                    want = "string_enum=foo",
                 },
                 new
                 {

--- a/src/StripeTests/Infrastructure/JsonConverters/AnyOfConverterTest.cs
+++ b/src/StripeTests/Infrastructure/JsonConverters/AnyOfConverterTest.cs
@@ -71,7 +71,7 @@ namespace StripeTests
                 {
                     Id = "id_123",
                     Bar = 42,
-                }
+                },
             };
 
             var expected =

--- a/src/StripeTests/Infrastructure/JsonConverters/ExpandableFieldConverterTest.cs
+++ b/src/StripeTests/Infrastructure/JsonConverters/ExpandableFieldConverterTest.cs
@@ -49,7 +49,7 @@ namespace StripeTests
                 {
                     Id = "id_not_expanded",
                     ExpandedObject = null,
-                }
+                },
             };
 
             var expected = "{\n  \"nested\": \"id_not_expanded\"\n}";
@@ -70,7 +70,7 @@ namespace StripeTests
                 {
                     Id = nested.Id,
                     ExpandedObject = nested,
-                }
+                },
             };
 
             var expected =
@@ -87,7 +87,7 @@ namespace StripeTests
                 {
                     Id = null,
                     ExpandedObject = null,
-                }
+                },
             };
 
             var expected = "{\n  \"nested\": null\n}";

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -54,7 +54,7 @@ namespace StripeTests
                 Name = "MyAwesomeApp",
                 PartnerId = "pp_123",
                 Version = "1.2.34",
-                Url = "https://myawesomeapp.info"
+                Url = "https://myawesomeapp.info",
             };
 
             var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/StripeTests/Infrastructure/SerializationTest.cs
+++ b/src/StripeTests/Infrastructure/SerializationTest.cs
@@ -27,7 +27,7 @@ namespace StripeTests
         {
             var obj = new TestObjectDateTime
             {
-                Date = null
+                Date = null,
             };
 
             var reloaded = JsonConvert.DeserializeObject<TestObjectDateTime>(JsonConvert.SerializeObject(obj));

--- a/src/StripeTests/MockHttpClientFixture.cs
+++ b/src/StripeTests/MockHttpClientFixture.cs
@@ -14,7 +14,7 @@ namespace StripeTests
         {
             this.MockHandler = new Mock<HttpClientHandler>
             {
-                CallBase = true
+                CallBase = true,
             };
             this.HttpClient = new SystemNetHttpClient(
                 new System.Net.Http.HttpClient(this.MockHandler.Object));
@@ -35,6 +35,8 @@ namespace StripeTests
         /// <summary>
         /// Asserts that a single HTTP request was made with the specified method and path.
         /// </summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The HTTP path.</param>
         public void AssertRequest(HttpMethod method, string path)
         {
             this.MockHandler.Protected()
@@ -51,6 +53,10 @@ namespace StripeTests
         /// Stubs an HTTP request with the specified method and path to return the specified status
         /// code and response body.
         /// </summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The HTTP path.</param>
+        /// <param name="status">The status code to return.</param>
+        /// <param name="response">The response body to return.</param>
         public void StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
         {
             var responseMessage = new HttpResponseMessage(status);

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -104,7 +104,7 @@ namespace StripeTests
 
             this.rejectOptions = new AccountRejectOptions
             {
-                Reason = "terms_of_service"
+                Reason = "terms_of_service",
             };
 
             this.listOptions = new AccountListOptions

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -24,7 +24,7 @@ namespace StripeTests
 
             this.createOptions = new ApplePayDomainCreateOptions
             {
-                DomainName = "example.com"
+                DomainName = "example.com",
             };
 
             this.listOptions = new ApplePayDomainListOptions

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -50,7 +50,7 @@ namespace StripeTests
                 {
                     32,
                     45,
-                }
+                },
             };
         }
 

--- a/src/StripeTests/Services/Charges/ChargeCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeCreateOptionsTest.cs
@@ -16,7 +16,7 @@ namespace StripeTests
                 new
                 {
                     data = new ChargeCreateOptions { },
-                    want = string.Empty
+                    want = string.Empty,
                 },
 
                 // Source is a non-null, non-empty string
@@ -26,7 +26,7 @@ namespace StripeTests
                     {
                         Source = "tok_visa",
                     },
-                    want = "source=tok_visa"
+                    want = "source=tok_visa",
                 },
 
                 // Source is a non-null, empty string
@@ -36,7 +36,7 @@ namespace StripeTests
                     {
                         Source = string.Empty,
                     },
-                    want = "source="
+                    want = "source=",
                 },
 
                 // Source is a null string
@@ -46,7 +46,7 @@ namespace StripeTests
                     {
                         Source = (string)null,
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
 
                 // Source is a non-null CardCreateNestedOptions
@@ -61,7 +61,7 @@ namespace StripeTests
                             ExpYear = 2030,
                         },
                     },
-                    want = "source[object]=card&source[exp_month]=1&source[exp_year]=2030&source[number]=4242424242424242"
+                    want = "source[object]=card&source[exp_month]=1&source[exp_year]=2030&source[number]=4242424242424242",
                 },
 
                 // Source is a null CardCreateNestedOptions
@@ -71,7 +71,7 @@ namespace StripeTests
                     {
                         Source = (CardCreateNestedOptions)null,
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
 
                 // Source is null
@@ -81,7 +81,7 @@ namespace StripeTests
                     {
                         Source = null,
                     },
-                    want = string.Empty
+                    want = string.Empty,
                 },
             };
 

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -56,7 +56,7 @@ namespace StripeTests.Checkout
                             PostalCode = "90210",
                             Country = "US",
                         },
-                    }
+                    },
                 },
                 PaymentMethodTypes = new List<string>
                 {

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -33,7 +33,7 @@ namespace StripeTests.Issuing
                     {
                         DisputeExplanation = "Explanation",
                         UncategorizedFile = "file_123",
-                    }
+                    },
                 },
                 Reason = "fraudulent",
             };

--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
 
             this.createOptions = new LoginLinkCreateOptions
             {
-                RedirectUrl = "https://stripe.com/redirect?param=value"
+                RedirectUrl = "https://stripe.com/redirect?param=value",
             };
         }
 

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -33,9 +33,9 @@ namespace StripeTests
                     new OrderItemOptions
                     {
                         Parent = "sku_123",
-                        Quantity = 1
+                        Quantity = 1,
                     },
-                }
+                },
             };
 
             this.updateOptions = new OrderUpdateOptions

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -53,7 +53,7 @@ namespace StripeTests
                 {
                     Amount = 100,
                     Destination = "acct_123",
-                }
+                },
             };
 
             this.listOptions = new PaymentIntentListOptions

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -51,7 +51,7 @@ namespace StripeTests
                     AccountOpener = true,
                     Owner = true,
                     PercentOwnership = 30.5m,
-                }
+                },
             };
 
             this.listOptions = new PersonListOptions
@@ -60,7 +60,7 @@ namespace StripeTests
                 Relationship = new PersonRelationshipListOptions
                 {
                     Director = true,
-                }
+                },
             };
         }
 

--- a/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
@@ -23,7 +23,7 @@ namespace StripeTests
                     {
                         UnitAmount = 2000,
                         UpTo = PlanTierUpTo.Inf,
-                    }
+                    },
                 },
             };
 

--- a/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionCreateOptionsTest.cs
@@ -19,12 +19,12 @@ namespace StripeTests
                     new SubscriptionItemOption
                     {
                         Plan = "plan_123",
-                        Quantity = 2
+                        Quantity = 2,
                     },
                     new SubscriptionItemOption
                     {
                         Plan = "plan_124",
-                        Quantity = 3
+                        Quantity = 3,
                     },
                 },
             };

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -39,12 +39,12 @@ namespace StripeTests
                     new SubscriptionItemOption
                     {
                         Plan = "plan_123",
-                        Quantity = 2
+                        Quantity = 2,
                     },
                     new SubscriptionItemOption
                     {
                         Plan = "plan_124",
-                        Quantity = 3
+                        Quantity = 3,
                     },
                 },
             };

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -8,9 +8,10 @@ namespace StripeTests
 
     public class StripeMockFixture : IDisposable
     {
-        /// <value>Minimum required version of stripe-mock</value>
+        /// <value>Minimum required version of stripe-mock.</value>
         /// <remarks>
-        /// If you bump this, don't forget to bump `STRIPE_MOCK_VERSION` in `appveyor.yml` as well.
+        /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
+        /// as well.
         /// </remarks>
         private const string MockMinimumVersion = "0.64.0";
 
@@ -43,6 +44,7 @@ namespace StripeTests
         /// The <see cref="IHttpClient"/> client to use. If <c>null</c>, an HTTP client will be
         /// created with default parameters.
         /// </param>
+        /// <returns>The new <see cref="StripeClient"/> instance.</returns>
         public StripeClient BuildStripeClient(IHttpClient httpClient = null)
         {
             return new StripeClient(
@@ -59,9 +61,9 @@ namespace StripeTests
         /// Use the special <c>*</c> character to specify that all fields should be
         /// expanded.
         /// </summary>
-        /// <param name="path">API path to use to get a fixture for stripe-mock</param>
-        /// <param name="expansions">Set of expansions that should be applied</param>
-        /// <returns>Fixture data encoded as JSON</returns>
+        /// <param name="path">API path to use to get a fixture for stripe-mock.</param>
+        /// <param name="expansions">Set of expansions that should be applied.</param>
+        /// <returns>Fixture data encoded as JSON.</returns>
         public string GetFixture(string path, string[] expansions = null)
         {
             string url = $"http://localhost:{this.port}{path}";
@@ -107,7 +109,7 @@ namespace StripeTests
         /// </summary>
         /// <param name="a">A version string (e.g. "1.2.3").</param>
         /// <param name="b">Another version string.</param>
-        /// <returns>-1 if a > b, 1 if a < b, 0 if a == b</returns>
+        /// <returns>-1 if a &gt; b, 1 if a &lt; b, 0 if a == b.</returns>
         private static int CompareVersions(string a, string b)
         {
             var version1 = new Version(a);

--- a/src/StripeTests/StripeMockHandler.cs
+++ b/src/StripeTests/StripeMockHandler.cs
@@ -14,7 +14,8 @@ namespace StripeTests
         private static int port = -1;
 
         /// <summary>
-        /// The port on which stripe-mock is listening, or -1 if no stripe-mock process was started.
+        /// Gets the port on which stripe-mock is listening, or -1 if no stripe-mock process was
+        /// started.
         /// </summary>
         public static int Port { get => port; }
 

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -18,7 +19,7 @@
     <PackageReference Include="coverlet.msbuild" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">
+    <PackageReference Include="Stylecop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
+++ b/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
@@ -9,8 +9,8 @@ namespace StripeTests
     using Xunit;
 
     /// <summary>
-    /// This wholesome test ensures that lists (as in `List<>`) are used instead of arrays (`[]`)
-    /// in Stripe entities and options classes.
+    /// This wholesome test ensures that lists (as in <see cref="List{T}"/>) are used instead of
+    /// arrays (<c>[]</c>) in Stripe entities and options classes.
     /// </summary>
     public class UseListsInsteadOfArrays : WholesomeTest
     {

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -17,7 +17,9 @@ namespace StripeTests
         /// <summary>
         /// Verifies that a list of strings is empty. If not, display the sorted contents of the
         /// list and fail the test with the provided message.
-        /// <summary>
+        /// </summary>
+        /// <param name="results">The list of strings to check.</param>
+        /// <param name="message">The message to display if the list is not empty.</param>
         protected static void AssertEmpty(List<string> results, string message)
         {
             if (results.Any())
@@ -40,6 +42,8 @@ namespace StripeTests
         /// <summary>
         /// Returns the list of classes that are subclasses of the provided type.
         /// </summary>
+        /// <param name="parentClass">The parent class.</param>
+        /// <returns>The list of classes that are subclasses of the provided type.</returns>
         protected static List<Type> GetSubclassesOf(Type parentClass)
         {
             var assembly = parentClass.GetTypeInfo().Assembly;
@@ -52,6 +56,8 @@ namespace StripeTests
         /// <summary>
         /// Returns the list of classes that implement the provided interface.
         /// </summary>
+        /// <param name="implementedInterface">The implemented interface.</param>
+        /// <returns>The list of classes that implement the provided interface.</returns>
         protected static List<Type> GetClassesWithInterface(Type implementedInterface)
         {
             var assembly = implementedInterface.GetTypeInfo().Assembly;

--- a/src/_stylecop/StripeTests.ruleset
+++ b/src/_stylecop/StripeTests.ruleset
@@ -8,11 +8,15 @@
     <Rule Id="CS0618" Action="None" />
 
     <!--
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      SA1600: ElementsMustBeDocumented
+      SA1602: EnumerationItemsMustBeDocumented
       SA1633: FileMustHaveHeader
-      SA1652: EnableXmlDocumentationOutput
       Documentation related warnings, not applicable to tests.
     -->
+    <Rule Id="CS1591" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1602" Action="None" />
     <Rule Id="SA1633" Action="None" />
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Bump Stylecop.Analyzers (linter) to latest version, and fix all new warnings.

Nothing major, mostly tweaking and adding documentation strings, and renaming type parameters in generic classes/interfaces so they start with `T`.
