### PR TITLE
Add disputed to Charge and charge to DisputeListOptions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.72.0
+  STRIPE_MOCK_VERSION: 0.73.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -194,6 +194,12 @@ namespace Stripe
         #endregion
 
         /// <summary>
+        /// Whether the charge has been disputed. More than one dispute may exist on this charge.
+        /// </summary>
+        [JsonProperty("disputed")]
+        public bool Disputed { get; set; }
+
+        /// <summary>
         /// Error code explaining reason for charge failure if available (see the errors section for a list of codes).
         /// </summary>
         [JsonProperty("failure_code")]

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -61,6 +61,26 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        #region Expandable PaymentIntent
+        [JsonIgnore]
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
+        }
+
+        [JsonIgnore]
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
+        }
+
+        [JsonProperty("payment_intent")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
+        internal ExpandableField<PaymentIntent> InternalPaymentIntent { get; set; }
+        #endregion
+
         [JsonProperty("reason")]
         public string Reason { get; set; }
 

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -92,6 +92,26 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        #region Expandable PaymentIntent
+        [JsonIgnore]
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
+        }
+
+        [JsonIgnore]
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
+        }
+
+        [JsonProperty("payment_intent")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
+        internal ExpandableField<PaymentIntent> InternalPaymentIntent { get; set; }
+        #endregion
+
         [JsonProperty("reason")]
         public string Reason { get; set; }
 

--- a/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
@@ -7,5 +7,10 @@ namespace Stripe
     /// </summary>
     public class DisputeListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// Only return disputes that are associated with the Charge specified by this Charge ID.
+        /// </summary>
+        [JsonProperty("charge")]
+        public string Charge { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundCreateOptions.cs
@@ -13,7 +13,7 @@ namespace Stripe
         public long? Amount { get; set; }
 
         /// <summary>
-        /// REQUIRED. The identifier of the charge to refund.
+        /// The ID of the Charge to refund.
         /// </summary>
         [JsonProperty("charge")]
         public string Charge { get; set; }
@@ -26,6 +26,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The ID of the PaymentIntent to refund.
+        /// </summary>
+        [JsonProperty("payment_intent")]
+        public string PaymentIntent { get; set; }
 
         /// <summary>
         /// String indicating the reason for the refund. If set, possible values are

--- a/src/Stripe.net/Services/Refunds/RefundListOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundListOptions.cs
@@ -4,7 +4,16 @@ namespace Stripe
 
     public class RefundListOptions : ListOptionsWithCreated
     {
+        /// <summary>
+        /// Only return refunds for the Charge specified by this ID.
+        /// </summary>
         [JsonProperty("charge")]
         public string Charge { get; set; }
+
+        /// <summary>
+        /// Only return refunds for the PaymentIntent specified by this ID.
+        /// </summary>
+        [JsonProperty("payment_intent")]
+        public string PaymentIntent { get; set; }
     }
 }

--- a/src/StripeTests/Entities/Disputes/DisputeTest.cs
+++ b/src/StripeTests/Entities/Disputes/DisputeTest.cs
@@ -28,6 +28,7 @@ namespace StripeTests
             string[] expansions =
             {
               "charge",
+              "payment_intent",
             };
 
             string json = this.GetFixture("/v1/disputes/dp_123", expansions);
@@ -39,6 +40,9 @@ namespace StripeTests
 
             Assert.NotNull(dispute.Charge);
             Assert.Equal("charge", dispute.Charge.Object);
+
+            Assert.NotNull(dispute.PaymentIntent);
+            Assert.Equal("payment_intent", dispute.PaymentIntent.Object);
         }
     }
 }

--- a/src/StripeTests/Entities/Refunds/RefundTest.cs
+++ b/src/StripeTests/Entities/Refunds/RefundTest.cs
@@ -30,6 +30,7 @@ namespace StripeTests
               "balance_transaction",
               "charge",
               "failure_balance_transaction",
+              "payment_intent",
               "source_transfer_reversal",
               "transfer_reversal",
             };
@@ -49,6 +50,9 @@ namespace StripeTests
 
             Assert.NotNull(refund.FailureBalanceTransaction);
             Assert.Equal("balance_transaction", refund.FailureBalanceTransaction.Object);
+
+            Assert.NotNull(refund.PaymentIntent);
+            Assert.Equal("payment_intent", refund.PaymentIntent.Object);
 
             Assert.NotNull(refund.SourceTransferReversal);
             Assert.Equal("transfer_reversal", refund.SourceTransferReversal.Object);

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.72.0";
+        private const string MockMinimumVersion = "0.73.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Multiple API changes
* Add `Disputed` to `Charge`
* Add `PaymentIntent` to `Refund` and `Dispute`
* Add `Charge` to `DisputeListParams`
* Add `PaymentIntent` to `RefundListParams` and `RefundParams`

r? @remi-stripe 