### PR TITLE
Remove conditional compilation macros in tests

### DIFF
--- a/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/FormEncoderTest.cs
@@ -399,7 +399,6 @@ namespace StripeTests
             Assert.Contains("enum=test_one", FormEncoder.CreateQueryString(options));
         }
 
-        #if !NETCOREAPP1_1
         [Fact]
         public void IgnoresCulture()
         {
@@ -420,7 +419,6 @@ namespace StripeTests
                 Thread.CurrentThread.CurrentCulture = currentCulture;
             }
         }
-        #endif
 
         [Fact]
         public void UrlEncodesKeysAndValues()

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net45</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Stylecop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -26,7 +26,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
+++ b/src/StripeTests/Wholesome/AllStripeObjectClassesPresentInDictionary.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -47,4 +46,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/CorrectJsonConvertersForTypes.cs
+++ b/src/StripeTests/Wholesome/CorrectJsonConvertersForTypes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -118,4 +117,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontForgetEntityType.cs
+++ b/src/StripeTests/Wholesome/DontForgetEntityType.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -55,4 +54,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
+++ b/src/StripeTests/Wholesome/DontForgetIHasInterfaces.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -65,4 +64,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -73,4 +72,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/JsonNamesAreSnakeCase.cs
+++ b/src/StripeTests/Wholesome/JsonNamesAreSnakeCase.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -54,4 +53,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
+++ b/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -65,4 +64,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
+++ b/src/StripeTests/Wholesome/NoDuplicateJsonPropertyValues.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -57,4 +56,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/NullableValueTypes.cs
+++ b/src/StripeTests/Wholesome/NullableValueTypes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -60,4 +59,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/PropertiesHaveJsonAttributes.cs
+++ b/src/StripeTests/Wholesome/PropertiesHaveJsonAttributes.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -59,4 +58,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
+++ b/src/StripeTests/Wholesome/UseListsInsteadOfArrays.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -53,4 +52,3 @@ namespace StripeTests
         }
     }
 }
-#endif

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 namespace StripeTests
 {
     using System;
@@ -68,4 +67,3 @@ namespace StripeTests
         }
     }
 }
-#endif


### PR DESCRIPTION
r? @cjavilla-stripe @remi-stripe 
cc @stripe/api-libraries 

- Remove all conditional compilation preprocessor macros in tests
- Change `net452` target framework in tests to `net45` (I can't remember why we were using `net452`, but tests pass with `net45` now so we might as well test with the minimum version we support)
- Bump `Moq` test dependency to latest version
