### PR TITLE
Adds several breaking changes to bring inline with the spec

### DIFF
--- a/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeEvidenceOptions.cs
@@ -1,9 +1,8 @@
 namespace Stripe
 {
-    using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class DisputeEvidenceOptions : INestedOptions, IHasMetadata
+    public class DisputeEvidenceOptions : INestedOptions
     {
         [JsonProperty("access_activity_log")]
         public string AccessActivityLog { get; set; }
@@ -43,9 +42,6 @@ namespace Stripe
 
         [JsonProperty("duplicate_charge_id")]
         public string DuplicateChargeId { get; set; }
-
-        [JsonProperty("metadata")]
-        public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("product_description")]
         public string ProductDescription { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
@@ -4,21 +4,13 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class InvoiceListOptions : ListOptions
+    public class InvoiceListOptions : ListOptionsWithCreated
     {
         /// <summary>
         /// Either <c>charge_automatically</c>, or <c>send_invoice</c>.
         /// </summary>
         [JsonProperty("collection_method")]
         public string CollectionMethod { get; set; }
-
-        /// <summary>
-        /// A filter on the list based on the object <c>created</c> field. The value can be a
-        /// <see cref="DateTime"/> or a <see cref="DateRangeOptions"/>.
-        /// </summary>
-        [JsonProperty("created")]
-        [JsonConverter(typeof(AnyOfConverter))]
-        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return invoices for the customer specified by this customer ID.
@@ -33,12 +25,6 @@ namespace Stripe
         [JsonProperty("due_date")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, DateRangeOptions> DueDate { get; set; }
-
-        /// <summary>
-        /// A filter on the list based on the object paid field.
-        /// </summary>
-        [JsonProperty("paid")]
-        public bool? Paid { get; set; }
 
         /// <summary>
         /// Only return invoices with a given status. Must be one of

--- a/src/Stripe.net/Services/Sources/SourceMandateAcceptanceOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceMandateAcceptanceOptions.cs
@@ -13,9 +13,6 @@ namespace Stripe
         [JsonProperty("ip")]
         public string Ip { get; set; }
 
-        [JsonProperty("notification_method")]
-        public string NotificationMethod { get; set; }
-
         [JsonProperty("offline")]
         public SourceMandateAcceptanceOfflineOptions Offline { get; set; }
 

--- a/src/Stripe.net/Services/Sources/SourceMandateOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceMandateOptions.cs
@@ -6,5 +6,17 @@ namespace Stripe
     {
         [JsonProperty("acceptance")]
         public SourceMandateAcceptanceOptions Acceptance { get; set; }
+
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        [JsonProperty("notification_method")]
+        public string NotificationMethod { get; set; }
     }
 }

--- a/src/StripeTests/Services/Sources/SourceServiceTest.cs
+++ b/src/StripeTests/Services/Sources/SourceServiceTest.cs
@@ -43,10 +43,12 @@ namespace StripeTests
                     {
                         Date = DateTime.Parse("Mon, 01 Jan 2001 00:00:00Z"),
                         Ip = "127.0.0.1",
-                        NotificationMethod = "manual",
                         Status = "accepted",
                         UserAgent = "User-Agent",
                     },
+                    NotificationMethod = "manual",
+                    Amount = 1000,
+                    Currency = "USD",
                 },
                 Owner = new SourceOwnerOptions
                 {


### PR DESCRIPTION
- [x] ⚠️ Removes metadata from `DisputeEvidenceOptions` (not supported)
- [x] ⚠️ Updates `InvoiceListOptions` to use `ListOptionsWithCreated` base and uses created options from base rather than concrete class. Also removes `paid` from `InvoiceListOptions` (use status instead)
- [x] ⚠️ Moves `notification_method` from `SourceMandateAcceptanceOptions` to `SourceMandateOptions`


r? @remi-stripe 
cc @stripe/api-libraries 