### PR TITLE
[wip] Add support for raw requests

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -5,7 +5,6 @@ namespace Stripe
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
-    using Stripe.Infrastructure;
     using Stripe.Infrastructure.FormEncoding;
 
     /// <summary>

--- a/src/Stripe.net/Services/_base/BaseOptions.cs
+++ b/src/Stripe.net/Services/_base/BaseOptions.cs
@@ -61,5 +61,25 @@ namespace Stripe
         {
             this.ExtraParams.Add(key, value);
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseOptions"/> class from a dictionary.
+        /// </summary>
+        /// <param name="dict">The dictionary.</param>
+        /// <returns>The new instance.</returns>
+        internal static BaseOptions FromDictionary(IDictionary<string, object> dict)
+        {
+            var options = new BaseOptions();
+
+            if (dict != null)
+            {
+                foreach (KeyValuePair<string, object> entry in dict)
+                {
+                    options.AddExtraParam(entry.Key, entry.Value);
+                }
+            }
+
+            return options;
+        }
     }
 }


### PR DESCRIPTION
cc @remi-stripe @alexander-stripe 

Add support for raw requests.

E.g. to send a `POST` requests to `/v1/things` with `foo=bar`:

```c#

var stripe = new StripeClient("sk_test_123");

var thing = await stripe.RawRequestAsync(
  HttpMethod.Post,
  "/v1/things",
  new Dictionary<string, object> { { "foo", "bar" } },
  null);

var thingId = thing["id"];
```
