### PR TITLE
Remove obsolete fields

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/Cardholder.cs
@@ -75,14 +75,6 @@ namespace Stripe.Issuing
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [Obsolete("Use PhoneNumber instead")]
-        [JsonIgnore]
-        public string PhonNumber
-        {
-            get => this.PhoneNumber;
-            set => this.PhoneNumber = value;
-        }
-
         /// <summary>
         /// The cardholder’s phone number.
         /// </summary>

--- a/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonSharedOptions.cs
@@ -109,10 +109,6 @@ namespace Stripe
         [JsonProperty("person_token")]
         public string PersonToken { get; set; }
 
-        [Obsolete("This field was never supported. Use IdNumber instead")]
-        [JsonProperty("personal_id_number")]
-        public string PersonalIdNumber { get; set; }
-
         /// <summary>
         /// The person’s phone number.
         /// </summary>


### PR DESCRIPTION
Remove two fields with typos in their name.

r? @ob-stripe 
cc @stripe/api-libraries 