### PR TITLE
Add support for `AmountTotal`, `AmountSubtotal`, `Currency` and `TotalDetails` on Checkout `Session`

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -19,6 +19,18 @@ namespace Stripe.Checkout
         public string Object { get; set; }
 
         /// <summary>
+        /// Total of all items before discounts or taxes are applied.
+        /// </summary>
+        [JsonProperty("amount_subtotal")]
+        public long? AmountSubtotal { get; set; }
+
+        /// <summary>
+        /// Total of all items after discounts and taxes are applied.
+        /// </summary>
+        [JsonProperty("amount_total")]
+        public long? AmountTotal { get; set; }
+
+        /// <summary>
         /// Specify whether Checkout should collect the customer’s billing address. If set to
         /// <c>required</c>, Checkout will always collect the customer’s billing address. If left
         /// blank or set to <c>auto</c> Checkout will only collect the billing address when
@@ -40,6 +52,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("client_reference_id")]
         public string ClientReferenceId { get; set; }
+
+        /// <summary>
+        /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
 
         #region Expandable Customer
 
@@ -232,5 +250,11 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("success_url")]
         public string SuccessUrl { get; set; }
+
+        /// <summary>
+        /// Tax and discount details for the computed total amount.
+        /// </summary>
+        [JsonProperty("total_details")]
+        public SessionTotalDetails TotalDetails { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetails.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetails.cs
@@ -1,0 +1,27 @@
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionTotalDetails : StripeEntity<SessionTotalDetails>
+    {
+        /// <summary>
+        /// This is the sum of all the line item discounts.
+        /// </summary>
+        [JsonProperty("amount_discount")]
+        public long AmountDiscount { get; set; }
+
+        /// <summary>
+        /// This is the sum of all the line item tax amounts.
+        /// </summary>
+        [JsonProperty("amount_tax")]
+        public long AmountTax { get; set; }
+
+        /// <summary>
+        /// Breakdown of individual tax and discount amounts that add up to the
+        /// totals. This field is not included by default. To include it in
+        /// the response, expand the breakdown field.
+        /// </summary>
+        [JsonProperty("breakdown")]
+        public SessionTotalDetailsBreakdown Breakdown { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdown.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdown.cs
@@ -1,0 +1,20 @@
+namespace Stripe.Checkout
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SessionTotalDetailsBreakdown : StripeEntity<SessionTotalDetailsBreakdown>
+    {
+        /// <summary>
+        /// The aggregated line item discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<SessionTotalDetailsBreakdownDiscount> Discounts { get; set; }
+
+        /// <summary>
+        /// The aggregated line item tax amounts by rate.
+        /// </summary>
+        [JsonProperty("taxes")]
+        public List<SessionTotalDetailsBreakdownTax> Taxes { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownDiscount.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownDiscount.cs
@@ -1,0 +1,19 @@
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionTotalDetailsBreakdownDiscount : StripeEntity<SessionTotalDetailsBreakdownDiscount>
+    {
+        /// <summary>
+        /// The amount discounted.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// The discount applied.
+        /// </summary>
+        [JsonProperty("discount")]
+        public Discount Discount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownTax.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownTax.cs
@@ -1,0 +1,19 @@
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionTotalDetailsBreakdownTax : StripeEntity<SessionTotalDetailsBreakdownTax>
+    {
+        /// <summary>
+        /// Amount of tax applied for this rate.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// The tax rate applied.
+        /// </summary>
+        [JsonProperty("rate")]
+        public TaxRate Rate { get; set; }
+    }
+}


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 