### PR TITLE
Add `Network` `GeneratedCard` on `Charge`

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
@@ -71,6 +71,14 @@ namespace Stripe
         public bool? Moto { get; set; }
 
         /// <summary>
+        /// Identifies which network this charge was processed on. Can be<c>amex</c>, <c>diners</c>,
+        /// <c>discover</c>, <c>interac</c>, <c>jcb</c>, <c>mastercard</c>, <c>unionpay</c>,
+        /// <c>visa</c>, or <c>unknown</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
         /// Populated if this transaction used 3D Secure authentication.
         /// </summary>
         [JsonProperty("three_d_secure")]

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
@@ -1,40 +1,100 @@
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsCardPresent : StripeEntity<ChargePaymentMethodDetailsCardPresent>
     {
+        /// <summary>
+        /// Card brand. Can be <c>amex</c>, <c>diners</c>, <c>discover</c>, <c>jcb</c>,
+        /// <c>mastercard</c>, <c>unionpay</c>, <c>visa</c>, or <c>unknown</c>.
+        /// </summary>
         [JsonProperty("brand")]
         public string Brand { get; set; }
 
+        /// <summary>
+        /// Two-letter ISO code representing the country of the card. You could use this attribute
+        /// to get a sense of the international breakdown of cards you’ve collected.
+        /// </summary>
         [JsonProperty("country")]
         public string Country { get; set; }
 
+        /// <summary>
+        /// Authorization response cryptogram.
+        /// </summary>
         [JsonProperty("emv_auth_data")]
         public string EmvAuthData { get; set; }
 
+        /// <summary>
+        /// Two-digit number representing the card’s expiration month.
+        /// </summary>
         [JsonProperty("exp_month")]
         public long ExpMonth { get; set; }
 
+        /// <summary>
+        /// Four-digit number representing the card’s expiration year.
+        /// </summary>
         [JsonProperty("exp_year")]
         public long ExpYear { get; set; }
 
+        /// <summary>
+        /// Uniquely identifies this particular card number. You can use this attribute to check
+        /// whether two customers who’ve signed up with you are using the same card number, for
+        /// example.
+        /// </summary>
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
 
+        /// <summary>
+        /// Card funding type. Can be <c>credit</c>, <c>debit</c>, <c>prepaid</c>, or
+        /// <c>unknown</c>.
+        /// </summary>
         [JsonProperty("funding")]
         public string Funding { get; set; }
 
+        /// <summary>
+        /// ID of a card PaymentMethod generated from the card_present PaymentMethod that may be
+        /// attached to a Customer for future transactions. Only present if it was possible to
+        /// generate a card PaymentMethod.
+        /// </summary>
         [JsonProperty("generated_card")]
-        public string GeneratedCardId { get; set; }
+        public string GeneratedCard { get; set; }
 
+        [Obsolete("Use GeneratedCard instead.")]
+        [JsonIgnore]
+        public string GeneratedCardId
+        {
+            get => this.GeneratedCard;
+            set => this.GeneratedCardId = value;
+        }
+
+        /// <summary>
+        /// The last four digits of the card.
+        /// </summary>
         [JsonProperty("last4")]
         public string Last4 { get; set; }
 
+        /// <summary>
+        /// Identifies which network this charge was processed on. Can be<c>amex</c>, <c>diners</c>,
+        /// <c>discover</c>, <c>interac</c>, <c>jcb</c>, <c>mastercard</c>, <c>unionpay</c>,
+        /// <c>visa</c>, or <c>unknown</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// How were card details read in this transaction. Can be <c>contact_emv</c>,
+        /// <c>contactless_emv</c>, <c>magnetic_stripe_fallback</c>, <c>magnetic_stripe_track2</c>,
+        /// or <c>contactless_magstripe_mode</c>.
+        /// </summary>
         [JsonProperty("read_method")]
         public string ReadMethod { get; set; }
 
+        /// <summary>
+        /// A collection of fields required to be displayed on receipts. Only required for EMV
+        /// transactions.
+        /// </summary>
         [JsonProperty("receipt")]
         public ChargePaymentMethodDetailsCardPresentReceipt Receipt { get; set; }
     }


### PR DESCRIPTION
* Adds `Network` to `ChargePaymentMethodDetailsCard`
* Adds `Network` and `GeneratedCard` to `ChargePaymentMethodDetailsCardPresent` and make `GeneratedCardId` deprecated.

r? @ob-stripe 
cc @stripe/api-libraries 