### PR TITLE
Fix Bacs mandate Event network_status deserialization

### DIFF
--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsBacsDebit.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsBacsDebit.cs
@@ -8,7 +8,7 @@ namespace Stripe
         /// The status of the mandate on the network and whether it's been accepted or revoked.
         /// </summary>
         [JsonProperty("network_status")]
-        public long NetworkStatus { get; set; }
+        public string NetworkStatus { get; set; }
 
         /// <summary>
         /// The reference associated with the mandate.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries

When `mandate.updated` Events are delivered, Stripe dotnet attempts to incorrectly
deserialize the `network_status` attribute as a long and not a string causing
an exception. 