### PR TITLE
Add support for `PurchaseDetails` on Issuing `Transaction`

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -182,6 +182,12 @@ namespace Stripe.Issuing
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
+        /// Additional purchase information that is optionally provided by the merchant.
+        /// </summary>
+        [JsonProperty("purchase_details")]
+        public TransactionPurchaseDetails PurchaseDetails { get; set; }
+
+        /// <summary>
         /// The nature of the transaction. One of <c>capture</c>, or <c>refund</c>.
         /// </summary>
         [JsonProperty("type")]

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetails.cs
@@ -1,0 +1,38 @@
+namespace Stripe.Issuing
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class TransactionPurchaseDetails : StripeEntity<TransactionPurchaseDetails>
+    {
+        /// <summary>
+        /// Information about the flight that was purchased with this transaction.
+        /// </summary>
+        [JsonProperty("flight")]
+        public TransactionPurchaseDetailsFlight Flight { get; set; }
+
+        /// <summary>
+        /// Information about fuel that was purchased with this transaction.
+        /// </summary>
+        [JsonProperty("fuel")]
+        public TransactionPurchaseDetailsFuel Fuel { get; set; }
+
+        /// <summary>
+        /// Information about lodging that was purchased with this transaction.
+        /// </summary>
+        [JsonProperty("lodging")]
+        public TransactionPurchaseDetailsLodging Lodging { get; set; }
+
+        /// <summary>
+        /// The line items in the purchase.
+        /// </summary>
+        [JsonProperty("receipt")]
+        public List<TransactionPurchaseDetailsReceipt> Receipt { get; set; }
+
+        /// <summary>
+        /// A merchant-specific order number.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFlight.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFlight.cs
@@ -1,0 +1,41 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionPurchaseDetailsFlight : StripeEntity<TransactionPurchaseDetailsFlight>
+    {
+        /// <summary>
+        /// The time that the flight departed.
+        /// </summary>
+        [JsonProperty("departure_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? DepartureAt { get; set; }
+
+        /// <summary>
+        /// The name of the passenger.
+        /// </summary>
+        [JsonProperty("passenger_name")]
+        public string PassengerName { get; set; }
+
+        /// <summary>
+        /// Whether the ticket is refundable.
+        /// </summary>
+        [JsonProperty("refundable")]
+        public bool? Refundable { get; set; }
+
+        /// <summary>
+        /// The legs of the trip.
+        /// </summary>
+        [JsonProperty("segments")]
+        public List<TransactionPurchaseDetailsFlightSegment> Segments { get; set; }
+
+        /// <summary>
+        /// The travel agency that issued the ticket.
+        /// </summary>
+        [JsonProperty("travel_agency")]
+        public string TravelAgency { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFlightSegment.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFlightSegment.cs
@@ -1,0 +1,43 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class TransactionPurchaseDetailsFlightSegment : StripeEntity<TransactionPurchaseDetailsFlightSegment>
+    {
+        /// <summary>
+        /// The flight's destination airport code.
+        /// </summary>
+        [JsonProperty("arrival_airport_code")]
+        public string ArrivalAirportCode { get; set; }
+
+        /// <summary>
+        /// The airline carrier code.
+        /// </summary>
+        [JsonProperty("carrier")]
+        public string Carrier { get; set; }
+
+        /// <summary>
+        /// The airport code that the flight departed from.
+        /// </summary>
+        [JsonProperty("departure_airport_code")]
+        public string DepartureAirportCode { get; set; }
+
+        /// <summary>
+        /// The flight number.
+        /// </summary>
+        [JsonProperty("flight_number")]
+        public string FlightNumber { get; set; }
+
+        /// <summary>
+        /// The flight's service class.
+        /// </summary>
+        [JsonProperty("service_class")]
+        public string ServiceClass { get; set; }
+
+        /// <summary>
+        /// Whether a stopover is allowed on this flight.
+        /// </summary>
+        [JsonProperty("stopover_allowed")]
+        public bool? StopoverAllowed { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFuel.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFuel.cs
@@ -1,0 +1,37 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionPurchaseDetailsFuel : StripeEntity<TransactionPurchaseDetailsFuel>
+    {
+        /// <summary>
+        /// The type of fuel that was purchased. One of <c>diesel</c>, <c>unleaded_plus</c>,
+        /// <c>unleaded_regular</c>, <c>unleaded_super</c>, or <c>other</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The units for <see cref="VolumeDecimal"/>. One of <c>us_gallon</c> or <c>liter</c>.
+        /// </summary>
+        [JsonProperty("unit")]
+        public string Unit { get; set; }
+
+        /// <summary>
+        /// The cost in cents per each unit of fuel, represented as a decimal string with at most 12
+        /// decimal places.
+        /// </summary>
+        [JsonProperty("unit_cost_decimal")]
+        public decimal? UnitCostDecimal { get; set; }
+
+        /// <summary>
+        /// The volume of the fuel that was pumped, represented as a decimal string with at most 12
+        /// decimal places.
+        /// </summary>
+        [JsonProperty("volume_decimal")]
+        public decimal? VolumeDecimal { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsLodging.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsLodging.cs
@@ -1,0 +1,23 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionPurchaseDetailsLodging : StripeEntity<TransactionPurchaseDetailsLodging>
+    {
+        /// <summary>
+        /// The time of checking into the lodging.
+        /// </summary>
+        [JsonProperty("check_in_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? CheckInAt { get; set; }
+
+        /// <summary>
+        /// The number of nights stayed at the lodging.
+        /// </summary>
+        [JsonProperty("nights")]
+        public long? Nights { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsReceipt.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsReceipt.cs
@@ -1,0 +1,31 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class TransactionPurchaseDetailsReceipt : StripeEntity<TransactionPurchaseDetailsReceipt>
+    {
+        /// <summary>
+        /// The description of the item. The maximum length of this field is 26.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The quantity of the item.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public decimal? Quantity { get; set; }
+
+        /// <summary>
+        /// The total for this line item (two decimal places are implied).
+        /// </summary>
+        [JsonProperty("total")]
+        public long? Total { get; set; }
+
+        /// <summary>
+        /// The unit cost of the item (two decimal places are implied).
+        /// </summary>
+        [JsonProperty("unit_cost")]
+        public long? UnitCost { get; set; }
+    }
+}


### PR DESCRIPTION
Same as https://github.com/stripe/stripe-java/pull/1030

r? @richardm-stripe 
cc @stripe/api-libraries 