### PR TITLE
Release API version `2019-11-05`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.69.0
+  STRIPE_MOCK_VERSION: 0.71.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionSchedule.cs
@@ -20,29 +20,12 @@ namespace Stripe
         public string Object { get; set; }
 
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period.
-        /// </summary>
-        [JsonProperty("billing_thresholds")]
-        public SubscriptionBillingThresholds BillingThresholds { get; set; }
-
-        /// <summary>
         /// Time at which the subscription schedule was canceled. Measured in seconds since the
         /// Unix epoch.
         /// </summary>
         [JsonProperty("canceled_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CanceledAt { get; set; }
-
-        /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging
-        /// automatically, Stripe will attempt to pay this subscription at the
-        /// end of the cycle using the default source attached to the customer.
-        /// When sending an invoice, Stripe will email your customer an invoice
-        /// with payment instructions.
-        /// </summary>
-        [JsonProperty("collection_method")]
-        public string CollectionMethod { get; set; }
 
         /// <summary>
         /// Time at which the subscription schedule was completed. Measured in seconds since the
@@ -94,53 +77,11 @@ namespace Stripe
         internal ExpandableField<Customer> InternalCustomer { get; set; }
         #endregion
 
-        #region Expandable DefaultPaymentMethod
-
         /// <summary>
-        /// ID of the default payment method for the subscription schedule.
+        /// Object representing the subscription schedule’s default settings.
         /// </summary>
-        [JsonIgnore]
-        public string DefaultPaymentMethodId
-        {
-            get => this.InternalDefaultPaymentMethod?.Id;
-            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
-        }
-
-        [JsonIgnore]
-        public PaymentMethod DefaultPaymentMethod
-        {
-            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
-            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
-        }
-
-        [JsonProperty("default_payment_method")]
-        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
-        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
-        #endregion
-
-        #region Expandable DefaultSource
-
-        /// <summary>
-        /// ID of the default source for the subscription schedule.
-        /// </summary>
-        [JsonIgnore]
-        public string DefaultSourceId
-        {
-            get => this.InternalDefaultSource?.Id;
-            set => this.InternalDefaultSource = SetExpandableFieldId(value, this.InternalDefaultSource);
-        }
-
-        [JsonIgnore]
-        public IPaymentSource DefaultSource
-        {
-            get => this.InternalDefaultSource?.ExpandedObject;
-            set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
-        }
-
-        [JsonProperty("default_source")]
-        [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
-        internal ExpandableField<IPaymentSource> InternalDefaultSource { get; set; }
-        #endregion
+        [JsonProperty("default_settings")]
+        public SubscriptionScheduleDefaultSettings DefaultSettings { get; set; }
 
         /// <summary>
         /// Behavior of the subscription schedule and underlying subscription when it ends. Possible
@@ -148,12 +89,6 @@ namespace Stripe
         /// </summary>
         [JsonProperty("end_behavior")]
         public string EndBehavior { get; set; }
-
-        /// <summary>
-        /// The schedule's default invoice settings.
-        /// </summary>
-        [JsonProperty("invoice_settings")]
-        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value

--- a/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleDefaultSettings.cs
+++ b/src/Stripe.net/Entities/SubscriptionsSchedules/SubscriptionScheduleDefaultSettings.cs
@@ -1,0 +1,57 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionScheduleDefaultSettings : StripeEntity<SubscriptionScheduleDefaultSettings>
+    {
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholds BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging
+        /// automatically, Stripe will attempt to pay this subscription at the
+        /// end of the cycle using the default source attached to the customer.
+        /// When sending an invoice, Stripe will email your customer an invoice
+        /// with payment instructions.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
+        #region Expandable DefaultPaymentMethod
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonIgnore]
+        public string DefaultPaymentMethodId
+        {
+            get => this.InternalDefaultPaymentMethod?.Id;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldId(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonIgnore]
+        public PaymentMethod DefaultPaymentMethod
+        {
+            get => this.InternalDefaultPaymentMethod?.ExpandedObject;
+            set => this.InternalDefaultPaymentMethod = SetExpandableFieldObject(value, this.InternalDefaultPaymentMethod);
+        }
+
+        [JsonProperty("default_payment_method")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentMethod>))]
+        internal ExpandableField<PaymentMethod> InternalDefaultPaymentMethod { get; set; }
+        #endregion
+
+        /// <summary>
+        /// The schedule's default invoice settings.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettings InvoiceSettings { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-10-17";
+        public static string ApiVersion => "2019-11-05";
 
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
@@ -1,0 +1,37 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionScheduleDefaultSettingsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// </summary>
+        [JsonProperty("billing_thresholds")]
+        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
+
+        /// <summary>
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
+        /// charging automatically, Stripe will attempt to pay the underlying
+        /// subscription at the end of each billing cycle using the default
+        /// source attached to the customer. When sending an invoice, Stripe
+        /// will email your customer an invoice with payment instructions.
+        /// Defaults to <c>charge_automatically</c> on creation.
+        /// </summary>
+        [JsonProperty("collection_method")]
+        public string CollectionMethod { get; set; }
+
+        /// <summary>
+        /// ID of the default payment method for the subscription schedule.
+        /// </summary>
+        [JsonProperty("default_payment_method")]
+        public string DefaultPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Define the default settings applied to invoices created by this subscription schedule.
+        /// </summary>
+        [JsonProperty("invoice_settings")]
+        public SubscriptionScheduleInvoiceSettingsOptions InvoiceSettings { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleSharedOptions.cs
@@ -8,34 +8,10 @@ namespace Stripe
     public abstract class SubscriptionScheduleSharedOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
-        /// new billing period. Pass an empty string to remove previously-defined thresholds.
+        /// Object representing the subscription schedule’s default settings.
         /// </summary>
-        [JsonProperty("billing_thresholds")]
-        public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
-
-        /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
-        /// charging automatically, Stripe will attempt to pay the underlying
-        /// subscription at the end of each billing cycle using the default
-        /// source attached to the customer. When sending an invoice, Stripe
-        /// will email your customer an invoice with payment instructions.
-        /// Defaults to <c>charge_automatically</c> on creation.
-        /// </summary>
-        [JsonProperty("collection_method")]
-        public string CollectionMethod { get; set; }
-
-        /// <summary>
-        /// ID of the default payment method for the subscription schedule.
-        /// </summary>
-        [JsonProperty("default_payment_method")]
-        public string DefaultPaymentMethod { get; set; }
-
-        /// <summary>
-        /// ID of the default source for the subscription schedule.
-        /// </summary>
-        [JsonProperty("default_source")]
-        public string DefaultSource { get; set; }
+        [JsonProperty("default_settings")]
+        public SubscriptionScheduleDefaultSettingsOptions DefaultSettings { get; set; }
 
         /// <summary>
         /// Behavior of the subscription schedule and underlying subscription when it ends. Possible

--- a/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
+++ b/src/StripeTests/Entities/SubscriptionSchedules/SubscriptionScheduleTest.cs
@@ -29,6 +29,7 @@ namespace StripeTests
             string[] expansions =
             {
               "customer",
+              "default_settings.default_payment_method",
               "phases.plans.plan",
               "subscription",
             };
@@ -42,6 +43,9 @@ namespace StripeTests
 
             Assert.NotNull(schedule.Customer);
             Assert.Equal("customer", schedule.Customer.Object);
+
+            Assert.NotNull(schedule.DefaultSettings.DefaultPaymentMethod);
+            Assert.Equal("payment_method", schedule.DefaultSettings.DefaultPaymentMethod.Object);
 
             Assert.NotNull(schedule.Subscription);
             Assert.Equal("subscription", schedule.Subscription.Object);

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.69.0";
+        private const string MockMinimumVersion = "0.71.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Move to the latest API version and add new changes
* Move to API version `2019-11-05`
* Add `DefaultSettings` on `SubscritionSchedule`
* Remove `BillingThresholds`, `CollectionMethod`, `DefaultPaymentMethod` and `DefaultSource` and `invoice_settings` from `SubscriptionSchedule`.
* Add `Charge` filter when listing `Dispute`.

r? @ob-stripe 
cc @stripe/api-libraries @cjavilla-stripe 