### PR TITLE
Add support for `ThreeDSecure` on Issuing `Authorization`

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationVerificationDataThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationVerificationDataThreeDSecure.cs
@@ -1,0 +1,13 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class AuthorizationVerificationDataThreeDSecure : StripeEntity<AuthorizationVerificationDataThreeDSecure>
+    {
+        /// <summary>
+        /// The outcome of the 3D Secure authentication request.
+        /// </summary>
+        [JsonProperty("result")]
+        public string Result { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/VerificationData.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/VerificationData.cs
@@ -1,5 +1,6 @@
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
 
     public class VerificationData : StripeEntity<VerificationData>
@@ -19,6 +20,7 @@ namespace Stripe.Issuing
         /// <summary>
         /// One of <c>success</c>, <c>failure</c>, <c>exempt</c>, or <c>none</c>.
         /// </summary>
+        [Obsolete("Use ThreeDSecure instead")]
         [JsonProperty("authentication")]
         public string Authentication { get; set; }
 
@@ -33,5 +35,11 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("expiry_check")]
         public string ExpiryCheck { get; set; }
+
+        /// <summary>
+        /// 3D Secure details on this authorization.
+        /// </summary>
+        [JsonProperty("three_d_secure")]
+        public AuthorizationVerificationDataThreeDSecure ThreeDSecure { get; set; }
     }
 }


### PR DESCRIPTION
Docs: https://stripe.com/docs/api/issuing/authorizations/object#issuing_authorization_object-verification_data-three_d_secure

r? @ob-stripe 
cc @stripe/api-libraries 