### PR TITLE
stripe-dotnet v33

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.69.0
+  STRIPE_MOCK_VERSION: 0.71.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
@@ -37,6 +37,6 @@ namespace Stripe.Reporting
 
         [JsonProperty("succeeded_at")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime SucceededAt { get; set; }
+        public DateTime? SucceededAt { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -20,29 +20,12 @@ namespace Stripe
         public string Object { get; set; }
 
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period.
-        /// </summary>
-        [JsonProperty("billing_thresholds")]
-        public SubscriptionBillingThresholds BillingThresholds { get; set; }
-
-        /// <summary>
         /// Time at which the subscription schedule was canceled. Measured in seconds since the
         /// Unix epoch.
         /// </summary>
         [JsonProperty("canceled_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CanceledAt { get; set; }
-
-        /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging
-        /// automatically, Stripe will attempt to pay this subscription at the
-        /// end of the cycle using the default source attached to the customer.
-        /// When sending an invoice, Stripe will email your customer an invoice
-        /// with payment instructions.
-        /// </summary>
-        [JsonProperty("collection_method")]
-        public string CollectionMethod { get; set; }
 
         /// <summary>
         /// Time at which the subscription schedule was completed. Measured in seconds since the
@@ -94,53 +77,11 @@ namespace Stripe
         internal ExpandableField<Customer> InternalCustomer { get; set; }
         #endregion
 
-        #region Expandable DefaultPaymentMethod
-
         /// <summary>
-        /// ID of the default payment method for the subscription schedule.
+        /// Object representing the subscription schedule’s default settings.
         /// </summary>
-        [JsonIgnore]
-        public string DefaultPaymentMethodId
-        {
-            get => this.InternalDefaultPaymentMethod?.Id;
-            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
-        }
-
-        [JsonIgnore]
-        public PaymentMethod DefaultPaymentMethod
-        {
-            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
-            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
-        }
-
-        [JsonProperty("default_payment_method")]
-        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
-        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
-        #endregion
-
-        #region Expandable DefaultSource
-
-        /// <summary>
-        /// ID of the default source for the subscription schedule.
-        /// </summary>
-        [JsonIgnore]
-        public string DefaultSourceId
-        {
-            get => this.InternalDefaultSource?.Id;
-            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
-        }
-
-        [JsonIgnore]
-        public IPaymentSource DefaultSource
-        {
-            get => this.InternalDefaultSource?.ExpandedObject;
-            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
-        }
-
-        [JsonProperty("default_source")]
-        [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
-        internal ExpandableField<IPaymentSource> InternalDefaultSource { get; set; }
-        #endregion
+        [JsonProperty("default_settings")]
+        public SubscriptionScheduleDefaultSettings DefaultSettings { get; set; }
 
         /// <summary>
         /// Behavior of the subscription schedule and underlying subscription when it ends. Possible
@@ -148,12 +89,6 @@ namespace Stripe
         /// </summary>
         [JsonProperty("end_behavior")]
         public string EndBehavior { get; set; }
-
-        /// <summary>
-        /// The schedule's default invoice settings.
-        /// </summary>
-        [JsonProperty("invoice_settings")]
-        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleDefaultSettings.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleDefaultSettings.cs
@@ -1,0 +1,57 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleDefaultSettings : StripeEntity<SubscriptionScheduleDefaultSettings>
+    {
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholds BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging
+        /// automatically, Stripe will attempt to pay this subscription at the
+        /// end of the cycle using the default source attached to the customer.
+        /// When sending an invoice, Stripe will email your customer an invoice
+        /// with payment instructions.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonProperty("default_payment_method")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
+        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
+        #endregion
+
+        /// <summary>
+        /// The schedule's default invoice settings.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -4,6 +4,7 @@ namespace Stripe
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     [JsonObject(MemberSerialization.OptIn)]
     public abstract class StripeEntity : IStripeEntity
@@ -19,7 +20,7 @@ namespace Stripe
         /// <returns>The deserialized Stripe object from the JSON string.</returns>
         public static IHasObject FromJson(string value)
         {
-            return JsonConvert.DeserializeObject<IHasObject>(value, StripeConfiguration.SerializerSettings);
+            return JsonUtils.DeserializeObject<IHasObject>(value, StripeConfiguration.SerializerSettings);
         }
 
         /// <summary>Deserializes the JSON to the specified Stripe object type.</summary>
@@ -29,7 +30,7 @@ namespace Stripe
         public static T FromJson<T>(string value)
             where T : IStripeEntity
         {
-            return JsonConvert.DeserializeObject<T>(value, StripeConfiguration.SerializerSettings);
+            return JsonUtils.DeserializeObject<T>(value, StripeConfiguration.SerializerSettings);
         }
 
         /// <summary>Reports a Stripe object as a string.</summary>
@@ -51,7 +52,7 @@ namespace Stripe
         /// <returns>An indented JSON string represensation of the object.</returns>
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(
+            return JsonUtils.SerializeObject(
                 this,
                 Formatting.Indented,
                 StripeConfiguration.SerializerSettings);

--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -131,7 +131,7 @@ namespace Stripe.Infrastructure.FormEncoding
                     break;
 
                 case Enum e:
-                    flatParams = SingleParam(keyPrefix, JsonConvert.SerializeObject(e).Trim('"'));
+                    flatParams = SingleParam(keyPrefix, JsonUtils.SerializeObject(e).Trim('"'));
                     break;
 
                 default:

--- a/src/Stripe.net/Infrastructure/JsonUtils.cs
+++ b/src/Stripe.net/Infrastructure/JsonUtils.cs
@@ -1,0 +1,85 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using Newtonsoft.Json;
+
+    internal static class JsonUtils
+    {
+        /// <summary>
+        /// Deserializes the JSON to the specified .NET type using
+        /// <see cref="JsonSerializerSettings"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+        /// <param name="value">The JSON to deserialize.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
+        /// </param>
+        /// <returns>The deserialized object from the JSON string.</returns>
+        public static T DeserializeObject<T>(
+            string value,
+            JsonSerializerSettings settings = null)
+        {
+            return (T)DeserializeObject(value, typeof(T), settings);
+        }
+
+        /// <summary>
+        /// Deserializes the JSON to the specified .NET type using
+        /// <see cref="JsonSerializerSettings"/>.
+        /// </summary>
+        /// <param name="value">The JSON to deserialize.</param>
+        /// <param name="type">The type of the object to deserialize to.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
+        /// </param>
+        /// <returns>The deserialized object from the JSON string.</returns>
+        public static object DeserializeObject(
+            string value,
+            Type type,
+            JsonSerializerSettings settings = null)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
+
+            using (JsonTextReader reader = new JsonTextReader(new StringReader(value)))
+            {
+                return jsonSerializer.Deserialize(reader, type);
+            }
+        }
+
+        /// <summary>
+        /// Serializes the specified object to a JSON string without using any default settings.
+        /// </summary>
+        /// <param name="value">The object to serialize.</param>
+        /// <param name="formatting">Indicates how the output should be formatted.</param>
+        /// <param name="settings">
+        /// The <see cref="JsonSerializerSettings"/> used to serialize the object.
+        /// </param>
+        /// <returns>A JSON string representation of the object.</returns>
+        public static string SerializeObject(
+            object value,
+            Formatting formatting = Formatting.None,
+            JsonSerializerSettings settings = null)
+        {
+            JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
+            jsonSerializer.Formatting = formatting;
+
+            StringBuilder sb = new StringBuilder(256);
+            StringWriter sw = new StringWriter(sb, CultureInfo.InvariantCulture);
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = jsonSerializer.Formatting;
+
+                jsonSerializer.Serialize(jsonWriter, value);
+            }
+
+            return sw.ToString();
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
+++ b/src/Stripe.net/Infrastructure/Public/RequestTelemetry.cs
@@ -6,6 +6,7 @@ namespace Stripe
     using System.Linq;
     using System.Net.Http;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     /// <summary>
     /// Helper class used by <see cref="SystemNetHttpClient"/> to manage request telemetry.
@@ -37,7 +38,7 @@ namespace Stripe
 
             var payload = new ClientTelemetryPayload { LastRequestMetrics = requestMetrics };
 
-            headers.Add("X-Stripe-Client-Telemetry", JsonConvert.SerializeObject(payload, Formatting.None));
+            headers.Add("X-Stripe-Client-Telemetry", JsonUtils.SerializeObject(payload, Formatting.None));
         }
 
         /// <summary>

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-10-17";
+        public static string ApiVersion => "2019-11-05";
 
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -218,7 +218,7 @@ namespace Stripe
                 values.Add("application", this.appInfo);
             }
 
-            return JsonConvert.SerializeObject(values, Formatting.None);
+            return JsonUtils.SerializeObject(values, Formatting.None);
         }
 
         private string BuildUserAgentString()

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -5,7 +5,6 @@ namespace Stripe
     using System.Linq;
     using System.Security.Cryptography;
     using System.Text;
-    using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
     /// <summary>
@@ -36,7 +35,7 @@ namespace Stripe
         /// </remarks>
         public static Event ParseEvent(string json, bool throwOnApiVersionMismatch = true)
         {
-            var stripeEvent = JsonConvert.DeserializeObject<Event>(
+            var stripeEvent = JsonUtils.DeserializeObject<Event>(
                 json,
                 StripeConfiguration.SerializerSettings);
 

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentConfirmOptions.cs
@@ -21,8 +21,7 @@ namespace Stripe
         /// charge them later</a>.
         /// </summary>
         [JsonProperty("off_session")]
-        [JsonConverter(typeof(AnyOfConverter))]
-        public AnyOf<bool?, string> OffSession { get; set; }
+        public bool? OffSession { get; set; }
 
         /// <summary>
         /// ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -88,8 +88,7 @@ namespace Stripe
         /// charge them later</a>.
         /// </summary>
         [JsonProperty("off_session")]
-        [JsonConverter(typeof(AnyOfConverter))]
-        public AnyOf<bool?, string> OffSession { get; set; }
+        public bool? OffSession { get; set; }
 
         /// <summary>
         /// The Stripe account ID for which these funds are intended. For details, see the

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
@@ -1,0 +1,37 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleDefaultSettingsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
+        /// charging automatically, Stripe will attempt to pay the underlying
+        /// subscription at the end of each billing cycle using the default
+        /// source attached to the customer. When sending an invoice, Stripe
+        /// will email your customer an invoice with payment instructions.
+        /// Defaults to <c>charge_automatically</c> on creation.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Define the default settings applied to invoices created by this subscription schedule.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettingsOptions InvoiceSettings { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
@@ -8,34 +8,10 @@ namespace Stripe
     public abstract class SubscriptionScheduleSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// Object representing the subscription schedule’s default settings.
         /// </summary>
-        [JsonProperty("billing_thresholds")]
-        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
-
-        /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
-        /// charging automatically, Stripe will attempt to pay the underlying
-        /// subscription at the end of each billing cycle using the default
-        /// source attached to the customer. When sending an invoice, Stripe
-        /// will email your customer an invoice with payment instructions.
-        /// Defaults to <c>charge_automatically</c> on creation.
-        /// </summary>
-        [JsonProperty("collection_method")]
-        public string CollectionMethod { get; set; }
-
-        /// <summary>
-        /// ID of the default payment method for the subscription schedule.
-        /// </summary>
-        [JsonProperty("default_payment_method")]
-        public string DefaultPaymentMethod { get; set; }
-
-        /// <summary>
-        /// ID of the default source for the subscription schedule.
-        /// </summary>
-        [JsonProperty("default_source")]
-        public string DefaultSource { get; set; }
+        [JsonProperty("default_settings")]
+        public SubscriptionScheduleDefaultSettingsOptions DefaultSettings { get; set; }
 
         /// <summary>
         /// Behavior of the subscription schedule and underlying subscription when it ends. Possible

--- a/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
+++ b/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
@@ -29,6 +29,7 @@ namespace StripeTests
             string[] expansions =
             {
               "customer",
+              "default_settings.default_payment_method",
               "phases.plans.plan",
               "subscription",
             };
@@ -42,6 +43,9 @@ namespace StripeTests
 
             Assert.NotNull(schedule.Customer);
             Assert.Equal("customer", schedule.Customer.Object);
+
+            Assert.NotNull(schedule.DefaultSettings.DefaultPaymentMethod);
+            Assert.Equal("payment_method", schedule.DefaultSettings.DefaultPaymentMethod.Object);
 
             Assert.NotNull(schedule.Subscription);
             Assert.Equal("subscription", schedule.Subscription.Object);

--- a/src/StripeTests/Infrastructure/JsonUtilsTest.cs
+++ b/src/StripeTests/Infrastructure/JsonUtilsTest.cs
@@ -1,0 +1,87 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class JsonUtilsTest : BaseStripeTest
+    {
+        [Fact]
+        public void DeserializeObjectIgnoresDefaultSettings()
+        {
+            var origDefaultSettings = JsonConvert.DefaultSettings;
+
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    MissingMemberHandling = MissingMemberHandling.Error,
+                };
+
+                var s = "{\"int\":234,\"string\":\"Hello!\",\"foo\":\"bar\"}";
+
+                // Deserialization throws an exception because of the extra `foo` property that is
+                // missing in the TestObject class.
+                Assert.Throws<JsonSerializationException>(() =>
+                    JsonConvert.DeserializeObject<TestObject>(s));
+
+                // Deserialization succeeds because we're not using DefaultSettings, so
+                // MissingMemberHandling is set to its default value Ignore instead of Error.
+                var objStripe = JsonUtils.DeserializeObject<TestObject>(s);
+                Assert.NotNull(objStripe);
+                Assert.Equal(234, objStripe.Int);
+                Assert.Equal("Hello!", objStripe.String);
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = origDefaultSettings;
+            }
+        }
+
+        [Fact]
+        public void SerializeObjectIgnoresDefaultSettings()
+        {
+            var origDefaultSettings = JsonConvert.DefaultSettings;
+
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented,
+                    PreserveReferencesHandling = PreserveReferencesHandling.All,
+                };
+
+                var o = new TestObject { Int = 234, String = "Hello!" };
+
+                // Serialized string is formatted with newlines and indentation because of
+                // Formatting.Indented, and includes `$id` keys because of
+                // PreserveReferencesHandling.All.
+                var jsonDefault = JsonConvert.SerializeObject(o);
+                jsonDefault = jsonDefault.Replace("\r\n", "\n");
+                Assert.Equal(
+                    "{\n  \"$id\": \"1\",\n  \"int\": 234,\n  \"string\": \"Hello!\"\n}",
+                    jsonDefault);
+
+                // Serialized string is not formatted and doesn't include `$id` keys because
+                // we're not using DefaultSettings.
+                var jsonStripe = JsonUtils.SerializeObject(o);
+                jsonStripe = jsonStripe.Replace("\r\n", "\n");
+                Assert.Equal("{\"int\":234,\"string\":\"Hello!\"}", jsonStripe);
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = origDefaultSettings;
+            }
+        }
+
+        [JsonObject]
+        private class TestObject
+        {
+            [JsonProperty("int")]
+            public int Int { get; set; }
+
+            [JsonProperty("string")]
+            public string String { get; set; }
+        }
+    }
+}

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
@@ -15,13 +15,6 @@ namespace StripeTests
             };
 
             Assert.Equal("off_session=True", FormEncoder.CreateQueryString(options_bool));
-
-            var options_enum = new PaymentIntentConfirmOptions
-            {
-                OffSession = "one_off",
-            };
-
-            Assert.Equal("off_session=one_off", FormEncoder.CreateQueryString(options_enum));
         }
     }
 }

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
@@ -15,13 +15,6 @@ namespace StripeTests
             };
 
             Assert.Equal("off_session=True", FormEncoder.CreateQueryString(options_bool));
-
-            var options_enum = new PaymentIntentCreateOptions
-            {
-                OffSession = "one_off",
-            };
-
-            Assert.Equal("off_session=one_off", FormEncoder.CreateQueryString(options_enum));
         }
     }
 }

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.69.0";
+        private const string MockMinimumVersion = "0.71.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Integration branch for the next major version.

(⚠️ = breaking changes)

- [x] ⚠️ Do not use `JsonConvert.DefaultSettings` when serializing or deserializing JSON (#1825)
- [x] ⚠️ Remove support for string values in `OffSession` (#1832)
- [x] ⚠️ Move to API version `2019-11-05` (#1834)