### PR TITLE
[wip] Support for expandable arrays of resources

### DIFF
--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -4,8 +4,11 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Discount : StripeEntity<Discount>, IHasObject
+    public class Discount : StripeEntity<Discount>, IHasId, IHasObject
     {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
         [JsonProperty("object")]
         public string Object { get; set; }
 

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -313,6 +314,26 @@ namespace Stripe
         /// </summary>
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
+
+        #region Expandable Discounts
+
+        [JsonIgnore]
+        public List<string> DiscountIds
+        {
+            get => this.InternalDiscounts?.Select((x) => x.Id).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
+        }
+
+        [JsonIgnore]
+        public List<Discount> Discounts
+        {
+            get => this.InternalDiscounts?.Select((x) => x.ExpandedObject).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayObjects(value);
+        }
+
+        [JsonProperty("discounts", ItemConverterType = typeof(ExpandableFieldConverter<Discount>))]
+        internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
+        #endregion
 
         /// <summary>
         /// The date on which payment for this invoice is due. This value will be null for invoices

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -1,6 +1,8 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Newtonsoft.Json;
@@ -150,6 +152,29 @@ namespace Stripe
             expandable.ExpandedObject = obj;
 
             return expandable;
+        }
+
+        protected static List<ExpandableField<T>> SetExpandableArrayIds<T>(List<string> ids)
+            where T : IHasId
+        {
+            return ids?.Select((id) =>
+            {
+                var expandable = new ExpandableField<T>();
+                expandable.Id = id;
+                return expandable;
+            }).ToList();
+        }
+
+        protected static List<ExpandableField<T>> SetExpandableArrayObjects<T>(List<T> objects)
+            where T : IHasId
+        {
+            return objects?.Select((obj) =>
+            {
+                var expandable = new ExpandableField<T>();
+                expandable.Id = obj.Id;
+                expandable.ExpandedObject = obj;
+                return expandable;
+            }).ToList();
         }
 
         private object GetIdString()

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -56,6 +57,210 @@ namespace StripeTests
 
             Assert.NotNull(invoice.Subscription);
             Assert.Equal("subscription", invoice.Subscription.Object);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsNull()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": null}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.Null(invoice.DiscountIds);
+
+            Assert.Null(invoice.Discounts);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsEmpty()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": []}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Empty(invoice.DiscountIds);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Empty(invoice.Discounts);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsUnexpanded()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": [\"di_123\", \"di_456\"]}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Equal(2, invoice.DiscountIds.Count);
+            Assert.Equal("di_123", invoice.DiscountIds[0]);
+            Assert.Equal("di_456", invoice.DiscountIds[1]);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Equal(2, invoice.Discounts.Count);
+            Assert.Null(invoice.Discounts[0]);
+            Assert.Null(invoice.Discounts[1]);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsExpanded()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": [{\"id\": \"di_123\", \"object\": \"discount\"}, {\"id\": \"di_456\", \"object\": \"discount\"}]}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Equal(2, invoice.DiscountIds.Count);
+            Assert.Equal("di_123", invoice.DiscountIds[0]);
+            Assert.Equal("di_456", invoice.DiscountIds[1]);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Equal(2, invoice.Discounts.Count);
+            Assert.NotNull(invoice.Discounts[0]);
+            Assert.Equal("di_123", invoice.Discounts[0].Id);
+            Assert.Equal("discount", invoice.Discounts[0].Object);
+            Assert.NotNull(invoice.Discounts[1]);
+            Assert.Equal("di_456", invoice.Discounts[1].Id);
+            Assert.Equal("discount", invoice.Discounts[1].Object);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsNull()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = null;
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.Null(deserialized.DiscountIds);
+
+            Assert.Null(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsNull()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = null;
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.Null(deserialized.DiscountIds);
+
+            Assert.Null(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = new List<string>();
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Empty(deserialized.DiscountIds);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Empty(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = new List<Discount>();
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Empty(deserialized.DiscountIds);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Empty(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsNotEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = new List<string> { "di_123", "di_456" };
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Equal(2, deserialized.DiscountIds.Count);
+            Assert.Equal("di_123", deserialized.DiscountIds[0]);
+            Assert.Equal("di_456", deserialized.DiscountIds[1]);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Equal(2, deserialized.Discounts.Count);
+            Assert.Null(deserialized.Discounts[0]);
+            Assert.Null(deserialized.Discounts[1]);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsNotEmpty()
+        {
+            var discount1 = new Discount();
+            discount1.Id = "di_123";
+            discount1.Object = "discount";
+
+            var discount2 = new Discount();
+            discount2.Id = "di_456";
+            discount2.Object = "discount";
+
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = new List<Discount> { discount1, discount2 };
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Equal(2, deserialized.DiscountIds.Count);
+            Assert.Equal("di_123", deserialized.DiscountIds[0]);
+            Assert.Equal("di_456", deserialized.DiscountIds[1]);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Equal(2, deserialized.Discounts.Count);
+            Assert.NotNull(deserialized.Discounts[0]);
+            Assert.Equal("di_123", deserialized.Discounts[0].Id);
+            Assert.Equal("discount", deserialized.Discounts[0].Object);
+            Assert.NotNull(deserialized.Discounts[1]);
+            Assert.Equal("di_456", deserialized.Discounts[1].Id);
+            Assert.Equal("discount", deserialized.Discounts[1].Object);
         }
     }
 }


### PR DESCRIPTION
It just works for the most part. Note that when accessing the array of expanded objects when the field was not expanded, it will return a non-null array containing as many `null` values as there are unexpanded IDs.
