### PR TITLE
Exclude auto-implemented properties from code coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
 
 after_test:
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
-  - dotnet test -c Debug -f netcoreapp2.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+  - dotnet test -c Debug -f netcoreapp2.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
   - ps: |
       # Secure env vars are not available on all branches, so make sure the
       # token is available before invoking Coveralls.

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.4.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.0.2">


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Exclude [auto-implemented properties](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties) from code coverage.
