### PR TITLE
Adds `BillingCycleAnchor` to default_settings and phases for `SubscriptionSchedules`

### DIFF
--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionScheduleDefaultSettings.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionScheduleDefaultSettings.cs
@@ -6,6 +6,14 @@ namespace Stripe
     public class SubscriptionScheduleDefaultSettings : StripeEntity<SubscriptionScheduleDefaultSettings>
     {
         /// <summary>
+        /// Can be set to <c>phase_start</c> to set the anchor to the start of the phase
+        /// or <c>automatic</c> to automatically change it if needed. Cannot be set to
+        /// <c>phase_start</c> if this phase specifies a trial.
+        /// </summary>
+        [JsonProperty("billing_cycle_anchor")]
+        public string BillingCycleAnchor { get; set; }
+
+        /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
         /// new billing period.
         /// </summary>

--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
@@ -23,6 +23,16 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
+        /// Possible values are <c>phase_start</c> or <c>automatic</c>. If
+        /// <c>phase_start</c> then billing cycle anchor of the
+        /// subscription is set to the start of the phase when entering
+        /// the phase. If <c>automatic</c> then the billing cycle anchor
+        /// is automatically modified as needed when entering the phase.
+        /// </summary>
+        [JsonProperty("billing_cycle_anchor")]
+        public string BillingCycleAnchor { get; set; }
+
+        /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
         /// new billing period.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleDefaultSettingsOptions.cs
@@ -5,6 +5,15 @@ namespace Stripe
     public class SubscriptionScheduleDefaultSettingsOptions : INestedOptions
     {
         /// <summary>
+        /// Can be set to <c>phase_start</c> to set the anchor to the
+        /// start of the phase or <c>automatic</c> to automatically
+        /// change it if needed. Cannot be set to <c>phase_start</c> if
+        /// this phase specifies a trial.
+        /// </summary>
+        [JsonProperty("billing_cycle_anchor")]
+        public string BillingCycleAnchor { get; set; }
+
+        /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
         /// new billing period. Pass an empty string to remove previously-defined thresholds.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -23,6 +23,15 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
+        /// Can be set to <c>phase_start</c> to set the anchor to the
+        /// start of the phase or <c>automatic</c> to automatically
+        /// change it if needed. Cannot be set to <c>phase_start</c> if
+        /// this phase specifies a trial.
+        /// </summary>
+        [JsonProperty("billing_cycle_anchor")]
+        public string BillingCycleAnchor { get; set; }
+
+        /// <summary>
         /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
         /// new billing period. Pass an empty string to remove previously-defined thresholds.
         /// </summary>


### PR DESCRIPTION
Adds billing_cycle_anchor to default_settings and phases for SubscriptionSchedules:
  * Adds `billing_cycle_anchor` to `default_settings` and `phases` for `SubscriptionSchedules`

r? @remi-stripe 
cc @stripe/api-libraries 