### PR TITLE
Remove deprecated `tax_percent` field

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -528,10 +528,6 @@ namespace Stripe
         [JsonProperty("tax")]
         public long? Tax { get; set; }
 
-        [Obsolete("Use DefaultTaxRates instead")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         /// <summary>
         /// If <see cref="BillingReason" /> is set to <c>subscription_threshold</c> this
         /// returns more information on which threshold rules triggered the invoice.

--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
@@ -142,14 +142,6 @@ namespace Stripe
         public DateTime StartDate { get; set; }
 
         /// <summary>
-        /// If provided, each invoice created during this phase of the subscription schedule will
-        /// apply the tax rate, increasing the amount billed to the customer.
-        /// </summary>
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
-        /// <summary>
         /// The account (if any) the subscription's payments will be attributed
         /// to for tax reporting, and where funds from each payment will be
         /// transferred to for each of the subscription's invoices.

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -366,10 +366,6 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         /// <summary>
         /// If specified, the funds from the subscription’s invoices will be transferred to the
         /// destination and the ID of the resulting transfers will be found on the resulting

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -108,9 +108,6 @@ namespace Stripe
         [JsonProperty("tax_id_data")]
         public List<CustomerTaxIdDataOptions> TaxIdData { get; set; }
 
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, SubscriptionTrialEnd> TrialEnd { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -100,13 +100,6 @@ namespace Stripe
         [JsonProperty("subscription")]
         public string Subscription { get; set; }
 
-        /// <summary>
-        /// The percent tax rate applied to the invoice, represented as a decimal number.
-        /// </summary>
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         [JsonProperty("transfer_data")]
         public InvoiceTransferDataOptions TransferData { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -77,10 +77,6 @@ namespace Stripe
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }
 
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         [JsonProperty("transfer_data")]
         public InvoiceTransferDataOptions TransferData { get; set; }
     }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -116,15 +116,6 @@ namespace Stripe
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with
-        /// that tax percent. If set, one of <c>subscription_items</c> or
-        /// <c>subscription is required</c>.
-        /// </summary>
-        [Obsolete("Use SubscriptionDefaultTaxRates")]
-        [JsonProperty("subscription_tax_percent")]
-        public decimal? SubscriptionTaxPercent { get; set; }
-
-        /// <summary>
-        /// If provided, the invoice returned will preview updating or creating a subscription with
         /// that trial end. If set, one of <c>subscription_items</c> or <c>subscription</c> is
         /// required.
         /// </summary>

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -134,15 +134,6 @@ namespace Stripe
 
         /// <summary>
         /// If provided, the invoice returned will preview updating or creating a subscription with
-        /// that tax percent. If set, one of <c>subscription_items</c> or
-        /// <c>subscription is required</c>.
-        /// </summary>
-        [Obsolete("Use SubscriptionDefaultTaxRates")]
-        [JsonProperty("subscription_tax_percent")]
-        public decimal? SubscriptionTaxPercent { get; set; }
-
-        /// <summary>
-        /// If provided, the invoice returned will preview updating or creating a subscription with
         /// that trial end. If set, one of <c>subscription_items</c> or <c>subscription</c> is
         /// required.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -114,16 +114,6 @@ namespace Stripe
         public DateTime? StartDate { get; set; }
 
         /// <summary>
-        /// A non-negative decimal (with at most four decimal places) between 0 and 100. This
-        /// represents the percentage of the subscription invoice subtotal that will be calculated
-        /// and added as tax to the final amount each billing period. For example, a plan which
-        /// charges $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per invoice.
-        /// </summary>
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
-        /// <summary>
         /// The account (if any) the subscription's payments will be attributed
         /// to for tax reporting, and where funds from each payment will be
         /// transferred to for each of the subscription's invoices.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -202,18 +202,6 @@ namespace Stripe
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
-        /// <summary>
-        /// A non-negative decimal (with at most four decimal places) between 0
-        /// and 100. This represents the percentage of the subscription invoice
-        /// subtotal that will be calculated and added as tax to the final
-        /// amount each billing period. For example, a plan which charges
-        /// $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per
-        /// invoice.
-        /// </summary>
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         [JsonProperty("transfer_data")]
         public SubscriptionTransferDataOptions TransferData { get; set; }
 

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -201,18 +201,6 @@ namespace Stripe
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
-        /// <summary>
-        /// A non-negative decimal (with at most four decimal places) between 0
-        /// and 100. This represents the percentage of the subscription invoice
-        /// subtotal that will be calculated and added as tax to the final
-        /// amount each billing period. For example, a plan which charges
-        /// $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per
-        /// invoice.
-        /// </summary>
-        [Obsolete("Use DefaultTaxRates")]
-        [JsonProperty("tax_percent")]
-        public decimal? TaxPercent { get; set; }
-
         [JsonProperty("transfer_data")]
         public SubscriptionTransferDataOptions TransferData { get; set; }
 

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -35,7 +35,6 @@ namespace StripeTests
             this.createOptions = new InvoiceCreateOptions
             {
                 Customer = "cus_123",
-                TaxPercent = 12.5m,
             };
 
             this.updateOptions = new InvoiceUpdateOptions


### PR DESCRIPTION
  * ⚠️ Remove deprecated `tax_percent` field from `Customer`, `Invoice`, `Subscription`, and `SubscriptionSchedule`

r? @remi-stripe 
cc @stripe/api-libraries 