### PR TITLE
Add support for `ProductData` on `SessionLineItemPriceDataOptions`

### DIFF
--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
@@ -19,6 +19,12 @@ namespace Stripe
         public string Product { get; set; }
 
         /// <summary>
+        /// Data used to generate a new product object inline.
+        /// </summary>
+        [JsonProperty("product_data")]
+        public SessionLineItemPriceDataProductDataOptions ProductData { get; set; }
+
+        /// <summary>
         /// The recurring components of a price such as its interval.
         /// </summary>
         [JsonProperty("recurring")]

--- a/src/Stripe.net/Services/Products/SessionLineItemPriceDataProductDataOptions.cs
+++ b/src/Stripe.net/Services/Products/SessionLineItemPriceDataProductDataOptions.cs
@@ -1,0 +1,35 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SessionLineItemPriceDataProductDataOptions : INestedOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+        /// </summary>
+        [JsonProperty("images")]
+        public List<string> Images { get; set; }
+
+        /// <summary>
+        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
+        /// additional information about the object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The product’s name, meant to be displayable to the customer. Whenever this product is
+        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
r? @cjavilla-stripe 
cc @stripe/api-libraries 