### PR TITLE
Add support for `Product` for Klarna `Source`

### DIFF
--- a/src/Stripe.net/Services/Sources/SourceKlarnaCreateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceKlarnaCreateOptions.cs
@@ -64,6 +64,9 @@ namespace Stripe
         [JsonProperty("payment_method_categories")]
         public string PaymentMethodCategories { get; set; }
 
+        [JsonProperty("product")]
+        public string Product { get; set; }
+
         [JsonProperty("purchase_country")]
         public string PurchaseCountry { get; set; }
 


### PR DESCRIPTION
Add the missing `klarna[product]` parameter on Klarna Source creation as it's required according to the documentation.

Fixes https://github.com/stripe/stripe-dotnet/issues/2029

r? @matthewling-stripe (I hope it's okay as I know you worked on Klarna recently)
cc @stripe/api-libraries 
