### PR TITLE
Add support for `metadata` and `livemode` to Terminal Reader and Location

### DIFF
--- a/src/Stripe.net/Entities/Terminal/Locations/Location.cs
+++ b/src/Stripe.net/Entities/Terminal/Locations/Location.cs
@@ -5,7 +5,7 @@ namespace Stripe.Terminal
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Location : StripeEntity<Location>, IHasId, IHasObject
+    public class Location : StripeEntity<Location>, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -24,5 +24,20 @@ namespace Stripe.Terminal
 
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value
+        /// <c>false</c> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can
+        /// be useful for storing additional information about the object in a
+        /// structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
@@ -5,7 +5,7 @@ namespace Stripe.Terminal
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Reader : StripeEntity<Reader>, IHasId, IHasObject
+    public class Reader : StripeEntity<Reader>, IHasId, IHasMetadata, IHasObject
     {
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -31,8 +31,23 @@ namespace Stripe.Terminal
         [JsonProperty("label")]
         public string Label { get; set; }
 
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value
+        /// <c>false</c> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
         [JsonProperty("location")]
         public string Location { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can
+        /// be useful for storing additional information about the object in a
+        /// structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("serial_number")]
         public string SerialNumber { get; set; }

--- a/src/Stripe.net/Services/Terminal/Locations/LocationSharedOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationSharedOptions.cs
@@ -1,14 +1,23 @@
 namespace Stripe.Terminal
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
-    public class LocationSharedOptions : BaseOptions
+    public class LocationSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("address")]
         public AddressOptions Address { get; set; }
 
         [JsonProperty("display_name")]
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderSharedOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderSharedOptions.cs
@@ -1,11 +1,20 @@
 namespace Stripe.Terminal
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
-    public class ReaderSharedOptions : BaseOptions
+    public class ReaderSharedOptions : BaseOptions, IHasMetadata
     {
         [JsonProperty("label")]
         public string Label { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }


### PR DESCRIPTION
I'm not 100% sure if I needed to import `Stripe.Infrastructure` into those Options objects, but it seems like that might be where IHasMetadata lives.


r? @remi-stripe 
cc @stripe/api-libraries 
