### PR TITLE
Add support for `Description`, `Iin` and `Issuer` on `PaymentMethod`

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCard.cs
@@ -26,6 +26,13 @@ namespace Stripe
         public string Country { get; set; }
 
         /// <summary>
+        /// Card description. (Only for internal use only and not typically available in standard
+        /// API requests).
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// Two-digit number representing the card’s expiration month.
         /// </summary>
         [JsonProperty("exp_month")]
@@ -53,10 +60,24 @@ namespace Stripe
         public string Funding { get; set; }
 
         /// <summary>
+        /// Issuer identification number of the card. (Only for internal use only and not typically
+        /// available in standard API requests).
+        /// </summary>
+        [JsonProperty("iin")]
+        public string Iin { get; set; }
+
+        /// <summary>
         /// Installment details for this payment (Mexico only).
         /// </summary>
         [JsonProperty("installments")]
         public ChargePaymentMethodDetailsCardInstallments Installments { get; set; }
+
+        /// <summary>
+        /// Issuer bank name of the card. (Only for internal use only and not typically available in
+        /// standard API requests).
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
 
         /// <summary>
         /// The last four digits of the card.

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodCard.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodCard.cs
@@ -4,33 +4,89 @@ namespace Stripe
 
     public class PaymentMethodCard : StripeEntity<PaymentMethodCard>
     {
+        /// <summary>
+        /// Card brand. Can be <c>amex</c>, <c>diners</c>, <c>discover</c>, <c>jcb</c>,
+        /// <c>mastercard</c>, <c>unionpay</c>, <c>visa</c>, or <c>unknown</c>.
+        /// </summary>
         [JsonProperty("brand")]
         public string Brand { get; set; }
 
+        /// <summary>
+        /// Checks on Card address and CVC if provided.
+        /// </summary>
         [JsonProperty("checks")]
         public PaymentMethodCardChecks Checks { get; set; }
 
+        /// <summary>
+        /// Two-letter ISO code representing the country of the card. You could use this attribute
+        /// to get a sense of the international breakdown of cards you’ve collected.
+        /// </summary>
         [JsonProperty("country")]
         public string Country { get; set; }
 
+        /// <summary>
+        /// Card description. (Only for internal use only and not typically available in standard
+        /// API requests).
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Two-digit number representing the card’s expiration month.
+        /// </summary>
         [JsonProperty("exp_month")]
         public long ExpMonth { get; set; }
 
+        /// <summary>
+        /// Four-digit number representing the card’s expiration year.
+        /// </summary>
         [JsonProperty("exp_year")]
         public long ExpYear { get; set; }
 
+        /// <summary>
+        /// Uniquely identifies this particular card number. You can use this attribute to check
+        /// whether two customers who’ve signed up with you are using the same card number, for
+        /// example.
+        /// </summary>
         [JsonProperty("fingerprint")]
         public string Fingerprint { get; set; }
 
+        /// <summary>
+        /// Card funding type. Can be <c>credit</c>, <c>debit</c>, <c>prepaid</c>, or
+        /// <c>unknown</c>.
+        /// </summary>
         [JsonProperty("funding")]
         public string Funding { get; set; }
 
+        /// <summary>
+        /// Issuer identification number of the card. (Only for internal use only and not typically
+        /// available in standard API requests).
+        /// </summary>
+        [JsonProperty("iin")]
+        public string Iin { get; set; }
+
+        /// <summary>
+        /// Issuer bank name of the card. (Only for internal use only and not typically available in
+        /// standard API requests.).
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// The last four digits of the card.
+        /// </summary>
         [JsonProperty("last4")]
         public string Last4 { get; set; }
 
+        /// <summary>
+        /// Contains details on how this Card maybe be used for 3D Secure authentication.
+        /// </summary>
         [JsonProperty("three_d_secure_usage")]
         public PaymentMethodCardThreeDSecureUsage ThreeDSecureUsage { get; set; }
 
+        /// <summary>
+        /// If this Card is part of a card wallet, this contains the details of the card wallet.
+        /// </summary>
         [JsonProperty("wallet")]
         public PaymentMethodCardWallet Wallet { get; set; }
     }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/1943

r? @ob-stripe 
cc @stripe/api-libraries 