### PR TITLE
Enable test for JSON<->property name consistency

### DIFF
--- a/src/Stripe.net/Infrastructure/AllowNameMismatch.cs
+++ b/src/Stripe.net/Infrastructure/AllowNameMismatch.cs
@@ -1,0 +1,17 @@
+namespace Stripe.Infrastructure
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Used to indicate that a particular property is allowed to have a name that isn't a strict
+    /// <c>snake_case</c> -> <c>CamelCase</c> conversion from the JSON name defined its
+    /// <see cref="JsonPropertyAttribute" /> property.
+    /// </summary>
+    /// <remarks>
+    /// This is only used for an internal wholesome test.
+    /// </remarks>
+    [System.AttributeUsage(System.AttributeTargets.Property)]
+    internal class AllowNameMismatch : System.Attribute
+    {
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOption.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class InvoiceUpcomingInvoiceItemOption : INestedOptions, IHasMetadata
     {
@@ -36,6 +37,7 @@ namespace Stripe
         /// Ids of the tax rates to apply to this invoice item.
         /// </summary>
         [JsonProperty("invoiceitem")]
+        [AllowNameMismatch]
         public string InvoiceItem { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
@@ -65,6 +64,7 @@ namespace Stripe
         public PersonRelationshipOptions Relationship { get; set; }
 
         [JsonProperty("ssn_last_4")]
+        [AllowNameMismatch]
         public string SSNLast4 { get; set; }
 
         [JsonProperty("verification")]

--- a/src/Stripe.net/Services/TaxRates/TaxRatePercentageRangeOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRatePercentageRangeOptions.cs
@@ -1,20 +1,24 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class TaxRatePercentageRangeOptions : INestedOptions
     {
         [JsonProperty("gt")]
+        [AllowNameMismatch]
         public decimal? GreaterThan { get; set; }
 
         [JsonProperty("gte")]
+        [AllowNameMismatch]
         public decimal? GreaterThanOrEqual { get; set; }
 
         [JsonProperty("lt")]
+        [AllowNameMismatch]
         public decimal? LessThan { get; set; }
 
         [JsonProperty("lte")]
+        [AllowNameMismatch]
         public decimal? LessThanOrEqual { get; set; }
     }
 }

--- a/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
+++ b/src/Stripe.net/Services/ThreeDSecure/ThreeDSecureCreateOptions.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class ThreeDSecureCreateOptions : BaseOptions
     {
@@ -17,6 +18,7 @@ namespace Stripe
         /// If you pass a card id, you must also pass the customer id.
         /// </summary>
         [JsonProperty("card")]
+        [AllowNameMismatch]
         public string CardTokenOrCardId { get; set; }
 
         [JsonProperty("customer")]

--- a/src/Stripe.net/Services/_common/DateRangeOptions.cs
+++ b/src/Stripe.net/Services/_common/DateRangeOptions.cs
@@ -8,18 +8,22 @@ namespace Stripe
     {
         [JsonProperty("gt")]
         [JsonConverter(typeof(DateTimeConverter))]
+        [AllowNameMismatch]
         public DateTime? GreaterThan { get; set; }
 
         [JsonProperty("gte")]
         [JsonConverter(typeof(DateTimeConverter))]
+        [AllowNameMismatch]
         public DateTime? GreaterThanOrEqual { get; set; }
 
         [JsonProperty("lt")]
         [JsonConverter(typeof(DateTimeConverter))]
+        [AllowNameMismatch]
         public DateTime? LessThan { get; set; }
 
         [JsonProperty("lte")]
         [JsonConverter(typeof(DateTimeConverter))]
+        [AllowNameMismatch]
         public DateTime? LessThanOrEqual { get; set; }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Enables the JSON<->property name consistency test.

Adds a `AllowNameMismatch` attribute to flag allowed exceptions.
