### PR TITLE
Add support for returning orders

### DIFF
--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -7,18 +7,30 @@ namespace Stripe
 
     public class Order : StripeEntity<Order>, IHasId, IHasMetadata, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type
+        /// share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
         /// <summary>
-        /// A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a 0-decimal currency) representing the total amount for the order.
+        /// A positive integer in the smallest currency unit (that is, 100
+        /// cents for $1.00, or 1 for ¥1, Japanese Yen being a 0-decimal
+        /// currency) representing the total amount for the order.
         /// </summary>
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
+        /// <summary>
+        /// The total amount that was returned to the customer.
+        /// </summary>
         [JsonProperty("amount_returned")]
         public long? AmountReturned { get; set; }
 
@@ -28,14 +40,18 @@ namespace Stripe
         [JsonProperty("application")]
         public string Application { get; set; }
 
+        /// <summary>
+        /// A fee in cents that will be applied to the order and transferred to
+        /// the application owner’s Stripe account.
+        /// </summary>
         [JsonProperty("application_fee")]
         public long? ApplicationFee { get; set; }
 
         #region Expandable Charge
 
         /// <summary>
-        /// <para>The ID of the payment used to pay for the order. Present if the order status is paid, fulfilled, or refunded.</para>
-        /// <para>Expandable.</para>
+        /// The ID of the payment used to pay for the order. Present if the
+        /// order status is paid, fulfilled, or refunded.
         /// </summary>
         [JsonIgnore]
         public string ChargeId
@@ -95,6 +111,9 @@ namespace Stripe
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// External coupon code to load for this order.
+        /// </summary>
         [JsonProperty("external_coupon_code")]
         public string ExternalCouponCode { get; set; }
 
@@ -104,38 +123,55 @@ namespace Stripe
         [JsonProperty("items")]
         public List<OrderItem> OrderItems { get; set; }
 
+        /// <summary>
+        /// Has the value true if the object exists in live mode or the value
+        /// false if the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
         /// <summary>
-        /// A set of key/value pairs that you can attach to an order object. It can be useful for storing additional information about the order in a structured format.
+        /// A set of key/value pairs that you can attach to an order object. It
+        /// can be useful for storing additional information about the order in
+        /// a structured format.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// A list of returns that have taken place for this order.
+        /// </summary>
         [JsonProperty("returns")]
         public StripeList<OrderReturn> Returns { get; set; }
 
         /// <summary>
-        /// The shipping method that is currently selected for this order, if any. If present, it is equal to one of the ids of shipping methods in the shipping_methods array. At order creation time, if there are multiple shipping methods, Stripe will automatically selected the first method.
+        /// The shipping method that is currently selected for this order, if
+        /// any. If present, it is equal to one of the ids of shipping methods
+        /// in the shipping_methods array. At order creation time, if there are
+        /// multiple shipping methods, Stripe will automatically selected the
+        /// first method.
         /// </summary>
         [JsonProperty("selected_shipping_method")]
         public string SelectedShippingMethod { get; set; }
 
         /// <summary>
-        /// The shipping address for the order. Present if the order is for goods to be shipped.
+        /// The shipping address for the order. Present if the order is for
+        /// goods to be shipped.
         /// </summary>
         [JsonProperty("shipping")]
         public Shipping Shipping { get; set; }
 
         /// <summary>
-        /// A list of supported shipping methods for this order. The desired shipping method can be specified either by updating the order, or when paying it.
+        /// A list of supported shipping methods for this order. The desired
+        /// shipping method can be specified either by updating the order, or
+        /// when paying it.
         /// </summary>
         [JsonProperty("shipping_methods")]
         public List<ShippingMethod> ShippingMethods { get; set; }
 
         /// <summary>
-        /// Current order status. One of created, paid, canceled, fulfilled, or returned.
+        /// Current order status. One of created, paid, canceled, fulfilled, or
+        /// returned.
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
@@ -146,6 +182,10 @@ namespace Stripe
         [JsonProperty("status_transitions")]
         public StatusTransitions StatusTransitions { get; set; }
 
+        /// <summary>
+        /// Time at which the object was last updated. Measured in seconds
+        /// since the Unix epoch.
+        /// </summary>
         [JsonProperty("updated")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Updated { get; set; }

--- a/src/Stripe.net/Entities/Orders/OrderReturn.cs
+++ b/src/Stripe.net/Entities/Orders/OrderReturn.cs
@@ -7,18 +7,31 @@ namespace Stripe
 
     public class OrderReturn : StripeEntity<OrderReturn>, IHasId, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type
+        /// share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
         /// <summary>
-        /// A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a 0-decimal currency) representing the total amount for the returned line item.
+        /// A positive integer in the smallest currency unit (that is, 100
+        /// cents for $1.00, or 1 for ¥1, Japanese Yen being a 0-decimal
+        /// currency) representing the total amount for the returned line item.
         /// </summary>
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the
+        /// Unix epoch.
+        /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
@@ -35,6 +48,10 @@ namespace Stripe
         [JsonProperty("items")]
         public List<OrderItem> OrderItems { get; set; }
 
+        /// <summary>
+        /// Has the value true if the object exists in live mode or the value
+        /// false if the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 

--- a/src/Stripe.net/Services/Orders/OrderReturnItemOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderReturnItemOptions.cs
@@ -1,0 +1,40 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class OrderReturnItemOptions : INestedOptions
+    {
+        /// <summary>
+        /// The amount (price) for this order item to return.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// If returning a tax item, use description to disambiguate which one
+        /// to return.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The ID of the SKU, tax, or shipping item being returned.
+        /// </summary>
+        [JsonProperty("parent")]
+        public string Parent { get; set; }
+
+        /// <summary>
+        /// When type is sku, this is the number of instances of the SKU to be
+        /// returned.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long? Quantity { get; set; }
+
+        /// <summary>
+        /// The type of this order item. Must be <c>sku</c>, <c>tax</c>, or
+        /// <c>shipping</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Orders/OrderReturnOptions.cs
+++ b/src/Stripe.net/Services/Orders/OrderReturnOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class OrderReturnOptions : BaseOptions
+    {
+        /// <summary>
+        /// List of items to return.
+        /// </summary>
+        [JsonProperty("items")]
+        public List<OrderReturnItemOptions> Items { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -69,6 +69,16 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/pay", options, requestOptions, cancellationToken);
         }
 
+        public virtual OrderReturn Return(string orderId, OrderReturnOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<OrderReturn>(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/returns", options, requestOptions);
+        }
+
+        public virtual Task<OrderReturn> ReturnAsync(string orderId, OrderReturnOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.RequestAsync<OrderReturn>(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/returns", options, requestOptions, cancellationToken);
+        }
+
         public virtual Order Update(string orderId, OrderUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(orderId, options, requestOptions);

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -16,6 +16,7 @@ namespace StripeTests
         private readonly OrderCreateOptions createOptions;
         private readonly OrderUpdateOptions updateOptions;
         private readonly OrderPayOptions payOptions;
+        private readonly OrderReturnOptions returnOptions;
         private readonly OrderListOptions listOptions;
 
         public OrderServiceTest(
@@ -38,12 +39,9 @@ namespace StripeTests
                 },
             };
 
-            this.updateOptions = new OrderUpdateOptions
+            this.listOptions = new OrderListOptions
             {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "key", "value" },
-                },
+                Limit = 1,
             };
 
             this.payOptions = new OrderPayOptions
@@ -51,9 +49,24 @@ namespace StripeTests
                 Customer = "cus_123",
             };
 
-            this.listOptions = new OrderListOptions
+            this.returnOptions = new OrderReturnOptions
             {
-                Limit = 1,
+                Items = new List<OrderReturnItemOptions>
+                {
+                    new OrderReturnItemOptions
+                    {
+                        Parent = "sku_123",
+                        Quantity = 1,
+                    },
+                },
+            };
+
+            this.updateOptions = new OrderUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
             };
         }
 
@@ -139,6 +152,24 @@ namespace StripeTests
             this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123/pay");
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
+        }
+
+        [Fact]
+        public void Return()
+        {
+            var orderReturn = this.service.Return(OrderId, this.returnOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123/returns");
+            Assert.NotNull(orderReturn);
+            Assert.Equal("order_return", orderReturn.Object);
+        }
+
+        [Fact]
+        public async Task ReturnAsync()
+        {
+            var orderReturn = await this.service.ReturnAsync(OrderId, this.returnOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/orders/or_123/returns");
+            Assert.NotNull(orderReturn);
+            Assert.Equal("order_return", orderReturn.Object);
         }
 
         [Fact]


### PR DESCRIPTION
While deprecated, this is currently available in the API so we should support it.

This is my first time adding a custom method to a service like this where the return type is different than the underlying entity. I.e. returning an order, returns an OrderReturn object, I think I did this right, but could use another set of eyes. Another note, I created OrderReturnItemOptions as a new type because OrderItemOptions has the additional `currency` field. LMK if that was the wrong move.

r? @remi-stripe 
cc @stripe/api-libraries @ob-stripe 