### PR TITLE
Fix `LineItems` on Checkout `Session` to be a `StripeList`

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -85,7 +85,7 @@ namespace Stripe.Checkout
         /// The line items associated with this session.
         /// </summary>
         [JsonProperty("line_items")]
-        public List<LineItem> LineItems { get; set; }
+        public StripeList<LineItem> LineItems { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value

--- a/src/StripeTests/Entities/Checkout/SessionTest.cs
+++ b/src/StripeTests/Entities/Checkout/SessionTest.cs
@@ -30,6 +30,7 @@ namespace StripeTests.Checkout
             {
               "customer",
               "payment_intent",
+              "line_items",
               "setup_intent",
               "subscription",
             };
@@ -43,6 +44,9 @@ namespace StripeTests.Checkout
 
             Assert.NotNull(session.Customer);
             Assert.Equal("customer", session.Customer.Object);
+
+            Assert.NotNull(session.LineItems);
+            Assert.Equal("item", session.LineItems.Data[0].Object);
 
             Assert.NotNull(session.PaymentIntent);
             Assert.Equal("payment_intent", session.PaymentIntent.Object);


### PR DESCRIPTION
After chatting with @ob-stripe it felt safer to release this as a patch since this is a real issue with the current minor.

r? @cjavilla-stripe 
cc @stripe/api-libraries 