### PR TITLE
Make `ReportRun.SucceededAt` nullable

### DIFF
--- a/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
@@ -37,6 +37,6 @@ namespace Stripe.Reporting
 
         [JsonProperty("succeeded_at")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime SucceededAt { get; set; }
+        public DateTime? SucceededAt { get; set; }
     }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Make `ReportRun.SucceededAt` nullable.

Fixes #1823.
