### PR TITLE
Adds missing fields found with autogen

### DIFF
--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -12,6 +12,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsCardInstallments Installments { get; set; }
 
         /// <summary>
+        /// Selected network to process this PaymentIntent on. Depends on the available networks of the card
+        /// attached to the PaymentIntent. Can be only set confirm-time.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
         /// We strongly recommend that you rely on our SCA engine to automatically prompt your
         /// customers for authentication based on risk level and other requirements. However, if
         /// you wish to request authentication based on logic from your own fraud engine, provide

--- a/src/Stripe.net/Entities/Sources/SourceReceiver.cs
+++ b/src/Stripe.net/Entities/Sources/SourceReceiver.cs
@@ -27,5 +27,19 @@ namespace Stripe
         /// </summary>
         [JsonProperty("amount_returned")]
         public long AmountReturned { get; set; }
+
+        /// <summary>
+        /// Type of refund attribute method, one of <c>email</c>, <c>manual</c>,
+        /// or <c>none</c>.
+        /// </summary>
+        [JsonProperty("refund_attributes_method")]
+        public string RefundAttributesMethod { get; set; }
+
+        /// <summary>
+        /// Type of refund attribute status, one of <c>missing</c>, <c>requested</c>, or
+        /// <c>available</c>.
+        /// </summary>
+        [JsonProperty("refund_attributes_status")]
+        public string RefundAttributesStatus { get; set; }
     }
 }


### PR DESCRIPTION
Adds missing fields found with autogen
  * Add `Network` on `PaymentMethodCardOptions`
  * Add `RefundAttributesMethod` and `RefundAttributesStatus` on `SourceReceiver`



r? @remi-stripe 
cc @stripe/api-libraries 