### PR TITLE
Pin to API version 2019-12-03

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.76.0
+  STRIPE_MOCK_VERSION: 0.78.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -32,7 +32,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-11-05";
+        public static string ApiVersion => "2019-12-03";
 
 #if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.76.0";
+        private const string MockMinimumVersion = "0.78.0";
 
         private readonly string port;
 


### PR DESCRIPTION
This is similar to https://github.com/stripe/stripe-java/pull/911 but there are no other changes as those deprecated properties have been removed before.

r? @richardm-stripe 
cc @stripe/api-libraries 