### PR TITLE
Add support for `Timezone` on `ReportRun`

### DIFF
--- a/src/Stripe.net/Entities/Reporting/ReportRuns/Parameters.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/Parameters.cs
@@ -29,5 +29,8 @@ namespace Stripe.Reporting
 
         [JsonProperty("reporting_category")]
         public string ReportingCategory { get; set; }
+
+        [JsonProperty("timezone")]
+        public string Timezone { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunParametersOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunParametersOptions.cs
@@ -29,5 +29,8 @@ namespace Stripe.Reporting
 
         [JsonProperty("reporting_category")]
         public string ReportingCategory { get; set; }
+
+        [JsonProperty("timezone")]
+        public string Timezone { get; set; }
     }
 }


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 