### PR TITLE
No op changes preparing for autogen

### DIFF
--- a/src/Stripe.net/Entities/AccountLinks/AccountLink.cs
+++ b/src/Stripe.net/Entities/AccountLinks/AccountLink.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
+++ b/src/Stripe.net/Entities/ApplicationFees/ApplicationFee.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+
         [JsonIgnore]
         public string AccountId
         {
@@ -39,6 +40,7 @@ namespace Stripe
         public long AmountRefunded { get; set; }
 
         #region Expandable Application
+
         [JsonIgnore]
         public string ApplicationId
         {
@@ -58,7 +60,8 @@ namespace Stripe
         internal ExpandableField<Application> InternalApplication { get; set; }
         #endregion
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
+
         [JsonIgnore]
         public string BalanceTransactionId
         {
@@ -79,6 +82,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Charge
+
         [JsonIgnore]
         public string ChargeId
         {
@@ -108,7 +112,8 @@ namespace Stripe
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
-        #region Expandable Originating Transaction
+        #region Expandable OriginatingTransaction
+
         [JsonIgnore]
         public string OriginatingTransactionId
         {

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+
         [JsonIgnore]
         public string AccountId
         {
@@ -48,6 +49,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+
         [JsonIgnore]
         public string CustomerId
         {
@@ -73,7 +75,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("fingerprint")]

--- a/src/Stripe.net/Entities/BillingPortal/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Sessions/Session.cs
@@ -1,7 +1,6 @@
 namespace Stripe.BillingPortal
 {
     using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -13,6 +13,7 @@ namespace Stripe
         public string Object { get; set; }
 
         #region Expandable Account
+
         [JsonIgnore]
         public string AccountId
         {
@@ -69,6 +70,7 @@ namespace Stripe
         public string Currency { get; set; }
 
         #region Expandable Customer
+
         [JsonIgnore]
         public string CustomerId
         {
@@ -97,7 +99,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("dynamic_last4")]
@@ -125,6 +127,7 @@ namespace Stripe
         public string Name { get; set; }
 
         #region Expandable Recipient
+
         [JsonIgnore]
         public string RecipientId
         {

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -26,6 +26,7 @@ namespace Stripe
         public long AmountRefunded { get; set; }
 
         #region Expandable Application
+
         [JsonIgnore]
         public string ApplicationId
         {
@@ -45,7 +46,8 @@ namespace Stripe
         internal ExpandableField<Application> InternalApplication { get; set; }
         #endregion
 
-        #region Expandable Application Fee
+        #region Expandable ApplicationFee
+
         [JsonIgnore]
         public string ApplicationFeeId
         {
@@ -74,7 +76,7 @@ namespace Stripe
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
 
         /// <summary>
         /// ID of the balance transaction that describes the impact of this charge on your account balance (not including refunds or disputes).
@@ -156,6 +158,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+
         [JsonIgnore]
         public string DestinationId
         {
@@ -179,6 +182,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Dispute
+
         [JsonIgnore]
         public string DisputeId
         {
@@ -258,7 +262,7 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        #region Expandable OnBehalfOf (Account)
+        #region Expandable OnBehalfOf
 
         /// <summary>
         /// The account (if any) the charge was made on behalf of without triggering an automatic transfer. See the Connect documentation for details.
@@ -431,7 +435,7 @@ namespace Stripe
         [JsonConverter(typeof(StripeObjectConverter))]
         public IPaymentSource Source { get; set; }
 
-        #region Expandable Transfer
+        #region Expandable SourceTransfer
 
         /// <summary>
         /// The transfer ID which created this charge. Only present if the charge came from another Stripe account. See the Connect documentation for details.

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -1,6 +1,5 @@
 namespace Stripe.Checkout
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
@@ -190,6 +189,17 @@ namespace Stripe.Checkout
         [JsonProperty("shipping_address_collection")]
         public SessionShippingAddressCollection ShippingAddressCollection { get; set; }
 
+        /// <summary>
+        /// Describes the type of transaction being performed by Checkout in
+        /// order to customize relevant text on the page, such as the Submit
+        /// button. <c>submit_type</c> can only be specified on checkout
+        /// sessions using line items or a SKU, and not checkout sessions for
+        /// subscriptions. Supported values are <c>auto</c>, <c>book</c>,
+        /// <c>donate</c>, or <c>pay</c>.
+        /// </summary>
+        [JsonProperty("submit_type")]
+        public string SubmitType { get; set; }
+
         #region Expandable Subscription
 
         /// <summary>
@@ -216,17 +226,6 @@ namespace Stripe.Checkout
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]
         internal ExpandableField<Subscription> InternalSubscription { get; set; }
         #endregion
-
-        /// <summary>
-        /// Describes the type of transaction being performed by Checkout in
-        /// order to customize relevant text on the page, such as the Submit
-        /// button. <c>submit_type</c> can only be specified on checkout
-        /// sessions using line items or a SKU, and not checkout sessions for
-        /// subscriptions. Supported values are <c>auto</c>, <c>book</c>,
-        /// <c>donate</c>, or <c>pay</c>.
-        /// </summary>
-        [JsonProperty("submit_type")]
-        public string SubmitType { get; set; }
 
         /// <summary>
         /// The URL the customer will be directed to after a successful payment.

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -20,6 +20,7 @@ namespace Stripe
         public List<BalanceTransaction> BalanceTransactions { get; set; }
 
         #region Expandable Charge
+
         [JsonIgnore]
         public string ChargeId
         {
@@ -62,6 +63,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         #region Expandable PaymentIntent
+
         [JsonIgnore]
         public string PaymentIntentId
         {

--- a/src/Stripe.net/Entities/FileLinks/FileLink.cs
+++ b/src/Stripe.net/Entities/FileLinks/FileLink.cs
@@ -33,13 +33,6 @@ namespace Stripe
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? ExpiresAt { get; set; }
 
-        /// <summary>
-        /// Has the value <c>true</c> if the object exists in live mode or the value
-        /// <c>false</c> if the object exists in test mode.
-        /// </summary>
-        [JsonProperty("livemode")]
-        public bool Livemode { get; set; }
-
         #region Expandable File
 
         /// <summary>
@@ -66,6 +59,13 @@ namespace Stripe
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
         internal ExpandableField<File> InternalFile { get; set; }
         #endregion
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value
+        /// <c>false</c> if the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
 
         /// <summary>
         /// Set of key-value pairs that you can attach to an object. This can be useful for storing

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -270,6 +270,7 @@ namespace Stripe
         #endregion
 
         #region Expandable DefaultSource
+
         [JsonIgnore]
         public string DefaultSourceId
         {
@@ -298,7 +299,7 @@ namespace Stripe
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         /// <summary>

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -1,9 +1,7 @@
 namespace Stripe.Issuing
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class Dispute : StripeEntity<Dispute>, IHasId, IHasObject
     {

--- a/src/Stripe.net/Entities/Mandates/Mandate.cs
+++ b/src/Stripe.net/Entities/Mandates/Mandate.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntent.cs
@@ -224,7 +224,7 @@ namespace Stripe
         [JsonProperty("next_action")]
         public PaymentIntentNextAction NextAction { get; set; }
 
-        #region Expandable OnBehalfOf (Account)
+        #region Expandable OnBehalfOf
 
         /// <summary>
         /// The account (if any) for which the funds of the PaymentIntent are intended.

--- a/src/Stripe.net/Entities/Payouts/Payout.cs
+++ b/src/Stripe.net/Entities/Payouts/Payout.cs
@@ -23,7 +23,8 @@ namespace Stripe
         [JsonProperty("automatic")]
         public bool Automatic { get; set; }
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
+
         [JsonIgnore]
         public string BalanceTransactionId
         {
@@ -54,6 +55,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+
         [JsonIgnore]
         public string DestinationId
         {
@@ -73,7 +75,7 @@ namespace Stripe
         internal ExpandableField<IExternalAccount> InternalDestination { get; set; }
         #endregion
 
-        #region Expandable Failure Balance Transaction
+        #region Expandable FailureBalanceTransaction
 
         /// <summary>
         /// If the payout failed or was canceled, this will be the ID of the balance transaction that reversed the initial balance transaction, and puts the funds from the failed payout back in your balance.
@@ -121,7 +123,6 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
-        // example: bank_account
         [JsonProperty("type")]
         public string Type { get; set; }
     }

--- a/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
+++ b/src/Stripe.net/Entities/Radar/EarlyFraudWarnings/EarlyFraudWarning.cs
@@ -1,7 +1,6 @@
 namespace Stripe.Radar
 {
     using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/Radar/ValueListItems/ValueListItem.cs
+++ b/src/Stripe.net/Entities/Radar/ValueListItems/ValueListItem.cs
@@ -1,7 +1,6 @@
 namespace Stripe.Radar
 {
     using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -16,7 +16,8 @@ namespace Stripe
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
+
         [JsonIgnore]
         public string BalanceTransactionId
         {
@@ -37,6 +38,7 @@ namespace Stripe
         #endregion
 
         #region Expandable Charge
+
         [JsonIgnore]
         public string ChargeId
         {
@@ -66,7 +68,8 @@ namespace Stripe
         [JsonProperty("description")]
         public string Description { get; set; }
 
-        #region Expandable Failure Balance Transaction
+        #region Expandable FailureBalanceTransaction
+
         [JsonIgnore]
         public string FailureBalanceTransactionId
         {
@@ -93,6 +96,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         #region Expandable PaymentIntent
+
         [JsonIgnore]
         public string PaymentIntentId
         {
@@ -118,7 +122,8 @@ namespace Stripe
         [JsonProperty("receipt_number")]
         public string ReceiptNumber { get; set; }
 
-        #region Expandable Source Transfer Reversal
+        #region Expandable SourceTransferReversal
+
         [JsonIgnore]
         public string SourceTransferReversalId
         {
@@ -141,7 +146,8 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
-        #region Expandable  Transfer Reversal
+        #region Expandable TransferReversal
+
         [JsonIgnore]
         public string TransferReversalId
         {

--- a/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
@@ -1,7 +1,6 @@
 namespace Stripe.Reporting
 {
     using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
@@ -154,7 +154,7 @@ namespace Stripe
         [JsonProperty("next_action")]
         public SetupIntentNextAction NextAction { get; set; }
 
-        #region Expandable OnBehalfOf (Account)
+        #region Expandable OnBehalfOf
 
         /// <summary>
         /// ID of the account (if any) for which the setup is intended.

--- a/src/Stripe.net/Entities/Terminal/ConnectionTokens/ConnectionToken.cs
+++ b/src/Stripe.net/Entities/Terminal/ConnectionTokens/ConnectionToken.cs
@@ -1,9 +1,6 @@
 namespace Stripe.Terminal
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ConnectionToken : StripeEntity<ConnectionToken>, IHasObject
     {

--- a/src/Stripe.net/Entities/Terminal/Locations/Location.cs
+++ b/src/Stripe.net/Entities/Terminal/Locations/Location.cs
@@ -1,9 +1,7 @@
 namespace Stripe.Terminal
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class Location : StripeEntity<Location>, IHasId, IHasMetadata, IHasObject
     {
@@ -19,7 +17,7 @@ namespace Stripe.Terminal
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("display_name")]

--- a/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
@@ -1,9 +1,7 @@
 namespace Stripe.Terminal
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class Reader : StripeEntity<Reader>, IHasId, IHasMetadata, IHasObject
     {
@@ -16,7 +14,7 @@ namespace Stripe.Terminal
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
-        [JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
         [JsonProperty("device_sw_version")]

--- a/src/Stripe.net/Entities/Topups/Topup.cs
+++ b/src/Stripe.net/Entities/Topups/Topup.cs
@@ -19,7 +19,7 @@ namespace Stripe
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
 
         /// <summary>
         /// ID of the balance transaction that describes the impact of this Top-up on your account balance (not including refunds or disputes).

--- a/src/Stripe.net/Entities/Transfers/Transfer.cs
+++ b/src/Stripe.net/Entities/Transfers/Transfer.cs
@@ -19,7 +19,8 @@ namespace Stripe
         [JsonProperty("amount_reversed")]
         public long AmountReversed { get; set; }
 
-        #region Expandable Balance Transaction
+        #region Expandable BalanceTransaction
+
         [JsonIgnore]
         public string BalanceTransactionId
         {
@@ -50,6 +51,7 @@ namespace Stripe
         public string Description { get; set; }
 
         #region Expandable Destination
+
         [JsonIgnore]
         public string DestinationId
         {
@@ -69,7 +71,8 @@ namespace Stripe
         internal ExpandableField<Account> InternalDestination { get; set; }
         #endregion
 
-        #region Expandable Destination Payment
+        #region Expandable DestinationPayment
+
         [JsonIgnore]
         public string DestinationPaymentId
         {
@@ -101,7 +104,8 @@ namespace Stripe
         [JsonProperty("reversed")]
         public bool Reversed { get; set; }
 
-        #region Expandable Source Transaction
+        #region Expandable SourceTransaction
+
         [JsonIgnore]
         public string SourceTransactionId
         {

--- a/src/Stripe.net/Services/AccountLinks/AccountLinkCreateOptions.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkCreateOptions.cs
@@ -1,9 +1,6 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class AccountLinkCreateOptions : BaseOptions
     {

--- a/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
@@ -1,10 +1,7 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class AccountLinkService : Service<AccountLink>,
         ICreatable<AccountLink, AccountLinkCreateOptions>

--- a/src/Stripe.net/Services/Accounts/AccountListOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountListOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class AccountListOptions : ListOptions
     {
     }

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainCreateOptions.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainCreateOptions.cs
@@ -1,7 +1,5 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class ApplePayDomainCreateOptions : BaseOptions

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
@@ -1,9 +1,6 @@
 namespace Stripe.BillingPortal
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class SessionCreateOptions : BaseOptions
     {

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
@@ -1,11 +1,7 @@
 namespace Stripe.BillingPortal
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SessionService : Service<Session>,
         ICreatable<Session, SessionCreateOptions>

--- a/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCaptureOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class ChargeCaptureOptions : BaseOptions

--- a/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeCreateOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;

--- a/src/Stripe.net/Services/Charges/ChargeListOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeListOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
 
     public class ChargeListOptions : ListOptionsWithCreated

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -1,9 +1,7 @@
 namespace Stripe.Checkout
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class SessionCreateOptions : BaseOptions, IHasMetadata
     {
@@ -31,18 +29,18 @@ namespace Stripe.Checkout
         public string ClientReferenceId { get; set; }
 
         /// <summary>
-        /// The email address used to create the customer object. If you already know your
-        /// customer’s email address, use this attribute to prefill it on Checkout.
-        /// </summary>
-        [JsonProperty("customer_email")]
-        public string CustomerEmail { get; set; }
-
-        /// <summary>
         /// ID of the customer this Checkout Session is for if one exists. May only be used with
         /// <c>LineItems</c>. Usage with <c>SubscriptionData</c> is not yet available.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
+
+        /// <summary>
+        /// The email address used to create the customer object. If you already know your
+        /// customer’s email address, use this attribute to prefill it on Checkout.
+        /// </summary>
+        [JsonProperty("customer_email")]
+        public string CustomerEmail { get; set; }
 
         /// <summary>
         /// A list of items your customer is purchasing.

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -1,12 +1,9 @@
 namespace Stripe.Checkout
 {
-    using System;
     using System.Collections.Generic;
-    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Stripe.Infrastructure;
 
     public class SessionService : Service<Session>,
         ICreatable<Session, SessionCreateOptions>,

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteUpdateOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteUpdateOptions.cs
@@ -1,9 +1,7 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class CreditNoteUpdateOptions : BaseOptions, IHasMetadata
     {

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;

--- a/src/Stripe.net/Services/FileLinks/FileLinkCreateOptions.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkCreateOptions.cs
@@ -15,16 +15,16 @@ namespace Stripe
         public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
+        /// The ID of the file.
+        /// </summary>
+        [JsonProperty("file")]
+        public string File { get; set; }
+
+        /// <summary>
         /// Set of key-value pairs that you can attach to an object. This can be useful for storing
         /// additional information about the object in a structured format.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
-
-        /// <summary>
-        /// The ID of the file.
-        /// </summary>
-        [JsonProperty("file")]
-        public string File { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationListOptions.cs
@@ -5,16 +5,16 @@ namespace Stripe.Issuing
     public class AuthorizationListOptions : ListOptionsWithCreated
     {
         /// <summary>
-        /// Only return transactions that belong to the given card.
-        /// </summary>
-        [JsonProperty("cardholder")]
-        public string Cardholder { get; set; }
-
-        /// <summary>
         /// Only return transactions that belong to the given cardholder.
         /// </summary>
         [JsonProperty("card")]
         public string Card { get; set; }
+
+        /// <summary>
+        /// Only return transactions that belong to the given card.
+        /// </summary>
+        [JsonProperty("cardholder")]
+        public string Cardholder { get; set; }
 
         /// <summary>
         /// Only return authorizations with the given status.  One of <c>closed</c>,

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderUpdateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderUpdateOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe.Issuing
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Services/Issuing/Cards/CardUpdateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardUpdateOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe.Issuing
 {
-    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
 


### PR DESCRIPTION
Timing out for the night, this'll put a dent in some insignificant changes, but there are likely more coming. 

r? @remi-stripe 
cc @stripe/api-libraries 


* Confirmed the removal of the using statements with Visual Studio
* Updated the expandable fields so that they are of the format, where we use the pascal case name of the field, then a newline (required to pass lint when we have a doc string), then the docstring or the JsonIgnore attribute:

```cs
#region Expandable PascalCaseNoSpacesName

/// docstring
[JsonIgnore]
```

* on save, the editor changed some of these from (no space), I'm fine going one way or another for these:
`[JsonProperty("deleted", NullValueHandling=NullValueHandling.Ignore)]` to (space around equals operator)`[JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]`

* fixed some alphabetization


