### PR TITLE
Properly use `ScheduledQueryRunError` for the `Error` property

### DIFF
--- a/src/Stripe.net/Entities/Sigma/ScheduledQueryRuns/ScheduledQueryRun.cs
+++ b/src/Stripe.net/Entities/Sigma/ScheduledQueryRuns/ScheduledQueryRun.cs
@@ -36,7 +36,7 @@ namespace Stripe.Sigma
         /// If the query run was not successful, this field contains information about the failure.
         /// </summary>
         [JsonProperty("error")]
-        public string Error { get; set; }
+        public ScheduledQueryRunError Error { get; set; }
 
         /// <summary>
         /// The file object representing the results of the query.


### PR DESCRIPTION
Properly fix https://github.com/stripe/stripe-dotnet/pull/1992 this time

r? @ob-stripe 
cc @stripe/api-libraries 