### PR TITLE
Correct namespace statements for issuing/checkout

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderCompany.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderCompany.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividual.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividual.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualDob.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualDob.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualVerification.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualVerification.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualVerificationDocument.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderIndividualVerificationDocument.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using Newtonsoft.Json;
     using Stripe.Infrastructure;

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderRequirements.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderRequirements.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControls.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControls.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControlsSpendingLimit.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControlsSpendingLimit.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Issuing
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataOptions.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Checkout
 {
     using Newtonsoft.Json;
 

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataRecurringOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataRecurringOptions.cs
@@ -1,4 +1,4 @@
-namespace Stripe
+namespace Stripe.Checkout
 {
     using Newtonsoft.Json;
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

First of a couple PRs with breaking changes. This one corrects the namespaces.