### PR TITLE
Add support for the new file purpose additional verification

### DIFF
--- a/src/Stripe.net/Constants/FilePurpose.cs
+++ b/src/Stripe.net/Constants/FilePurpose.cs
@@ -2,6 +2,8 @@ namespace Stripe
 {
     public static class FilePurpose
     {
+        public const string AdditionalVerification = "additional_verification";
+
         public const string BusinessLogo = "business_logo";
 
         public const string DisputeEvidence = "dispute_evidence";


### PR DESCRIPTION
After adapting my project to the new version of stripe connect we found that the new file purpuse `additional_verification` is not supported in the class FilePurpose part of the Constants folder.

#### Our actual implementation with version 34.16.0

![image](https://user-images.githubusercontent.com/2849699/74679126-3ea6a980-51bd-11ea-9fc5-026348bda0ba.png)

#### We would like for the new version 😉

![image](https://user-images.githubusercontent.com/2849699/74679215-7e6d9100-51bd-11ea-869f-0033f3258bfd.png)


Thanks.


