### PR TITLE
Add decimal properties to PlanTierOptions for plan create

### DIFF
--- a/src/Stripe.net/Services/Plans/PlanTierOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanTierOptions.cs
@@ -12,10 +12,24 @@ namespace Stripe
         public long? FlatAmount { get; set; }
 
         /// <summary>
+        /// Same as flat_amount, but accepts a decimal value representing an integer in the minor
+        /// units of the currency. Only one of flat_amount and flat_amount_decimal can be set.
+        /// </summary>
+        [JsonProperty("flat_amount_decimal")]
+        public decimal? FlatAmountDecimal { get; set; }
+
+        /// <summary>
         /// The per unit billing amount for each individual unit for which this tier applies.
         /// </summary>
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
+
+        /// <summary>
+        /// Same as unit_amount, but accepts a decimal value with at most 12 decimal places.
+        /// Only one of unit_amount and unit_amount_decimal can be set.
+        /// </summary>
+        [JsonProperty("unit_amount_decimal")]
+        public decimal? UnitAmountDecimal { get; set; }
 
         /// <summary>
         /// Specifies the upper bound of this tier. The lower bound of a tier is the upper bound of

--- a/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
+++ b/src/StripeTests/Services/Plans/PlanCreateOptionsTest.cs
@@ -32,5 +32,33 @@ namespace StripeTests
                 "tiers[1][unit_amount]=2000&tiers[1][up_to]=inf",
                 FormEncoder.CreateQueryString(options));
         }
+
+        [Fact]
+        public void SerializeDecimalTiersProperly()
+        {
+            var options = new PlanCreateOptions
+            {
+                Tiers = new List<PlanTierOptions>
+                {
+                    new PlanTierOptions
+                    {
+                        UnitAmountDecimal = 0.003m,
+                        FlatAmountDecimal = 0.12m,
+                        UpTo = 10,
+                    },
+                    new PlanTierOptions
+                    {
+                        UnitAmountDecimal = 0.004m,
+                        FlatAmountDecimal = 0.24m,
+                        UpTo = PlanTierUpTo.Inf,
+                    }
+                },
+            };
+
+            Assert.Equal(
+                "tiers[0][flat_amount_decimal]=0.12&tiers[0][unit_amount_decimal]=0.003&tiers[0][up_to]=10&" +
+                "tiers[1][flat_amount_decimal]=0.24&tiers[1][unit_amount_decimal]=0.004&tiers[1][up_to]=inf",
+                FormEncoder.CreateQueryString(options));
+        }
     }
 }

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -14,6 +14,7 @@ namespace StripeTests
 
         private readonly PlanService service;
         private readonly PlanCreateOptions createOptions;
+        private readonly PlanCreateOptions createDecimalTierOptions;
         private readonly PlanUpdateOptions updateOptions;
         private readonly PlanListOptions listOptions;
 
@@ -36,6 +37,30 @@ namespace StripeTests
                 },
             };
 
+            this.createDecimalTierOptions = new PlanCreateOptions
+            {
+                Currency = "usd",
+                Interval = "month",
+                Nickname = "Plan Nickmame",
+                Product = new PlanProductCreateOptions
+                {
+                    Name = "Product Name",
+                },
+                Tiers = new List<PlanTierOptions>
+                {
+                    new PlanTierOptions
+                    {
+                        UnitAmountDecimal = 0.04m,
+                        UpTo = 10,
+                    },
+                    new PlanTierOptions
+                    {
+                        UnitAmountDecimal = 0.03m,
+                        UpTo = PlanTierUpTo.Inf,
+                    }
+                },
+            };
+
             this.updateOptions = new PlanUpdateOptions
             {
                 Metadata = new Dictionary<string, string>
@@ -54,6 +79,24 @@ namespace StripeTests
         public void Create()
         {
             var plan = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans");
+            Assert.NotNull(plan);
+            Assert.Equal("plan", plan.Object);
+        }
+
+        [Fact]
+        public void Create_DecimalTiers()
+        {
+            var plan = this.service.Create(this.createDecimalTierOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/plans");
+            Assert.NotNull(plan);
+            Assert.Equal("plan", plan.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync_DecimalTiers()
+        {
+            var plan = await this.service.CreateAsync(this.createDecimalTierOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/plans");
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);


### PR DESCRIPTION
Added in tiers.flat_amount_decimal and  tiers.unit_amount_decimal to the tier options for creating a new plan.