### PR TITLE
Fix deadlock in `AsyncUtils.ToEnumerable()`

### DIFF
--- a/src/Stripe.net/Infrastructure/AsyncUtils.cs
+++ b/src/Stripe.net/Infrastructure/AsyncUtils.cs
@@ -53,7 +53,7 @@ namespace Stripe.Infrastructure
 
             if (!awaiter.IsCompleted)
             {
-                task.AsTask().GetAwaiter().GetResult();
+                task.AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 return;
             }
 
@@ -66,7 +66,7 @@ namespace Stripe.Infrastructure
 
             if (!awaiter.IsCompleted)
             {
-                return task.AsTask().GetAwaiter().GetResult();
+                return task.AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             return awaiter.GetResult();


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

All async calls in libraries should use `ConfigureAwait(false)` to avoid deadlocks. This is the same issue that I fixed a while back in #1658.

This [blog post](https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f) explains why this is necessary.

Fixes the issue reported in https://github.com/stripe/stripe-dotnet/issues/1946#issuecomment-610873922. 