### PR TITLE
Fix `Quantity` to be nullable on `CreditNoteLineItem`

### DIFF
--- a/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItem.cs
+++ b/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItem.cs
@@ -55,7 +55,7 @@ namespace Stripe
         /// The number of units of product being credited.
         /// </summary>
         [JsonProperty("quantity")]
-        public long Quantity { get; set; }
+        public long? Quantity { get; set; }
 
         /// <summary>
         /// The amount of tax calculated per tax rate for this line item.


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/2035

I also checked in the spec that all other scalars both on `CreditNoteLineItem` and `CreditNote` has the right nullable setting.

r? @ob-stripe 
cc @stripe/api-libraries 