### PR TITLE
Add dotnet-format check to Appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Run tests for a single target framework:
 dotnet test --framework netcoreapp2.1
 ```
 
+The library uses [`dotnet-format`][dotnet-format] for code formatting. Code
+must be formatted before PRs are submitted, otherwise CI will fail. Run the
+formatter with:
+
+```sh
+dotnet format src/Stripe.net.sln
+```
+
 For any requests, bug or comments, please [open an issue][issues] or [submit a
 pull request][pulls].
 
@@ -138,6 +146,7 @@ pull request][pulls].
 [api-keys]: https://dashboard.stripe.com/apikeys
 [connect-auth]: https://stripe.com/docs/connect/authentication#authentication-via-the-stripe-account-header
 [dotnet-core-cli-tools]: https://docs.microsoft.com/en-us/dotnet/core/tools/
+[dotnet-format]: https://github.com/dotnet/format
 [idempotency-keys]: https://stripe.com/docs/api/idempotent_requests?lang=dotnet
 [issues]: https://github.com/stripe/stripe-dotnet/issues/new
 [nuget-cli]: https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
       $app = Start-Process -FilePath ".\stripe-mock\stripe-mock_${env:STRIPE_MOCK_VERSION}\stripe-mock.exe" -ArgumentList "-strict-version-check" -NoNewWindow -PassThru
       Write-Host ("stripe-mock running, Id = $($app.Id)`n") -ForegroundColor Green
       $env:PATH += ";" + (Get-Item -Path ".\stripe-mock\stripe-mock_${env:STRIPE_MOCK_VERSION}").FullName
+  - dotnet tool install dotnet-format --version 4.1.131201 --tool-path tools
   - dotnet tool install coveralls.net --version 1.0.0 --tool-path tools
 
 before_build:
@@ -54,6 +55,8 @@ test_script:
   - dotnet test src\StripeTests\StripeTests.csproj
 
 after_test:
+  - ps: Write-Host $("`n               RUNNING FORMAT CHECK               `n") -BackgroundColor DarkCyan
+  - .\tools\dotnet-format --check src/Stripe.net.sln
   - ps: Write-Host $("`n               RUNNING COVERAGE               `n") -BackgroundColor DarkCyan
   - dotnet test -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
   - ps: |

--- a/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/FormEncoder.cs
@@ -75,10 +75,10 @@ namespace Stripe.Infrastructure.FormEncoding
         /// <returns>The URL-encoded string.</returns>
         private static string UrlEncode(string value)
         {
+            // Don't use strict form encoding by changing the square bracket control
+            // characters back to their literals. This is fine by the server, and
+            // makes these parameter strings easier to read.
             return WebUtility.UrlEncode(value)
-                /* Don't use strict form encoding by changing the square bracket control
-                 * characters back to their literals. This is fine by the server, and
-                 * makes these parameter strings easier to read. */
                 .Replace("%5B", "[")
                 .Replace("%5D", "]");
         }
@@ -285,9 +285,9 @@ namespace Stripe.Infrastructure.FormEncoding
                 index += 1;
             }
 
-            /* Because application/x-www-form-urlencoded cannot represent an empty list, convention
-             * is to take the list parameter and just set it to an empty string. (E.g. A regular
-             * list might look like `a[0]=1&b[1]=2`. Emptying it would look like `a=`.) */
+            // Because application/x-www-form-urlencoded cannot represent an empty list, convention
+            // is to take the list parameter and just set it to an empty string. (E.g. A regular
+            // list might look like `a[0]=1&b[1]=2`. Emptying it would look like `a=`.)
             if (!flatParams.Any())
             {
                 flatParams.Add(new KeyValuePair<string, object>(keyPrefix, string.Empty));


### PR DESCRIPTION
r? @cjavilla-stripe 
cc @stripe/api-libraries 

Add `dotnet-format` check to Appveyor. This should prevent badly formatted files from being merged.

I've verified that a PR including a badly formatted file will cause the CI build to fail.
