### PR TITLE
Fix parameter classes to pass `Product` or `ProductData` on `Price`

### DIFF
--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
@@ -16,7 +16,7 @@ namespace Stripe
         /// The ID of the product that this price will belong to.
         /// </summary>
         [JsonProperty("product")]
-        internal string Product { get; set; }
+        public string Product { get; set; }
 
         /// <summary>
         /// The recurring components of a price such as its interval.

--- a/src/Stripe.net/Services/Invoices/InvoiceItemPriceDataOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceItemPriceDataOptions.cs
@@ -16,7 +16,7 @@ namespace Stripe
         /// The ID of the product that this price will belong to.
         /// </summary>
         [JsonProperty("product")]
-        internal string Product { get; set; }
+        public string Product { get; set; }
 
         /// <summary>
         /// The amount in cents to be charged on the interval specified.

--- a/src/Stripe.net/Services/Prices/PriceCreateOptions.cs
+++ b/src/Stripe.net/Services/Prices/PriceCreateOptions.cs
@@ -54,13 +54,13 @@ namespace Stripe
         /// The ID of the product that this price will belong to.
         /// </summary>
         [JsonProperty("product")]
-        internal string Product { get; set; }
+        public string Product { get; set; }
 
         /// <summary>
         /// These fields can be used to create a new product that this price will belong to.
         /// </summary>
         [JsonProperty("product_data")]
-        internal PriceProductDataOptions ProductData { get; set; }
+        public PriceProductDataOptions ProductData { get; set; }
 
         /// <summary>
         /// The recurring components of a price such as its interval.

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemPriceDataOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemPriceDataOptions.cs
@@ -15,7 +15,7 @@ namespace Stripe
         /// The ID of the product that this price will belong to.
         /// </summary>
         [JsonProperty("product")]
-        internal string Product { get; set; }
+        public string Product { get; set; }
 
         /// <summary>
         /// The recurring components of a price such as its interval.


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/2042

r? @ob-stripe 
cc @stripe/api-libraries 