### PR TITLE
Removes unused imports, alphabetizes, and removes some comments

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountBusinessProfile.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountBusinessProfile.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class AccountBusinessProfile : StripeEntity<AccountBusinessProfile>
     {

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -102,7 +102,6 @@ namespace Stripe
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
-        // This property is not returned as part of standard API requests.
         [JsonProperty("description")]
         public string Description { get; set; }
 
@@ -121,11 +120,9 @@ namespace Stripe
         [JsonProperty("funding")]
         public string Funding { get; set; }
 
-        // This property is not returned as part of standard API requests.
         [JsonProperty("iin")]
         public string Iin { get; set; }
 
-        // This property is not returned as part of standard API requests.
         [JsonProperty("issuer")]
         public string Issuer { get; set; }
 

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsCard : StripeEntity<ChargePaymentMethodDetailsCard>
     {

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsCardPresent : StripeEntity<ChargePaymentMethodDetailsCardPresent>
     {

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardWalletMasterpass.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardWalletMasterpass.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsCardWalletMasterpass : StripeEntity<ChargePaymentMethodDetailsCardWalletMasterpass>
     {

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardWalletVisaCheckout.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardWalletVisaCheckout.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsCardWalletVisaCheckout : StripeEntity<ChargePaymentMethodDetailsCardWalletVisaCheckout>
     {

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class ChargePaymentMethodDetailsInteracPresent : StripeEntity<ChargePaymentMethodDetailsInteracPresent>
     {

--- a/src/Stripe.net/Entities/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Disputes/Dispute.cs
@@ -62,7 +62,6 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
-        // This property is not returned as part of standard API requests.
         [JsonProperty("network_reason_code")]
         public string NetworkReasonCode { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class PaymentIntentPaymentMethodOptionsCard : StripeEntity<PaymentIntentPaymentMethodOptionsCard>
     {

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardInstallments.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardInstallments.cs
@@ -2,7 +2,6 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class PaymentIntentPaymentMethodOptionsCardInstallments : StripeEntity<PaymentIntentPaymentMethodOptionsCardInstallments>
     {

--- a/src/Stripe.net/Entities/Sources/SourceAlipay.cs
+++ b/src/Stripe.net/Entities/Sources/SourceAlipay.cs
@@ -1,10 +1,6 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class SourceAlipay : StripeEntity<SourceAlipay>
     {
-        // The Alipay sources do not have any specific property today.
-        // The only ones available in the spec are used for mobile SDKs.
     }
 }

--- a/src/Stripe.net/Entities/Sources/SourceEps.cs
+++ b/src/Stripe.net/Entities/Sources/SourceEps.cs
@@ -1,10 +1,6 @@
 namespace Stripe
 {
-    using Newtonsoft.Json;
-
     public class SourceEps : StripeEntity<SourceEps>
     {
-        // The Eps sources do not have any specific property today.
-        // The only ones available in the spec are for private betas.
     }
 }

--- a/src/Stripe.net/Entities/Sources/SourceOwner.cs
+++ b/src/Stripe.net/Entities/Sources/SourceOwner.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class SourceOwner : StripeEntity<SourceOwner>
     {

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentIntentTransferDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentIntentTransferDataOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe.Checkout
 {
-    using System;
     using Newtonsoft.Json;
 
     public class SessionPaymentIntentTransferDataOptions : INestedOptions

--- a/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSubscriptionItemOptions.cs
@@ -6,12 +6,6 @@ namespace Stripe
     public class InvoiceSubscriptionItemOptions : BaseOptions, IHasId, IHasMetadata
     {
         /// <summary>
-        /// Subscription item to update.
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
-        /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
         /// new billing period.
         /// </summary>
@@ -30,6 +24,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("deleted")]
         public bool? Deleted { get; set; }
+
+        /// <summary>
+        /// Subscription item to update.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
         /// <summary>
         /// A set of key/value pairs that you can attach to a charge object. It can be useful for

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/Stripe.net/Services/Skus/InventoryOptions.cs
+++ b/src/Stripe.net/Services/Skus/InventoryOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class InventoryOptions : INestedOptions

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;


### PR DESCRIPTION
I removed the comments like `This property is not returned as part of standard API requests.` because we're not able to auto-gen those, if we want to add overrides for those, we could.

r? @remi-stripe 
cc @stripe/api-libraries 