### PR TITLE
Add Newtonsoft.Json version to X-Stripe-Client-User-Agent

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -228,19 +228,35 @@ namespace Stripe
                 { "stripe_net_target_framework", StripeNetTargetFramework },
             };
 
-            // The following values are in a try/catch block on the off chance that the
+            // The following values are in try/catch blocks on the off chance that the
             // RuntimeInformation methods fail in an unexpected way. This should ~never happen, but
             // if it does it should not prevent users from sending requests.
             // See https://github.com/stripe/stripe-dotnet/issues/1986 for context.
             try
             {
                 values.Add("lang_version", RuntimeInformation.GetRuntimeVersion());
-                values.Add("os_version", RuntimeInformation.GetOSVersion());
             }
             catch (Exception)
             {
                 values.Add("lang_version", "(unknown)");
+            }
+
+            try
+            {
+                values.Add("os_version", RuntimeInformation.GetOSVersion());
+            }
+            catch (Exception)
+            {
                 values.Add("os_version", "(unknown)");
+            }
+
+            try
+            {
+                values.Add("newtonsoft_json_version", RuntimeInformation.GetNewtonsoftJsonVersion());
+            }
+            catch (Exception)
+            {
+                values.Add("newtonsoft_json_version", "(unknown)");
             }
 
             if (this.appInfo != null)

--- a/src/Stripe.net/Infrastructure/RuntimeInformation.cs
+++ b/src/Stripe.net/Infrastructure/RuntimeInformation.cs
@@ -63,6 +63,15 @@ namespace Stripe.Infrastructure
             return Unknown;
         }
 
+        /// <summary>Returns a string with the Newtonsoft.Json assembly version number.</summary>
+        /// <returns>A string with the Newtonsoft.Json assembly version number.</returns>
+        public static string GetNewtonsoftJsonVersion()
+        {
+            var assembly = Assembly.GetAssembly(typeof(Newtonsoft.Json.JsonConvert));
+            var fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
+            return fileVersion.FileVersion;
+        }
+
         internal static string GetMonoVersion()
         {
             var monoRuntimeType = Type.GetType("Mono.Runtime");


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add Newtonsoft.Json version to `X-Stripe-Client-User-Agent` header.

Unfortunately AFAICT Newtonsoft.Json does not expose its version number, so I had to resort to some fugly reflection.

I've verified this works by spying on the requests:
```
X-Stripe-Client-User-Agent: {"bindings_version":"37.15.0","lang":".net","publisher":"stripe","stripe_net_target_framework":"net45","lang_version":"Mono 6.4.0.198 (2019-06/fe64a4765e6 Wed)","os_version":"Unix 19.4.0.0","newtonsoft_json_version":"9.0.1.19813"}
```
