### PR TITLE
Fix installments to use the correct type

### DIFF
--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -10,7 +10,7 @@ namespace Stripe
         /// Installment details for this payment (Mexico only).
         /// </summary>
         [JsonProperty("installments")]
-        public string Installments { get; set; }
+        public PaymentIntentPaymentMethodOptionsCardInstallments Installments { get; set; }
 
         /// <summary>
         /// We strongly recommend that you rely on our SCA engine to automatically prompt your


### PR DESCRIPTION
Fix `Installments` in `PaymentIntentPaymentMethodOptionsCard` to have the right type

r? @ob-stripe 
cc @stripe/api-libraries 