### PR TITLE
Add support for listing Checkout `Session` and passing tax rate information

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.79.0
+  STRIPE_MOCK_VERSION: 0.82.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemOptions.cs
@@ -40,5 +40,11 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// The tax rates which apply to this line item. This is only allowed in subscription mode.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
@@ -1,0 +1,19 @@
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionListOptions : ListOptionsWithCreated
+    {
+        /// <summary>
+        /// Only return the Checkout Session for the PaymentIntent specified.
+        /// </summary>
+        [JsonProperty("payment_intent")]
+        public string PaymentIntent { get; set; }
+
+        /// <summary>
+        /// Only return the Checkout Session for the Subscription specified.
+        /// </summary>
+        [JsonProperty("subscription")]
+        public string Subscription { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -1,5 +1,6 @@
 namespace Stripe.Checkout
 {
+    using System;
     using System.Collections.Generic;
     using System.Net;
     using System.Threading;
@@ -7,7 +8,9 @@ namespace Stripe.Checkout
     using Stripe.Infrastructure;
 
     public class SessionService : Service<Session>,
-        ICreatable<Session, SessionCreateOptions>
+        ICreatable<Session, SessionCreateOptions>,
+        IListable<Session, SessionListOptions>,
+        IRetrievable<Session, SessionGetOptions>
     {
         public SessionService()
             : base(null)
@@ -39,6 +42,21 @@ namespace Stripe.Checkout
         public virtual Task<Session> GetAsync(string sessionId, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.GetEntityAsync(sessionId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<Session> List(SessionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<Session>> ListAsync(SessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Session> ListAutoPaging(SessionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
         }
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataItemOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataItemOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class SessionSubscriptionDataItemOptions : INestedOptions
@@ -15,5 +16,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
+
+        /// <summary>
+        /// The tax rates which apply to this item. When set, the default tax
+        /// rates on subscription data do not apply to this item.
+        /// </summary>
+        [JsonProperty("tax_rates")]
+        public List<string> TaxRates { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
@@ -18,6 +18,14 @@ namespace Stripe.Checkout
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
+        /// The tax rates that will apply to any subscription item that does
+        /// not have tax rates set. Invoices created will have their
+        /// default tax rates populated from the subscription.
+        /// </summary>
+        [JsonProperty("default_tax_rates")]
+        public List<string> DefaultTaxRates { get; set; }
+
+        /// <summary>
         /// List of items, each with an attached plan.
         /// </summary>
         [JsonProperty("items")]

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests.Checkout
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
 
@@ -13,6 +14,7 @@ namespace StripeTests.Checkout
         private const string SessionId = "cs_123";
         private readonly SessionService service;
         private readonly SessionCreateOptions createOptions;
+        private readonly SessionListOptions listOptions;
 
         public SessionServiceTest(
             StripeMockFixture stripeMockFixture,
@@ -64,6 +66,11 @@ namespace StripeTests.Checkout
                 },
                 SuccessUrl = "https://stripe.com/success",
             };
+
+            this.listOptions = new SessionListOptions
+            {
+                Limit = 1,
+            };
         }
 
         [Fact]
@@ -100,6 +107,36 @@ namespace StripeTests.Checkout
             this.AssertRequest(HttpMethod.Get, "/v1/checkout/sessions/cs_123");
             Assert.NotNull(session);
             Assert.Equal("checkout.session", session.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var intents = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/checkout/sessions");
+            Assert.NotNull(intents);
+            Assert.Equal("list", intents.Object);
+            Assert.Single(intents.Data);
+            Assert.Equal("checkout.session", intents.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var intents = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/checkout/sessions");
+            Assert.NotNull(intents);
+            Assert.Equal("list", intents.Object);
+            Assert.Single(intents.Data);
+            Assert.Equal("checkout.session", intents.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
+            Assert.NotNull(intents);
+            Assert.Equal("checkout.session", intents[0].Object);
         }
     }
 }

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.79.0";
+        private const string MockMinimumVersion = "0.82.0";
 
         private readonly string port;
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 