### PR TITLE
Rename many properties to have the name matching the API in the JSON

### DIFF
--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -152,7 +152,7 @@ namespace Stripe
         public string Description { get; set; }
 
         [JsonProperty("iin")]
-        public string IIN { get; set; }
+        public string Iin { get; set; }
 
         [JsonProperty("issuer")]
         public string Issuer { get; set; }

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -353,7 +353,7 @@ namespace Stripe
         /// ID of the PaymentMethod associated with this charge.
         /// </summary>
         [JsonProperty("payment_method")]
-        public string PaymentMethodId { get; set; }
+        public string PaymentMethod { get; set; }
 
         /// <summary>
         /// Transaction-specific details of the payment method used in the payment.

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsBitcoin.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsBitcoin.cs
@@ -15,7 +15,7 @@ namespace Stripe
         public long AmountCharged { get; set; }
 
         [JsonProperty("amount_received")]
-        public long AmountReceivd { get; set; }
+        public long AmountReceived { get; set; }
 
         [JsonProperty("amount_returned")]
         public long AmountReturned { get; set; }

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsIdeal.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsIdeal.cs
@@ -5,15 +5,28 @@ namespace Stripe
 
     public class ChargePaymentMethodDetailsIdeal : StripeEntity<ChargePaymentMethodDetailsIdeal>
     {
+        /// <summary>
+        /// The customer’s bank.
+        /// </summary>
         [JsonProperty("bank")]
-        public string BankCode { get; set; }
+        public string Bank { get; set; }
 
+        /// <summary>
+        /// The Bank Identifier Code of the customer’s bank.
+        /// </summary>
         [JsonProperty("bic")]
         public string Bic { get; set; }
 
+        /// <summary>
+        /// Last four characters of the IBAN.
+        /// </summary>
         [JsonProperty("iban_last4")]
         public string IbanLast4 { get; set; }
 
+        /// <summary>
+        /// Owner’s verified full name. Values are verified or provided by iDEAL directly (if
+        /// supported) at the time of authorization or settlement. They cannot be set or mutated.
+        /// </summary>
         [JsonProperty("verified_name")]
         public string VerifiedName { get; set; }
     }

--- a/src/Stripe.net/Entities/Disputes/DisputeEvidence.cs
+++ b/src/Stripe.net/Entities/Disputes/DisputeEvidence.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -86,7 +87,7 @@ namespace Stripe
         public string CustomerName { get; set; }
 
         [JsonProperty("customer_purchase_ip")]
-        public string CustomerPurchaseIP { get; set; }
+        public string CustomerPurchaseIp { get; set; }
 
         #region Expandable Customer Signature
 

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
@@ -30,7 +30,7 @@ namespace Stripe
         public bool Discountable { get; set; }
 
         [JsonProperty("invoice_item")]
-        public string InvoiceItemId { get; set; }
+        public string InvoiceItem { get; set; }
 
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
@@ -57,10 +57,10 @@ namespace Stripe
         public long? Quantity { get; set; }
 
         [JsonProperty("subscription")]
-        public string SubscriptionId { get; set; }
+        public string Subscription { get; set; }
 
         [JsonProperty("subscription_item")]
-        public string SubscriptionItemId { get; set; }
+        public string SubscriptionItem { get; set; }
 
         /// <summary>
         /// The tax amounts which apply to this line item.

--- a/src/Stripe.net/Entities/OrderReturns/OrderReturn.cs
+++ b/src/Stripe.net/Entities/OrderReturns/OrderReturn.cs
@@ -46,7 +46,7 @@ namespace Stripe
         /// The items included in this order return.
         /// </summary>
         [JsonProperty("items")]
-        public List<OrderItem> OrderItems { get; set; }
+        public List<OrderItem> Items { get; set; }
 
         /// <summary>
         /// Has the value true if the object exists in live mode or the value

--- a/src/Stripe.net/Entities/Orders/Order.cs
+++ b/src/Stripe.net/Entities/Orders/Order.cs
@@ -121,7 +121,7 @@ namespace Stripe
         /// List of items constituting the order.
         /// </summary>
         [JsonProperty("items")]
-        public List<OrderItem> OrderItems { get; set; }
+        public List<OrderItem> Items { get; set; }
 
         /// <summary>
         /// Has the value true if the object exists in live mode or the value

--- a/src/Stripe.net/Entities/Persons/Person.cs
+++ b/src/Stripe.net/Entities/Persons/Person.cs
@@ -23,7 +23,7 @@ namespace Stripe
         /// The account the person is associated with.
         /// </summary>
         [JsonProperty("account")]
-        public string AccountId { get; set; }
+        public string Account { get; set; }
 
         /// <summary>
         /// The person’s address.

--- a/src/Stripe.net/Entities/Recipients/Recipient.cs
+++ b/src/Stripe.net/Entities/Recipients/Recipient.cs
@@ -17,7 +17,7 @@ namespace Stripe
         public BankAccount ActiveAccount { get; set; }
 
         [JsonProperty("cards")]
-        public StripeList<Card> CardList { get; set; }
+        public StripeList<Card> Cards { get; set; }
 
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]

--- a/src/Stripe.net/Entities/Sources/SourceAcssDebit.cs
+++ b/src/Stripe.net/Entities/Sources/SourceAcssDebit.cs
@@ -14,7 +14,7 @@ namespace Stripe
         public string BankAddressLine2 { get; set; }
 
         [JsonProperty("bank_address_postal_code")]
-        public string BankAddressLinePostalCode { get; set; }
+        public string BankAddressPostalCode { get; set; }
 
         [JsonProperty("bank_name")]
         public string BankName { get; set; }

--- a/src/Stripe.net/Entities/Sources/SourceThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Sources/SourceThreeDSecure.cs
@@ -32,7 +32,7 @@ namespace Stripe
         /// The card used to create this 3DS source.
         /// </summary>
         [JsonProperty("card")]
-        public string CardId { get; set; }
+        public string Card { get; set; }
 
         /// <summary>
         /// Two-letter ISO code representing the country of the card.
@@ -44,7 +44,7 @@ namespace Stripe
         /// The ID of the customer to which the card belongs, if any.
         /// </summary>
         [JsonProperty("customer")]
-        public string CustomerId { get; set; }
+        public string Customer { get; set; }
 
         /// <summary>
         /// If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`.
@@ -92,7 +92,7 @@ namespace Stripe
         /// This is an internal property that is not returned in standard API requests.
         /// </summary>
         [JsonProperty("iin")]
-        public string IIN { get; set; }
+        public string Iin { get; set; }
 
         /// <summary>
         /// This is an internal property that is not returned in standard API requests.

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -11,7 +11,7 @@ namespace Stripe
 
         /// <summary>For card errors, the ID of the failed charge.</summary>
         [JsonProperty("charge")]
-        public string ChargeId { get; set; }
+        public string Charge { get; set; }
 
         /// <summary>
         /// For some errors that could be handled programmatically, a short string indicating the
@@ -47,7 +47,7 @@ namespace Stripe
         /// you can use this to display a message near the correct form field.
         /// </summary>
         [JsonProperty("param")]
-        public string Parameter { get; set; }
+        public string Param { get; set; }
 
         /// <summary>
         /// The <see cref="Stripe.PaymentIntent"/> object for errors returned on a request
@@ -83,7 +83,7 @@ namespace Stripe
         /// <c>invalid_request_error</c>, or <c>rate_limit_error</c>.
         /// </summary>
         [JsonProperty("type")]
-        public string ErrorType { get; set; }
+        public string Type { get; set; }
 
         /*
          * For OAuth Errors:

--- a/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummary.cs
+++ b/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummary.cs
@@ -13,7 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         [JsonProperty("invoice")]
-        public string InvoiceId { get; set; }
+        public string Invoice { get; set; }
 
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
@@ -22,7 +22,7 @@ namespace Stripe
         public Period Period { get; set; }
 
         [JsonProperty("subscription_item")]
-        public string SubscriptionItemId { get; set; }
+        public string SubscriptionItem { get; set; }
 
         [JsonProperty("total_usage")]
         public long TotalUsage { get; set; }

--- a/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
@@ -30,7 +30,7 @@ namespace Stripe
         public string CustomerName { get; set; }
 
         [JsonProperty("customer_purchase_ip")]
-        public string CustomerPurchaseIP { get; set; }
+        public string CustomerPurchaseIp { get; set; }
 
         [JsonProperty("customer_signature")]
         public string CustomerSignature { get; set; }

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -106,7 +106,7 @@ namespace StripeTests
 
             Assert.NotNull(exception);
             Assert.Equal(HttpStatusCode.PaymentRequired, exception.HttpStatusCode);
-            Assert.Equal("card_error", exception.StripeError.ErrorType);
+            Assert.Equal("card_error", exception.StripeError.Type);
             Assert.Equal(response, exception.StripeResponse);
         }
 

--- a/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
+++ b/src/StripeTests/Wholesome/JsonNamesMatchPropertyNames.cs
@@ -11,22 +11,37 @@ namespace StripeTests
     using Xunit;
 
     /// <summary>
-    /// This wholesome test ensures that `JsonProperty` attributes in options classes have names
-    /// that match their property's name. E.g. if the property's name is `FooBar`, then the JSON
-    /// name should be `foo_bar`.
+    /// This wholesome test ensures that `JsonProperty` attributes in entity and options classes
+    /// have names that match their property's name. E.g. if the property's name is `FooBar`, then
+    /// the JSON name should be `foo_bar`.
     /// </summary>
+    /// <remarks>
+    /// At the moment this test only checks `public` properties. `internal` properties, such as
+    /// the ones used for expandable fields, are ignored. This should be fixed, but handling
+    /// expandable fields will require more complex handling.
+    /// </remarks>
     public class JsonNamesMatchPropertyNames : WholesomeTest
     {
         private const string AssertionMessage =
             "Found at least one JsonProperty name mismatched with its property name.";
+
+        // Map of words that have a non-standard snake_case -> PascalCase transformation. This is
+        // mostly useful for two-letter acronyms, which should stay capitalized per Microsoft's
+        // recommendations: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions#capitalization-rules-for-identifiers.
+        private static Dictionary<string, string> overrides = new Dictionary<string, string>
+        {
+            // Commented out as we prefer to standardize on `Ip` for the moment to minimize breaking changes.
+            // { "ip", "IP" },
+        };
 
         [Fact]
         public void Check()
         {
             List<string> results = new List<string>();
 
-            // Get all classes that implement INestedOptions
-            var stripeClasses = GetClassesWithInterface(typeof(INestedOptions));
+            // Get all classes that derive from StripeEntity or implement INestedOptions
+            var stripeClasses = GetSubclassesOf(typeof(StripeEntity));
+            stripeClasses.AddRange(GetClassesWithInterface(typeof(INestedOptions)));
 
             foreach (Type stripeClass in stripeClasses)
             {
@@ -41,10 +56,10 @@ namespace StripeTests
                         continue;
                     }
 
-                    var snakeCasedPropName = Stripe.Infrastructure.StringUtils.ToSnakeCase(property.Name);
+                    var pascalCasedJsonName = ToPascalCase(jsonPropertyAttribute.PropertyName);
 
                     // Skip properties when the property name matches the JSON name
-                    if (jsonPropertyAttribute.PropertyName == snakeCasedPropName)
+                    if (property.Name == pascalCasedJsonName)
                     {
                         continue;
                     }
@@ -56,11 +71,21 @@ namespace StripeTests
                         continue;
                     }
 
-                    results.Add($"{stripeClass.Name}.{property.Name}: {jsonPropertyAttribute.PropertyName} != {snakeCasedPropName}");
+                    results.Add($"{stripeClass.Name}.{property.Name}: {property.Name} != {pascalCasedJsonName}");
                 }
             }
 
             AssertEmpty(results, AssertionMessage);
+        }
+
+        private static string ToPascalCase(string snakeCase)
+        {
+            return snakeCase.Split('_')
+                .Select(s =>
+                    overrides.ContainsKey(s)
+                        ? overrides[s]
+                        : char.ToUpperInvariant(s[0]) + s.Substring(1, s.Length - 1))
+                .Aggregate(string.Empty, (s1, s2) => s1 + s2);
         }
     }
 }


### PR DESCRIPTION
Since we had another bug in master found by @ob-stripe and fixed in https://github.com/stripe/stripe-dotnet/pull/2044 we took the time to add a test that ensures the names are identical between the API and stripe-dotnet.

For now, we're keeping `Ip` since it's the most used though 2-letters words should be in upper-case. We've also found a large number of names mismatches, a few being real bugs.

List of changes:
  * Properties lost their `Id` suffix such as `PaymentMethodId` renamed to `PaymentMethod` on `Charge`
  * `IIN` is now `Iin` on `Card`
  * `AmountReceivd` is now `AmountReceived` on `ChargePaymentMethodDetailsBitcoin`
  * `BankCode` is now `Bank` on `ChargePaymentMethodDetailsIdeal`.
  * `CustomerPurchaseIP` is now `CustomerPurchaseIp` on `DisputeEvidence` and `DisputeEvidenceOptions`
  * `OrderItems` is now `Items` on `Order` and `OrderReturn`
  * `CardList` is now `Cards` on `Recipient`
  * `BankAddressLinePostalCode` is now `BankAddressPostalCode` on `SourceAcssDebit`
  * Properties on `StripeError` have been renamed, `ChargeId` is `Charge`, `ErrorType` is `Type` and `Parameter` is `Param`


r? @cjavilla-stripe 
cc @stripe/api-libraries 