### PR TITLE
Use a static instance for default `HttpClient`

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -21,6 +21,9 @@ namespace Stripe
     /// </summary>
     public class SystemNetHttpClient : IHttpClient
     {
+        private static readonly Lazy<System.Net.Http.HttpClient> LazyDefaultHttpClient
+            = new Lazy<System.Net.Http.HttpClient>(BuildDefaultSystemNetHttpClient);
+
         private readonly System.Net.Http.HttpClient httpClient;
 
         private readonly int maxNetworkRetries;
@@ -69,7 +72,7 @@ namespace Stripe
                 SecurityProtocolType.Tls12;
 #endif
 
-            this.httpClient = httpClient ?? BuildDefaultSystemNetHttpClient();
+            this.httpClient = httpClient ?? LazyDefaultHttpClient.Value;
             this.maxNetworkRetries = maxNetworkRetries;
             this.appInfo = appInfo;
             this.enableTelemetry = enableTelemetry;


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

Update `Stripe.SystemNetHttpClient` to use a static instance of `System.Net.HttpClient` when no HTTP client is passed to the constructor. This means that multiple clients will share the same instance of `System.Net.HttpClient`.

This is what Microsoft advises in https://docs.microsoft.com/en-us/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client#create-and-initialize-httpclient:
> **HttpClient** is intended to be instantiated once and reused throughout the life of an application.

This is thread-safe. The only method we're using is `SendAsync`, which is explicitly listed as thread-safe in the documentation: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?redirectedfrom=MSDN&view=netframework-4.8#remarks.

The default instance is wrapped in a [`Lazy<>`](https://docs.microsoft.com/en-us/dotnet/api/system.lazy-1) initializer, so it's only initialized the first time it's needed (to avoid initializing it if it's never used, e.g. because the user is always supplying their own instance).

It's difficult to write a test for this because `httpClient` is private, but I temporarily bumped its visibility and verified that this test passed:
```c#
var client1 = new SystemNetHttpClient();
var client2 = new SystemNetHttpClient();

Assert.NotSame(client1, client2);
Assert.Same(client1.HttpClient, client2.HttpClient);
```

Fixes #1918.
