### PR TITLE
Move to API version `2020-03-02` and remove deprecated properties

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.82.0
+  STRIPE_MOCK_VERSION: 0.83.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardPresent.cs
@@ -61,14 +61,6 @@ namespace Stripe
         [JsonProperty("generated_card")]
         public string GeneratedCard { get; set; }
 
-        [Obsolete("Use GeneratedCard instead.")]
-        [JsonIgnore]
-        public string GeneratedCardId
-        {
-            get => this.GeneratedCard;
-            set => this.GeneratedCardId = value;
-        }
-
         /// <summary>
         /// The last four digits of the card.
         /// </summary>

--- a/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/WebhookEndpoints/WebhookEndpoint.cs
@@ -31,14 +31,6 @@ namespace Stripe
         [JsonProperty("application")]
         public string Application { get; set; }
 
-        [Obsolete("Use Application instead")]
-        [JsonIgnore]
-        public string ApplicationId
-        {
-            get => this.Application;
-            set => this.Application = value;
-        }
-
         [Obsolete("This property was never returned. Use Application instead")]
         [JsonProperty("connect")]
         public bool Connect { get; set; }

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -30,7 +30,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2019-12-03";
+        public static string ApiVersion => "2020-03-02";
 
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>

--- a/src/Stripe.net/Services/Charges/ChargeListOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeListOptions.cs
@@ -18,10 +18,6 @@ namespace Stripe
         [JsonProperty("payment_intent")]
         public string PaymentIntent { get; set; }
 
-        [Obsolete("This parameter is deprecated. Filter the returned list of charges instead.")]
-        [JsonProperty("source")]
-        public ChargeSourceListOptions Source { get; set; }
-
         /// <summary>
         /// Only return charges for this transfer group.
         /// </summary>

--- a/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/AuthorizationControlsOptions.cs
@@ -19,10 +19,6 @@ namespace Stripe.Issuing
         [JsonProperty("blocked_categories")]
         public List<string> BlockedCategories { get; set; }
 
-        [Obsolete("Use SpendingLimits instead.")]
-        [JsonProperty("max_amount")]
-        public long? MaxAmount { get; set; }
-
         /// <summary>
         /// Maximum count of approved authorizations on this card. Counts all authorizations
         /// retroactively.

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.82.0";
+        private const string MockMinimumVersion = "0.83.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Multiple API changes
* Move to API version `2020-03-02`
* Removed `GeneratedCardId`, use `GeneratedCard` instead.
* Removed `ApplicationId`, use `Application` instead.
* Removed `Source` parameter when listing charges as this is deprecated.
* Removed `MaxAmount` in `AuthorizationControlsOptions` as this is deprecated.

r? @ob-stripe 
cc @stripe/api-libraries 
