### PR TITLE
Add support for `PendingUpdate` and `ProrationBehavior` on `Subscription` APIs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.78.0
+  STRIPE_MOCK_VERSION: 0.79.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -242,6 +242,18 @@ namespace Stripe
         public const string CustomerSubscriptionDeleted = "customer.subscription.deleted";
 
         /// <summary>
+        /// Occurs whenever a customer's subscription's pending update is
+        /// applied, and the subscription is updated.
+        /// </summary>
+        public const string CustomerSubscriptionPendingUpdateApplied = "customer.subscription.pending_update_applied";
+
+        /// <summary>
+        /// Occurs whenever a customer's subscription's pending update expires
+        /// before the related invoice is paid.
+        /// </summary>
+        public const string CustomerSubscriptionPendingUpdateExpired = "customer.subscription.pending_update_expired";
+
+        /// <summary>
         /// Occurs three days before the trial period of a subscription is scheduled to end.
         /// </summary>
         public const string CustomerSubscriptionTrialWillEnd = "customer.subscription.trial_will_end";

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -45,9 +45,24 @@ namespace Stripe
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CancelAt { get; set; }
 
+        /// <summary>
+        /// If the subscription has been canceled with the <c>AtPeriodEnd</c> flag
+        /// set to true, <c>CancelAtPeriodEnd</c> on the subscription will be true.
+        /// You can use this attribute to determine whether a subscription that
+        /// has a status of active is scheduled to be canceled at the end of
+        /// the current period.
+        /// </summary>
         [JsonProperty("cancel_at_period_end")]
         public bool CancelAtPeriodEnd { get; set; }
 
+        /// <summary>
+        /// If the subscription has been canceled, the date of that
+        /// cancellation. If the subscription was canceled with
+        /// <c>CancelAtPeriodEnd</c>, <c>CanceledAt</c> will still reflect the
+        /// date of the initial cancellation request, not the end of the
+        /// subscription period when the subscription is automatically moved to
+        /// a canceled state.
+        /// </summary>
         [JsonProperty("canceled_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CanceledAt { get; set; }
@@ -280,6 +295,13 @@ namespace Stripe
         [JsonConverter(typeof(ExpandableFieldConverter<SetupIntent>))]
         internal ExpandableField<SetupIntent> InternalPendingSetupIntent { get; set; }
         #endregion
+
+        /// <summary>
+        /// If specified, deferred upgrade changes that will be applied to the
+        /// subscription once the latest_invoice has been paid.
+        /// </summary>
+        [JsonProperty("pending_update")]
+        public SubscriptionPendingUpdate PendingUpdate { get; set; }
 
         /// <summary>
         /// Plan the customer is subscribed to. Only set if the subscription contains a single plan.

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -46,11 +46,12 @@ namespace Stripe
         public DateTime? CancelAt { get; set; }
 
         /// <summary>
-        /// If the subscription has been canceled with the <c>AtPeriodEnd</c> flag
-        /// set to true, <c>CancelAtPeriodEnd</c> on the subscription will be true.
-        /// You can use this attribute to determine whether a subscription that
-        /// has a status of active is scheduled to be canceled at the end of
-        /// the current period.
+        /// If the subscription has been canceled with the
+        /// <see cref="CancelAtPeriodEnd" /> flag set to true,
+        /// <see cref="CancelAtPeriodEnd" /> on the
+        /// subscription will be true.  You can use this attribute to determine
+        /// whether a subscription that has a status of active is scheduled to
+        /// be canceled at the end of the current period.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]
         public bool CancelAtPeriodEnd { get; set; }
@@ -58,7 +59,7 @@ namespace Stripe
         /// <summary>
         /// If the subscription has been canceled, the date of that
         /// cancellation. If the subscription was canceled with
-        /// <c>CancelAtPeriodEnd</c>, <c>CanceledAt</c> will still reflect the
+        /// <see cref="CancelAtPeriodEnd" />, <see cref="CanceledAt" /> will still reflect the
         /// date of the initial cancellation request, not the end of the
         /// subscription period when the subscription is automatically moved to
         /// a canceled state.
@@ -298,7 +299,7 @@ namespace Stripe
 
         /// <summary>
         /// If specified, deferred upgrade changes that will be applied to the
-        /// subscription once the latest_invoice has been paid.
+        /// subscription once the <see cref="LatestInvoice" /> has been paid.
         /// </summary>
         [JsonProperty("pending_update")]
         public SubscriptionPendingUpdate PendingUpdate { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
@@ -9,7 +9,7 @@ namespace Stripe
     {
         /// <summary>
         /// If the update is applied, determines the date of the first full
-        /// invoice, and, for plans with <c>month</c> or year <c>intervals</c>,
+        /// invoice, and, for plans with <c>month</c> or <c>year</c> intervals,
         /// the day of the month for subsequent invoices.
         /// </summary>
         [JsonProperty("billing_cycle_anchor")]
@@ -41,10 +41,10 @@ namespace Stripe
         public DateTime? TrialEnd { get; set; }
 
         /// <summary>
-        /// Indicates if a <see cref="Plan" />’s <c>TrialPeriodDays</c> should
-        /// be applied to the subscription. Setting <see cref="TrialEnd" /> per
+        /// Indicates if a <see cref="Plan.TrialPeriodDays"/> should
+        /// be applied to the subscription. Setting <see cref="TrialEnd"/> per
         /// subscription is preferred, and this defaults to false. Setting this
-        /// flag to true together with trial_end is not allowed.
+        /// flag to true together with <see cref="TrialEnd"/> is not allowed.
         /// </summary>
         [JsonProperty("trial_from_plan")]
         public bool TrialFromPlan { get; set; }

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
@@ -1,0 +1,52 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionPendingUpdate : StripeEntity<SubscriptionPendingUpdate>
+    {
+        /// <summary>
+        /// If the update is applied, determines the date of the first full
+        /// invoice, and, for plans with <c>month</c> or year <c>intervals</c>,
+        /// the day of the month for subsequent invoices.
+        /// </summary>
+        [JsonProperty("billing_cycle_anchor")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? BillingCycleAnchor { get; set; }
+
+        /// <summary>
+        /// The point after which the changes reflected by this update will be
+        /// discarded and no longer applied.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// List of subscription items, each with an attached plan, that will
+        /// be set if the update is applied.
+        /// </summary>
+        [JsonProperty("subscription_items")]
+        public StripeList<SubscriptionItem> SubscriptionItems { get; set; }
+
+        /// <summary>
+        /// Unix timestamp representing the end of the trial period the
+        /// customer will get before being charged for the first time, if the
+        /// update is applied.
+        /// </summary>
+        [JsonProperty("trial_end")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? TrialEnd { get; set; }
+
+        /// <summary>
+        /// Indicates if a <see cref="Plan" />’s <c>TrialPeriodDays</c> should
+        /// be applied to the subscription. Setting <see cref="TrialEnd" /> per
+        /// subscription is preferred, and this defaults to false. Setting this
+        /// flag to true together with trial_end is not allowed.
+        /// </summary>
+        [JsonProperty("trial_from_plan")]
+        public bool TrialFromPlan { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
@@ -29,7 +29,7 @@ namespace Stripe
         /// be set if the update is applied.
         /// </summary>
         [JsonProperty("subscription_items")]
-        public StripeList<SubscriptionItem> SubscriptionItems { get; set; }
+        public List<SubscriptionItem> SubscriptionItems { get; set; }
 
         /// <summary>
         /// Unix timestamp representing the end of the trial period the

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPendingUpdate.cs
@@ -22,7 +22,7 @@ namespace Stripe
         /// </summary>
         [JsonProperty("expires_at")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? ExpiresAt { get; set; }
+        public DateTime ExpiresAt { get; set; }
 
         /// <summary>
         /// List of subscription items, each with an attached plan, that will
@@ -47,6 +47,6 @@ namespace Stripe
         /// flag to true together with <see cref="TrialEnd"/> is not allowed.
         /// </summary>
         [JsonProperty("trial_from_plan")]
-        public bool TrialFromPlan { get; set; }
+        public bool? TrialFromPlan { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -102,6 +102,17 @@ namespace Stripe
         public bool? SubscriptionProrate { get; set; }
 
         /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items
+        /// should be created. Prorations can be disabled by setting the value
+        /// to <c>none</c>.
+        /// </summary>
+        [JsonProperty("subscription_proration_behavior")]
+        public string SubscriptionProrationBehavior { get; set; }
+
+        /// <summary>
         /// If previewing an update to a subscription, and doing proration,
         /// <c>subscription_proration_date</c> forces the proration to be calculated as though the
         /// update was done at the specified time. The time given must be within the current

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
@@ -43,6 +43,17 @@ namespace Stripe
         public bool? Prorate { get; set; }
 
         /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items should
+        /// be created. Prorations can be disabled by setting the value to
+        /// <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+
+        /// <summary>
         /// If set, the proration will be calculated as though the subscription was updated at the
         /// given time. This can be used to apply the same proration that was previewed with the
         /// upcoming invoice endpoint.

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
@@ -50,6 +50,17 @@ namespace Stripe
         public bool? Prorate { get; set; }
 
         /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items should
+        /// be created. Prorations can be disabled by setting the value to
+        /// <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+
+        /// <summary>
         /// If set, the proration will be calculated as though the subscription was updated at the
         /// given time. This can be used to apply the same proration that was previewed with the
         /// upcoming invoice endpoint.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -180,6 +180,17 @@ namespace Stripe
         [JsonProperty("prorate")]
         public bool? Prorate { get; set; }
 
+        /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items
+        /// should be created. Prorations can be disabled by setting the value
+        /// to <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+
         [Obsolete("Use Items")]
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -161,6 +161,17 @@ namespace Stripe
         public bool? Prorate { get; set; }
 
         /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items
+        /// should be created. Prorations can be disabled by setting the value
+        /// to <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+
+        /// <summary>
         /// If set, the proration will be calculated as though the subscription
         /// was updated at the given time. This can be used to apply exactly
         /// the same proration that was previewed with

--- a/src/StripeTests/Entities/Charges/ChargeTest.cs
+++ b/src/StripeTests/Entities/Charges/ChargeTest.cs
@@ -31,7 +31,6 @@ namespace StripeTests
               "application_fee",
               "balance_transaction",
               "customer",
-              "dispute",
               "invoice",
               "on_behalf_of",
               "order",
@@ -58,9 +57,6 @@ namespace StripeTests
 
             Assert.NotNull(charge.Customer);
             Assert.Equal("customer", charge.Customer.Object);
-
-            Assert.NotNull(charge.Dispute);
-            Assert.Equal("dispute", charge.Dispute.Object);
 
             Assert.NotNull(charge.Invoice);
             Assert.Equal("invoice", charge.Invoice.Object);

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.78.0";
+        private const string MockMinimumVersion = "0.79.0";
 
         private readonly string port;
 


### PR DESCRIPTION
I don't feel super confident in the type for `SubscriptionItems` on PendingUpdate here and am just trying to wrap up testing of deserialization locally.

r? @remi-stripe 
cc @stripe/api-libraries 

