### PR TITLE
Add support for `SubscriptionScheduleStartDate.Now`

### DIFF
--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCreateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleCreateOptions.cs
@@ -25,7 +25,7 @@ namespace Stripe
         /// The date at which the subscription schedule starts.
         /// </summary>
         [JsonProperty("start_date")]
-        [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? StartDate { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, SubscriptionScheduleStartDate> StartDate { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleStartDate.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleStartDate.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    public class SubscriptionScheduleStartDate : StringEnum
+    {
+        /// <summary>Special value used to start a subscription schedule immediately.</summary>
+        public static readonly SubscriptionScheduleStartDate Now = new SubscriptionScheduleStartDate("now");
+
+        private SubscriptionScheduleStartDate(string value)
+            : base(value)
+        {
+        }
+    }
+}

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -35,6 +35,7 @@ namespace StripeTests
             this.createOptions = new SubscriptionScheduleCreateOptions
             {
                 Customer = "cus_123",
+                StartDate = SubscriptionScheduleStartDate.Now,
             };
 
             this.releaseOptions = new SubscriptionScheduleReleaseOptions


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

Similar to https://github.com/stripe/stripe-go/pull/994