### PR TITLE
Allow VoidedAt on CreditNote to be nullable

### DIFF
--- a/src/Stripe.net/Entities/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNote.cs
@@ -190,6 +190,6 @@ namespace Stripe
         /// </summary>
         [JsonProperty("voided_at")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime VoidedAt { get; set; }
+        public DateTime? VoidedAt { get; set; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1782

r? @ob-stripe 
cc @stripe/api-libraries 

Is this a breaking change?