### PR TITLE
Fix `Quantity` to be nullable on `SubscriptionSchedulePhaseItem`

### DIFF
--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedulePhaseItem.cs
@@ -45,7 +45,7 @@ namespace Stripe
         /// Quantity of the plan to which the customer should be subscribed.
         /// </summary>
         [JsonProperty("quantity")]
-        public long Quantity { get; set; }
+        public long? Quantity { get; set; }
 
         /// <summary>
         /// The tax rates which apply to this specific item on the phase for a subscription


### PR DESCRIPTION
On a phase in a `SubscriptionSchedule`, the `Quantity` can be null. This is confirmed by the openapi spec:

```yaml
    subscription_schedule_configuration_item:
      properties:
        (...)
        quantity:
          description: Quantity of the plan to which the customer should be subscribed.
          nullable: true
          type: integer
```

Fixes https://github.com/stripe/stripe-dotnet/issues/1808

r? @ob-stripe 
cc @stripe/api-libraries 