### PR TITLE
Remove more deprecated stuff

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -139,9 +139,5 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
-
-        [Obsolete("This property has never been filled and should be ignored.")]
-        [JsonProperty("billing")]
-        public Billing Billing { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Plans/PlanTier.cs
+++ b/src/Stripe.net/Entities/Plans/PlanTier.cs
@@ -36,13 +36,5 @@ namespace Stripe
         /// </summary>
         [JsonProperty("up_to")]
         public long? UpTo { get; set; }
-
-        [Obsolete("Use UnitAmountDecimal instead")]
-        [JsonIgnore]
-        public decimal? UnitAmountDecinal
-        {
-            get => this.UnitAmountDecimal;
-            set => this.UnitAmountDecimal = value;
-        }
     }
 }

--- a/src/Stripe.net/Entities/Sources/SourceAuBecsDebit.cs
+++ b/src/Stripe.net/Entities/Sources/SourceAuBecsDebit.cs
@@ -5,19 +5,11 @@ namespace Stripe
 
     public class SourceAuBecsDebit : StripeEntity<SourceAuBecsDebit>
     {
-        [Obsolete("This property is deprecated, Account Number will not be returned from Stripe API.")]
-        [JsonProperty("account_number")]
-        public string AccountNumber { get; set; }
-
         [JsonProperty("bsb_number")]
         public string BsbNumber { get; set; }
 
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
-
-        [Obsolete("This property is deprecated, please use Last4 going forward.")]
-        [JsonProperty("last3")]
-        public string Last3 { get; set; }
 
         [JsonProperty("last4")]
         public string Last4 { get; set; }

--- a/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
@@ -45,26 +45,6 @@ namespace Stripe
         /// <value>The ID of the request, as returned by Stripe.</value>
         public string RequestId => MaybeGetHeader(this.Headers, "Request-Id");
 
-        /// <summary>
-        /// Gets the body of the response.
-        /// This method is deprecated and will be removed in a future version, please use the
-        /// <see cref="Content"/> property getter instead.
-        /// </summary>
-        /// <value>The body of the response.</value>
-        // TODO: remove this in a future a major version
-        [Obsolete("Use Content instead")]
-        public string ResponseJson => this.Content;
-
-        /// <summary>
-        /// Gets the date of the request, as returned by Stripe.
-        /// This method is deprecated and will be removed in a future version, please use the
-        /// <see cref="Date"/> property getter instead.
-        /// </summary>
-        /// <value>The date of the request, as returned by Stripe.</value>
-        // TODO: remove this in a future a major version
-        [Obsolete("Use Date instead")]
-        public DateTime RequestDate => this.Date?.DateTime ?? default(DateTime);
-
         internal int NumRetries { get; set; }
 
         /// <summary>Returns a string that represents the <see cref="StripeResponse"/>.</summary>

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -23,24 +23,6 @@ namespace Stripe
         /// </summary>
         public string StripeAccount { get; set; }
 
-        /// <summary>
-        /// <para>
-        /// Get or sets the
-        /// <a href="https://stripe.com/docs/connect/authentication#authentication-via-the-stripe-account-header">ID
-        /// of the connected account</a> to use for the request.
-        /// </para>
-        /// <para>
-        /// This property is deprecated and will be removed in a future version, please use the
-        /// <see cref="StripeAccount"/> property accessors instead.
-        /// </para>
-        /// </summary>
-        [Obsolete("Use StripeAccount instead.")]
-        public string StripeConnectAccountId
-        {
-            get => this.StripeAccount;
-            set => this.StripeAccount = value;
-        }
-
         /// <summary>Gets or sets the base URL for the request.</summary>
         /// <remarks>
         /// This is an internal property. It is set by services or individual request methods when

--- a/src/StripeTests/Entities/Plans/PlanTest.cs
+++ b/src/StripeTests/Entities/Plans/PlanTest.cs
@@ -53,7 +53,6 @@ namespace StripeTests
             Assert.NotNull(plan.Id);
             Assert.Equal("plan", plan.Object);
             Assert.Equal(199, plan.Tiers[0].UnitAmountDecimal);
-            Assert.Equal(199, plan.Tiers[0].UnitAmountDecinal);
         }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Remove more deprecated methods and fields:
- `Issuing.Card.Billing` (never actually used)
- `PlanTier.UnitAmountDecinal` (typo, replaced by `PlanTier.UnitAmountDecimal`)
- `SourceAuBecsDebit.AccountNumber` and `SourceAuBecsDebit.Last3` (never actually used)
- `StripeResponse.ResponseJson` (replaced by `StripeResponse.Content`)
- `StripeResponse.RequestDate` (replaced by `StripeResponse.Date`)
- `RequestOptions.StripeConnectAccountId` (replaced by `RequestOptions.StripeAccount`)