### PR TITLE
Drop support for .NET Framework 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/rg0pg5tlr1a6f8tf/branch/master?svg=true)](https://ci.appveyor.com/project/stripe/stripe-dotnet)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
-The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.5+.
+The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.6.1+.
 
 ## Installation
 

--- a/src/Stripe.net/Infrastructure/AsyncUtils.cs
+++ b/src/Stripe.net/Infrastructure/AsyncUtils.cs
@@ -1,4 +1,3 @@
-#if !NET45
 namespace Stripe.Infrastructure
 {
     using System;
@@ -73,4 +72,3 @@ namespace Stripe.Infrastructure
         }
     }
 }
-#endif

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -29,8 +29,6 @@ namespace Stripe
             "netstandard2.0"
 #elif NET461
             "net461"
-#elif NET45
-            "net45"
 #else
             "unknown"
 #endif

--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -79,12 +79,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Account> ListAutoPagingAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Account Reject(string id, AccountRejectOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -67,11 +67,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ApplePayDomain> ListAutoPagingAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(applicationFeeId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ApplicationFeeRefund> ListAutoPagingAsync(string applicationFeeId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(applicationFeeId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual ApplicationFeeRefund Update(string applicationFeeId, string id, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -45,11 +45,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ApplicationFee> ListAutoPagingAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -45,11 +45,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<BalanceTransaction> ListAutoPagingAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -70,12 +70,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options ?? new BankAccountListOptions(), requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<BankAccount> ListAutoPagingAsync(string parentId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
         }
-#endif
 
         public virtual BankAccount Update(string parentId, string id, BankAccountUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -47,12 +47,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Capability> ListAutoPagingAsync(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Capability Update(string parentId, string id, CapabilityUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -69,12 +69,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options ?? new CardListOptions(), requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(string parentId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options ?? new CardListOptions(), requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Card Update(string parentId, string id, CardUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Charge> ListAutoPagingAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Charge Update(string id, ChargeUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -57,12 +57,10 @@ namespace Stripe.Checkout
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Session> ListAutoPagingAsync(SessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual StripeList<LineItem> ListLineItems(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
@@ -79,11 +77,9 @@ namespace Stripe.Checkout
             return this.ListRequestAutoPaging<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -45,11 +45,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<CountrySpec> ListAutoPagingAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Coupon> ListAutoPagingAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Coupon Update(string id, CouponUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<CreditNote> ListAutoPagingAsync(CreditNoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual StripeList<CreditNoteLineItem> ListLineItems(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
@@ -80,12 +78,10 @@ namespace Stripe
             return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<CreditNoteLineItem> ListLineItemsAutoPagingAsync(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual StripeList<CreditNoteLineItem> ListPreviewLineItems(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
@@ -102,12 +98,10 @@ namespace Stripe
             return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<CreditNoteLineItem> ListPreviewLineItemsAutoPagingAsync(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual CreditNote Preview(CreditNotePreviewOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<CustomerBalanceTransaction> ListAutoPagingAsync(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual CustomerBalanceTransaction Update(string parentId, string id, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Customer> ListAutoPagingAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Customer Update(string id, CustomerUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -45,11 +45,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<IExternalAccount> ListAutoPagingAsync(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual IExternalAccount Update(string parentId, string id, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<FileLink> ListAutoPagingAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual FileLink Update(string id, FileLinkUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<File> ListAutoPagingAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         private RequestOptions SetupRequestOptionsForFilesRequest(RequestOptions requestOptions)
         {

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<InvoiceItem> ListAutoPagingAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual InvoiceItem Update(string id, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -79,12 +79,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Invoice> ListAutoPagingAsync(InvoiceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual StripeList<InvoiceLineItem> ListLineItems(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
@@ -101,12 +99,10 @@ namespace Stripe
             return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<InvoiceLineItem> ListLineItemsAutoPagingAsync(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
@@ -123,12 +119,10 @@ namespace Stripe
             return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPagingAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Invoice MarkUncollectible(string id, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -67,12 +67,10 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Authorization> ListAutoPagingAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Authorization Update(string id, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -57,12 +57,10 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Cardholder> ListAutoPagingAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Cardholder Update(string id, CardholderUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -57,12 +57,10 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Card Update(string id, CardUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -57,12 +57,10 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -46,12 +46,10 @@ namespace Stripe.Issuing
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Transaction> ListAutoPagingAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Transaction Update(string id, TransactionUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Orders/OrderService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Order> ListAutoPagingAsync(OrderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Order Pay(string id, OrderPayOptions options = null, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -88,12 +88,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<PaymentIntent> ListAutoPagingAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual PaymentIntent Update(string id, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -78,12 +78,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<PaymentMethod> ListAutoPagingAsync(PaymentMethodListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual PaymentMethod Update(string id, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Payout> ListAutoPagingAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Payout Update(string id, PayoutUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -69,12 +69,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Person> ListAutoPagingAsync(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Person Update(string parentId, string id, PersonUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Plan> ListAutoPagingAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Plan Update(string id, PlanUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Prices/PriceService.cs
+++ b/src/Stripe.net/Services/Prices/PriceService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Price> ListAutoPagingAsync(PriceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Price Update(string id, PriceUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Product> ListAutoPagingAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Product Update(string id, ProductUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -45,11 +45,9 @@ namespace Stripe.Radar
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<EarlyFraudWarning> ListAutoPagingAsync(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -67,11 +67,9 @@ namespace Stripe.Radar
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ValueListItem> ListAutoPagingAsync(ValueListItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -67,12 +67,10 @@ namespace Stripe.Radar
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ValueList> ListAutoPagingAsync(ValueListListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual ValueList Update(string id, ValueListUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Refund> ListAutoPagingAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Refund Update(string id, RefundUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -56,11 +56,9 @@ namespace Stripe.Reporting
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ReportRun> ListAutoPagingAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -45,11 +45,9 @@ namespace Stripe.Reporting
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ReportType> ListAutoPagingAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -56,11 +56,9 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Review> ListAutoPagingAsync(ReviewListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -78,12 +78,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<SetupIntent> ListAutoPagingAsync(SetupIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual SetupIntent Update(string id, SetupIntentUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -45,11 +45,9 @@ namespace Stripe.Sigma
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<ScheduledQueryRun> ListAutoPagingAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Skus/SkuService.cs
+++ b/src/Stripe.net/Services/Skus/SkuService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Sku> ListAutoPagingAsync(SkuListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Sku Update(string id, SkuUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -34,11 +34,9 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(sourceId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<SourceTransaction> ListAutoPagingAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(sourceId, options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -78,12 +78,10 @@ namespace Stripe
             return this.ListRequestAutoPaging<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Source> ListAutoPagingAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListRequestAutoPagingAsync<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Source Update(string id, SourceUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<SubscriptionItem> ListAutoPagingAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual SubscriptionItem Update(string id, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<SubscriptionSchedule> ListAutoPagingAsync(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual SubscriptionSchedule Release(string id, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -67,12 +67,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Subscription> ListAutoPagingAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Subscription Update(string id, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -68,11 +68,9 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<TaxId> ListAutoPagingAsync(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<TaxRate> ListAutoPagingAsync(TaxRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual TaxRate Update(string id, TaxRateUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -68,12 +68,10 @@ namespace Stripe.Terminal
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Location> ListAutoPagingAsync(LocationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Location Update(string id, LocationUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -68,12 +68,10 @@ namespace Stripe.Terminal
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Reader> ListAutoPagingAsync(ReaderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Reader Update(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Topup> ListAutoPagingAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Topup Update(string id, TopupUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -58,12 +58,10 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<TransferReversal> ListAutoPagingAsync(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual TransferReversal Update(string parentId, string id, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -57,12 +57,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<Transfer> ListAutoPagingAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual Transfer Update(string id, TransferUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -34,11 +34,9 @@ namespace Stripe
             return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<UsageRecordSummary> ListAutoPagingAsync(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
         }
-#endif
     }
 }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -68,12 +68,10 @@ namespace Stripe
             return this.ListEntitiesAutoPaging(options, requestOptions);
         }
 
-#if !NET45
         public virtual IAsyncEnumerable<WebhookEndpoint> ListAutoPagingAsync(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
-#endif
 
         public virtual WebhookEndpoint Update(string id, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null)
         {

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -139,7 +139,6 @@ namespace Stripe
                 requestOptions);
         }
 
-#if !NET45
         protected IAsyncEnumerable<TEntityReturned> ListNestedEntitiesAutoPagingAsync(
             string parentId,
             ListOptions options,
@@ -152,7 +151,6 @@ namespace Stripe
                 requestOptions,
                 cancellationToken);
         }
-#endif
 
         protected TEntityReturned UpdateNestedEntity(
             string parentId,

--- a/src/Stripe.net/Services/_interfaces/IListable.cs
+++ b/src/Stripe.net/Services/_interfaces/IListable.cs
@@ -14,8 +14,6 @@ namespace Stripe
 
         IEnumerable<TEntity> ListAutoPaging(TOptions listOptions = null, RequestOptions requestOptions = null);
 
-#if !NET45
         IAsyncEnumerable<TEntity> ListAutoPagingAsync(TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
-#endif
     }
 }

--- a/src/Stripe.net/Services/_interfaces/INestedListable.cs
+++ b/src/Stripe.net/Services/_interfaces/INestedListable.cs
@@ -14,8 +14,6 @@ namespace Stripe
 
         IEnumerable<TEntity> ListAutoPaging(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null);
 
-#if !NET45
         IAsyncEnumerable<TEntity> ListAutoPagingAsync(string parentId, TOptions listOptions = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default);
-#endif
     }
 }

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -8,7 +8,7 @@
     <Version>37.14.0</Version>
     <LangVersion>8</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>Stripe.net</AssemblyName>
     <PackageId>Stripe.net</PackageId>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
@@ -46,12 +46,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -221,7 +221,6 @@ namespace StripeTests
             Assert.Equal("account", account.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -229,7 +228,6 @@ namespace StripeTests
             Assert.NotNull(account);
             Assert.Equal("account", account.Object);
         }
-#endif
 
         [Fact]
         public void Reject()

--- a/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
+++ b/src/StripeTests/Services/ApplePayDomains/ApplePayDomainServiceTest.cs
@@ -115,7 +115,6 @@ namespace StripeTests
             Assert.Equal("apple_pay_domain", domain.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -123,6 +122,5 @@ namespace StripeTests
             Assert.NotNull(domain);
             Assert.Equal("apple_pay_domain", domain.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFeeRefunds/ApplicationFeeRefundServiceTest.cs
@@ -114,7 +114,6 @@ namespace StripeTests
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -122,7 +121,6 @@ namespace StripeTests
             Assert.NotNull(applicationFeeRefund);
             Assert.Equal("fee_refund", applicationFeeRefund.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
+++ b/src/StripeTests/Services/ApplicationFees/ApplicationFeeServiceTest.cs
@@ -75,7 +75,6 @@ namespace StripeTests
             Assert.Equal("application_fee", applicationFee.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -83,6 +82,5 @@ namespace StripeTests
             Assert.NotNull(applicationFee);
             Assert.Equal("application_fee", applicationFee.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/AutoPagingTest.cs
+++ b/src/StripeTests/Services/AutoPagingTest.cs
@@ -287,7 +287,6 @@ namespace StripeTests
                     ItExpr.IsAny<CancellationToken>());
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -635,7 +634,6 @@ namespace StripeTests
                         m.RequestUri.Query == "?limit=2&starting_after=pm_124"),
                     ItExpr.IsAny<CancellationToken>());
         }
-#endif
 
         public class PageableModel : StripeEntity<PageableModel>, IHasId
         {
@@ -657,12 +655,10 @@ namespace StripeTests
                 return this.ListEntitiesAutoPaging(options, requestOptions);
             }
 
-#if !NET45
             public IAsyncEnumerable<PageableModel> ListAutoPagingAsync(ListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
             {
                 return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
             }
-#endif
         }
     }
 }

--- a/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/BalanceTransactions/BalanceTransactionServiceTest.cs
@@ -75,7 +75,6 @@ namespace StripeTests
             Assert.Equal("balance_transaction", balanceTransaction.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -83,6 +82,5 @@ namespace StripeTests
             Assert.NotNull(balanceTransaction);
             Assert.Equal("balance_transaction", balanceTransaction.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
+++ b/src/StripeTests/Services/BankAccounts/BankAccountServiceTest.cs
@@ -129,14 +129,12 @@ namespace StripeTests
             Assert.NotNull(bankAccount);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var bankAccount = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
             Assert.NotNull(bankAccount);
         }
-#endif
 
         // stripe-mock does not return a bank account object on update today so we do not test
         // the returned value's object

--- a/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/CapabilityServiceTest.cs
@@ -81,7 +81,6 @@ namespace StripeTests
             Assert.Equal("capability", capabilitie.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -89,7 +88,6 @@ namespace StripeTests
             Assert.NotNull(capabilitie);
             Assert.Equal("capability", capabilitie.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Cards/CardServiceTest.cs
+++ b/src/StripeTests/Services/Cards/CardServiceTest.cs
@@ -123,14 +123,12 @@ namespace StripeTests
             Assert.NotNull(card);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var card = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
             Assert.NotNull(card);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Charges/ChargeServiceTest.cs
+++ b/src/StripeTests/Services/Charges/ChargeServiceTest.cs
@@ -135,7 +135,6 @@ namespace StripeTests
             Assert.Equal("charge", charge.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -143,7 +142,6 @@ namespace StripeTests
             Assert.NotNull(charge);
             Assert.Equal("charge", charge.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Checkout/SessionServiceTest.cs
+++ b/src/StripeTests/Services/Checkout/SessionServiceTest.cs
@@ -167,7 +167,6 @@ namespace StripeTests.Checkout
             Assert.Equal("checkout.session", intent.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -175,7 +174,6 @@ namespace StripeTests.Checkout
             Assert.NotNull(intent);
             Assert.Equal("checkout.session", intent.Object);
         }
-#endif
 
         [Fact]
         public void ListLineItems()
@@ -207,7 +205,6 @@ namespace StripeTests.Checkout
             Assert.Equal("item", lineItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListLineItemsAutoPagingAsync()
         {
@@ -215,6 +212,5 @@ namespace StripeTests.Checkout
             Assert.NotNull(lineItem);
             Assert.Equal("item", lineItem.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
+++ b/src/StripeTests/Services/CountrySpecs/CountrySpecServiceTest.cs
@@ -75,7 +75,6 @@ namespace StripeTests
             Assert.Equal("country_spec", countrySpec.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -83,6 +82,5 @@ namespace StripeTests
             Assert.NotNull(countrySpec);
             Assert.Equal("country_spec", countrySpec.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Coupons/CouponServiceTest.cs
+++ b/src/StripeTests/Services/Coupons/CouponServiceTest.cs
@@ -126,7 +126,6 @@ namespace StripeTests
             Assert.Equal("coupon", coupon.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -134,7 +133,6 @@ namespace StripeTests
             Assert.NotNull(coupon);
             Assert.Equal("coupon", coupon.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
+++ b/src/StripeTests/Services/CreditNotes/CreditNoteServiceTest.cs
@@ -137,7 +137,6 @@ namespace StripeTests
             Assert.Equal("credit_note", creditNote.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -145,7 +144,6 @@ namespace StripeTests
             Assert.NotNull(creditNote);
             Assert.Equal("credit_note", creditNote.Object);
         }
-#endif
 
         [Fact]
         public void ListLineItems()
@@ -177,7 +175,6 @@ namespace StripeTests
             Assert.Equal("credit_note_line_item", lineItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListLineItemsAutoPagingAsync()
         {
@@ -185,7 +182,6 @@ namespace StripeTests
             Assert.NotNull(lineItem);
             Assert.Equal("credit_note_line_item", lineItem.Object);
         }
-#endif
 
         [Fact]
         public void Preview()
@@ -235,7 +231,6 @@ namespace StripeTests
             Assert.Equal("credit_note_line_item", lineItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListPreviewLineItemsAutoPagingAsync()
         {
@@ -243,7 +238,6 @@ namespace StripeTests
             Assert.NotNull(lineItem);
             Assert.Equal("credit_note_line_item", lineItem.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/CustomerBalanceTransactions/CustomerBalanceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/CustomerBalanceTransactions/CustomerBalanceTransactionServiceTest.cs
@@ -107,7 +107,6 @@ namespace StripeTests
             Assert.Equal("customer_balance_transaction", transaction.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -115,7 +114,6 @@ namespace StripeTests
             Assert.NotNull(transaction);
             Assert.Equal("customer_balance_transaction", transaction.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Customers/CustomerServiceTest.cs
+++ b/src/StripeTests/Services/Customers/CustomerServiceTest.cs
@@ -126,7 +126,6 @@ namespace StripeTests
             Assert.Equal("customer", customer.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -134,7 +133,6 @@ namespace StripeTests
             Assert.NotNull(customer);
             Assert.Equal("customer", customer.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
+++ b/src/StripeTests/Services/Disputes/DisputeServiceTest.cs
@@ -103,7 +103,6 @@ namespace StripeTests
             Assert.Equal("dispute", dispute.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -111,7 +110,6 @@ namespace StripeTests
             Assert.NotNull(dispute);
             Assert.Equal("dispute", dispute.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Events/EventServiceTest.cs
+++ b/src/StripeTests/Services/Events/EventServiceTest.cs
@@ -75,7 +75,6 @@ namespace StripeTests
             Assert.Equal("event", evt.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -83,6 +82,5 @@ namespace StripeTests
             Assert.NotNull(evt);
             Assert.Equal("event", evt.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
+++ b/src/StripeTests/Services/ExternalAccounts/ExternalAccountServiceTest.cs
@@ -130,14 +130,12 @@ namespace StripeTests
             Assert.NotNull(externalAccount);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var externalAccount = await this.service.ListAutoPagingAsync(AccountId, this.listOptions).FirstAsync();
             Assert.NotNull(externalAccount);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
+++ b/src/StripeTests/Services/FileLinks/FileLinkServiceTest.cs
@@ -110,7 +110,6 @@ namespace StripeTests
             Assert.Equal("file_link", domain.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -118,7 +117,6 @@ namespace StripeTests
             Assert.NotNull(domain);
             Assert.Equal("file_link", domain.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -111,7 +111,6 @@ namespace StripeTests
             Assert.Equal("file", file.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -119,6 +118,5 @@ namespace StripeTests
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
+++ b/src/StripeTests/Services/InvoiceItems/InvoiceItemServiceTest.cs
@@ -127,7 +127,6 @@ namespace StripeTests
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -135,7 +134,6 @@ namespace StripeTests
             Assert.NotNull(invoiceItem);
             Assert.Equal("invoiceitem", invoiceItem.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -194,7 +194,6 @@ namespace StripeTests
             Assert.Equal("invoice", invoice.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -202,7 +201,6 @@ namespace StripeTests
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
-#endif
 
         [Fact]
         public void ListLineItems()
@@ -234,7 +232,6 @@ namespace StripeTests
             Assert.Equal("line_item", lineItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListLineItemsAutoPagingAsync()
         {
@@ -242,7 +239,6 @@ namespace StripeTests
             Assert.NotNull(lineItem);
             Assert.Equal("line_item", lineItem.Object);
         }
-#endif
 
         [Fact]
         public void ListUpcomingLineItems()
@@ -274,7 +270,6 @@ namespace StripeTests
             Assert.Equal("line_item", lineItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListUpcomingLineItemsAutoPagingAsync()
         {
@@ -282,7 +277,6 @@ namespace StripeTests
             Assert.NotNull(lineItem);
             Assert.Equal("line_item", lineItem.Object);
         }
-#endif
 
         [Fact]
         public void MarkUncollectible()

--- a/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Authorizations/AuthorizationServiceTest.cs
@@ -109,7 +109,6 @@ namespace StripeTests.Issuing
             Assert.Equal("issuing.authorization", authorization.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -117,7 +116,6 @@ namespace StripeTests.Issuing
             Assert.NotNull(authorization);
             Assert.Equal("issuing.authorization", authorization.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cardholders/CardholderServiceTest.cs
@@ -146,7 +146,6 @@ namespace StripeTests.Issuing
             Assert.Equal("issuing.cardholder", cardholder.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -154,7 +153,6 @@ namespace StripeTests.Issuing
             Assert.NotNull(cardholder);
             Assert.Equal("issuing.cardholder", cardholder.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Cards/IssuingCardServiceTest.cs
@@ -116,7 +116,6 @@ namespace StripeTests.Issuing
             Assert.Equal("issuing.card", card.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -124,7 +123,6 @@ namespace StripeTests.Issuing
             Assert.NotNull(card);
             Assert.Equal("issuing.card", card.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -94,7 +94,6 @@ namespace StripeTests.Issuing
             Assert.Equal("issuing.dispute", dispute.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -102,7 +101,6 @@ namespace StripeTests.Issuing
             Assert.NotNull(dispute);
             Assert.Equal("issuing.dispute", dispute.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Transactions/TransactionServiceTest.cs
@@ -77,7 +77,6 @@ namespace StripeTests.Issuing
             Assert.Equal("issuing.transaction", transaction.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -85,7 +84,6 @@ namespace StripeTests.Issuing
             Assert.NotNull(transaction);
             Assert.Equal("issuing.transaction", transaction.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Orders/OrderServiceTest.cs
+++ b/src/StripeTests/Services/Orders/OrderServiceTest.cs
@@ -136,7 +136,6 @@ namespace StripeTests
             Assert.Equal("order", order.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -144,7 +143,6 @@ namespace StripeTests
             Assert.NotNull(order);
             Assert.Equal("order", order.Object);
         }
-#endif
 
         [Fact]
         public void Pay()

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentServiceTest.cs
@@ -203,7 +203,6 @@ namespace StripeTests
             Assert.Equal("payment_intent", intent.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -211,7 +210,6 @@ namespace StripeTests
             Assert.NotNull(intent);
             Assert.Equal("payment_intent", intent.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
+++ b/src/StripeTests/Services/PaymentMethods/PaymentMethodServiceTest.cs
@@ -161,7 +161,6 @@ namespace StripeTests
             Assert.Equal("payment_method", payment_method.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -169,6 +168,5 @@ namespace StripeTests
             Assert.NotNull(payment_method);
             Assert.Equal("payment_method", payment_method.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
+++ b/src/StripeTests/Services/Payouts/PayoutServiceTest.cs
@@ -128,7 +128,6 @@ namespace StripeTests
             Assert.Equal("payout", payout.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -136,7 +135,6 @@ namespace StripeTests
             Assert.NotNull(payout);
             Assert.Equal("payout", payout.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Persons/PersonServiceTest.cs
+++ b/src/StripeTests/Services/Persons/PersonServiceTest.cs
@@ -153,7 +153,6 @@ namespace StripeTests
             Assert.Equal("person", person.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -161,7 +160,6 @@ namespace StripeTests
             Assert.NotNull(person);
             Assert.Equal("person", person.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Plans/PlanServiceTest.cs
+++ b/src/StripeTests/Services/Plans/PlanServiceTest.cs
@@ -175,7 +175,6 @@ namespace StripeTests
             Assert.Equal("plan", plan.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -183,7 +182,6 @@ namespace StripeTests
             Assert.NotNull(plan);
             Assert.Equal("plan", plan.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Prices/PriceServiceTest.cs
+++ b/src/StripeTests/Services/Prices/PriceServiceTest.cs
@@ -173,7 +173,6 @@ namespace StripeTests
             Assert.Equal("price", price.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -181,7 +180,6 @@ namespace StripeTests
             Assert.NotNull(price);
             Assert.Equal("price", price.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Products/ProductServiceTest.cs
+++ b/src/StripeTests/Services/Products/ProductServiceTest.cs
@@ -138,7 +138,6 @@ namespace StripeTests
             Assert.Equal("product", product.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -146,7 +145,6 @@ namespace StripeTests
             Assert.NotNull(product);
             Assert.Equal("product", product.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
+++ b/src/StripeTests/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningServiceTest.cs
@@ -77,7 +77,6 @@ namespace StripeTests.Radar
             Assert.Equal("radar.early_fraud_warning", warning.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -85,6 +84,5 @@ namespace StripeTests.Radar
             Assert.NotNull(warning);
             Assert.Equal("radar.early_fraud_warning", warning.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueListItems/ValueListItemServiceTest.cs
@@ -117,7 +117,6 @@ namespace StripeTests.Radar
             Assert.Equal("radar.value_list_item", valueListItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -125,6 +124,5 @@ namespace StripeTests.Radar
             Assert.NotNull(valueListItem);
             Assert.Equal("radar.value_list_item", valueListItem.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
+++ b/src/StripeTests/Services/Radar/ValueLists/ValueListServiceTest.cs
@@ -128,7 +128,6 @@ namespace StripeTests.Radar
             Assert.Equal("radar.value_list", valueList.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -136,7 +135,6 @@ namespace StripeTests.Radar
             Assert.NotNull(valueList);
             Assert.Equal("radar.value_list", valueList.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Refunds/RefundServiceTest.cs
+++ b/src/StripeTests/Services/Refunds/RefundServiceTest.cs
@@ -110,7 +110,6 @@ namespace StripeTests
             Assert.Equal("refund", refund.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -118,7 +117,6 @@ namespace StripeTests
             Assert.NotNull(refund);
             Assert.Equal("refund", refund.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportRuns/ReportRunServiceTest.cs
@@ -93,13 +93,11 @@ namespace StripeTests.Reporting
             Assert.NotNull(reportRun);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var reportRun = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
             Assert.NotNull(reportRun);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -65,13 +65,11 @@ namespace StripeTests.Reporting
             Assert.NotNull(reportType);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var reportType = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
             Assert.NotNull(reportType);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
+++ b/src/StripeTests/Services/Reviews/ReviewServiceTest.cs
@@ -97,7 +97,6 @@ namespace StripeTests
             Assert.Equal("review", review.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -105,6 +104,5 @@ namespace StripeTests
             Assert.NotNull(review);
             Assert.Equal("review", review.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
+++ b/src/StripeTests/Services/SetupIntents/SetupIntentServiceTest.cs
@@ -171,7 +171,6 @@ namespace StripeTests
             Assert.Equal("setup_intent", intent.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -179,7 +178,6 @@ namespace StripeTests
             Assert.NotNull(intent);
             Assert.Equal("setup_intent", intent.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
+++ b/src/StripeTests/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunServiceTest.cs
@@ -75,7 +75,6 @@ namespace StripeTests
             Assert.Equal("scheduled_query_run", run.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -83,6 +82,5 @@ namespace StripeTests
             Assert.NotNull(run);
             Assert.Equal("scheduled_query_run", run.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Skus/SkuServiceTest.cs
+++ b/src/StripeTests/Services/Skus/SkuServiceTest.cs
@@ -144,7 +144,6 @@ namespace StripeTests
             Assert.Equal("sku", sku.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -152,7 +151,6 @@ namespace StripeTests
             Assert.NotNull(sku);
             Assert.Equal("sku", sku.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
+++ b/src/StripeTests/Services/SourceTransactions/SourceTransactionServiceTest.cs
@@ -57,7 +57,6 @@ namespace StripeTests
             Assert.Equal("source_transaction", sourceTransaction.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -65,6 +64,5 @@ namespace StripeTests
             Assert.NotNull(sourceTransaction);
             Assert.Equal("source_transaction", sourceTransaction.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -214,14 +214,12 @@ namespace StripeTests
             Assert.NotNull(source);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
             var source = await this.service.ListAutoPagingAsync(CustomerId, this.listOptions).FirstAsync();
             Assert.NotNull(source);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionItems/SubscriptionItemServiceTest.cs
@@ -144,7 +144,6 @@ namespace StripeTests
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -152,7 +151,6 @@ namespace StripeTests
             Assert.NotNull(subscriptionItem);
             Assert.Equal("subscription_item", subscriptionItem.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
+++ b/src/StripeTests/Services/SubscriptionSchedules/SubscriptionScheduleServiceTest.cs
@@ -141,7 +141,6 @@ namespace StripeTests
             Assert.Equal("subscription_schedule", subscription.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -149,7 +148,6 @@ namespace StripeTests
             Assert.NotNull(subscription);
             Assert.Equal("subscription_schedule", subscription.Object);
         }
-#endif
 
         [Fact]
         public void Release()

--- a/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
+++ b/src/StripeTests/Services/Subscriptions/SubscriptionServiceTest.cs
@@ -157,7 +157,6 @@ namespace StripeTests
             Assert.Equal("subscription", subscription.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -165,7 +164,6 @@ namespace StripeTests
             Assert.NotNull(subscription);
             Assert.Equal("subscription", subscription.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
+++ b/src/StripeTests/Services/TaxIds/TaxIdServiceTest.cs
@@ -119,7 +119,6 @@ namespace StripeTests
             Assert.Equal("tax_id", person.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -127,6 +126,5 @@ namespace StripeTests
             Assert.NotNull(person);
             Assert.Equal("tax_id", person.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
+++ b/src/StripeTests/Services/TaxRates/TaxRateServiceTest.cs
@@ -111,7 +111,6 @@ namespace StripeTests
             Assert.Equal("tax_rate", taxRate.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -119,7 +118,6 @@ namespace StripeTests
             Assert.NotNull(taxRate);
             Assert.Equal("tax_rate", taxRate.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Locations/LocationServiceTest.cs
@@ -119,7 +119,6 @@ namespace StripeTests.Terminal
             Assert.Equal("terminal.location", location.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -127,7 +126,6 @@ namespace StripeTests.Terminal
             Assert.NotNull(location);
             Assert.Equal("terminal.location", location.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/Terminal/Readers/ReaderServiceTest.cs
@@ -112,7 +112,6 @@ namespace StripeTests.Terminal
             Assert.Equal("terminal.reader", reader.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -120,7 +119,6 @@ namespace StripeTests.Terminal
             Assert.NotNull(reader);
             Assert.Equal("terminal.reader", reader.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Topups/TopupServiceTest.cs
+++ b/src/StripeTests/Services/Topups/TopupServiceTest.cs
@@ -129,7 +129,6 @@ namespace StripeTests
             Assert.Equal("topup", topup.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -137,7 +136,6 @@ namespace StripeTests
             Assert.NotNull(topup);
             Assert.Equal("topup", topup.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
+++ b/src/StripeTests/Services/TransferReversals/TransferReversalServiceTest.cs
@@ -110,7 +110,6 @@ namespace StripeTests
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -118,7 +117,6 @@ namespace StripeTests
             Assert.NotNull(transferReversal);
             Assert.Equal("transfer_reversal", transferReversal.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/Transfers/TransferServiceTest.cs
+++ b/src/StripeTests/Services/Transfers/TransferServiceTest.cs
@@ -111,7 +111,6 @@ namespace StripeTests
             Assert.Equal("transfer", transfer.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -119,7 +118,6 @@ namespace StripeTests
             Assert.NotNull(transfer);
             Assert.Equal("transfer", transfer.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
+++ b/src/StripeTests/Services/UsageRecordSummaries/UsageRecordSummaryServiceTest.cs
@@ -56,7 +56,6 @@ namespace StripeTests
             Assert.Equal("usage_record_summary", summarie.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -64,6 +63,5 @@ namespace StripeTests
             Assert.NotNull(summarie);
             Assert.Equal("usage_record_summary", summarie.Object);
         }
-#endif
     }
 }

--- a/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
+++ b/src/StripeTests/Services/WebhookEndpoints/WebhookEndpointServiceTest.cs
@@ -129,7 +129,6 @@ namespace StripeTests
             Assert.Equal("webhook_endpoint", endpoint.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -137,7 +136,6 @@ namespace StripeTests
             Assert.NotNull(endpoint);
             Assert.Equal("webhook_endpoint", endpoint.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -107,12 +107,10 @@ namespace StripeTests
                 return this.ListEntitiesAutoPaging(options, requestOptions);
             }
 
-#if !NET45
             public virtual IAsyncEnumerable<TestEntity> ListAutoPagingAsync(ListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
             {
                 return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
             }
-#endif
         }
     }
 }

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\netfx.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.0;net461;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.0;net461</TargetFrameworks>
     <AssemblyName>StripeTests</AssemblyName>
     <LangVersion>8</LangVersion>
     <PackageId>StripeTests</PackageId>
@@ -37,10 +37,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Drop support for .NET Framework 4.5.

Less than 0.5% of users on stripe-dotnet >= 35.0 are still running .NET Framework 4.5. Everyone else is running .NET Framework 4.6.1 or some .NET Standard 2.0-compatible runtime.
