### PR TITLE
Add `DeviceType` filter when listing Terminal `Reader`s

### DIFF
--- a/src/Stripe.net/Services/Terminal/Readers/ReaderListOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderListOptions.cs
@@ -6,6 +6,12 @@ namespace Stripe.Terminal
     public class ReaderListOptions : ListOptions
     {
         /// <summary>
+        /// Filters readers by device type.
+        /// </summary>
+        [JsonProperty("device_type")]
+        public string DeviceType { get; set; }
+
+        /// <summary>
         /// A location ID to filter the response list to only readers at the specific location.
         /// </summary>
         [JsonProperty("location")]


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 