### PR TITLE
Add support for `Result` and `ResultReason` in `ChargePaymentMethodDetailsCardThreeDSecure`

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails/ChargePaymentMethodDetailsCardThreeDSecure.cs
@@ -13,6 +13,18 @@ namespace Stripe
         public bool Authenticated { get; set; }
 
         /// <summary>
+        /// Indicates the outcome of 3D Secure authentication.
+        /// </summary>
+        [JsonProperty("result")]
+        public string Result { get; set; }
+
+        /// <summary>
+        /// Additional information about why 3D Secure succeeded or failed.
+        /// </summary>
+        [JsonProperty("result_reason")]
+        public string ResultReason { get; set; }
+
+        /// <summary>
         /// Whether or not 3D Secure succeeded.
         /// </summary>
         [JsonProperty("succeeded")]


### PR DESCRIPTION
r? @cjavilla-stripe 
cc @stripe/api-libraries 