### PR TITLE
Mark `Metadata` on `CreditNoteLineOptions` as obsolete

### DIFF
--- a/src/Stripe.net/Services/CreditNotes/CreditNoteLineOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteLineOptions.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
@@ -27,11 +28,7 @@ namespace Stripe
         [JsonProperty("invoice_line_item")]
         public string InvoiceLineItem { get; set; }
 
-        /// <summary>
-        /// A set of key/value pairs that you can attach to a charge object. It can be useful for
-        /// storing additional information about the customer in a structured format. It's often a
-        /// good idea to store an email address in metadata for tracking later.
-        /// </summary>
+        [Obsolete("This parameter is not supported.")]
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/2023
r? @ob-stripe 
cc @stripe/api-libraries 