### PR TITLE
Default number of network retries to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,19 @@ Please refer to the [Advanced client usage][advanced-client-usage] wiki page
 to see more examples of using custom clients, e.g. for using a proxy server, a
 custom message handler, etc.
 
-### Configuring automatic retries
+### Automatic retries
 
-The library can be configured to automatically retry requests that fail due to
-an intermittent network problem or other knowingly non-deterministic errors:
+The library automatically retries requests on intermittent failures like on a
+connection error, timeout, or on certain API responses like a status `409
+Conflict`. [Idempotency keys][idempotency-keys] are always added to requests to
+make any such subsequent retries safe.
+
+By default, it will perform up to two retries. That number can be configured
+with `StripeConfiguration.MaxNetworkRetries`:
 
 ```c#
-StripeConfiguration.MaxNetworkRetries = 2;
+StripeConfiguration.MaxNetworkRetries = 0; // Zero retries
 ```
-
-[Idempotency keys][idempotency-keys] are added to requests to guarantee that
-retries are safe.
 
 ### Writing a plugin
 

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -20,7 +20,7 @@ namespace Stripe
 
         private static bool enableTelemetry = true;
 
-        private static int maxNetworkRetries;
+        private static int maxNetworkRetries = SystemNetHttpClient.DefaultMaxNumberRetries;
 
         private static IStripeClient stripeClient;
 

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -21,6 +21,9 @@ namespace Stripe
     /// </summary>
     public class SystemNetHttpClient : IHttpClient
     {
+        /// <summary>Default maximum number of retries made by the client.</summary>
+        public const int DefaultMaxNumberRetries = 2;
+
         private const string StripeNetTargetFramework =
 #if NETSTANDARD2_0
             "netstandard2.0"
@@ -70,7 +73,7 @@ namespace Stripe
         /// </param>
         public SystemNetHttpClient(
             System.Net.Http.HttpClient httpClient = null,
-            int maxNetworkRetries = 0,
+            int maxNetworkRetries = DefaultMaxNumberRetries,
             AppInfo appInfo = null,
             bool enableTelemetry = true)
         {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Default number of network retries to 2.
