### PR TITLE
Drop support for .NET Standard 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
-The official [Stripe][stripe] .NET library, supporting .NET Standard 1.2+, .NET Core 1.0+, and .NET Framework 4.5+.
+The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.5+.
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,12 +55,12 @@ test_script:
 
 after_test:
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
-  - dotnet test -c Debug -f netcoreapp3.0 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
+  - dotnet test -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
   - ps: |
       # Secure env vars are not available on all branches, so make sure the
       # token is available before invoking Coveralls.
       if (Test-Path env:COVERALLS_REPO_TOKEN) {
-        .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.netcoreapp3.0.opencover.xml --useRelativePaths
+        .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml --useRelativePaths
       }
 
 artifacts:

--- a/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
@@ -46,14 +46,12 @@ namespace Stripe.Infrastructure.FormEncoding
             var fileName = "blob";
             var extension = string.Empty;
 
-#if NET45 || NETSTANDARD2_0
             FileStream fileStream = value as FileStream;
             if ((fileStream != null) && (!string.IsNullOrEmpty(fileStream.Name)))
             {
                 fileName = fileStream.Name;
                 extension = Path.GetExtension(fileName);
             }
-#endif
 
             var content = new StreamContent(value);
             content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -2,12 +2,10 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Configuration;
     using System.Reflection;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
-#if NET45 || NETSTANDARD2_0
-    using System.Configuration;
-#endif
 
     /// <summary>
     /// Global configuration class for Stripe.net settings.
@@ -34,26 +32,21 @@ namespace Stripe
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion => "2019-12-03";
 
-#if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>
         /// You can also set the API key using the <c>StripeApiKey</c> key in
         /// <see cref="System.Configuration.ConfigurationManager.AppSettings"/>.
         /// </remarks>
-#else
-        /// <summary>Gets or sets the API key.</summary>
-#endif
         public static string ApiKey
         {
             get
             {
-#if NET45 || NETSTANDARD2_0
                 if (string.IsNullOrEmpty(apiKey) &&
                     !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeApiKey"]))
                 {
                     apiKey = ConfigurationManager.AppSettings["StripeApiKey"];
                 }
-#endif
+
                 return apiKey;
             }
 
@@ -68,26 +61,21 @@ namespace Stripe
             }
         }
 
-#if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the client ID.</summary>
         /// <remarks>
         /// You can also set the client ID using the <c>StripeClientId</c> key in
         /// <see cref="System.Configuration.ConfigurationManager.AppSettings"/>.
         /// </remarks>
-#else
-        /// <summary>Gets or sets the client ID.</summary>
-#endif
         public static string ClientId
         {
             get
             {
-#if NET45 || NETSTANDARD2_0
                 if (string.IsNullOrEmpty(apiKey) &&
                     !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeClientId"]))
                 {
                     clientId = ConfigurationManager.AppSettings["StripeClientId"];
                 }
-#endif
+
                 return clientId;
             }
 

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -219,8 +219,6 @@ namespace Stripe
             var stripeNetTargetFramework =
 #if NET45
                 "net45"
-#elif NETSTANDARD1_2
-                "netstandard1.2"
 #elif NETSTANDARD2_0
                 "netstandard2.0"
 #else

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>34.26.0</VersionPrefix>
     <Version>34.26.0</Version>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AssemblyName>Stripe.net</AssemblyName>
     <PackageId>Stripe.net</PackageId>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
@@ -16,8 +16,6 @@
     <PackageLicenseUrl>https://raw.github.com/stripe/stripe-dotnet/master/LICENSE</PackageLicenseUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.2' ">$(PackageTargetFallback);netcoreapp1.0</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.2' ">1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -26,21 +24,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
-  <!--
-       .NET Core (and the .NET Standard) refactors the API's surface so that it
-       exists in a collection of smaller assemblies. As part of traditional
-       .NET (e.g., net45), System.Console existed as part of the standard
-       System assembly, but for the new standard it was added to its own.
-
-       Here we conditionally include System.Console for the .NET Standard
-       target (which also allows us to use it in .NET Core).
-
-       Reference: https://github.com/dotnet/corefx/issues/683
-  -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
-    <PackageReference Include="System.Console" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
@@ -68,10 +51,6 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;netcoreapp3.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net452</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Drop support for .NET Standard 1.2.
