### PR TITLE
Make CreditNote OutOfBandAmount nullable fixes #1901

### DIFF
--- a/src/Stripe.net/Entities/CreditNotes/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNotes/CreditNote.cs
@@ -152,7 +152,7 @@ namespace Stripe
         /// Amount that was credited outside of Stripe.
         /// </summary>
         [JsonProperty("out_of_band_amount")]
-        public long OutOfBandAmount { get; set; }
+        public long? OutOfBandAmount { get; set; }
 
         /// <summary>
         /// The link to download the PDF of the credit note.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

fixes #1901 