### PR TITLE
Public Service.Client setter

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -41,10 +41,14 @@ namespace Stripe
         public virtual string BaseUrl => this.Client.ApiBase;
 
         /// <summary>
-        /// Gets the client used by this service to send requests. If no client was set when the
+        /// Gets or sets the client used by this service to send requests. If no client was set when the
         /// service instance was created, then the default client in
         /// <see cref="StripeConfiguration.StripeClient"/> is used instead.
         /// </summary>
+        /// <remarks>
+        /// Setting the client at runtime may not be thread-safe.
+        /// If you wish to use a custom client, it is recommended that you pass it to the service's constructor and not change it during the service's lifetime.
+        /// </remarks>
         public IStripeClient Client
         {
             get => this.client ?? StripeConfiguration.StripeClient;

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -48,6 +48,7 @@ namespace Stripe
         public IStripeClient Client
         {
             get => this.client ?? StripeConfiguration.StripeClient;
+            set => this.client = value;
         }
 
         protected TEntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)


### PR DESCRIPTION
We would love this change to build more generic code to `new` up services and set the `Client`, without knowing the concrete type of the service.

This might also be useful if services are dependency injected but may need to use different `IStripeClient` depending on context.