### PR TITLE
stripe-dotnet v35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
-The official [Stripe][stripe] .NET library, supporting .NET Standard 1.2+, .NET Core 1.0+, and .NET Framework 4.5+.
+The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.5+.
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,12 +55,12 @@ test_script:
 
 after_test:
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
-  - dotnet test -c Debug -f netcoreapp3.0 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
+  - dotnet test -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
   - ps: |
       # Secure env vars are not available on all branches, so make sure the
       # token is available before invoking Coveralls.
       if (Test-Path env:COVERALLS_REPO_TOKEN) {
-        .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.netcoreapp3.0.opencover.xml --useRelativePaths
+        .\tools\csmacnz.Coveralls --opencover -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml --useRelativePaths
       }
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.82.0
+  STRIPE_MOCK_VERSION: 0.83.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
@@ -61,14 +61,6 @@ namespace Stripe
         [JsonProperty("generated_card")]
         public string GeneratedCard { get; set; }
 
-        [Obsolete("Use GeneratedCard instead.")]
-        [JsonIgnore]
-        public string GeneratedCardId
-        {
-            get => this.GeneratedCard;
-            set => this.GeneratedCardId = value;
-        }
-
         /// <summary>
         /// The last four digits of the card.
         /// </summary>

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -135,6 +135,12 @@ namespace Stripe
         public string Name { get; set; }
 
         /// <summary>
+        /// The suffix of the customer’s next invoice number.
+        /// </summary>
+        [JsonProperty("next_invoice_sequence")]
+        public long NextInvoiceSequence { get; set; }
+
+        /// <summary>
         /// The customer’s phone number.
         /// </summary>
         [JsonProperty("phone")]

--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -31,14 +31,6 @@ namespace Stripe
         [JsonProperty("application")]
         public string Application { get; set; }
 
-        [Obsolete("Use Application instead")]
-        [JsonIgnore]
-        public string ApplicationId
-        {
-            get => this.Application;
-            set => this.Application = value;
-        }
-
         [Obsolete("This property was never returned. Use Application instead")]
         [JsonProperty("connect")]
         public bool Connect { get; set; }

--- a/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/MultipartFormDataContent.cs
@@ -46,14 +46,12 @@ namespace Stripe.Infrastructure.FormEncoding
             var fileName = "blob";
             var extension = string.Empty;
 
-#if NET45 || NETSTANDARD2_0
             FileStream fileStream = value as FileStream;
             if ((fileStream != null) && (!string.IsNullOrEmpty(fileStream.Name)))
             {
                 fileName = fileStream.Name;
                 extension = Path.GetExtension(fileName);
             }
-#endif
 
             var content = new StreamContent(value);
             content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -30,7 +30,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-12-03";
+        public static string ApiVersion => "2020-03-02";
 
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -2,12 +2,10 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Configuration;
     using System.Reflection;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
-#if NET45 || NETSTANDARD2_0
-    using System.Configuration;
-#endif
 
     /// <summary>
     /// Global configuration class for Stripe.net settings.
@@ -34,26 +32,21 @@ namespace Stripe
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion => "2019-12-03";
 
-#if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>
         /// You can also set the API key using the <c>StripeApiKey</c> key in
         /// <see cref="System.Configuration.ConfigurationManager.AppSettings"/>.
         /// </remarks>
-#else
-        /// <summary>Gets or sets the API key.</summary>
-#endif
         public static string ApiKey
         {
             get
             {
-#if NET45 || NETSTANDARD2_0
                 if (string.IsNullOrEmpty(apiKey) &&
                     !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeApiKey"]))
                 {
                     apiKey = ConfigurationManager.AppSettings["StripeApiKey"];
                 }
-#endif
+
                 return apiKey;
             }
 
@@ -68,26 +61,21 @@ namespace Stripe
             }
         }
 
-#if NET45 || NETSTANDARD2_0
         /// <summary>Gets or sets the client ID.</summary>
         /// <remarks>
         /// You can also set the client ID using the <c>StripeClientId</c> key in
         /// <see cref="System.Configuration.ConfigurationManager.AppSettings"/>.
         /// </remarks>
-#else
-        /// <summary>Gets or sets the client ID.</summary>
-#endif
         public static string ClientId
         {
             get
             {
-#if NET45 || NETSTANDARD2_0
                 if (string.IsNullOrEmpty(apiKey) &&
                     !string.IsNullOrEmpty(ConfigurationManager.AppSettings["StripeClientId"]))
                 {
                     clientId = ConfigurationManager.AppSettings["StripeClientId"];
                 }
-#endif
+
                 return clientId;
             }
 

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -219,8 +219,6 @@ namespace Stripe
             var stripeNetTargetFramework =
 #if NET45
                 "net45"
-#elif NETSTANDARD1_2
-                "netstandard1.2"
 #elif NETSTANDARD2_0
                 "netstandard2.0"
 #else

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -21,6 +21,16 @@ namespace Stripe
     /// </summary>
     public class SystemNetHttpClient : IHttpClient
     {
+        private const string StripeNetTargetFramework =
+#if NETSTANDARD2_0
+            "netstandard2.0"
+#elif NET45
+            "net45"
+#else
+            "unknown"
+#endif
+        ;
+
         private static readonly Lazy<System.Net.Http.HttpClient> LazyDefaultHttpClient
             = new Lazy<System.Net.Http.HttpClient>(BuildDefaultSystemNetHttpClient);
 
@@ -204,28 +214,10 @@ namespace Stripe
                 { "bindings_version", StripeConfiguration.StripeNetVersion },
                 { "lang", ".net" },
                 { "publisher", "stripe" },
-                { "lang_version", RuntimeInformation.GetLanguageVersion() },
+                { "lang_version", RuntimeInformation.GetRuntimeVersion() },
                 { "os_version", RuntimeInformation.GetOSVersion() },
+                { "stripe_net_target_framework", StripeNetTargetFramework },
             };
-
-#if NET45
-            string monoVersion = RuntimeInformation.GetMonoVersion();
-            if (!string.IsNullOrEmpty(monoVersion))
-            {
-                values.Add("mono_version", monoVersion);
-            }
-#endif
-
-            var stripeNetTargetFramework =
-#if NET45
-                "net45"
-#elif NETSTANDARD2_0
-                "netstandard2.0"
-#else
-                "unknown"
-#endif
-            ;
-            values.Add("stripe_net_target_framework", stripeNetTargetFramework);
 
             if (this.appInfo != null)
             {

--- a/src/Stripe.net/Infrastructure/RuntimeInformation.cs
+++ b/src/Stripe.net/Infrastructure/RuntimeInformation.cs
@@ -1,53 +1,264 @@
 namespace Stripe.Infrastructure
 {
-#if NET45
     using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
     using System.Reflection;
-    using Microsoft.Win32;
-#endif
+    using System.Runtime.Versioning;
+    using static System.Runtime.InteropServices.RuntimeInformation;
 
+    /// <summary>
+    /// This class is used to gather information about the runtime environment. This is actually a
+    /// non-trivial task. The code below is largely borrowed from the
+    /// <a href="https://github.com/dotnet/BenchmarkDotNet">BenchmarkDotNet</a> project.
+    /// </summary>
     internal static class RuntimeInformation
     {
-        public static string GetLanguageVersion()
-        {
-#if NET45
-            return ".NET Framework 4.5+";
-#else
-            return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-#endif
-        }
+        internal const string Unknown = "?";
 
+        internal static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+
+        internal static bool IsFullFramework => FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsNetCore => FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(typeof(object).Assembly.Location);
+
+        /// <summary>
+        /// "The north star for CoreRT is to be a flavor of .NET Core" -> CoreRT reports .NET Core everywhere.
+        /// </summary>
+        internal static bool IsCoreRT
+            => FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase)
+               && string.IsNullOrEmpty(typeof(object).Assembly.Location); // but it's merged to a single .exe and .Location returns null here ;)
+
+        internal static bool IsRunningInContainer => string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true");
+
+        /// <summary>Returns a string that describes the operating system on which the app is running.</summary>
+        /// <returns>A string that describes the operating system on which the app is running.</returns>
         public static string GetOSVersion()
         {
-#if NET45
-            return Environment.OSVersion.ToString();
-#else
-            return System.Runtime.InteropServices.RuntimeInformation.OSDescription;
-#endif
+            return OSDescription;
         }
 
-#if NET45
-        public static string GetMonoVersion()
+        /// <summary>Returns a string that indicates the name of the .NET installation on which an app is running.</summary>
+        /// <returns>A string that indicates the name of the .NET installation on which an app is running.</returns>
+        public static string GetRuntimeVersion()
         {
-            Type monoRuntimeType = typeof(object).Assembly.GetType("Mono.Runtime");
-
-            if (monoRuntimeType != null)
+            if (IsMono)
             {
-                MethodInfo getDisplayNameMethod = monoRuntimeType.GetMethod(
-                    "GetDisplayName",
-                    BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding,
-                    null,
-                    Type.EmptyTypes,
-                    null);
+                return GetMonoVersion();
+            }
+            else if (IsFullFramework)
+            {
+                return GetFullFrameworkVersion();
+            }
+            else if (IsNetCore)
+            {
+                return GetNetCoreVersion();
+            }
+            else if (IsCoreRT)
+            {
+                return FrameworkDescription.Replace("Core ", "CoreRT ");
+            }
 
-                if (getDisplayNameMethod != null)
+            return Unknown;
+        }
+
+        internal static string GetMonoVersion()
+        {
+            var monoRuntimeType = Type.GetType("Mono.Runtime");
+            var monoDisplayName = monoRuntimeType?.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+            if (monoDisplayName != null)
+            {
+                string version = monoDisplayName.Invoke(null, null)?.ToString();
+                if (version != null)
                 {
-                    return (string)getDisplayNameMethod.Invoke(null, null);
+                    int bracket1 = version.IndexOf('('), bracket2 = version.IndexOf(')');
+                    if (bracket1 != -1 && bracket2 != -1)
+                    {
+                        string comment = version.Substring(bracket1 + 1, bracket2 - bracket1 - 1);
+                        var commentParts = comment.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (commentParts.Length > 2)
+                        {
+                            version = version.Substring(0, bracket1) + "(" + commentParts[0] + " " + commentParts[1] + ")";
+                        }
+                    }
+                }
+
+                return "Mono " + version;
+            }
+
+            return Unknown;
+        }
+
+        internal static string GetFullFrameworkVersion()
+        {
+            var fullName = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription; // sth like .NET Framework 4.7.3324.0
+            var servicingVersion = new string(fullName.SkipWhile(c => !char.IsDigit(c)).ToArray());
+            var releaseVersion = MapToReleaseVersion(servicingVersion);
+
+            return $".NET Framework {releaseVersion}";
+        }
+
+        internal static string MapToReleaseVersion(string servicingVersion)
+        {
+            // the following code assumes that .NET 4.5 is the oldest supported version
+            if (string.Compare(servicingVersion, "4.5.1") < 0)
+            {
+                return "4.5";
+            }
+
+            if (string.Compare(servicingVersion, "4.5.2") < 0)
+            {
+                return "4.5.1";
+            }
+
+            if (string.Compare(servicingVersion, "4.6") < 0)
+            {
+                return "4.5.2";
+            }
+
+            if (string.Compare(servicingVersion, "4.6.1") < 0)
+            {
+                return "4.6";
+            }
+
+            if (string.Compare(servicingVersion, "4.6.2") < 0)
+            {
+                return "4.6.1";
+            }
+
+            if (string.Compare(servicingVersion, "4.7") < 0)
+            {
+                return "4.6.2";
+            }
+
+            if (string.Compare(servicingVersion, "4.7.1") < 0)
+            {
+                return "4.7";
+            }
+
+            if (string.Compare(servicingVersion, "4.7.2") < 0)
+            {
+                return "4.7.1";
+            }
+
+            if (string.Compare(servicingVersion, "4.8") < 0)
+            {
+                return "4.7.2";
+            }
+
+            return "4.8"; // most probably the last major release of Full .NET Framework
+        }
+
+        internal static string GetNetCoreVersion()
+        {
+            string runtimeVersion = TryGetCoreRuntimeVersion(out var version) ? version.ToString() : "?";
+
+            return $".NET Core {runtimeVersion}";
+        }
+
+        internal static bool TryGetCoreRuntimeVersion(out Version version)
+        {
+            // we can't just use System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription
+            // because it can be null and it reports versions like 4.6.* for .NET Core 2.*
+            string runtimeDirectory = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+            if (TryGetVersionFromRuntimeDirectory(runtimeDirectory, out version))
+            {
+                return true;
+            }
+
+            // systemPrivateCoreLib.Product*Part properties return 0 so we have to implement some ugly parsing...
+            var systemPrivateCoreLib = FileVersionInfo.GetVersionInfo(typeof(object).Assembly.Location);
+            if (TryGetVersionFromProductInfo(systemPrivateCoreLib.ProductVersion, systemPrivateCoreLib.ProductName, out version))
+            {
+                return true;
+            }
+
+            string frameworkName = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+            if (TryGetVersionFromFrameworkName(frameworkName, out version))
+            {
+                return true;
+            }
+
+            if (IsRunningInContainer)
+            {
+                return Version.TryParse(Environment.GetEnvironmentVariable("DOTNET_VERSION"), out version)
+                    || Version.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_VERSION"), out version);
+            }
+
+            version = null;
+            return false;
+        }
+
+        // sample input:
+        // for dotnet run: C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.1.12\
+        // for dotnet publish: C:\Users\adsitnik\source\repos\ConsoleApp25\ConsoleApp25\bin\Release\netcoreapp2.0\win-x64\publish\
+        internal static bool TryGetVersionFromRuntimeDirectory(string runtimeDirectory, out Version version)
+        {
+            if (!string.IsNullOrEmpty(runtimeDirectory) && Version.TryParse(GetParsableVersionPart(new DirectoryInfo(runtimeDirectory).Name), out version))
+            {
+                return true;
+            }
+
+            version = null;
+            return false;
+        }
+
+        // sample input:
+        // 2.0: 4.6.26614.01 @BuiltBy: dlab14-DDVSOWINAGE018 @Commit: a536e7eec55c538c94639cefe295aa672996bf9b, Microsoft .NET Framework
+        // 2.1: 4.6.27817.01 @BuiltBy: dlab14-DDVSOWINAGE101 @Branch: release/2.1 @SrcCode: https://github.com/dotnet/coreclr/tree/6f78fbb3f964b4f407a2efb713a186384a167e5c, Microsoft .NET Framework
+        // 2.2: 4.6.27817.03 @BuiltBy: dlab14-DDVSOWINAGE101 @Branch: release/2.2 @SrcCode: https://github.com/dotnet/coreclr/tree/ce1d090d33b400a25620c0145046471495067cc7, Microsoft .NET Framework
+        // 3.0: 3.0.0-preview8.19379.2+ac25be694a5385a6a1496db40de932df0689b742, Microsoft .NET Core
+        // 5.0: 5.0.0-alpha1.19413.7+0ecefa44c9d66adb8a997d5778dc6c246ad393a7, Microsoft .NET Core
+        internal static bool TryGetVersionFromProductInfo(string productVersion, string productName, out Version version)
+        {
+            if (!string.IsNullOrEmpty(productVersion) && !string.IsNullOrEmpty(productName))
+            {
+                if (productName.IndexOf(".NET Core", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    string parsableVersion = GetParsableVersionPart(productVersion);
+                    if (Version.TryParse(productVersion, out version) || Version.TryParse(parsableVersion, out version))
+                    {
+                        return true;
+                    }
+                }
+
+                // yes, .NET Core 2.X has a product name == .NET Framework...
+                if (productName.IndexOf(".NET Framework", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    const string releaseVersionPrefix = "release/";
+                    int releaseVersionIndex = productVersion.IndexOf(releaseVersionPrefix);
+                    if (releaseVersionIndex > 0)
+                    {
+                        string releaseVersion = GetParsableVersionPart(productVersion.Substring(releaseVersionIndex + releaseVersionPrefix.Length));
+
+                        return Version.TryParse(releaseVersion, out version);
+                    }
                 }
             }
 
-            return null;
+            version = null;
+            return false;
         }
-#endif
+
+        // sample input:
+        // .NETCoreApp,Version=v2.0
+        // .NETCoreApp,Version=v2.1
+        internal static bool TryGetVersionFromFrameworkName(string frameworkName, out Version version)
+        {
+            const string versionPrefix = ".NETCoreApp,Version=v";
+            if (!string.IsNullOrEmpty(frameworkName) && frameworkName.StartsWith(versionPrefix))
+            {
+                string frameworkVersion = GetParsableVersionPart(frameworkName.Substring(versionPrefix.Length));
+
+                return Version.TryParse(frameworkVersion, out version);
+            }
+
+            version = null;
+            return false;
+        }
+
+        // Version.TryParse does not handle thing like 3.0.0-WORD
+        private static string GetParsableVersionPart(string fullVersionName) => new string(fullVersionName.TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
     }
 }

--- a/src/Stripe.net/Services/Accounts/AccountDeleteOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class AccountDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe
 
     public class AccountService : Service<Account>,
         ICreatable<Account, AccountCreateOptions>,
-        IDeletable<Account>,
+        IDeletable<Account, AccountDeleteOptions>,
         IListable<Account, AccountListOptions>,
         IRetrievable<Account, AccountGetOptions>,
         IUpdatable<Account, AccountUpdateOptions>
@@ -35,14 +35,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Account Delete(string accountId, RequestOptions requestOptions = null)
+        public virtual Account Delete(string accountId, AccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(accountId, null, requestOptions);
+            return this.DeleteEntity(accountId, options, requestOptions);
         }
 
-        public virtual Task<Account> DeleteAsync(string accountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Account> DeleteAsync(string accountId, AccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(accountId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
         public virtual Account Get(string accountId, AccountGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainDeleteOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ApplePayDomainDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class ApplePayDomainService : Service<ApplePayDomain>,
         ICreatable<ApplePayDomain, ApplePayDomainCreateOptions>,
-        IDeletable<ApplePayDomain>,
+        IDeletable<ApplePayDomain, ApplePayDomainDeleteOptions>,
         IListable<ApplePayDomain, ApplePayDomainListOptions>,
         IRetrievable<ApplePayDomain, ApplePayDomainGetOptions>
     {
@@ -32,14 +32,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual ApplePayDomain Delete(string domainId, RequestOptions requestOptions = null)
+        public virtual ApplePayDomain Delete(string domainId, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(domainId, null, requestOptions);
+            return this.DeleteEntity(domainId, options, requestOptions);
         }
 
-        public virtual Task<ApplePayDomain> DeleteAsync(string domainId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ApplePayDomain> DeleteAsync(string domainId, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(domainId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(domainId, options, requestOptions, cancellationToken);
         }
 
         public virtual ApplePayDomain Get(string domainId, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/BankAccounts/BankAccountDeleteOptions.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class BankAccountDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe
 
     public class BankAccountService : ServiceNested<BankAccount>,
         INestedCreatable<BankAccount, BankAccountCreateOptions>,
-        INestedDeletable<BankAccount>,
+        INestedDeletable<BankAccount, BankAccountDeleteOptions>,
         INestedListable<BankAccount, BankAccountListOptions>,
         INestedRetrievable<BankAccount, BankAccountGetOptions>,
         INestedUpdatable<BankAccount, BankAccountUpdateOptions>
@@ -35,14 +35,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
-        public virtual BankAccount Delete(string customerId, string bankAccountId, RequestOptions requestOptions = null)
+        public virtual BankAccount Delete(string customerId, string bankAccountId, BankAccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(customerId, bankAccountId, null, requestOptions);
+            return this.DeleteNestedEntity(customerId, bankAccountId, options, requestOptions);
         }
 
-        public virtual Task<BankAccount> DeleteAsync(string customerId, string bankAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<BankAccount> DeleteAsync(string customerId, string bankAccountId, BankAccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteNestedEntityAsync(customerId, bankAccountId, null, requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(customerId, bankAccountId, options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Get(string customerId, string bankAccountId, BankAccountGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Cards/CardDeleteOptions.cs
+++ b/src/Stripe.net/Services/Cards/CardDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CardDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class CardService : ServiceNested<Card>,
         INestedCreatable<Card, CardCreateOptions>,
-        INestedDeletable<Card>,
+        INestedDeletable<Card, CardDeleteOptions>,
         INestedListable<Card, CardListOptions>,
         INestedRetrievable<Card, CardGetOptions>,
         INestedUpdatable<Card, CardUpdateOptions>
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
-        public virtual Card Delete(string customerId, string cardId, RequestOptions requestOptions = null)
+        public virtual Card Delete(string customerId, string cardId, CardDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(customerId, cardId, null, requestOptions);
+            return this.DeleteNestedEntity(customerId, cardId, options, requestOptions);
         }
 
-        public virtual Task<Card> DeleteAsync(string customerId, string cardId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Card> DeleteAsync(string customerId, string cardId, CardDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteNestedEntityAsync(customerId, cardId, null, requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(customerId, cardId, options, requestOptions, cancellationToken);
         }
 
         public virtual Card Get(string customerId, string cardId, CardGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Charges/ChargeListOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeListOptions.cs
@@ -18,10 +18,6 @@ namespace Stripe
         [JsonProperty("payment_intent")]
         public string PaymentIntent { get; set; }
 
-        [Obsolete("This parameter is deprecated. Filter the returned list of charges instead.")]
-        [JsonProperty("source")]
-        public ChargeSourceListOptions Source { get; set; }
-
         /// <summary>
         /// Only return charges for this transfer group.
         /// </summary>

--- a/src/Stripe.net/Services/Coupons/CouponDeleteOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CouponDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class CouponService : Service<Coupon>,
         ICreatable<Coupon, CouponCreateOptions>,
-        IDeletable<Coupon>,
+        IDeletable<Coupon, CouponDeleteOptions>,
         IListable<Coupon, CouponListOptions>,
         IRetrievable<Coupon, CouponGetOptions>,
         IUpdatable<Coupon, CouponUpdateOptions>
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Coupon Delete(string couponId, RequestOptions requestOptions = null)
+        public virtual Coupon Delete(string couponId, CouponDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(couponId, null, requestOptions);
+            return this.DeleteEntity(couponId, options, requestOptions);
         }
 
-        public virtual Task<Coupon> DeleteAsync(string couponId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Coupon> DeleteAsync(string couponId, CouponDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(couponId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(couponId, options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Get(string couponId, CouponGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -47,6 +47,12 @@ namespace Stripe
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// The suffix of the customer’s next invoice number.
+        /// </summary>
+        [JsonProperty("next_invoice_sequence")]
+        public long? NextInvoiceSequence { get; set; }
+
         [JsonProperty("payment_method")]
         public string PaymentMethod { get; set; }
 

--- a/src/Stripe.net/Services/Customers/CustomerDeleteOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class CustomerDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class CustomerService : Service<Customer>,
         ICreatable<Customer, CustomerCreateOptions>,
-        IDeletable<Customer>,
+        IDeletable<Customer, CustomerDeleteOptions>,
         IListable<Customer, CustomerListOptions>,
         IRetrievable<Customer, CustomerGetOptions>,
         IUpdatable<Customer, CustomerUpdateOptions>
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Customer Delete(string customerId, RequestOptions requestOptions = null)
+        public virtual Customer Delete(string customerId, CustomerDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(customerId, null, requestOptions);
+            return this.DeleteEntity(customerId, options, requestOptions);
         }
 
-        public virtual Task<Customer> DeleteAsync(string customerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Customer> DeleteAsync(string customerId, CustomerDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(customerId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Get(string customerId, CustomerGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -51,6 +51,12 @@ namespace Stripe
         public string Name { get; set; }
 
         /// <summary>
+        /// The suffix of the customer’s next invoice number.
+        /// </summary>
+        [JsonProperty("next_invoice_sequence")]
+        public long? NextInvoiceSequence { get; set; }
+
+        /// <summary>
         /// The customer’s phone number.
         /// </summary>
         [JsonProperty("phone")]

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyDeleteOptions.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class EphemeralKeyDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class EphemeralKeyService : Service<EphemeralKey>,
         ICreatable<EphemeralKey, EphemeralKeyCreateOptions>,
-        IDeletable<EphemeralKey>
+        IDeletable<EphemeralKey, EphemeralKeyDeleteOptions>
     {
         public EphemeralKeyService()
             : base(null)
@@ -46,14 +46,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual EphemeralKey Delete(string keyId, RequestOptions requestOptions = null)
+        public virtual EphemeralKey Delete(string keyId, EphemeralKeyDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(keyId, null, requestOptions);
+            return this.DeleteEntity(keyId, options, requestOptions);
         }
 
-        public virtual Task<EphemeralKey> DeleteAsync(string keyId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<EphemeralKey> DeleteAsync(string keyId, EphemeralKeyDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(keyId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(keyId, options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountDeleteOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ExternalAccountDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class ExternalAccountService : ServiceNested<IExternalAccount>,
         INestedCreatable<IExternalAccount, ExternalAccountCreateOptions>,
-        INestedDeletable<IExternalAccount>,
+        INestedDeletable<IExternalAccount, ExternalAccountDeleteOptions>,
         INestedListable<IExternalAccount, ExternalAccountListOptions>,
         INestedRetrievable<IExternalAccount, ExternalAccountGetOptions>,
         INestedUpdatable<IExternalAccount, ExternalAccountUpdateOptions>
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
-        public virtual IExternalAccount Delete(string accountId, string externalAccountId, RequestOptions requestOptions = null)
+        public virtual IExternalAccount Delete(string accountId, string externalAccountId, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(accountId, externalAccountId, null, requestOptions);
+            return this.DeleteNestedEntity(accountId, externalAccountId, options, requestOptions);
         }
 
-        public virtual Task<IExternalAccount> DeleteAsync(string accountId, string externalAccountId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<IExternalAccount> DeleteAsync(string accountId, string externalAccountId, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteNestedEntityAsync(accountId, externalAccountId, null, requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(accountId, externalAccountId, options, requestOptions, cancellationToken);
         }
 
         public virtual IExternalAccount Get(string accountId, string externalAccountId, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemDeleteOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class InvoiceItemDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class InvoiceItemService : Service<InvoiceItem>,
         ICreatable<InvoiceItem, InvoiceItemCreateOptions>,
-        IDeletable<InvoiceItem>,
+        IDeletable<InvoiceItem, InvoiceItemDeleteOptions>,
         IListable<InvoiceItem, InvoiceItemListOptions>,
         IRetrievable<InvoiceItem, InvoiceItemGetOptions>,
         IUpdatable<InvoiceItem, InvoiceItemUpdateOptions>
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual InvoiceItem Delete(string invoiceitemId, RequestOptions requestOptions = null)
+        public virtual InvoiceItem Delete(string invoiceitemId, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(invoiceitemId, null, requestOptions);
+            return this.DeleteEntity(invoiceitemId, options, requestOptions);
         }
 
-        public virtual Task<InvoiceItem> DeleteAsync(string invoiceitemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<InvoiceItem> DeleteAsync(string invoiceitemId, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(invoiceitemId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(invoiceitemId, options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceItem Get(string invoiceitemId, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Invoices/InvoiceDeleteOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class InvoiceDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -8,6 +8,7 @@ namespace Stripe
 
     public class InvoiceService : Service<Invoice>,
         ICreatable<Invoice, InvoiceCreateOptions>,
+        IDeletable<Invoice, InvoiceDeleteOptions>,
         IListable<Invoice, InvoiceListOptions>,
         IRetrievable<Invoice, InvoiceGetOptions>,
         IUpdatable<Invoice, InvoiceUpdateOptions>
@@ -34,14 +35,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice Delete(string invoiceId, RequestOptions requestOptions = null)
+        public virtual Invoice Delete(string invoiceId, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(invoiceId, null, requestOptions);
+            return this.DeleteEntity(invoiceId, options, requestOptions);
         }
 
-        public virtual Task<Invoice> DeleteAsync(string invoiceId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Invoice> DeleteAsync(string invoiceId, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(invoiceId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(invoiceId, options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice FinalizeInvoice(string invoiceId, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
@@ -19,10 +19,6 @@ namespace Stripe.Issuing
         [JsonProperty("blocked_categories")]
         public List<string> BlockedCategories { get; set; }
 
-        [Obsolete("Use SpendingLimits instead.")]
-        [JsonProperty("max_amount")]
-        public long? MaxAmount { get; set; }
-
         /// <summary>
         /// Maximum count of approved authorizations on this card. Counts all authorizations
         /// retroactively.

--- a/src/Stripe.net/Services/Persons/PersonDeleteOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PersonDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -7,6 +7,7 @@ namespace Stripe
 
     public class PersonService : ServiceNested<Person>,
         INestedCreatable<Person, PersonCreateOptions>,
+        INestedDeletable<Person, PersonDeleteOptions>,
         INestedListable<Person, PersonListOptions>,
         INestedRetrievable<Person, PersonGetOptions>,
         INestedUpdatable<Person, PersonUpdateOptions>
@@ -33,14 +34,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
-        public virtual Person Delete(string accountId, string personId, RequestOptions requestOptions = null)
+        public virtual Person Delete(string accountId, string personId, PersonDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(accountId, personId, null, requestOptions);
+            return this.DeleteNestedEntity(accountId, personId, options, requestOptions);
         }
 
-        public virtual Task<Person> DeleteAsync(string accountId, string personId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Person> DeleteAsync(string accountId, string personId, PersonDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteNestedEntityAsync(accountId, personId, null, requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(accountId, personId, options, requestOptions, cancellationToken);
         }
 
         public virtual Person Get(string accountId, string personId, PersonGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Plans/PlanDeleteOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PlanDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class PlanService : Service<Plan>,
         ICreatable<Plan, PlanCreateOptions>,
-        IDeletable<Plan>,
+        IDeletable<Plan, PlanDeleteOptions>,
         IListable<Plan, PlanListOptions>,
         IRetrievable<Plan, PlanGetOptions>,
         IUpdatable<Plan, PlanUpdateOptions>
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Plan Delete(string planId, RequestOptions requestOptions = null)
+        public virtual Plan Delete(string planId, PlanDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(planId, null, requestOptions);
+            return this.DeleteEntity(planId, options, requestOptions);
         }
 
-        public virtual Task<Plan> DeleteAsync(string planId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Plan> DeleteAsync(string planId, PlanDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(planId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(planId, options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Get(string planId, PlanGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Products/ProductDeleteOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class ProductDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class ProductService : Service<Product>,
         ICreatable<Product, ProductCreateOptions>,
-        IDeletable<Product>,
+        IDeletable<Product, ProductDeleteOptions>,
         IListable<Product, ProductListOptions>,
         IRetrievable<Product, ProductGetOptions>,
         IUpdatable<Product, ProductUpdateOptions>
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Product Delete(string productId, RequestOptions requestOptions = null)
+        public virtual Product Delete(string productId, ProductDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(productId, null, requestOptions);
+            return this.DeleteEntity(productId, options, requestOptions);
         }
 
-        public virtual Task<Product> DeleteAsync(string productId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Product> DeleteAsync(string productId, ProductDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(productId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(productId, options, requestOptions, cancellationToken);
         }
 
         public virtual Product Get(string productId, ProductGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemDeleteOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Radar
+{
+    public class ValueListItemDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -6,6 +6,7 @@ namespace Stripe.Radar
 
     public class ValueListItemService : Service<ValueListItem>,
         ICreatable<ValueListItem, ValueListItemCreateOptions>,
+        IDeletable<ValueListItem, ValueListItemDeleteOptions>,
         IListable<ValueListItem, ValueListItemListOptions>,
         IRetrievable<ValueListItem, ValueListItemGetOptions>
     {
@@ -31,14 +32,14 @@ namespace Stripe.Radar
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual ValueListItem Delete(string valueListItemId, RequestOptions requestOptions = null)
+        public virtual ValueListItem Delete(string valueListItemId, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(valueListItemId, null, requestOptions);
+            return this.DeleteEntity(valueListItemId, options, requestOptions);
         }
 
-        public virtual Task<ValueListItem> DeleteAsync(string valueListItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ValueListItem> DeleteAsync(string valueListItemId, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(valueListItemId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(valueListItemId, options, requestOptions, cancellationToken);
         }
 
         public virtual ValueListItem Get(string valueListItemId, ValueListItemGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListDeleteOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Radar
+{
+    public class ValueListDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -6,6 +6,7 @@ namespace Stripe.Radar
 
     public class ValueListService : Service<ValueList>,
         ICreatable<ValueList, ValueListCreateOptions>,
+        IDeletable<ValueList, ValueListDeleteOptions>,
         IListable<ValueList, ValueListListOptions>,
         IRetrievable<ValueList, ValueListGetOptions>
     {
@@ -31,14 +32,14 @@ namespace Stripe.Radar
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual ValueList Delete(string valueListId, RequestOptions requestOptions = null)
+        public virtual ValueList Delete(string valueListId, ValueListDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(valueListId, null, requestOptions);
+            return this.DeleteEntity(valueListId, options, requestOptions);
         }
 
-        public virtual Task<ValueList> DeleteAsync(string valueListId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<ValueList> DeleteAsync(string valueListId, ValueListDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(valueListId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(valueListId, options, requestOptions, cancellationToken);
         }
 
         public virtual ValueList Get(string valueListId, ValueListGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Skus/SkuDeleteOptions.cs
+++ b/src/Stripe.net/Services/Skus/SkuDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SkuDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -7,7 +7,7 @@ namespace Stripe
 
     public class SkuService : Service<Sku>,
         ICreatable<Sku, SkuCreateOptions>,
-        IDeletable<Sku>,
+        IDeletable<Sku, SkuDeleteOptions>,
         IListable<Sku, SkuListOptions>,
         IRetrievable<Sku, SkuGetOptions>,
         IUpdatable<Sku, SkuUpdateOptions>
@@ -34,14 +34,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Sku Delete(string skuId, RequestOptions requestOptions = null)
+        public virtual Sku Delete(string skuId, SkuDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(skuId, null, requestOptions);
+            return this.DeleteEntity(skuId, options, requestOptions);
         }
 
-        public virtual Task<Sku> DeleteAsync(string skuId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Sku> DeleteAsync(string skuId, SkuDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(skuId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(skuId, options, requestOptions, cancellationToken);
         }
 
         public virtual Sku Get(string skuId, SkuGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemDeleteOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemDeleteOptions.cs
@@ -1,0 +1,36 @@
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SubscriptionItemDeleteOptions : BaseOptions
+    {
+        /// <summary>
+        /// Delete all usage for the given subscription item. Only allowed when the current plan’s
+        /// <c>usage_type</c> is metered.
+        /// </summary>
+        [JsonProperty("clear_usage")]
+        public bool? ClearUsage { get; set; }
+
+        /// <summary>
+        /// Determines how to handle
+        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes. The value defaults to
+        /// <c>create_prorations</c>, indicating that proration invoice items should
+        /// be created. Prorations can be disabled by setting the value to
+        /// <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+
+        /// <summary>
+        /// If set, the proration will be calculated as though the subscription was updated at the
+        /// given time. This can be used to apply the same proration that was previewed with the
+        /// upcoming invoice endpoint.
+        /// </summary>
+        [JsonProperty("proration_date")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? ProrationDate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class SubscriptionItemService : Service<SubscriptionItem>,
         ICreatable<SubscriptionItem, SubscriptionItemCreateOptions>,
-        IDeletable<SubscriptionItem>,
+        IDeletable<SubscriptionItem, SubscriptionItemDeleteOptions>,
         IListable<SubscriptionItem, SubscriptionItemListOptions>,
         IRetrievable<SubscriptionItem, SubscriptionItemGetOptions>,
         IUpdatable<SubscriptionItem, SubscriptionItemUpdateOptions>
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual SubscriptionItem Delete(string subscriptionItemId, RequestOptions requestOptions = null)
+        public virtual SubscriptionItem Delete(string subscriptionItemId, SubscriptionItemDeleteOptions options, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(subscriptionItemId, null, requestOptions);
+            return this.DeleteEntity(subscriptionItemId, options, requestOptions);
         }
 
-        public virtual Task<SubscriptionItem> DeleteAsync(string subscriptionItemId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<SubscriptionItem> DeleteAsync(string subscriptionItemId, SubscriptionItemDeleteOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(subscriptionItemId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(subscriptionItemId, options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Get(string subscriptionItemId, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/TaxIds/TaxIdDeleteOptions.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class TaxIdDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -7,6 +7,7 @@ namespace Stripe
 
     public class TaxIdService : ServiceNested<TaxId>,
         INestedCreatable<TaxId, TaxIdCreateOptions>,
+        INestedDeletable<TaxId, TaxIdDeleteOptions>,
         INestedListable<TaxId, TaxIdListOptions>,
         INestedRetrievable<TaxId, TaxIdGetOptions>
     {
@@ -32,14 +33,14 @@ namespace Stripe
             return this.CreateNestedEntityAsync(customerId, options, requestOptions, cancellationToken);
         }
 
-        public virtual TaxId Delete(string customerId, string taxIdId, RequestOptions requestOptions = null)
+        public virtual TaxId Delete(string customerId, string taxIdId, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(customerId, taxIdId, null, requestOptions);
+            return this.DeleteNestedEntity(customerId, taxIdId, options, requestOptions);
         }
 
-        public virtual Task<TaxId> DeleteAsync(string customerId, string taxIdId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<TaxId> DeleteAsync(string customerId, string taxIdId, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteNestedEntityAsync(customerId, taxIdId, null, requestOptions, cancellationToken);
+            return this.DeleteNestedEntityAsync(customerId, taxIdId, options, requestOptions, cancellationToken);
         }
 
         public virtual TaxId Get(string customerId, string taxIdId, TaxIdGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Terminal/Locations/LocationDeleteOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Terminal
+{
+    public class LocationDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Terminal
 
     public class LocationService : Service<Location>,
         ICreatable<Location, LocationCreateOptions>,
-        IDeletable<Location>,
+        IDeletable<Location, LocationDeleteOptions>,
         IListable<Location, LocationListOptions>,
         IRetrievable<Location, LocationGetOptions>,
         IUpdatable<Location, LocationUpdateOptions>
@@ -35,14 +35,14 @@ namespace Stripe.Terminal
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Location Delete(string locationId, RequestOptions requestOptions = null)
+        public virtual Location Delete(string locationId, LocationDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(locationId, null, requestOptions);
+            return this.DeleteEntity(locationId, options, requestOptions);
         }
 
-        public virtual Task<Location> DeleteAsync(string locationId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Location> DeleteAsync(string locationId, LocationDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(locationId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(locationId, options, requestOptions, cancellationToken);
         }
 
         public virtual Location Get(string locationId, LocationGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderDeleteOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe.Terminal
+{
+    public class ReaderDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Terminal
 
     public class ReaderService : Service<Reader>,
         ICreatable<Reader, ReaderCreateOptions>,
-        IDeletable<Reader>,
+        IDeletable<Reader, ReaderDeleteOptions>,
         IListable<Reader, ReaderListOptions>,
         IRetrievable<Reader, ReaderGetOptions>,
         IUpdatable<Reader, ReaderUpdateOptions>
@@ -35,14 +35,14 @@ namespace Stripe.Terminal
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Reader Delete(string readerId, RequestOptions requestOptions = null)
+        public virtual Reader Delete(string readerId, ReaderDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(readerId, null, requestOptions);
+            return this.DeleteEntity(readerId, options, requestOptions);
         }
 
-        public virtual Task<Reader> DeleteAsync(string readerId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<Reader> DeleteAsync(string readerId, ReaderDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(readerId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(readerId, options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Get(string readerId, ReaderGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointDeleteOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointDeleteOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class WebhookEndpointDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -6,7 +6,7 @@ namespace Stripe
 
     public class WebhookEndpointService : Service<WebhookEndpoint>,
         ICreatable<WebhookEndpoint, WebhookEndpointCreateOptions>,
-        IDeletable<WebhookEndpoint>,
+        IDeletable<WebhookEndpoint, WebhookEndpointDeleteOptions>,
         IListable<WebhookEndpoint, WebhookEndpointListOptions>,
         IRetrievable<WebhookEndpoint, WebhookEndpointGetOptions>,
         IUpdatable<WebhookEndpoint, WebhookEndpointUpdateOptions>
@@ -33,14 +33,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual WebhookEndpoint Delete(string endpointId, RequestOptions requestOptions = null)
+        public virtual WebhookEndpoint Delete(string endpointId, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(endpointId, null, requestOptions);
+            return this.DeleteEntity(endpointId, options, requestOptions);
         }
 
-        public virtual Task<WebhookEndpoint> DeleteAsync(string endpointId, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<WebhookEndpoint> DeleteAsync(string endpointId, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.DeleteEntityAsync(endpointId, null, requestOptions, cancellationToken);
+            return this.DeleteEntityAsync(endpointId, options, requestOptions, cancellationToken);
         }
 
         public virtual WebhookEndpoint Get(string endpointId, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/_interfaces/IDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/IDeletable.cs
@@ -3,11 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IDeletable<TEntity>
+    public interface IDeletable<TEntity, TOptions>
         where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions, new()
     {
-        TEntity Delete(string id, RequestOptions requestOptions = null);
+        TEntity Delete(string id, TOptions options = null, RequestOptions requestOptions = null);
 
-        Task<TEntity> DeleteAsync(string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> DeleteAsync(string id, TOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedDeletable.cs
@@ -3,11 +3,12 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface INestedDeletable<TEntity>
+    public interface INestedDeletable<TEntity, TOptions>
         where TEntity : IStripeEntity, IHasId
+        where TOptions : BaseOptions, new()
     {
-        TEntity Delete(string parentId, string id, RequestOptions requestOptions = null);
+        TEntity Delete(string parentId, string id, TOptions options = null, RequestOptions requestOptions = null);
 
-        Task<TEntity> DeleteAsync(string parentId, string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> DeleteAsync(string parentId, string id, TOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedRetrievable.cs
@@ -7,8 +7,8 @@ namespace Stripe
         where TEntity : IStripeEntity, IHasId
         where TOptions : BaseOptions, new()
     {
-        TEntity Get(string parentId, string id, TOptions retrieveOptions, RequestOptions requestOptions = null);
+        TEntity Get(string parentId, string id, TOptions retrieveOptions = null, RequestOptions requestOptions = null);
 
-        Task<TEntity> GetAsync(string parentId, string id, TOptions retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> GetAsync(string parentId, string id, TOptions retrieveOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IRetrievable.cs
+++ b/src/Stripe.net/Services/_interfaces/IRetrievable.cs
@@ -7,8 +7,8 @@ namespace Stripe
         where TEntity : IStripeEntity, IHasId
         where TOptions : BaseOptions, new()
     {
-        TEntity Get(string id, TOptions retrieveOptions, RequestOptions requestOptions = null);
+        TEntity Get(string id, TOptions retrieveOptions = null, RequestOptions requestOptions = null);
 
-        Task<TEntity> GetAsync(string id, TOptions retrieveOptions, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TEntity> GetAsync(string id, TOptions retrieveOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>34.26.0</VersionPrefix>
     <Version>34.26.0</Version>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AssemblyName>Stripe.net</AssemblyName>
     <PackageId>Stripe.net</PackageId>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
@@ -16,8 +16,6 @@
     <PackageLicenseUrl>https://raw.github.com/stripe/stripe-dotnet/master/LICENSE</PackageLicenseUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.2' ">$(PackageTargetFallback);netcoreapp1.0</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.2' ">1.6.1</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -26,21 +24,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
-  <!--
-       .NET Core (and the .NET Standard) refactors the API's surface so that it
-       exists in a collection of smaller assemblies. As part of traditional
-       .NET (e.g., net45), System.Console existed as part of the standard
-       System assembly, but for the new standard it was added to its own.
-
-       Here we conditionally include System.Console for the .NET Standard
-       target (which also allows us to use it in .NET Core).
-
-       Reference: https://github.com/dotnet/corefx/issues/683
-  -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
-    <PackageReference Include="System.Console" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
@@ -68,10 +51,6 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.2'">
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -39,6 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -399,7 +399,6 @@ namespace StripeTests
             Assert.Contains("enum=test_one", FormEncoder.CreateQueryString(options));
         }
 
-        #if !NETCOREAPP1_1
         [Fact]
         public void IgnoresCulture()
         {
@@ -420,7 +419,6 @@ namespace StripeTests
                 Thread.CurrentThread.CurrentCulture = currentCulture;
             }
         }
-        #endif
 
         [Fact]
         public void UrlEncodesKeysAndValues()

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -14,6 +14,7 @@ namespace StripeTests
 
         private readonly SubscriptionItemService service;
         private readonly SubscriptionItemCreateOptions createOptions;
+        private readonly SubscriptionItemDeleteOptions deleteOptions;
         private readonly SubscriptionItemUpdateOptions updateOptions;
         private readonly SubscriptionItemListOptions listOptions;
 
@@ -29,6 +30,11 @@ namespace StripeTests
                 Plan = "plan_123",
                 Quantity = 1,
                 Subscription = "sub_123",
+            };
+
+            this.deleteOptions = new SubscriptionItemDeleteOptions
+            {
+                ClearUsage = true,
             };
 
             this.updateOptions = new SubscriptionItemUpdateOptions
@@ -67,7 +73,7 @@ namespace StripeTests
         [Fact]
         public void Delete()
         {
-            var deleted = this.service.Delete(SubscriptionItemId);
+            var deleted = this.service.Delete(SubscriptionItemId, this.deleteOptions);
             this.AssertRequest(HttpMethod.Delete, "/v1/subscription_items/si_123");
             Assert.NotNull(deleted);
         }
@@ -75,7 +81,7 @@ namespace StripeTests
         [Fact]
         public async Task DeleteAsync()
         {
-            var deleted = await this.service.DeleteAsync(SubscriptionItemId);
+            var deleted = await this.service.DeleteAsync(SubscriptionItemId, this.deleteOptions);
             this.AssertRequest(HttpMethod.Delete, "/v1/subscription_items/si_123");
             Assert.NotNull(deleted);
         }

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.82.0";
+        private const string MockMinimumVersion = "0.83.0";
 
         private readonly string port;
 

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net45</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -26,7 +26,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;netcoreapp3.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net452</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>

--- a/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
+++ b/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -47,4 +46,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/CorrectJsonConvertersForTypes.cs
+++ b/src/StripeTests/Wholesome/CorrectJsonConvertersForTypes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -118,4 +117,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontForgetEntityType.cs
+++ b/src/StripeTests/Wholesome/DontForgetEntityType.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -55,4 +54,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
+++ b/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -65,4 +64,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -73,4 +72,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/JsonNamesAreSnakeCase.cs
+++ b/src/StripeTests/Wholesome/JsonNamesAreSnakeCase.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -54,4 +53,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
+++ b/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -65,4 +64,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
+++ b/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -57,4 +56,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/NullableValueTypes.cs
+++ b/src/StripeTests/Wholesome/NullableValueTypes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -60,4 +59,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/PropertiesHaveJsonAttributes.cs
+++ b/src/StripeTests/Wholesome/PropertiesHaveJsonAttributes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -59,4 +58,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
+++ b/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -53,4 +52,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -68,4 +67,3 @@ namespace StripeTests
         }
     }
 }
-#endif


### PR DESCRIPTION
(⚠️ = breaking changes)

- [x] ⚠️Drop support for .NET Standard 1.2 (#1933)
- [x] Remove conditional compilation macros in tests (#1935)
- [x] ⚠️Add support for passing parameters when deleting a Subscription Item (#1932)
- [x] Get accurate runtime version (#1936)
- [x] ⚠️Move to API version `2020-03-02` and remove deprecated properties (#1937)
- [x] Add support for `NextInvoiceSequence` on `Customer` (#1938)
