### PR TITLE
Ability to inspect the configuration of SystemNetHttpClient

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -38,11 +38,7 @@ namespace Stripe
 
         private readonly System.Net.Http.HttpClient httpClient;
 
-        private readonly int maxNetworkRetries;
-
         private readonly AppInfo appInfo;
-
-        private readonly bool enableTelemetry;
 
         private readonly RequestTelemetry requestTelemetry = new RequestTelemetry();
 
@@ -85,9 +81,9 @@ namespace Stripe
 #endif
 
             this.httpClient = httpClient ?? LazyDefaultHttpClient.Value;
-            this.maxNetworkRetries = maxNetworkRetries;
+            this.MaxNetworkRetries = maxNetworkRetries;
             this.appInfo = appInfo;
-            this.enableTelemetry = enableTelemetry;
+            this.EnableTelemetry = enableTelemetry;
 
             this.stripeClientUserAgentString = this.BuildStripeClientUserAgentString();
             this.userAgentString = this.BuildUserAgentString();
@@ -109,12 +105,12 @@ namespace Stripe
         /// <summary>
         /// Gets whether telemetry was enabled for this client.
         /// </summary>
-        public bool EnableTelemetry { get => this.enableTelemetry; }
+        public bool EnableTelemetry { get; }
 
         /// <summary>
         /// Gets how many network retries were configured for this client.
         /// </summary>
-        public int MaxNetworkRetries { get => this.maxNetworkRetries; }
+        public int MaxNetworkRetries { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the client should sleep between automatic

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -107,6 +107,16 @@ namespace Stripe
         public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
 
         /// <summary>
+        /// Gets whether telemetry was enabled for this client.
+        /// </summary>
+        public bool EnableTelemetry { get => this.enableTelemetry; }
+
+        /// <summary>
+        /// Gets how many network retries were configured for this client.
+        /// </summary>
+        public int MaxNetworkRetries { get => this.maxNetworkRetries; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the client should sleep between automatic
         /// request retries.
         /// </summary>
@@ -142,7 +152,7 @@ namespace Stripe
             HttpResponseMessage response = null;
             int retry = 0;
 
-            if (this.enableTelemetry)
+            if (this.EnableTelemetry)
             {
                 this.requestTelemetry.MaybeAddTelemetryHeader(request.StripeHeaders);
             }
@@ -192,7 +202,7 @@ namespace Stripe
                 throw requestException;
             }
 
-            if (this.enableTelemetry)
+            if (this.EnableTelemetry)
             {
                 this.requestTelemetry.MaybeEnqueueMetrics(response, duration);
             }
@@ -248,7 +258,7 @@ namespace Stripe
             HttpHeaders headers)
         {
             // Do not retry if we are out of retries.
-            if (numRetries >= this.maxNetworkRetries)
+            if (numRetries >= this.MaxNetworkRetries)
             {
                 return false;
             }

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -85,6 +85,26 @@ namespace StripeTests
                     ItExpr.IsAny<CancellationToken>());
         }
 
+        [Fact]
+        public void CanInspectMaxNetworkRetries()
+        {
+            var client = new SystemNetHttpClient(
+                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object),
+                maxNetworkRetries: 2);
+
+            Assert.Equal(2, client.MaxNetworkRetries);
+        }
+
+        [Fact]
+        public void CanInspectEnableTelemetry()
+        {
+            var client = new SystemNetHttpClient(
+                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object),
+                enableTelemetry: true);
+
+            Assert.True(client.EnableTelemetry);
+        }
+
         private bool VerifyHeaders(HttpRequestHeaders headers)
         {
             var userAgent = headers.UserAgent.ToString();


### PR DESCRIPTION
These read only properties now exist on the SystemNetHttpClient
- MaxNetworkRetries
- EnableTelemetry

This will allow application developers to write tests that ensure that their configuration code has properly setup the StripeClient with the desired network retries, or telemetry settings without resorting to reflection in order to read private attributes.
