### PR TITLE
Add new fields to Issuing `Card` and `Authorization`

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -20,6 +20,12 @@ namespace Stripe.Issuing
         public string Object { get; set; }
 
         /// <summary>
+        /// The total amount in the card's currency that was authorized or rejected.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
         /// Whether the authorization has been approved.
         /// </summary>
         [JsonProperty("approved")]
@@ -32,16 +38,11 @@ namespace Stripe.Issuing
         [JsonProperty("authorization_method")]
         public string AuthorizationMethod { get; set; }
 
-        /// <summary>
-        /// The amount that has been authorized. This will be 0 when the object is created, and
-        /// increase after it has been approved.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("authorized_amount")]
         public long AuthorizedAmount { get; set; }
 
-        /// <summary>
-        /// The currency that was presented to the cardholder for the authorization.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("authorized_currency")]
         public string AuthorizedCurrency { get; set; }
 
@@ -92,24 +93,20 @@ namespace Stripe.Issuing
         public DateTime Created { get; set; }
 
         /// <summary>
-        /// The amount the authorization is expected to be in the currency it's held in. When Stripe
-        /// holds funds from you, this is the amount reserved for the authorization. This will be 0
-        /// when the object is created, and increase after it has been approved. For multi-currency
-        /// transactions, held_amount can be used to determine the expected exchange rate.
+        /// Three-letter ISO currency code. Must be a supported currency.
         /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [Obsolete]
         [JsonProperty("held_amount")]
         public long HeldAmount { get; set; }
 
-        /// <summary>
-        /// The currency of the held amount. This will always be the card currency.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("held_currency")]
         public string HeldCurrency { get; set; }
 
-        /// <summary>
-        /// If set to <c>true</c>, you may provide <see cref="HeldAmount"/> to control how much to
-        /// hold for the authorization.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("is_held_amount_controllable")]
         public bool IsHeldAmountControllable { get; set; }
 
@@ -119,6 +116,19 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
+
+        /// <summary>
+        /// The total amount that was authorized or rejected in the local
+        /// <see cref="MerchantCurrency"/>.
+        /// </summary>
+        [JsonProperty("merchant_amount")]
+        public long MerchantAmount { get; set; }
+
+        /// <summary>
+        /// The currency of the held amount. This will always be the card currency.
+        /// </summary>
+        [JsonProperty("merchant_currency")]
+        public string MerchantCurrency { get; set; }
 
         /// <summary>
         /// Details about the merchant (grocery store, e-commerce website, etc.) where the card
@@ -133,25 +143,26 @@ namespace Stripe.Issuing
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        /// <summary>
-        /// The amount the user is requesting to be authorized. This field will only be non-zero
-        /// during an issuing.authorization.request webhook.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("pending_authorized_amount")]
         public long PendingAuthorizedAmount { get; set; }
 
-        /// <summary>
-        /// The additional amount Stripe will hold if the authorization is approved. This field will
-        /// only be non-zero during an issuing.authorization.request webhook.
-        /// </summary>
+        [Obsolete]
         [JsonProperty("pending_held_amount")]
         public long PendingHeldAmount { get; set; }
 
         /// <summary>
+        /// The pending authorization request. This field will only be non-null during an
+        /// <see cref="Events.IssuingAuthorizationRequest" /> webhook.
+        /// </summary>
+        [JsonProperty("pending_request")]
+        public AuthorizationPendingRequest PendingRequest { get; set; }
+
+        /// <summary>
         /// History of every time the authorization was approved/denied (whether approved/denied by
-        /// you directly, or by Stripe based on your authorization_controls). If the merchant
+        /// you directly, or by Stripe based on your authorization controls). If the merchant
         /// changes the authorization by performing an incremental authorization or partial capture,
-        /// you can look at request_history to see the previous states of the authorization.
+        /// you can look at the request history to see the previous states of the authorization.
         /// </summary>
         [JsonProperty("request_history")]
         public List<RequestHistory> RequestHistory { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequest.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequest.cs
@@ -1,0 +1,43 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class AuthorizationPendingRequest : StripeEntity<AuthorizationPendingRequest>
+    {
+        /// <summary>
+        /// The additional amount Stripe will hold if the authorization is approved, in the
+        /// currency, which is always the card’s currency.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// If set <c>true</c>, you may provide <c>Amount</c> to control how much to hold for the
+        /// authorization.
+        /// </summary>
+        [JsonProperty("is_amount_controllable")]
+        public bool IsAmountControllable { get; set; }
+
+        /// <summary>
+        /// The amount the merchant is requesting to be authorized in the
+        /// <see cref="MerchantCurrency"/>.
+        /// </summary>
+        [JsonProperty("merchant_amount")]
+        public long MerchantAmount { get; set; }
+
+        /// <summary>
+        /// The local currency the merchant is requesting to authorize.
+        /// </summary>
+        [JsonProperty("merchant_currency")]
+        public string MerchantCurrency { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/RequestHistory.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/RequestHistory.cs
@@ -8,20 +8,22 @@ namespace Stripe.Issuing
     public class RequestHistory : StripeEntity<RequestHistory>
     {
         /// <summary>
+        /// The total amount in the card's currency that was authorized or rejected.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
         /// Whether this request was approved.
         /// </summary>
         [JsonProperty("approved")]
         public bool Approved { get; set; }
 
-        /// <summary>
-        /// The amount that was authorized at the time of this request.
-        /// </summary>
+        [Obsolete("This field is considered deprecated.")]
         [JsonProperty("authorized_amount")]
         public long AuthorizedAmount { get; set; }
 
-        /// <summary>
-        /// The currency that was presented to the cardholder for the authorization.
-        /// </summary>
+        [Obsolete("This field is considered deprecated.")]
         [JsonProperty("authorized_currency")]
         public string AuthorizedCurrency { get; set; }
 
@@ -32,18 +34,26 @@ namespace Stripe.Issuing
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
-        /// <summary>
-        /// The amount Stripe held from your account to fund the authorization, if the request was
-        /// approved.
-        /// </summary>
+        [Obsolete("This field is considered deprecated.")]
         [JsonProperty("held_amount")]
         public long HeldAmount { get; set; }
 
-        /// <summary>
-        /// The currency of the held amount.
-        /// </summary>
+        [Obsolete("This field is considered deprecated.")]
         [JsonProperty("held_currency")]
         public string HeldCurrency { get; set; }
+
+        /// <summary>
+        /// The total amount that was authorized or rejected in the local
+        /// <see cref="MerchantCurrency"/>.
+        /// </summary>
+        [JsonProperty("merchant_amount")]
+        public long MerchantAmount { get; set; }
+
+        /// <summary>
+        /// The currency of the held amount. This will always be the card currency.
+        /// </summary>
+        [JsonProperty("merchant_currency")]
+        public string MerchantCurrency { get; set; }
 
         /// <summary>
         /// The reason for the approval or decline.

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -93,6 +93,33 @@ namespace Stripe.Issuing
         [JsonProperty("pin")]
         public CardPin Pin { get; set; }
 
+        #region Expandable ReplacedBy
+
+        /// <summary>
+        /// ID of the latest <see cref="Card"/> that replaces this card, if any.
+        /// </summary>
+        [JsonIgnore]
+        public string ReplacedById
+        {
+            get => this.InternalReplacedBy?.Id;
+            set => this.InternalReplacedBy = SetExpandableFieldId(value, this.InternalReplacedBy);
+        }
+
+        /// <summary>
+        /// (Expanded) The latest <see cref="Card"/> that replaces this card, if any.
+        /// </summary>
+        [JsonIgnore]
+        public Card ReplacedBy
+        {
+            get => this.InternalReplacedBy?.ExpandedObject;
+            set => this.InternalReplacedBy = SetExpandableFieldObject(value, this.InternalReplacedBy);
+        }
+
+        [JsonProperty("replaced_by")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Card>))]
+        internal ExpandableField<Card> InternalReplacedBy { get; set; }
+        #endregion
+
         #region Expandable ReplacementFor
 
         /// <summary>

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationApproveOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationApproveOptions.cs
@@ -3,7 +3,23 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class AuthorizationApproveOptions : BaseOptions
+    public class AuthorizationApproveOptions : BaseOptions, IHasMetadata
     {
+        /// <summary>
+        /// If the authorization’s <c>pending_request.is_amount_controllable</c> property is
+        /// <c>true</c>, you may provide this value to control how much to hold for the
+        /// authorization. Must be positive (use decline to decline an authorization request).
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format. Individual keys can be
+        /// unset by posting an empty value to them. All keys can be unset by posting an empty
+        /// value to metadata.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationDeclineOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationDeclineOptions.cs
@@ -3,7 +3,15 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class AuthorizationDeclineOptions : BaseOptions
+    public class AuthorizationDeclineOptions : BaseOptions, IHasMetadata
     {
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format. Individual keys can be
+        /// unset by posting an empty value to them. All keys can be unset by posting an empty
+        /// value to metadata.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }


### PR DESCRIPTION
Multiple API changes for Issuing `Card` and `Authorization`
  * Add `Amount` and `AmountCurrency` to `Authorization`
  * Add `MerchantAmount` and `MerchantCurrency` to `Authorization`
  * Add `PendingRequest` to `Authorization`
  * Add `ReplacedBy` to `Card`
  * Add `Amount` and `Metadata` to `AuthorizationApproveOptions`
  * Add `Metadata` to `AuthorizationDeclineOptions`

This is the same as https://github.com/stripe/stripe-dotnet/pull/1959 but with the correct base

r? @cjavilla-stripe 
cc @stripe/api-libraries 