### PR TITLE
Correct the nullability of properties based on the open api spec

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsBitcoin.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsBitcoin.cs
@@ -8,16 +8,16 @@ namespace Stripe
         public string Address { get; set; }
 
         [JsonProperty("amount")]
-        public long Amount { get; set; }
+        public long? Amount { get; set; }
 
         [JsonProperty("amount_charged")]
-        public long AmountCharged { get; set; }
+        public long? AmountCharged { get; set; }
 
         [JsonProperty("amount_received")]
-        public long AmountReceived { get; set; }
+        public long? AmountReceived { get; set; }
 
         [JsonProperty("amount_returned")]
-        public long AmountReturned { get; set; }
+        public long? AmountReturned { get; set; }
 
         [JsonProperty("refund_address")]
         public string RefundAddress { get; set; }

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
@@ -36,13 +36,13 @@ namespace Stripe
         /// Two-digit number representing the card’s expiration month.
         /// </summary>
         [JsonProperty("exp_month")]
-        public long ExpMonth { get; set; }
+        public long? ExpMonth { get; set; }
 
         /// <summary>
         /// Four-digit number representing the card’s expiration year.
         /// </summary>
         [JsonProperty("exp_year")]
-        public long ExpYear { get; set; }
+        public long? ExpYear { get; set; }
 
         /// <summary>
         /// Uniquely identifies this particular card number. You can use this attribute to check

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
@@ -35,13 +35,13 @@ namespace Stripe
         /// Two-digit number representing the card’s expiration month.
         /// </summary>
         [JsonProperty("exp_month")]
-        public long ExpMonth { get; set; }
+        public long? ExpMonth { get; set; }
 
         /// <summary>
         /// Four-digit number representing the card’s expiration year.
         /// </summary>
         [JsonProperty("exp_year")]
-        public long ExpYear { get; set; }
+        public long? ExpYear { get; set; }
 
         /// <summary>
         /// Uniquely identifies this particular card number. You can use this attribute to check

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
@@ -38,13 +38,13 @@ namespace Stripe
         /// Two-digit number representing the card's expiration month.
         /// </summary>
         [JsonProperty("exp_month")]
-        public long ExpMonth { get; set; }
+        public long? ExpMonth { get; set; }
 
         /// <summary>
         /// Four-digit number representing the card's expiration year.
         /// </summary>
         [JsonProperty("exp_year")]
-        public long ExpYear { get; set; }
+        public long? ExpYear { get; set; }
 
         /// <summary>
         /// Uniquely identifies this particular card number.

--- a/src/Stripe.net/Entities/Invoices/InvoiceThresholdReasonItemReason.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceThresholdReasonItemReason.cs
@@ -15,6 +15,6 @@ namespace Stripe
         /// The quantity threshold boundary that applied to the given line item.
         /// </summary>
         [JsonProperty("usage_gte")]
-        public long? UsageGte { get; set; }
+        public long UsageGte { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControlsSpendingLimit.cs
+++ b/src/Stripe.net/Entities/Issuing/Cardholders/CardholderSpendingControlsSpendingLimit.cs
@@ -9,7 +9,7 @@ namespace Stripe.Issuing
         /// Maximum amount allowed to spend per time interval.
         /// </summary>
         [JsonProperty("amount")]
-        public long? Amount { get; set; }
+        public long Amount { get; set; }
 
         /// <summary>
         /// Categories on which to apply the spending limit. Leave this empty to limit all charges.

--- a/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
@@ -25,7 +25,7 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("eta")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime Eta { get; set; }
+        public DateTime? Eta { get; set; }
 
         /// <summary>
         /// Recipient name.

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFuel.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionPurchaseDetailsFuel.cs
@@ -22,7 +22,7 @@ namespace Stripe.Issuing
         /// decimal places.
         /// </summary>
         [JsonProperty("unit_cost_decimal")]
-        public decimal? UnitCostDecimal { get; set; }
+        public decimal UnitCostDecimal { get; set; }
 
         /// <summary>
         /// The volume of the fuel that was pumped, represented as a decimal string with at most 12

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardInstallmentsPlan.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardInstallmentsPlan.cs
@@ -9,7 +9,7 @@ namespace Stripe
         /// your customer will make to their credit card.
         /// </summary>
         [JsonProperty("count")]
-        public long Count { get; set; }
+        public long? Count { get; set; }
 
         /// <summary>
         /// For <c>fixed_count</c> installment plans, this is the interval between installment

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentTransferData.cs
@@ -10,7 +10,7 @@ namespace Stripe
         /// charge amount is transferred to the destination account.
         /// </summary>
         [JsonProperty("amount")]
-        public long? Amount { get; set; }
+        public long Amount { get; set; }
 
         #region Expandable Destination
 

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodCardThreeDSecureUsage.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodCardThreeDSecureUsage.cs
@@ -5,6 +5,6 @@ namespace Stripe
     public class PaymentMethodCardThreeDSecureUsage : StripeEntity<PaymentMethodCardThreeDSecureUsage>
     {
         [JsonProperty("supported")]
-        public bool? Supported { get; set; }
+        public bool Supported { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Sources/SourceSourceOrderItem.cs
+++ b/src/Stripe.net/Entities/Sources/SourceSourceOrderItem.cs
@@ -34,7 +34,7 @@ namespace Stripe
         /// the number of instances of the SKU to be ordered.
         /// </summary>
         [JsonProperty("quantity")]
-        public long? Quantity { get; set; }
+        public long Quantity { get; set; }
 
         /// <summary>
         /// The type of this order item.

--- a/src/Stripe.net/Entities/Sources/SourceThreeDSecure.cs
+++ b/src/Stripe.net/Entities/Sources/SourceThreeDSecure.cs
@@ -20,7 +20,7 @@ namespace Stripe
         /// True if the cardholder went through the authentication flow and their bank indicated that authentication succeeded.
         /// </summary>
         [JsonProperty("authenticated")]
-        public bool Authenticated { get; set; }
+        public bool? Authenticated { get; set; }
 
         /// <summary>
         /// Card brand. Can be `American Express`, `Diners Club`, `Discover`, `JCB`, `MasterCard`, `UnionPay`, `Visa`, or `Unknown`.
@@ -68,13 +68,13 @@ namespace Stripe
         /// The expiration month of the card.
         /// </summary>
         [JsonProperty("exp_month")]
-        public long ExpMonth { get; set; }
+        public long? ExpMonth { get; set; }
 
         /// <summary>
         /// The expiration year of the card.
         /// </summary>
         [JsonProperty("exp_year")]
-        public long ExpYear { get; set; }
+        public long? ExpYear { get; set; }
 
         /// <summary>
         /// Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example.

--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
@@ -103,7 +103,7 @@ namespace Stripe
         /// </summary>
         [JsonProperty("end_date")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? EndDate { get; set; }
+        public DateTime EndDate { get; set; }
 
         /// <summary>
         /// The default invoice settings for this phase.
@@ -129,7 +129,7 @@ namespace Stripe
         /// </summary>
         [JsonProperty("start_date")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? StartDate { get; set; }
+        public DateTime StartDate { get; set; }
 
         /// <summary>
         /// If provided, each invoice created during this phase of the subscription schedule will

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -29,7 +29,7 @@ namespace Stripe
 
         [JsonProperty("billing_cycle_anchor")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? BillingCycleAnchor { get; set; }
+        public DateTime BillingCycleAnchor { get; set; }
 
         /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Most of these seem peaceful. I can override any of them in the autogen if we decide we don't want to fix with a breaking change.

The one I'm most concerned about is the change on the Subscription entity for billing_cycle_anchor because it's a core model and that seems like a field that would be used pretty frequently. 