### PR TITLE
Remove System.Linq.Async dependency

### DIFF
--- a/src/Stripe.net/Infrastructure/AsyncUtils.cs
+++ b/src/Stripe.net/Infrastructure/AsyncUtils.cs
@@ -1,0 +1,76 @@
+#if !NET45
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    internal static class AsyncUtils
+    {
+        /// <summary>
+        /// Converts an async-enumerable sequence to an enumerable sequence.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <param name="source">An async-enumerable sequence to convert to an enumerable sequence.</param>
+        /// <returns>The enumerable sequence containing the elements in the async-enumerable sequence.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        /// <remarks>
+        /// This code is largely borrowed from the System.Linq.Async project (see
+        /// https://github.com/dotnet/reactive/blob/7ad606b3dcd4bb2c6ae9622f8a59db7f8f52aa85/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToEnumerable.cs).
+        /// The reason we're not using System.Linq.Async directly is that it can cause issues with
+        /// some versions of EF Core (see https://github.com/stripe/stripe-dotnet/issues/1974).
+        /// </remarks>
+        public static IEnumerable<TSource> ToEnumerable<TSource>(IAsyncEnumerable<TSource> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var e = source.GetAsyncEnumerator(default);
+
+            try
+            {
+                while (true)
+                {
+                    if (!Wait(e.MoveNextAsync()))
+                    {
+                        break;
+                    }
+
+                    yield return e.Current;
+                }
+            }
+            finally
+            {
+                Wait(e.DisposeAsync());
+            }
+        }
+
+        private static void Wait(ValueTask task)
+        {
+            var awaiter = task.GetAwaiter();
+
+            if (!awaiter.IsCompleted)
+            {
+                task.AsTask().GetAwaiter().GetResult();
+                return;
+            }
+
+            awaiter.GetResult();
+        }
+
+        private static T Wait<T>(ValueTask<T> task)
+        {
+            var awaiter = task.GetAwaiter();
+
+            if (!awaiter.IsCompleted)
+            {
+                return task.AsTask().GetAwaiter().GetResult();
+            }
+
+            return awaiter.GetResult();
+        }
+    }
+}
+#endif

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -2,7 +2,6 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Reflection;
@@ -11,6 +10,7 @@ namespace Stripe
 #endif
     using System.Threading;
     using System.Threading.Tasks;
+    using Stripe.Infrastructure;
 
     /// <summary>Abstract base class for all services.</summary>
     /// <typeparam name="TEntityReturned">
@@ -268,8 +268,8 @@ namespace Stripe
             RequestOptions requestOptions)
             where T : IStripeEntity
         {
-            return this.ListRequestAutoPagingAsync<T>(url, options, requestOptions)
-                .ToEnumerable();
+            return AsyncUtils.ToEnumerable(
+                this.ListRequestAutoPagingAsync<T>(url, options, requestOptions));
         }
 
         protected async IAsyncEnumerable<T> ListRequestAutoPagingAsync<T>(

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -42,13 +42,11 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Remove the dependency on System.Linq.Async, by reimplementing the `.ToEnumerable()` method directly.

Fixes #1974.
