### PR TITLE
Renaming `AccountOpener` to `Representative` and moving to latest API version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.67.0
+  STRIPE_MOCK_VERSION: 0.68.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Persons/PersonRelationship.cs
+++ b/src/Stripe.net/Entities/Persons/PersonRelationship.cs
@@ -5,13 +5,6 @@ namespace Stripe
     public class PersonRelationship : StripeEntity<PersonRelationship>
     {
         /// <summary>
-        /// Whether the person opened the account. This person provides information about
-        /// themselves, and general information about the account.
-        /// </summary>
-        [JsonProperty("account_opener")]
-        public bool AccountOpener { get; set; }
-
-        /// <summary>
         /// Whether the person is a director of the account’s legal entity..
         /// </summary>
         [JsonProperty("director")]
@@ -35,6 +28,16 @@ namespace Stripe
         /// </summary>
         [JsonProperty("percent_ownership")]
         public decimal? PercentOwnership { get; set; }
+
+        /// <summary>
+        /// Whether the person is authorized as the primary representative of the account. This is
+        /// the person nominated by the business to provide information about themselves, and
+        /// general information about the account. There can only be one representative at any given
+        /// time. At the time the account is created, this person should be set to the person
+        /// responsible for opening the account.
+        /// </summary>
+        [JsonProperty("representative")]
+        public bool Representative { get; set; }
 
         /// <summary>
         /// The person’s title (e.g., CEO, Support Engineer).

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-09-09";
+        public static string ApiVersion => "2019-10-08";
 
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Services/Persons/PersonRelationshipListOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonRelationshipListOptions.cs
@@ -5,13 +5,6 @@ namespace Stripe
     public class PersonRelationshipListOptions : INestedOptions
     {
         /// <summary>
-        /// A filter on the list of people returned based on whether these people are the account
-        /// opener of the account’s company.
-        /// </summary>
-        [JsonProperty("account_opener")]
-        public bool? AccountOpener { get; set; }
-
-        /// <summary>
         /// A filter on the list of people returned based on whether these people are directors of
         /// the account’s company.
         /// </summary>
@@ -31,5 +24,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("owner")]
         public bool? Owner { get; set; }
+
+        /// <summary>
+        /// A filter on the list of people to find the account representative.
+        /// </summary>
+        [JsonProperty("representative")]
+        public bool? Representative { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Persons/PersonRelationshipOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonRelationshipOptions.cs
@@ -5,13 +5,6 @@ namespace Stripe
     public class PersonRelationshipOptions : INestedOptions
     {
         /// <summary>
-        /// Whether the person opened the account. This person provides information about
-        /// themselves, and general information about the account.
-        /// </summary>
-        [JsonProperty("account_opener")]
-        public bool? AccountOpener { get; set; }
-
-        /// <summary>
         /// Whether the person is a director of the account’s legal entity..
         /// </summary>
         [JsonProperty("director")]
@@ -35,6 +28,16 @@ namespace Stripe
         /// </summary>
         [JsonProperty("percent_ownership")]
         public decimal? PercentOwnership { get; set; }
+
+        /// <summary>
+        /// Whether the person is authorized as the primary representative of the account. This is
+        /// the person nominated by the business to provide information about themselves, and
+        /// general information about the account. There can only be one representative at any given
+        /// time. At the time the account is created, this person should be set to the person
+        /// responsible for opening the account.
+        /// </summary>
+        [JsonProperty("representative")]
+        public bool? Representative { get; set; }
 
         /// <summary>
         /// The person’s title (e.g., CEO, Support Engineer).

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -29,9 +29,9 @@ namespace StripeTests
                 FirstName = "John",
                 Relationship = new PersonRelationshipOptions
                 {
-                    AccountOpener = true,
                     Owner = true,
                     PercentOwnership = 30.5m,
+                    Representative = true,
                 },
                 Verification = new PersonVerificationOptions
                 {
@@ -53,9 +53,9 @@ namespace StripeTests
                 FirstName = "John",
                 Relationship = new PersonRelationshipOptions
                 {
-                    AccountOpener = true,
                     Owner = true,
                     PercentOwnership = 30.5m,
+                    Representative = true,
                 },
             };
 

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.67.0";
+        private const string MockMinimumVersion = "0.68.0";
 
         private readonly string port;
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 