### PR TITLE
A few Billing changes

### DIFF
--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -7,12 +7,23 @@ namespace Stripe
 
     public class Subscription : StripeEntity<Subscription>, IHasId, IHasMetadata, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <summary>
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner’s Stripe account.
+        /// </summary>
         [JsonProperty("application_fee_percent")]
         public decimal? ApplicationFeePercent { get; set; }
 
@@ -59,19 +70,33 @@ namespace Stripe
         [JsonProperty("collection_method")]
         public string CollectionMethod { get; set; }
 
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Created { get; set; }
 
+        /// <summary>
+        /// End of the current period that the subscription has been invoiced for. At the end of
+        /// this period, a new invoice will be created.
+        /// </summary>
         [JsonProperty("current_period_end")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CurrentPeriodEnd { get; set; }
 
+        /// <summary>
+        /// Start of the current period that the subscription has been invoiced for.
+        /// </summary>
         [JsonProperty("current_period_start")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CurrentPeriodStart { get; set; }
 
         #region Expandable Customer
+
+        /// <summary>
+        /// ID of the customer who owns the subscription.
+        /// </summary>
         [JsonIgnore]
         public string CustomerId
         {
@@ -79,6 +104,9 @@ namespace Stripe
             set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
+        /// <summary>
+        /// Customer who owns this subscription (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public Customer Customer
         {
@@ -109,6 +137,9 @@ namespace Stripe
             set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
         }
 
+        /// <summary>
+        /// Default payment method for the subscription (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public PaymentMethod DefaultPaymentMethod
         {
@@ -122,6 +153,10 @@ namespace Stripe
         #endregion
 
         #region Expandable DefaultSource
+
+        /// <summary>
+        /// ID of the default source for the subscription.
+        /// </summary>
         [JsonIgnore]
         public string DefaultSourceId
         {
@@ -129,6 +164,9 @@ namespace Stripe
             set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
         }
 
+        /// <summary>
+        /// Default source for the subscription (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public IPaymentSource DefaultSource
         {
@@ -142,22 +180,39 @@ namespace Stripe
         #endregion
 
         /// <summary>
-        /// The default tax rates that apply to this subscription.
+        /// The tax rates that will apply to any subscription item that does not have
+        /// <c>tax_rates</c> set. Invoices created will have their <c>default_tax_rates</c>
+        /// populated from the subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
         public List<TaxRate> DefaultTaxRates { get; set; }
 
+        /// <summary>
+        /// Describes the current discount applied to this subscription, if there is one. When
+        /// billing, a discount applied to a subscription overrides a discount applied on a
+        /// customer-wide basis.
+        /// </summary>
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
 
+        /// <summary>
+        /// If the subscription has ended, the date the subscription ended.
+        /// </summary>
         [JsonProperty("ended_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? EndedAt { get; set; }
 
+        /// <summary>
+        /// List of subscription items, each with an attached plan.
+        /// </summary>
         [JsonProperty("items")]
         public StripeList<SubscriptionItem> Items { get; set; }
 
         #region Expandable LatestInvoice
+
+        /// <summary>
+        /// ID of the most recent invoice this subscription has generated.
+        /// </summary>
         [JsonIgnore]
         public string LatestInvoiceId
         {
@@ -165,6 +220,9 @@ namespace Stripe
             set => this.InternalLatestInvoice = SetExpandableFieldId(value, this.InternalLatestInvoice);
         }
 
+        /// <summary>
+        /// The most recent invoice this subscription has generated (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public Invoice LatestInvoice
         {
@@ -177,9 +235,16 @@ namespace Stripe
         internal ExpandableField<Invoice> InternalLatestInvoice { get; set; }
         #endregion
 
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value
+        /// <c>false</c> if the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
+        /// <summary>
+        /// A set of key/value pairs that you can attach to a subscription object.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -196,7 +261,7 @@ namespace Stripe
         }
 
         /// <summary>
-        /// The pending SetupIntent associated with this subscription if any.
+        /// The pending SetupIntent associated with this subscription (if it was expanded).
         /// </summary>
         [JsonIgnore]
         public SetupIntent PendingSetupIntent
@@ -210,11 +275,45 @@ namespace Stripe
         internal ExpandableField<SetupIntent> InternalPendingSetupIntent { get; set; }
         #endregion
 
+        /// <summary>
+        /// Plan the customer is subscribed to. Only set if the subscription contains a single plan.
+        /// </summary>
         [JsonProperty("plan")]
         public Plan Plan { get; set; }
 
+        /// <summary>
+        /// The quantity of the plan to which the customer is subscribed. Only set if the
+        /// subscription contains a single plan.
+        /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        #region Expandable Schedule
+
+        /// <summary>
+        /// ID of the schedule attached to the subscription.
+        /// </summary>
+        [JsonIgnore]
+        public string ScheduleId
+        {
+            get => this.InternalSchedule?.Id;
+            set => this.InternalSchedule = SetExpandableFieldId(value, this.InternalSchedule);
+        }
+
+        /// <summary>
+        /// Schedule attached to the subscription (if it was expanded).
+        /// </summary>
+        [JsonIgnore]
+        public SubscriptionSchedule Schedule
+        {
+            get => this.InternalSchedule?.ExpandedObject;
+            set => this.InternalSchedule = SetExpandableFieldObject(value, this.InternalSchedule);
+        }
+
+        [JsonProperty("schedule")]
+        [JsonConverter(typeof(ExpandableFieldConverter<SubscriptionSchedule>))]
+        internal ExpandableField<SubscriptionSchedule> InternalSchedule { get; set; }
+        #endregion
 
         [Obsolete("Use StartDate")]
         [JsonProperty("start")]
@@ -229,6 +328,10 @@ namespace Stripe
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? StartDate { get; set; }
 
+        /// <summary>
+        /// Possible values are <c>incomplete</c>, <c>incomplete_expired</c>, <c>trialing</c>,
+        /// <c>active</c>, <c>past_due</c>, <c>canceled</c>, or <c>unpaid</c>.
+        /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
 
@@ -236,13 +339,24 @@ namespace Stripe
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+        /// <summary>
+        /// If specified, the funds from the subscription’s invoices will be transferred to the
+        /// destination and the ID of the resulting transfers will be found on the resulting
+        /// charges.
+        /// </summary>
         [JsonProperty("transfer_data")]
         public SubscriptionTransferData TransferData { get; set; }
 
+        /// <summary>
+        /// If the subscription has a trial, the end of that trial.
+        /// </summary>
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? TrialEnd { get; set; }
 
+        /// <summary>
+        /// If the subscription has a trial, the beginning of that trial.
+        /// </summary>
         [JsonProperty("trial_start")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? TrialStart { get; set; }

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhase.cs
@@ -15,6 +15,23 @@ namespace Stripe
         [JsonProperty("application_fee_percent")]
         public decimal? ApplicationFeePercent { get; set; }
 
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholds BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging
+        /// automatically, Stripe will attempt to pay this subscription at the
+        /// end of the cycle using the default source attached to the customer.
+        /// When sending an invoice, Stripe will email your customer an invoice
+        /// with payment instructions.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
         #region Expandable Coupon
 
         /// <summary>
@@ -44,6 +61,30 @@ namespace Stripe
         internal ExpandableField<Coupon> InternalCoupon { get; set; }
         #endregion
 
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonProperty("default_payment_method")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
+        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
+        #endregion
+
         /// <summary>
         /// The default tax rates which apply to the phase of this subscription schedule.
         /// </summary>
@@ -56,6 +97,12 @@ namespace Stripe
         [JsonProperty("end_date")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// The default invoice settings for this phase.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
 
         /// <summary>
         /// Plans to subscribe during this phase of the subscription schedule.

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -30,6 +30,13 @@ namespace Stripe
         public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
 
         /// <summary>
+        /// The identifier of the unstarted schedule whose upcoming invoice you’d like to retrieve.
+        /// Cannot be used with subscription or subscription fields.
+        /// </summary>
+        [JsonProperty("schedule")]
+        public string Schedule { get; set; }
+
+        /// <summary>
         /// For new subscriptions, a future <see cref="DateTime"/> to anchor the subscription’s
         /// <a href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</a>. This
         /// is used to determine the date of the first full invoice, and, for plans with
@@ -41,11 +48,24 @@ namespace Stripe
         public AnyOf<DateTime?, SubscriptionBillingCycleAnchor?> SubscriptionBillingCycleAnchor { get; set; }
 
         /// <summary>
+        /// Time at which the subscription would cancel.
+        /// </summary>
+        [JsonProperty("subscription_cancel_at")]
+        public DateTime? SubscriptionCancelAt { get; set; }
+
+        /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current
         /// period.
         /// </summary>
         [JsonProperty("subscription_cancel_at_period_end")]
         public bool? SubscriptionCancelAtPeriodEnd { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether the invoice returned would preview cancelling the
+        /// subscription immediately.
+        /// </summary>
+        [JsonProperty("subscription_cancel_now")]
+        public bool? SubscriptionCancelNow { get; set; }
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -30,6 +30,13 @@ namespace Stripe
         public List<InvoiceUpcomingInvoiceItemOption> InvoiceItems { get; set; }
 
         /// <summary>
+        /// The identifier of the unstarted schedule whose upcoming invoice you’d like to retrieve.
+        /// Cannot be used with subscription or subscription fields.
+        /// </summary>
+        [JsonProperty("schedule")]
+        public string Schedule { get; set; }
+
+        /// <summary>
         /// For new subscriptions, a future <see cref="DateTime"/> to anchor the subscription’s
         /// <a href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</a>. This
         /// is used to determine the date of the first full invoice, and, for plans with
@@ -41,11 +48,24 @@ namespace Stripe
         public AnyOf<DateTime?, SubscriptionBillingCycleAnchor?> SubscriptionBillingCycleAnchor { get; set; }
 
         /// <summary>
+        /// Time at which the subscription would cancel.
+        /// </summary>
+        [JsonProperty("subscription_cancel_at")]
+        public DateTime? SubscriptionCancelAt { get; set; }
+
+        /// <summary>
         /// Boolean indicating whether this subscription should cancel at the end of the current
         /// period.
         /// </summary>
         [JsonProperty("subscription_cancel_at_period_end")]
         public bool? SubscriptionCancelAtPeriodEnd { get; set; }
+
+        /// <summary>
+        /// Boolean indicating whether the invoice returned would preview cancelling the
+        /// subscription immediately.
+        /// </summary>
+        [JsonProperty("subscription_cancel_now")]
+        public bool? SubscriptionCancelNow { get; set; }
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -15,11 +15,35 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
+        /// charging automatically, Stripe will attempt to pay the underlying
+        /// subscription at the end of each billing cycle using the default
+        /// source attached to the customer. When sending an invoice, Stripe
+        /// will email your customer an invoice with payment instructions.
+        /// Defaults to <c>charge_automatically</c> on creation.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
+        /// <summary>
         /// The code of the coupon to apply to this subscription. A coupon applied to a
         /// subscription will only affect invoices created for that particular subscription.
         /// </summary>
         [JsonProperty("coupon")]
         public string CouponId { get; set; }
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethodId { get; set; }
 
         /// <summary>
         /// Ids of the tax rates to apply to this phase on the subscription schedule.
@@ -33,6 +57,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("end_date")]
         public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Define the default settings applied to invoices created by this subscription schedule.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettingsOptions InvoiceSettings { get; set; }
 
         /// <summary>
         /// Integer representing the multiplier applied to the plan interval. For example,

--- a/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
+++ b/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
-            // TODO: support expanding "phases.coupon" and "phases.plans.plan" with stripe-mock
+            // TODO: support expanding "phases.coupon" and "phases.plans.plan" and others with stripe-mock
             string[] expansions =
             {
               "customer",

--- a/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
+++ b/src/StripeTests/Entities/Subscriptions/SubscriptionTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
         [Fact]
         public void DeserializeWithExpansions()
         {
-            // TODO: Add support for expanding pending_setup_intent in the future.
+            // TODO: Add support for expanding pending_setup_intent and schedule in the future.
             string[] expansions =
             {
               "customer",


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1757 and other things I found:

A few Billing changes

* Add `Schedule` to `Subscription`
* Add missing parameters to `UpcomingInvoiceOptions` and
`UpcomingInvoiceListLineItemsOptions`
  * `Schedule`
  * `SubscriptionCancelAt`
  * `SubscriptionCancelNow`
* Add missing properties and parameters for a `SubscriptionSchedule` phase:
  * `BillingThresholds`
  * `CollectionMethod`
  * `DefaultPaymentMethod`
  * `InvoiceSettings`


r? @ob-stripe 
cc @stripe/api-libraries 