### PR TITLE
Fix sepa debit deserialization on MandatePaymentMethodDetails

### DIFF
--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
@@ -22,7 +22,7 @@ namespace Stripe
         /// If this mandate is associated with a SEPA debit payment method, this hash contains
         /// mandate information specific to the SEPA debit payment method.
         /// </summary>
-        [JsonProperty("offline")]
+        [JsonProperty("sepa_debit")]
         public MandatePaymentMethodDetailsSepaDebit SepaDebit { get; set; }
 
         /// <summary>


### PR DESCRIPTION
While testing the MandateService, I noticed that I could not retrieve SEPA debit information. On further inspection, it seems that SEPA debit data was not being deserialized properly. This change should allow the `reference` and `url` attributes to be surfaced via the MandateService and Mandate Entity.