### PR TITLE
Allow filtering Invoices by `Status`

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
@@ -41,6 +41,14 @@ namespace Stripe
         public bool? Paid { get; set; }
 
         /// <summary>
+        /// Only return invoices with a given status. Must be one of
+        /// <c>draft</c>, <c>open</c>, <c>paid</c>, <c>uncollectible</c>, or
+        /// <c>void</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
         /// Only return invoices for the subscription specified by this subscription ID.
         /// </summary>
         [JsonProperty("subscription")]


### PR DESCRIPTION
Adds `Status` to the supported filters for `InvoiceListOptions` to allow filtering Invoices by status for #1860 

r? @remi-stripe 
cc @stripe/api-libraries 

I'm 99% sure we just add these as strings, let me know if this should be some sort of enum or something. 