### PR TITLE
Add support for auto paging with ending_before

### DIFF
--- a/src/Stripe.net/Entities/StripeList.cs
+++ b/src/Stripe.net/Entities/StripeList.cs
@@ -42,5 +42,14 @@ namespace Stripe
         {
             return this.Data.GetEnumerator();
         }
+
+        /// <summary>
+        /// Reverse the order of the items in Data to support backward iteration
+        /// in autopagination with EndingBefore.
+        /// </summary>
+        public void Reverse()
+        {
+            this.Data.Reverse();
+        }
     }
 }

--- a/src/StripeTests/Resources/pageable_models/0b.json
+++ b/src/StripeTests/Resources/pageable_models/0b.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "id": "pm_122",
+      "object": "pageablemodel"
+    }
+  ],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/pageable_models"
+}


### PR DESCRIPTION
Looking for feedback on this solution re #1848 

## Reviewers
r? @ob-stripe 
cc @stripe/api-libraries @remi-stripe 

## Summary

Adds support for auto paging with `ending_before` by iterating backwards through pages. Currently, we only support iterating forwards and are forcing the `starting_after` option to be used. 

`ending_before` and `starting_after` are mutually exclusive, so when attempting to pass `EndingBefore` with auto paginate, it fails because we default to setting `StartingAfter` to retrieve the "next page."

We don't have a great "get previous page" or "get next page" construct in dotnet, yet. 

I followed this for reference: 

https://github.com/stripe/stripe-ruby/pull/865/files

