### PR TITLE
Add a handful of missing features

### DIFF
--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainListOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainListOptions.cs
@@ -4,5 +4,7 @@ namespace Stripe
 
     public class ApplePayDomainListOptions : ListOptions
     {
+        [JsonProperty("domain_name")]
+        public string DomainName { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
@@ -16,6 +16,9 @@ namespace Stripe.Issuing
         [JsonProperty("last4")]
         public string Last4 { get; set; }
 
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
         [JsonProperty("source")]
         public string Source { get; set; }
 

--- a/src/Stripe.net/Services/Sources/SourceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceUpdateOptions.cs
@@ -7,6 +7,12 @@ namespace Stripe
     public class SourceUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
+        /// Amount associated with the source.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
         /// Information about a mandate possiblity attached to a source object (generally for bank debits) as well as its acceptance status.
         /// </summary>
         [JsonProperty("mandate")]

--- a/src/Stripe.net/Services/Topups/TopupCreateOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupCreateOptions.cs
@@ -46,5 +46,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
+
+        /// <summary>
+        /// A string that identifies this top-up as part of a group.
+        /// </summary>
+        [JsonProperty("transfer_group")]
+        public string TransferGroup { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupListOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupListOptions.cs
@@ -1,6 +1,10 @@
 namespace Stripe
 {
+    using Newtonsoft.Json;
+
     public class TopupListOptions : ListOptionsWithCreated
     {
+        [JsonProperty("status")]
+        public string Status { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupUpdateOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupUpdateOptions.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class TopupUpdateOptions : BaseOptions, IHasMetadata
     {
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
     }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Note: I didn't add support for listing topups by amount, because we don't have a LongRangeOptions yet. Other than that, these are all (I think!) of the fields that were discovered for options classes when running autogen.