### PR TITLE
Fixed typo in SessionSubscriptionDataOptions

### DIFF
--- a/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
@@ -55,7 +55,7 @@ namespace Stripe.Checkout
 
         /// <summary>
         /// Indicates if a plan’s <see cref="Plan.TrialPeriodDays"/> should be applied to the
-        /// subscription. Setting <c>TrialEnd</c> on <c>DubscriptionData</c> is preferred. Defaults
+        /// subscription. Setting <c>TrialEnd</c> on <c>SubscriptionData</c> is preferred. Defaults
         /// to <c>false</c>.
         /// </summary>
         [JsonProperty("trial_from_plan")]


### PR DESCRIPTION
SessionSubscriptionDataOptions.TrialFromPlan had a typo that said "DubscriptionData" which is now corrected to "SubscriptionData"