### PR TITLE
Add net461 as a target framework

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -24,6 +24,8 @@ namespace Stripe
         private const string StripeNetTargetFramework =
 #if NETSTANDARD2_0
             "netstandard2.0"
+#elif NET461
+            "net461"
 #elif NET45
             "net45"
 #else

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>35.6.0</VersionPrefix>
     <Version>35.6.0</Version>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
     <AssemblyName>Stripe.net</AssemblyName>
     <PackageId>Stripe.net</PackageId>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
@@ -38,24 +38,20 @@
     <CodeAnalysisRuleSet>..\_stylecop\StyleCopRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.0;net461;net45</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <PackageId>StripeTests</PackageId>
     <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
@@ -26,9 +26,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
r? @cjavilla-stripe @remi-stripe 
cc @stripe/api-libraries 

Add `net461` (i.e. .NET Framework 4.6.1) as a target framework.

.NET Framework 4.6.1 is compatible with .NET Standard 2.0 (see https://docs.microsoft.com/en-us/dotnet/standard/net-standard), so in theory this shouldn't be needed, but there are a couple of reasons for this PR:
- currently, users running on .NET Framework 4.6.1 or more recent are using the `net45` assembly rather than the `netstandard2.0` one. This is not an issue at the moment, but it will be once #1947 is merged as those users would not be able to benefit from async autopagination despite the fact that their runtime can support it
- help us better measure the proportion of users still running on .NET Framework >= 4.5 but < 4.6.1. I suspect there are few such users and we'd eventually want to drop support for those versions
