### PR TITLE
Support for asynchronous autopagination

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -80,6 +80,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Account> ListAutoPagingAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Account Reject(string accountId, AccountRejectOptions options, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(accountId)}/reject", options, requestOptions);

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -66,5 +66,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ApplePayDomain> ListAutoPagingAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(applicationFeeId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<ApplicationFeeRefund> ListAutoPagingAsync(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(applicationFeeId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual ApplicationFeeRefund Update(string applicationFeeId, string refundId, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(applicationFeeId, refundId, options, requestOptions);

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -45,5 +45,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ApplicationFee> ListAutoPagingAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -45,5 +45,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<BalanceTransaction> ListAutoPagingAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -70,6 +70,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(customerId, options ?? new BankAccountListOptions(), requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<BankAccount> ListAutoPagingAsync(string customerId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(customerId, options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual BankAccount Update(string customerId, string bankAccountId, BankAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(customerId, bankAccountId, options, requestOptions);

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -47,6 +47,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(accountId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Capability> ListAutoPagingAsync(string accountId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(accountId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Capability Update(string accountId,  string capabilityId, CapabilityUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(accountId, capabilityId, options, requestOptions);

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(customerId, options ?? new CardListOptions(), requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(string customerId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(customerId, options ?? new CardListOptions(), requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Card Update(string customerId, string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(customerId, cardId, options, requestOptions);

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Charge> ListAutoPagingAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Charge Update(string chargeId, ChargeUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(chargeId, options, requestOptions);

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -58,5 +58,12 @@ namespace Stripe.Checkout
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<Session> ListAutoPagingAsync(SessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -44,5 +44,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<CountrySpec> ListAutoPagingAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Coupon> ListAutoPagingAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Coupon Update(string couponId, CouponUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(couponId, options, requestOptions);

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<CreditNote> ListAutoPagingAsync(CreditNoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual StripeList<CreditNoteLineItem> ListLineItems(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions);
@@ -73,6 +80,13 @@ namespace Stripe
             return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<CreditNoteLineItem> ListLineItemsAutoPagingAsync(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual StripeList<CreditNoteLineItem> ListPreviewLineItems(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("preview")}/lines", options, requestOptions);
@@ -87,6 +101,13 @@ namespace Stripe
         {
             return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<CreditNoteLineItem> ListPreviewLineItemsAutoPagingAsync(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions, cancellationToken);
+        }
+#endif
 
         public virtual CreditNote Preview(CreditNotePreviewOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
@@ -57,6 +57,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(customerId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<CustomerBalanceTransaction> ListAutoPagingAsync(string customerId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(customerId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual CustomerBalanceTransaction Update(string customerId, string transactionId, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(customerId, transactionId, options, requestOptions);

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Customer> ListAutoPagingAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Customer Update(string customerId, CustomerUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(customerId, options, requestOptions);

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(disputeId, options, requestOptions);

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -44,5 +44,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
+++ b/src/Stripe.net/Services/ExchangeRates/ExchangeRateService.cs
@@ -44,5 +44,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ExchangeRate> ListAutoPagingAsync(ExchangeRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(accountId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<IExternalAccount> ListAutoPagingAsync(string accountId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(accountId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual IExternalAccount Update(string accountId, string externalAccountId, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(accountId, externalAccountId, options, requestOptions);

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -57,6 +57,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<FileLink> ListAutoPagingAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual FileLink Update(string fileLinkId, FileLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(fileLinkId, options, requestOptions);

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<File> ListAutoPagingAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         private RequestOptions SetupRequestOptionsForFilesRequest(RequestOptions requestOptions)
         {
             if (requestOptions == null)

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<InvoiceItem> ListAutoPagingAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual InvoiceItem Update(string invoiceitemId, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(invoiceitemId, options, requestOptions);

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -80,6 +80,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Invoice> ListAutoPagingAsync(InvoiceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual StripeList<InvoiceLineItem> ListLineItems(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
@@ -95,6 +102,13 @@ namespace Stripe
             return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<InvoiceLineItem> ListLineItemsAutoPagingAsync(string invoiceId, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl(invoiceId)}/lines", options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
@@ -109,6 +123,13 @@ namespace Stripe
         {
             return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPagingAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
+        }
+#endif
 
         public virtual Invoice MarkUncollectible(string invoiceId, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -67,6 +67,13 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Authorization> ListAutoPagingAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Authorization Update(string authorizationId, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(authorizationId, options, requestOptions);

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -57,6 +57,13 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Cardholder> ListAutoPagingAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Cardholder Update(string cardholderId, CardholderUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(cardholderId, options, requestOptions);

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -68,6 +68,13 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Card Update(string cardId, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(cardId, options, requestOptions);

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -57,6 +57,13 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Dispute Update(string disputeId, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(disputeId, options, requestOptions);

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -46,6 +46,13 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Transaction> ListAutoPagingAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Transaction Update(string transactionId, TransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(transactionId, options, requestOptions);

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -59,6 +59,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Order> ListAutoPagingAsync(OrderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Order Pay(string orderId, OrderPayOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(orderId)}/pay", options, requestOptions);

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -89,6 +89,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<PaymentIntent> ListAutoPagingAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual PaymentIntent Update(string paymentIntentId, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(paymentIntentId, options, requestOptions);

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -79,6 +79,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<PaymentMethod> ListAutoPagingAsync(PaymentMethodListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual PaymentMethod Update(string paymentMethodId, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(paymentMethodId, options, requestOptions);

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Payout> ListAutoPagingAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Payout Update(string payoutId, PayoutUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(payoutId, options, requestOptions);

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(accountId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Person> ListAutoPagingAsync(string accountId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(accountId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Person Update(string accountId,  string personId, PersonUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(accountId, personId, options, requestOptions);

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Plan> ListAutoPagingAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Plan Update(string planId, PlanUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(planId, options, requestOptions);

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Product> ListAutoPagingAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Product Update(string productId, ProductUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(productId, options, requestOptions);

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -44,5 +44,12 @@ namespace Stripe.Radar
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<EarlyFraudWarning> ListAutoPagingAsync(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -66,5 +66,12 @@ namespace Stripe.Radar
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ValueListItem> ListAutoPagingAsync(ValueListItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -67,6 +67,13 @@ namespace Stripe.Radar
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<ValueList> ListAutoPagingAsync(ValueListListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual ValueList Update(string valueListId, ValueListUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(valueListId, options, requestOptions);

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Refund> ListAutoPagingAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Refund Update(string refundId, RefundUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(refundId, options, requestOptions);

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -55,5 +55,12 @@ namespace Stripe.Reporting
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ReportRun> ListAutoPagingAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -44,5 +44,12 @@ namespace Stripe.Reporting
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ReportType> ListAutoPagingAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -55,5 +55,12 @@ namespace Stripe
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<Review> ListAutoPagingAsync(ReviewListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -79,6 +79,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<SetupIntent> ListAutoPagingAsync(SetupIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual SetupIntent Update(string setupIntentId, SetupIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(setupIntentId, options, requestOptions);

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -44,5 +44,12 @@ namespace Stripe.Sigma
         {
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<ScheduledQueryRun> ListAutoPagingAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Sku> ListAutoPagingAsync(SkuListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Sku Update(string skuId, SkuUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(skuId, options, requestOptions);

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -33,5 +33,12 @@ namespace Stripe
         {
             return this.ListNestedEntitiesAutoPaging(sourceId, options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<SourceTransaction> ListAutoPagingAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(sourceId, options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -79,6 +79,13 @@ namespace Stripe
             return this.ListRequestAutoPaging<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Source> ListAutoPagingAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Source Update(string sourceId, SourceUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(sourceId, options, requestOptions);

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<SubscriptionItem> ListAutoPagingAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual SubscriptionItem Update(string subscriptionItemId, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(subscriptionItemId, options, requestOptions);

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<SubscriptionSchedule> ListAutoPagingAsync(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual SubscriptionSchedule Release(string scheduleId, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(scheduleId)}/release", options, requestOptions);

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Subscription> ListAutoPagingAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Subscription Update(string subscriptionId, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(subscriptionId, options, requestOptions);

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -67,5 +67,12 @@ namespace Stripe
         {
             return this.ListNestedEntitiesAutoPaging(customerId, options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<TaxId> ListAutoPagingAsync(string customerId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(customerId, options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<TaxRate> ListAutoPagingAsync(TaxRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual TaxRate Update(string taxRateId, TaxRateUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(taxRateId, options, requestOptions);

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -70,6 +70,13 @@ namespace Stripe.Terminal
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Location> ListAutoPagingAsync(LocationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Location Update(string locationId, LocationUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(locationId, options, requestOptions);

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -70,6 +70,13 @@ namespace Stripe.Terminal
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Reader> ListAutoPagingAsync(ReaderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Reader Update(string readerId, ReaderUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(readerId, options, requestOptions);

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -69,6 +69,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Topup> ListAutoPagingAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Topup Update(string topupId, TopupUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(topupId, options, requestOptions);

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(transferId, options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<TransferReversal> ListAutoPagingAsync(string transferId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(transferId, options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual TransferReversal Update(string transferId,  string reversalId, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateNestedEntity(transferId, reversalId, options, requestOptions);

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -58,6 +58,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<Transfer> ListAutoPagingAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual Transfer Update(string transferId, TransferUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(transferId, options, requestOptions);

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -33,5 +33,12 @@ namespace Stripe
         {
             return this.ListNestedEntitiesAutoPaging(subscriptionItemId, options, requestOptions);
         }
+
+#if !NET45
+        public virtual IAsyncEnumerable<UsageRecordSummary> ListAutoPagingAsync(string subscriptionItemId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListNestedEntitiesAutoPagingAsync(subscriptionItemId, options, requestOptions, cancellationToken);
+        }
+#endif
     }
 }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -68,6 +68,13 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
+#if !NET45
+        public virtual IAsyncEnumerable<WebhookEndpoint> ListAutoPagingAsync(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
         public virtual WebhookEndpoint Update(string endpointId, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null)
         {
             return this.UpdateEntity(endpointId, options, requestOptions);

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -139,6 +139,21 @@ namespace Stripe
                 requestOptions);
         }
 
+#if !NET45
+        protected IAsyncEnumerable<TEntityReturned> ListNestedEntitiesAutoPagingAsync(
+            string parentId,
+            ListOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
+        {
+            return this.ListRequestAutoPagingAsync<TEntityReturned>(
+                this.ClassUrl(parentId),
+                options,
+                requestOptions,
+                cancellationToken);
+        }
+#endif
+
         protected TEntityReturned UpdateNestedEntity(
             string parentId,
             string id,

--- a/src/Stripe.net/Services/_interfaces/IListable.cs
+++ b/src/Stripe.net/Services/_interfaces/IListable.cs
@@ -13,5 +13,9 @@ namespace Stripe
         Task<StripeList<TEntity>> ListAsync(TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
 
         IEnumerable<TEntity> ListAutoPaging(TOptions listOptions = null, RequestOptions requestOptions = null);
+
+#if !NET45
+        IAsyncEnumerable<TEntity> ListAutoPagingAsync(TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+#endif
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedListable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedListable.cs
@@ -13,5 +13,9 @@ namespace Stripe
         Task<StripeList<TEntity>> ListAsync(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
 
         IEnumerable<TEntity> ListAutoPaging(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null);
+
+#if !NET45
+        IAsyncEnumerable<TEntity> ListAutoPagingAsync(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+#endif
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -6,6 +6,9 @@
     <AssemblyTitle>Stripe.net</AssemblyTitle>
     <VersionPrefix>35.6.0</VersionPrefix>
     <Version>35.6.0</Version>
+    <LangVersion>8</LangVersion>
+    <VersionPrefix>35.3.0</VersionPrefix>
+    <Version>35.3.0</Version>
     <Authors>Stripe, Jayme Davis</Authors>
     <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Stripe.net</AssemblyName>
@@ -39,11 +42,15 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -216,10 +216,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var accounts = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(accounts);
-            Assert.Equal("account", accounts[0].Object);
+            var account = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(account);
+            Assert.Equal("account", account.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var account = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(account);
+            Assert.Equal("account", account.Object);
+        }
+#endif
 
         [Fact]
         public void Reject()

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -110,9 +110,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var domains = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(domains);
-            Assert.Equal("apple_pay_domain", domains[0].Object);
+            var domain = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(domain);
+            Assert.Equal("apple_pay_domain", domain.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var domain = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(domain);
+            Assert.Equal("apple_pay_domain", domain.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -109,10 +109,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var applicationFeeRefunds = this.service.ListAutoPaging(ApplicationFeeId, this.listOptions).ToList();
-            Assert.NotNull(applicationFeeRefunds);
-            Assert.Equal("fee_refund", applicationFeeRefunds[0].Object);
+            var applicationFeeRefund = this.service.ListAutoPaging(ApplicationFeeId, this.listOptions).First();
+            Assert.NotNull(applicationFeeRefund);
+            Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var applicationFeeRefund = await this.service.ListAutoPagingAsync(ApplicationFeeId, this.listOptions).FirstAsync();
+            Assert.NotNull(applicationFeeRefund);
+            Assert.Equal("fee_refund", applicationFeeRefund.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -70,9 +70,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var applicationFees = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(applicationFees);
-            Assert.Equal("application_fee", applicationFees[0].Object);
+            var applicationFee = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(applicationFee);
+            Assert.Equal("application_fee", applicationFee.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var applicationFee = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(applicationFee);
+            Assert.Equal("application_fee", applicationFee.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -287,6 +287,356 @@ namespace StripeTests
                     ItExpr.IsAny<CancellationToken>());
         }
 
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.0.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK);
+            response3.Content = new StringContent(GetResourceAsString("pageable_models.2.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Returns(Task.FromResult(response3))
+                .Throws(new StripeTestException("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService(this.StripeClient);
+            var options = new ListOptions
+            {
+                Limit = 2,
+            };
+            var models = await service.ListAutoPagingAsync(options).ToListAsync();
+
+            // Check results
+            Assert.Equal(5, models.Count);
+            Assert.Equal("pm_123", models[0].Id);
+            Assert.Equal("pm_124", models[1].Id);
+            Assert.Equal("pm_125", models[2].Id);
+            Assert.Equal("pm_126", models[3].Id);
+            Assert.Equal("pm_127", models[4].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_126"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ListAutoPagingAsync_NoParams()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.0.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK);
+            response3.Content = new StringContent(GetResourceAsString("pageable_models.2.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Returns(Task.FromResult(response3))
+                .Throws(new StripeTestException("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService(this.StripeClient);
+            var models = await service.ListAutoPagingAsync().ToListAsync();
+
+            // Check results
+            Assert.Equal(5, models.Count);
+            Assert.Equal("pm_123", models[0].Id);
+            Assert.Equal("pm_124", models[1].Id);
+            Assert.Equal("pm_125", models[2].Id);
+            Assert.Equal("pm_126", models[3].Id);
+            Assert.Equal("pm_127", models[4].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == string.Empty),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?starting_after=pm_124"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?starting_after=pm_126"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ListAutoPagingAsync_StartingAfter()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.2.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Throws(new StripeTestException("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService(this.StripeClient);
+            var options = new ListOptions
+            {
+                Limit = 2,
+                StartingAfter = "pm_124",
+            };
+            var models = await service.ListAutoPagingAsync(options).ToListAsync();
+
+            // Check results
+            Assert.Equal(3, models.Count);
+            Assert.Equal("pm_125", models[0].Id);
+            Assert.Equal("pm_126", models[1].Id);
+            Assert.Equal("pm_127", models[2].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_126"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ListAutoPagingAsync_EndingBefore()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.0.json"));
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK);
+            response3.Content = new StringContent(GetResourceAsString("pageable_models.0b.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Returns(Task.FromResult(response3))
+                .Throws(new StripeTestException("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService(this.StripeClient);
+            var options = new ListOptions
+            {
+                Limit = 2,
+                EndingBefore = "pm_127",
+            };
+            var models = await service.ListAutoPagingAsync(options).ToListAsync();
+
+            // Check results
+            Assert.Equal(5, models.Count);
+            Assert.Equal("pm_126", models[0].Id);
+            Assert.Equal("pm_125", models[1].Id);
+            Assert.Equal("pm_124", models[2].Id);
+            Assert.Equal("pm_123", models[3].Id);
+            Assert.Equal("pm_122", models[4].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&ending_before=pm_127"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&ending_before=pm_125"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&ending_before=pm_123"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ListAutoPagingAsync_WithCancellation()
+        {
+            // Set up stubbed requests
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK);
+            response1.Content = new StringContent(GetResourceAsString("pageable_models.0.json"));
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+            response2.Content = new StringContent(GetResourceAsString("pageable_models.1.json"));
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(response1))
+                .Returns(Task.FromResult(response2))
+                .Throws(new StripeTestException("Unexpected invocation!"));
+
+            // Call auto-paging method
+            var service = new PageableService(this.StripeClient);
+            var options = new ListOptions
+            {
+                Limit = 2,
+            };
+            var models = new List<PageableModel>();
+
+            var source = new CancellationTokenSource();
+
+            try
+            {
+                await foreach (var model in service.ListAutoPagingAsync(options).WithCancellation(source.Token))
+                {
+                    models.Add(model);
+
+                    // Cancel in the middle of the second page
+                    if (model.Id == "pm_125")
+                    {
+                        source.Cancel();
+                    }
+                }
+
+                Assert.True(false, "Exception OperationCanceledException to be thrown");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                source.Dispose();
+            }
+
+            // Check results
+            Assert.Equal(3, models.Count);
+            Assert.Equal("pm_123", models[0].Id);
+            Assert.Equal("pm_124", models[1].Id);
+            Assert.Equal("pm_125", models[2].Id);
+
+            // Check invocations
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2"),
+                    ItExpr.IsAny<CancellationToken>());
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Get &&
+                        m.RequestUri.AbsolutePath == "/v1/pageablemodels" &&
+                        m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+#endif
+
         public class PageableModel : StripeEntity<PageableModel>, IHasId
         {
             [JsonProperty("id")]
@@ -302,10 +652,17 @@ namespace StripeTests
 
             public override string BasePath => "/v1/pageablemodels";
 
-            public IEnumerable<PageableModel> ListAutoPaging(ListOptions options = null)
+            public IEnumerable<PageableModel> ListAutoPaging(ListOptions options = null, RequestOptions requestOptions = null)
             {
-                return this.ListEntitiesAutoPaging(options, null);
+                return this.ListEntitiesAutoPaging(options, requestOptions);
             }
+
+#if !NET45
+            public IAsyncEnumerable<PageableModel> ListAutoPagingAsync(ListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+            {
+                return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            }
+#endif
         }
     }
 }

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -70,9 +70,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var balanceTransactions = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(balanceTransactions);
-            Assert.Equal("balance_transaction", balanceTransactions[0].Object);
+            var balanceTransaction = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(balanceTransaction);
+            Assert.Equal("balance_transaction", balanceTransaction.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var balanceTransaction = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(balanceTransaction);
+            Assert.Equal("balance_transaction", balanceTransaction.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -125,9 +125,18 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var bankAccounts = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
-            Assert.NotNull(bankAccounts);
+            var bankAccount = this.service.ListAutoPaging(CustomerId, this.listOptions).First();
+            Assert.NotNull(bankAccount);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var bankAccount = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
+            Assert.NotNull(bankAccount);
+        }
+#endif
 
         // stripe-mock does not return a bank account object on update today so we do not test
         // the returned value's object

--- a/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
@@ -76,10 +76,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var capabilities = this.service.ListAutoPaging(AccountId, this.listOptions).ToList();
-            Assert.NotNull(capabilities);
-            Assert.Equal("capability", capabilities[0].Object);
+            var capabilitie = this.service.ListAutoPaging(AccountId, this.listOptions).First();
+            Assert.NotNull(capabilitie);
+            Assert.Equal("capability", capabilitie.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var capabilitie = await this.service.ListAutoPagingAsync(AccountId, this.listOptions).FirstAsync();
+            Assert.NotNull(capabilitie);
+            Assert.Equal("capability", capabilitie.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -119,9 +119,18 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var cards = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
-            Assert.NotNull(cards);
+            var card = this.service.ListAutoPaging(CustomerId, this.listOptions).First();
+            Assert.NotNull(card);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var card = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
+            Assert.NotNull(card);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -130,10 +130,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var charges = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(charges);
-            Assert.Equal("charge", charges[0].Object);
+            var charge = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(charge);
+            Assert.Equal("charge", charge.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var charge = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(charge);
+            Assert.Equal("charge", charge.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -134,9 +134,19 @@ namespace StripeTests.Checkout
         [Fact]
         public void ListAutoPaging()
         {
-            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(intents);
-            Assert.Equal("checkout.session", intents[0].Object);
+            var intent = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(intent);
+            Assert.Equal("checkout.session", intent.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var intent = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(intent);
+            Assert.Equal("checkout.session", intent.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -70,9 +70,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var countrySpecs = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(countrySpecs);
-            Assert.Equal("country_spec", countrySpecs[0].Object);
+            var countrySpec = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(countrySpec);
+            Assert.Equal("country_spec", countrySpec.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var countrySpec = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(countrySpec);
+            Assert.Equal("country_spec", countrySpec.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -121,10 +121,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var coupons = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(coupons);
-            Assert.Equal("coupon", coupons[0].Object);
+            var coupon = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(coupon);
+            Assert.Equal("coupon", coupon.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var coupon = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(coupon);
+            Assert.Equal("coupon", coupon.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
+++ b/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
@@ -132,10 +132,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var creditNotes = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(creditNotes);
-            Assert.Equal("credit_note", creditNotes[0].Object);
+            var creditNote = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(creditNote);
+            Assert.Equal("credit_note", creditNote.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var creditNote = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(creditNote);
+            Assert.Equal("credit_note", creditNote.Object);
+        }
+#endif
 
         [Fact]
         public void ListLineItems()
@@ -162,10 +172,20 @@ namespace StripeTests
         [Fact]
         public void ListLineItemsAutoPaging()
         {
-            var lineItems = this.service.ListLineItemsAutoPaging(CreditNoteId, this.listLineItemsOptions).ToList();
-            Assert.NotNull(lineItems);
-            Assert.Equal("credit_note_line_item", lineItems[0].Object);
+            var lineItem = this.service.ListLineItemsAutoPaging(CreditNoteId, this.listLineItemsOptions).First();
+            Assert.NotNull(lineItem);
+            Assert.Equal("credit_note_line_item", lineItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListLineItemsAutoPagingAsync()
+        {
+            var lineItem = await this.service.ListLineItemsAutoPagingAsync(CreditNoteId, this.listLineItemsOptions).FirstAsync();
+            Assert.NotNull(lineItem);
+            Assert.Equal("credit_note_line_item", lineItem.Object);
+        }
+#endif
 
         [Fact]
         public void Preview()
@@ -210,10 +230,20 @@ namespace StripeTests
         [Fact]
         public void ListPreviewLineItemsAutoPaging()
         {
-            var lineItems = this.service.ListPreviewLineItemsAutoPaging(this.listPreviewLineItemsOptions).ToList();
-            Assert.NotNull(lineItems);
-            Assert.Equal("credit_note_line_item", lineItems[0].Object);
+            var lineItem = this.service.ListPreviewLineItemsAutoPaging(this.listPreviewLineItemsOptions).First();
+            Assert.NotNull(lineItem);
+            Assert.Equal("credit_note_line_item", lineItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListPreviewLineItemsAutoPagingAsync()
+        {
+            var lineItem = await this.service.ListPreviewLineItemsAutoPagingAsync(this.listPreviewLineItemsOptions).FirstAsync();
+            Assert.NotNull(lineItem);
+            Assert.Equal("credit_note_line_item", lineItem.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/CustomerBalanceTransactions/CustomerBalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/CustomerBalanceTransactions/CustomerBalanceTransactionServiceTest.cs
@@ -102,10 +102,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var transactions = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
-            Assert.NotNull(transactions);
-            Assert.Equal("customer_balance_transaction", transactions[0].Object);
+            var transaction = this.service.ListAutoPaging(CustomerId, this.listOptions).First();
+            Assert.NotNull(transaction);
+            Assert.Equal("customer_balance_transaction", transaction.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var transaction = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
+            Assert.NotNull(transaction);
+            Assert.Equal("customer_balance_transaction", transaction.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -121,10 +121,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var customers = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(customers);
-            Assert.Equal("customer", customers[0].Object);
+            var customer = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(customer);
+            Assert.Equal("customer", customer.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var customer = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(customer);
+            Assert.Equal("customer", customer.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -98,10 +98,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var disputes = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(disputes);
-            Assert.Equal("dispute", disputes[0].Object);
+            var dispute = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(dispute);
+            Assert.Equal("dispute", dispute.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var dispute = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(dispute);
+            Assert.Equal("dispute", dispute.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -70,9 +70,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var events = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(events);
-            Assert.Equal("event", events[0].Object);
+            var evt = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(evt);
+            Assert.Equal("event", evt.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var evt = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(evt);
+            Assert.Equal("event", evt.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
+++ b/src/StripeTests/Services/ExchangeRates/ExchangeRateServiceTest.cs
@@ -68,9 +68,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var exchangeRates = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(exchangeRates);
-            Assert.Equal("exchange_rate", exchangeRates[0].Object);
+            var exchangeRate = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(exchangeRate);
+            Assert.Equal("exchange_rate", exchangeRate.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var exchangeRate = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(exchangeRate);
+            Assert.Equal("exchange_rate", exchangeRate.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -126,9 +126,18 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var externalAccounts = this.service.ListAutoPaging(AccountId, this.listOptions).ToList();
-            Assert.NotNull(externalAccounts);
+            var externalAccount = this.service.ListAutoPaging(AccountId, this.listOptions).First();
+            Assert.NotNull(externalAccount);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var externalAccount = await this.service.ListAutoPagingAsync(AccountId, this.listOptions).FirstAsync();
+            Assert.NotNull(externalAccount);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -105,10 +105,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var domains = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(domains);
-            Assert.Equal("file_link", domains[0].Object);
+            var domain = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(domain);
+            Assert.Equal("file_link", domain.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var domain = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(domain);
+            Assert.Equal("file_link", domain.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -106,9 +106,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var files = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(files);
-            Assert.Equal("file", files[0].Object);
+            var file = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(file);
+            Assert.Equal("file", file.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var file = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(file);
+            Assert.Equal("file", file.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -122,10 +122,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var invoiceItems = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(invoiceItems);
-            Assert.Equal("invoiceitem", invoiceItems[0].Object);
+            var invoiceItem = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(invoiceItem);
+            Assert.Equal("invoiceitem", invoiceItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var invoiceItem = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(invoiceItem);
+            Assert.Equal("invoiceitem", invoiceItem.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -189,10 +189,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var invoices = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(invoices);
-            Assert.Equal("invoice", invoices[0].Object);
+            var invoice = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var invoice = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(invoice);
+            Assert.Equal("invoice", invoice.Object);
+        }
+#endif
 
         [Fact]
         public void ListLineItems()
@@ -219,10 +229,20 @@ namespace StripeTests
         [Fact]
         public void ListLineItemsAutoPaging()
         {
-            var lineItems = this.service.ListLineItemsAutoPaging(InvoiceId, this.listLineItemsOptions).ToList();
-            Assert.NotNull(lineItems);
-            Assert.Equal("line_item", lineItems[0].Object);
+            var lineItem = this.service.ListLineItemsAutoPaging(InvoiceId, this.listLineItemsOptions).First();
+            Assert.NotNull(lineItem);
+            Assert.Equal("line_item", lineItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListLineItemsAutoPagingAsync()
+        {
+            var lineItem = await this.service.ListLineItemsAutoPagingAsync(InvoiceId, this.listLineItemsOptions).FirstAsync();
+            Assert.NotNull(lineItem);
+            Assert.Equal("line_item", lineItem.Object);
+        }
+#endif
 
         [Fact]
         public void ListUpcomingLineItems()
@@ -249,10 +269,20 @@ namespace StripeTests
         [Fact]
         public void ListUpcomingLineItemsAutoPaging()
         {
-            var lineItems = this.service.ListUpcomingLineItemsAutoPaging(this.upcomingListLineItemsOptions).ToList();
-            Assert.NotNull(lineItems);
-            Assert.Equal("line_item", lineItems[0].Object);
+            var lineItem = this.service.ListUpcomingLineItemsAutoPaging(this.upcomingListLineItemsOptions).First();
+            Assert.NotNull(lineItem);
+            Assert.Equal("line_item", lineItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListUpcomingLineItemsAutoPagingAsync()
+        {
+            var lineItem = await this.service.ListUpcomingLineItemsAutoPagingAsync(this.upcomingListLineItemsOptions).FirstAsync();
+            Assert.NotNull(lineItem);
+            Assert.Equal("line_item", lineItem.Object);
+        }
+#endif
 
         [Fact]
         public void MarkUncollectible()

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -104,9 +104,20 @@ namespace StripeTests.Issuing
         [Fact]
         public void ListAutoPaging()
         {
-            var authorizations = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(authorizations);
+            var authorization = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(authorization);
+            Assert.Equal("issuing.authorization", authorization.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var authorization = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(authorization);
+            Assert.Equal("issuing.authorization", authorization.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -145,9 +145,20 @@ namespace StripeTests.Issuing
         [Fact]
         public void ListAutoPaging()
         {
-            var cardholders = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(cardholders);
+            var cardholder = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(cardholder);
+            Assert.Equal("issuing.cardholder", cardholder.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var cardholder = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(cardholder);
+            Assert.Equal("issuing.cardholder", cardholder.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -126,9 +126,20 @@ namespace StripeTests.Issuing
         [Fact]
         public void ListAutoPaging()
         {
-            var cards = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(cards);
+            var card = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(card);
+            Assert.Equal("issuing.card", card.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var card = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(card);
+            Assert.Equal("issuing.card", card.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -103,9 +103,20 @@ namespace StripeTests.Issuing
         [Fact]
         public void ListAutoPaging()
         {
-            var disputes = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(disputes);
+            var dispute = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(dispute);
+            Assert.Equal("issuing.dispute", dispute.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var dispute = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(dispute);
+            Assert.Equal("issuing.dispute", dispute.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -72,9 +72,20 @@ namespace StripeTests.Issuing
         [Fact]
         public void ListAutoPaging()
         {
-            var transactions = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(transactions);
+            var transaction = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(transaction);
+            Assert.Equal("issuing.transaction", transaction.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var transaction = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(transaction);
+            Assert.Equal("issuing.transaction", transaction.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -131,10 +131,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var orders = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(orders);
-            Assert.Equal("order", orders[0].Object);
+            var order = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(order);
+            Assert.Equal("order", order.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var order = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(order);
+            Assert.Equal("order", order.Object);
+        }
+#endif
 
         [Fact]
         public void Pay()

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -198,10 +198,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(intents);
-            Assert.Equal("payment_intent", intents[0].Object);
+            var intent = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(intent);
+            Assert.Equal("payment_intent", intent.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var intent = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(intent);
+            Assert.Equal("payment_intent", intent.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
+++ b/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
@@ -156,9 +156,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var payment_methods = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(payment_methods);
-            Assert.Equal("payment_method", payment_methods[0].Object);
+            var payment_method = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(payment_method);
+            Assert.Equal("payment_method", payment_method.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var payment_method = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(payment_method);
+            Assert.Equal("payment_method", payment_method.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -123,10 +123,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var payouts = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(payouts);
-            Assert.Equal("payout", payouts[0].Object);
+            var payout = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(payout);
+            Assert.Equal("payout", payout.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var payout = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(payout);
+            Assert.Equal("payout", payout.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -148,10 +148,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var persons = this.service.ListAutoPaging(AccountId, this.listOptions).ToList();
-            Assert.NotNull(persons);
-            Assert.Equal("person", persons[0].Object);
+            var person = this.service.ListAutoPaging(AccountId, this.listOptions).First();
+            Assert.NotNull(person);
+            Assert.Equal("person", person.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var person = await this.service.ListAutoPagingAsync(AccountId, this.listOptions).FirstAsync();
+            Assert.NotNull(person);
+            Assert.Equal("person", person.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -170,10 +170,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var plans = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(plans);
-            Assert.Equal("plan", plans[0].Object);
+            var plan = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(plan);
+            Assert.Equal("plan", plan.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var plan = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(plan);
+            Assert.Equal("plan", plan.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -133,10 +133,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var products = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(products);
-            Assert.Equal("product", products[0].Object);
+            var product = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(product);
+            Assert.Equal("product", product.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var product = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(product);
+            Assert.Equal("product", product.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
+++ b/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
@@ -72,9 +72,19 @@ namespace StripeTests.Radar
         [Fact]
         public void ListAutoPaging()
         {
-            var warnings = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(warnings);
-            Assert.Equal("radar.early_fraud_warning", warnings[0].Object);
+            var warning = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(warning);
+            Assert.Equal("radar.early_fraud_warning", warning.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var warning = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(warning);
+            Assert.Equal("radar.early_fraud_warning", warning.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -112,9 +112,19 @@ namespace StripeTests.Radar
         [Fact]
         public void ListAutoPaging()
         {
-            var valueListItems = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(valueListItems);
-            Assert.Equal("radar.value_list_item", valueListItems[0].Object);
+            var valueListItem = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(valueListItem);
+            Assert.Equal("radar.value_list_item", valueListItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var valueListItem = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(valueListItem);
+            Assert.Equal("radar.value_list_item", valueListItem.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -123,10 +123,20 @@ namespace StripeTests.Radar
         [Fact]
         public void ListAutoPaging()
         {
-            var valueLists = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(valueLists);
-            Assert.Equal("radar.value_list", valueLists[0].Object);
+            var valueList = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(valueList);
+            Assert.Equal("radar.value_list", valueList.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var valueList = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(valueList);
+            Assert.Equal("radar.value_list", valueList.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -105,10 +105,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var refunds = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(refunds);
-            Assert.Equal("refund", refunds[0].Object);
+            var refund = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(refund);
+            Assert.Equal("refund", refund.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var refund = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(refund);
+            Assert.Equal("refund", refund.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -89,8 +89,17 @@ namespace StripeTests.Reporting
         [Fact]
         public void ListAutoPaging()
         {
-            var reportRuns = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(reportRuns);
+            var reportRun = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(reportRun);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var reportRun = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(reportRun);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -61,8 +61,17 @@ namespace StripeTests.Reporting
         [Fact]
         public void ListAutoPaging()
         {
-            var reportTypes = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(reportTypes);
+            var reportType = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(reportType);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var reportType = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(reportType);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -92,9 +92,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var reviews = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(reviews);
-            Assert.Equal("review", reviews[0].Object);
+            var review = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(review);
+            Assert.Equal("review", review.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var review = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(review);
+            Assert.Equal("review", review.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
+++ b/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
@@ -166,10 +166,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var intents = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(intents);
-            Assert.Equal("setup_intent", intents[0].Object);
+            var intent = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var intent = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(intent);
+            Assert.Equal("setup_intent", intent.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -70,9 +70,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var runs = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(runs);
-            Assert.Equal("scheduled_query_run", runs[0].Object);
+            var run = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(run);
+            Assert.Equal("scheduled_query_run", run.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var run = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(run);
+            Assert.Equal("scheduled_query_run", run.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -139,10 +139,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var skus = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(skus);
-            Assert.Equal("sku", skus[0].Object);
+            var sku = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(sku);
+            Assert.Equal("sku", sku.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var sku = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(sku);
+            Assert.Equal("sku", sku.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -52,9 +52,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var sourceTransactions = this.service.ListAutoPaging(SourceId, this.listOptions).ToList();
-            Assert.NotNull(sourceTransactions);
-            Assert.Equal("source_transaction", sourceTransactions[0].Object);
+            var sourceTransaction = this.service.ListAutoPaging(SourceId, this.listOptions).First();
+            Assert.NotNull(sourceTransaction);
+            Assert.Equal("source_transaction", sourceTransaction.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var sourceTransaction = await this.service.ListAutoPagingAsync(SourceId, this.listOptions).FirstAsync();
+            Assert.NotNull(sourceTransaction);
+            Assert.Equal("source_transaction", sourceTransaction.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -210,9 +210,18 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var sources = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
-            Assert.NotNull(sources);
+            var source = this.service.ListAutoPaging(CustomerId, this.listOptions).First();
+            Assert.NotNull(source);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var source = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
+            Assert.NotNull(source);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -129,10 +129,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var subscriptionItems = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(subscriptionItems);
-            Assert.Equal("subscription_item", subscriptionItems[0].Object);
+            var subscriptionItem = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(subscriptionItem);
+            Assert.Equal("subscription_item", subscriptionItem.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var subscriptionItem = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(subscriptionItem);
+            Assert.Equal("subscription_item", subscriptionItem.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -136,10 +136,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var subscriptions = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(subscriptions);
-            Assert.Equal("subscription_schedule", subscriptions[0].Object);
+            var subscription = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var subscription = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription_schedule", subscription.Object);
+        }
+#endif
 
         [Fact]
         public void Release()

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -142,10 +142,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var subscriptions = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(subscriptions);
-            Assert.Equal("subscription", subscriptions[0].Object);
+            var subscription = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription", subscription.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var subscription = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(subscription);
+            Assert.Equal("subscription", subscription.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
+++ b/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
@@ -114,9 +114,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var persons = this.service.ListAutoPaging(CustomerId, this.listOptions).ToList();
-            Assert.NotNull(persons);
-            Assert.Equal("tax_id", persons[0].Object);
+            var person = this.service.ListAutoPaging(CustomerId, this.listOptions).First();
+            Assert.NotNull(person);
+            Assert.Equal("tax_id", person.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var person = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
+            Assert.NotNull(person);
+            Assert.Equal("tax_id", person.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -106,10 +106,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var taxRates = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(taxRates);
-            Assert.Equal("tax_rate", taxRates[0].Object);
+            var taxRate = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var taxRate = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(taxRate);
+            Assert.Equal("tax_rate", taxRate.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -114,10 +114,20 @@ namespace StripeTests.Terminal
         [Fact]
         public void ListAutoPaging()
         {
-            var locations = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(locations);
-            Assert.Equal("terminal.location", locations[0].Object);
+            var location = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(location);
+            Assert.Equal("terminal.location", location.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var location = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(location);
+            Assert.Equal("terminal.location", location.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -107,10 +107,20 @@ namespace StripeTests.Terminal
         [Fact]
         public void ListAutoPaging()
         {
-            var readers = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(readers);
-            Assert.Equal("terminal.reader", readers[0].Object);
+            var reader = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(reader);
+            Assert.Equal("terminal.reader", reader.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var reader = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(reader);
+            Assert.Equal("terminal.reader", reader.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -124,10 +124,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var topups = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(topups);
-            Assert.Equal("topup", topups[0].Object);
+            var topup = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(topup);
+            Assert.Equal("topup", topup.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var topup = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(topup);
+            Assert.Equal("topup", topup.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -105,10 +105,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var transferReversals = this.service.ListAutoPaging(TransferId, this.listOptions).ToList();
-            Assert.NotNull(transferReversals);
-            Assert.Equal("transfer_reversal", transferReversals[0].Object);
+            var transferReversal = this.service.ListAutoPaging(TransferId, this.listOptions).First();
+            Assert.NotNull(transferReversal);
+            Assert.Equal("transfer_reversal", transferReversal.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var transferReversal = await this.service.ListAutoPagingAsync(TransferId, this.listOptions).FirstAsync();
+            Assert.NotNull(transferReversal);
+            Assert.Equal("transfer_reversal", transferReversal.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -106,10 +106,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var transfers = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(transfers);
-            Assert.Equal("transfer", transfers[0].Object);
+            var transfer = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(transfer);
+            Assert.Equal("transfer", transfer.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var transfer = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(transfer);
+            Assert.Equal("transfer", transfer.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -51,9 +51,19 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var summaries = this.service.ListAutoPaging(SubscriptionItemId, this.listOptions).ToList();
-            Assert.NotNull(summaries);
-            Assert.Equal("usage_record_summary", summaries[0].Object);
+            var summarie = this.service.ListAutoPaging(SubscriptionItemId, this.listOptions).First();
+            Assert.NotNull(summarie);
+            Assert.Equal("usage_record_summary", summarie.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var summarie = await this.service.ListAutoPagingAsync(SubscriptionItemId, this.listOptions).FirstAsync();
+            Assert.NotNull(summarie);
+            Assert.Equal("usage_record_summary", summarie.Object);
+        }
+#endif
     }
 }

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -124,10 +124,20 @@ namespace StripeTests
         [Fact]
         public void ListAutoPaging()
         {
-            var endpoints = this.service.ListAutoPaging(this.listOptions).ToList();
-            Assert.NotNull(endpoints);
-            Assert.Equal("webhook_endpoint", endpoints[0].Object);
+            var endpoint = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(endpoint);
+            Assert.Equal("webhook_endpoint", endpoint.Object);
         }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var endpoint = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(endpoint);
+            Assert.Equal("webhook_endpoint", endpoint.Object);
+        }
+#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -106,6 +106,13 @@ namespace StripeTests
             {
                 return this.ListEntitiesAutoPaging(options, requestOptions);
             }
+
+#if !NET45
+            public virtual IAsyncEnumerable<TestEntity> ListAutoPagingAsync(ListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+            {
+                return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            }
+#endif
         }
     }
 }

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.0;net461;net45</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
+    <LangVersion>8</LangVersion>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +27,16 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
r? @brandur-stripe @cjavilla-stripe @remi-stripe 
cc @stripe/api-libraries 

This PR adds support for asynchronous autopagination, using the new [`IAsyncEnumerable<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.iasyncenumerable-1?view=netcore-3.1) interface introduced in [C# 8](https://docs.microsoft.com/en-us/archive/msdn-magazine/2019/november/csharp-iterating-with-async-enumerables-in-csharp-8).

Normally, this would require .NET Standard 2.1, but we can use it without changing our target of .NET Standard 2.0 thanks to the [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/) package. Unfortunately there is (AFAIK) no way to support this with .NET Framework 4.5, so I had to add a gazillion `#if !NET45` preprocessor macros.

This PR is very large and I should have done a better job of splitting it into smaller commits, but it shouldn't be too hard to review:
- the core of the implementation is in `Service.cs`, in the new `ListRequestAutoPagingAsync<T>` method: https://github.com/stripe/stripe-dotnet/pull/1947/files#diff-0de0406b0f5569892ed33a084f9759ceR275. The implementation is very similar to the old synchronous `ListRequestAutoPaging<T>` method. The main differences are:
    - it uses `RequestAsync` instead of `Request` to fetch the pages
    - it has an additional `CancellationToken` parameter, and there are a couple of `cancellationToken.ThrowIfCancellationRequested();` in the loops to check if we need to stop iterating
- `Service.cs` has a new `ListEntitiesAutoPagingAsync` helper method: https://github.com/stripe/stripe-dotnet/pull/1947/files#diff-0de0406b0f5569892ed33a084f9759ceR169, and similarly `ServiceNested.cs` has a new `ListNestedEntitiesAutoPagingAsync` helper method: https://github.com/stripe/stripe-dotnet/pull/1947/files#diff-efcfb49f6a90c39650225af44e8ad09fR143
- the `IListable` and `INestedListable` interfaces were updated with a new `ListAutoPagingAsync` signature
- every service was updated to add the new `ListAutoPagingAsync` methods

For tests:
- `AutoPagingTest.cs` was updated to add tests for the new async methods. `ListAutoPagingAsync`, ListAutoPagingAsync_NoParams`, `ListAutoPagingAsync_StartingAfter` and `ListAutoPagingAsync_EndingBefore` are copies of the tests for the synchronous methods. `ListAutoPagingAsync_WithCancellation` is a new test unique to the async version to test the cancellation behavior.
- Every `ListAutoPaging` test in service test classes was updated to use `First()` instead of `ToList()`. [`ToList()`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tolist?view=netframework-4.8) forces the conversion of the `IEnumerable` into a `List`, which could cause many requests if there were many pages to fetch. This is not actually an issue when using stripe-mock, but better safe than sorry
- New `ListAutoPagingAsync` tests were added to all service test classes.

Fixes #1946.
