### PR TITLE
Do not use DefaultSettings when serializing or deserializing JSON

### DIFF
--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -4,6 +4,7 @@ namespace Stripe
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     [JsonObject(MemberSerialization.OptIn)]
     public abstract class StripeEntity : IStripeEntity
@@ -19,7 +20,7 @@ namespace Stripe
         /// <returns>The deserialized Stripe object from the JSON string.</returns>
         public static IHasObject FromJson(string value)
         {
-            return JsonConvert.DeserializeObject<IHasObject>(value, StripeConfiguration.SerializerSettings);
+            return JsonUtils.DeserializeObject<IHasObject>(value, StripeConfiguration.SerializerSettings);
         }
 
         /// <summary>Deserializes the JSON to the specified Stripe object type.</summary>
@@ -29,7 +30,7 @@ namespace Stripe
         public static T FromJson<T>(string value)
             where T : IStripeEntity
         {
-            return JsonConvert.DeserializeObject<T>(value, StripeConfiguration.SerializerSettings);
+            return JsonUtils.DeserializeObject<T>(value, StripeConfiguration.SerializerSettings);
         }
 
         /// <summary>Reports a Stripe object as a string.</summary>
@@ -51,7 +52,7 @@ namespace Stripe
         /// <returns>An indented JSON string represensation of the object.</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(
+            return JsonUtils.SerializeObject(
                 this,
                 Formatting.Indented,
                 StripeConfiguration.SerializerSettings);

--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -131,7 +131,7 @@ namespace Stripe.Infrastructure.FormEncoding
                     break;
 
                 case Enum e:
-                    flatParams = SingleParam(keyPrefix, JsonConvert.SerializeObject(e).Trim('"'));
+                    flatParams = SingleParam(keyPrefix, JsonUtils.SerializeObject(e).Trim('"'));
                     break;
 
                 default:

--- a/src/Stripe.net/Infrastructure/JsonUtils.cs
+++ b/src/Stripe.net/Infrastructure/JsonUtils.cs
@@ -1,0 +1,85 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using Newtonsoft.Json;
+
+    internal static class JsonUtils
+    {
+        /// <summary>
+        /// Deserializes the JSON to the specified .NET type using
+        /// <see cref="JsonSerializerSettings"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+        /// <param name="value">The JSON to deserialize.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
+        /// </param>
+        /// <returns>The deserialized object from the JSON string.</returns>
+        public static T DeserializeObject<T>(
+            string value,
+            JsonSerializerSettings settings = null)
+        {
+            return (T)DeserializeObject(value, typeof(T), settings);
+        }
+
+        /// <summary>
+        /// Deserializes the JSON to the specified .NET type using
+        /// <see cref="JsonSerializerSettings"/>.
+        /// </summary>
+        /// <param name="value">The JSON to deserialize.</param>
+        /// <param name="type">The type of the object to deserialize to.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
+        /// </param>
+        /// <returns>The deserialized object from the JSON string.</returns>
+        public static object DeserializeObject(
+            string value,
+            Type type,
+            JsonSerializerSettings settings = null)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
+
+            using (JsonTextReader reader = new JsonTextReader(new StringReader(value)))
+            {
+                return jsonSerializer.Deserialize(reader, type);
+            }
+        }
+
+        /// <summary>
+        /// Serializes the specified object to a JSON string without using any default settings.
+        /// </summary>
+        /// <param name="value">The object to serialize.</param>
+        /// <param name="formatting">Indicates how the output should be formatted.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to serialize the object.
+        /// </param>
+        /// <returns>A JSON string representation of the object.</returns>
+        public static string SerializeObject(
+            object value,
+            Formatting formatting = Formatting.None,
+            JsonSerializerSettings settings = null)
+        {
+            JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
+            jsonSerializer.Formatting = formatting;
+
+            StringBuilder sb = new StringBuilder(256);
+            StringWriter sw = new StringWriter(sb, CultureInfo.InvariantCulture);
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = jsonSerializer.Formatting;
+
+                jsonSerializer.Serialize(jsonWriter, value);
+            }
+
+            return sw.ToString();
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
+++ b/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
@@ -6,6 +6,7 @@ namespace Stripe
     using System.Linq;
     using System.Net.Http;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     /// <summary>
     /// Helper class used by <see cref="SystemNetHttpClient"/> to manage request telemetry.
@@ -37,7 +38,7 @@ namespace Stripe
 
             var payload = new ClientTelemetryPayload { LastRequestMetrics = requestMetrics };
 
-            headers.Add("X-Stripe-Client-Telemetry", JsonConvert.SerializeObject(payload, Formatting.None));
+            headers.Add("X-Stripe-Client-Telemetry", JsonUtils.SerializeObject(payload, Formatting.None));
         }
 
         /// <summary>

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -218,7 +218,7 @@ namespace Stripe
                 values.Add("application", this.appInfo);
             }
 
-            return JsonConvert.SerializeObject(values, Formatting.None);
+            return JsonUtils.SerializeObject(values, Formatting.None);
         }
 
         private string BuildUserAgentString()

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -5,7 +5,6 @@ namespace Stripe
     using System.Linq;
     using System.Security.Cryptography;
     using System.Text;
-    using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
     /// <summary>
@@ -36,7 +35,7 @@ namespace Stripe
         /// </remarks>
         public static Event ParseEvent(string json, bool throwOnApiVersionMismatch = true)
         {
-            var stripeEvent = JsonConvert.DeserializeObject<Event>(
+            var stripeEvent = JsonUtils.DeserializeObject<Event>(
                 json,
                 StripeConfiguration.SerializerSettings);
 

--- a/src/StripeTests/Infrastructure/JsonUtilsTest.cs
+++ b/src/StripeTests/Infrastructure/JsonUtilsTest.cs
@@ -1,0 +1,87 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class JsonUtilsTest : BaseStripeTest
+    {
+        [Fact]
+        public void DeserializeObjectIgnoresDefaultSettings()
+        {
+            var origDefaultSettings = JsonConvert.DefaultSettings;
+
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    MissingMemberHandling = MissingMemberHandling.Error,
+                };
+
+                var s = "{\"int\":234,\"string\":\"Hello!\",\"foo\":\"bar\"}";
+
+                // Deserialization throws an exception because of the extra `foo` property that is
+                // missing in the TestObject class.
+                Assert.Throws<JsonSerializationException>(() =>
+                    JsonConvert.DeserializeObject<TestObject>(s));
+
+                // Deserialization succeeds because we're not using DefaultSettings, so
+                // MissingMemberHandling is set to its default value Ignore instead of Error.
+                var objStripe = JsonUtils.DeserializeObject<TestObject>(s);
+                Assert.NotNull(objStripe);
+                Assert.Equal(234, objStripe.Int);
+                Assert.Equal("Hello!", objStripe.String);
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = origDefaultSettings;
+            }
+        }
+
+        [Fact]
+        public void SerializeObjectIgnoresDefaultSettings()
+        {
+            var origDefaultSettings = JsonConvert.DefaultSettings;
+
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented,
+                    PreserveReferencesHandling = PreserveReferencesHandling.All,
+                };
+
+                var o = new TestObject { Int = 234, String = "Hello!" };
+
+                // Serialized string is formatted with newlines and indentation because of
+                // Formatting.Indented, and includes `$id` keys because of
+                // PreserveReferencesHandling.All.
+                var jsonDefault = JsonConvert.SerializeObject(o);
+                jsonDefault = jsonDefault.Replace("\r\n", "\n");
+                Assert.Equal(
+                    "{\n  \"$id\": \"1\",\n  \"int\": 234,\n  \"string\": \"Hello!\"\n}",
+                    jsonDefault);
+
+                // Serialized string is not formatted and doesn't include `$id` keys because
+                // we're not using DefaultSettings.
+                var jsonStripe = JsonUtils.SerializeObject(o);
+                jsonStripe = jsonStripe.Replace("\r\n", "\n");
+                Assert.Equal("{\"int\":234,\"string\":\"Hello!\"}", jsonStripe);
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = origDefaultSettings;
+            }
+        }
+
+        [JsonObject]
+        private class TestObject
+        {
+            [JsonProperty("int")]
+            public int Int { get; set; }
+
+            [JsonProperty("string")]
+            public string String { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Newtonsoft.Json lets user define global default settings for serializing and deserializing JSON via the [`JsonConvert.DefaultSettings`](https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonConvert_DefaultSettings.htm) property.

Those settings are used when serializing/deserializing using the static methods in `JsonConvert`. Even if you provide a `JsonSerializerSettings` instance, those settings will be merged with the default settings.

Because we were using `JsonConvert.SerializeObject` / `JsonConvert.DeserializeObject` in a number of places in the library, this means that users could affect the serialization/deserialization by setting `JsonConvert.DefaultSettings`. I don't think that's desirable: the library should use its own settings, independent of the global default settings.

This PR defines new utility methods `JsonUtils.SerializeObject` / `JsonUtils.DeserializeObject` which are exactly the same as the ones provided by Newtonsoft.Json's `JsonConvert`, except that the global default settings are not used (practically speaking, the difference is that the `JsonSerializer` class is instantiated with `JsonSerializer.Create(settings)` instead of `JsonSerializer.CreateDefault(settings)`.

Here's the list of places where we were using Newtonsoft.Json's `JsonConvert` methods and are now using our own `JsonUtils` methods:
- deserialization:
    - `StripeEntity.FromJson` (both generic and non-generic variants)
        - we use our own `StripeConfiguration.SerializerSettings` instance here, so users are still able to customize the deserialization by modifying this property if they need to
    - `EventUtility.ParseEvent`
        - same as above
- serialization:
    - `StripeEntity.ToJson`
        - same as above, we use `StripeConfiguration.SerializerSettings` so users are still able to customize the serialization
    - `FormEncoder.FlattenParamsValue`:
        - this is kind of a hack to encode enum values to their string representation. There's really no reason to modify the behavior here, so we're not providing any settings instance
    - `RequestTelemetry.MaybeAddTelemetryHeader` and `SystemNetHttpClient.BuildStripeClientUserAgentString`:
        - we want the JSON strings to be as "standard" as possible here so not passing any settings instance either

I'm tagging this as `breaking-api-change` because it may affect users who are modifying `JsonConvert.DefaultSettings` and who may know need to modify `StripeConfiguation.SerializerSettings` instead, but the vast majority of users should not be affected.

(For context, what motivated this PR is that I noticed some malformed telemetry headers on the backend:
```json
{"$id":"1","last_request_metrics":{"$id":"2","request_id":"req_123","request_duration_ms":234}}
```

The `$id` keys are inserted because the user set `PreserveReferencesHandling` to `PreserveReferencesHandling.All` in `JsonConvert.DefaultSettings`.)
