### PR TITLE
Remove deprecated fields

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountBusinessProfileOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountBusinessProfileOptions.cs
@@ -18,10 +18,6 @@ namespace Stripe
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [Obsolete("Use AccountSettingsBrandingOptions.PrimaryColor instead.")]
-        [JsonProperty("primary_color")]
-        public string PrimaryColor { get; set; }
-
         /// <summary>
         /// Internal-only description of the product sold by, or service provided by, the business.
         /// Used by Stripe for risk and underwriting purposes.

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteLineOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteLineOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CreditNoteLineOptions : INestedOptions, IHasMetadata
+    public class CreditNoteLineOptions : INestedOptions
     {
         /// <summary>
         /// The line item amount to credit. Only valid when <see cref="Type"/> is
@@ -27,10 +27,6 @@ namespace Stripe
         /// </summary>
         [JsonProperty("invoice_line_item")]
         public string InvoiceLineItem { get; set; }
-
-        [Obsolete("This parameter is not supported.")]
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// The line item quantity to credit.


### PR DESCRIPTION
Remove deprecated fields
  * Removed `PrimaryColor` in `AccountBusinessProfileOptions`. Use `PrimaryColor` in `AccountSettingsBrandingOptions` instead.
  * Removed `metadata` on `CreditNoteLineOptions` as it was never supported

r? @cjavilla-stripe 
cc @stripe/api-libraries 