### PR TITLE
Correct the base Options class

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountListOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountListOptions.cs
@@ -1,6 +1,6 @@
 namespace Stripe
 {
-    public class AccountListOptions : ListOptions
+    public class AccountListOptions : ListOptionsWithCreated
     {
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe.Checkout
 {
     using Newtonsoft.Json;
 
-    public class SessionListOptions : ListOptionsWithCreated
+    public class SessionListOptions : ListOptions
     {
         /// <summary>
         /// Only return the Checkout Session for the PaymentIntent specified.

--- a/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class InvoiceSubscriptionItemOptions : BaseOptions, IHasId, IHasMetadata
+    public class InvoiceSubscriptionItemOptions : INestedOptions, IHasId, IHasMetadata
     {
         /// <summary>
         /// Subscription item to update.

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -8,7 +8,8 @@ namespace Stripe.Radar
         ICreatable<ValueList, ValueListCreateOptions>,
         IDeletable<ValueList, ValueListDeleteOptions>,
         IListable<ValueList, ValueListListOptions>,
-        IRetrievable<ValueList, ValueListGetOptions>
+        IRetrievable<ValueList, ValueListGetOptions>,
+        IUpdatable<ValueList, ValueListUpdateOptions>
     {
         public ValueListService()
             : base(null)

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class SubscriptionItemOptions : IHasId, INestedOptions, IHasMetadata
+    public class SubscriptionItemOptions : INestedOptions, IHasId, IHasMetadata
     {
         /// <summary>
         /// Delete all usage for a given subscription item. Only allowed when <c>deleted</c> is set

--- a/src/Stripe.net/Services/TaxRates/TaxRateGetOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateGetOptions.cs
@@ -1,6 +1,6 @@
 namespace Stripe
 {
-    public class TaxRateGetOptions : ListOptionsWithCreated
+    public class TaxRateGetOptions : BaseOptions
     {
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenPersonOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenPersonOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class TokenPersonOptions : BaseOptions, IHasMetadata
+    public class TokenPersonOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// The person’s address.

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointListOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointListOptions.cs
@@ -1,6 +1,6 @@
 namespace Stripe
 {
-    public class WebhookEndpointListOptions : ListOptionsWithCreated
+    public class WebhookEndpointListOptions : ListOptions
     {
     }
 }


### PR DESCRIPTION
Use the correct base classes and interfaces for Options classes. 

r? @remi-stripe 
cc @stripe/api-libraries 

I skipped adding `IRetrievable<ThreeDSecure, ThreeDSecureGetOptions>` to  `ThreeDSecureService` because it seems that is deprecated and we don't want to encourage? Also it would require adding a new class for the Get options, and the service methods etc.

