### PR TITLE
Add support for multiple coupons on Billing APIs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.93.0
+  STRIPE_MOCK_VERSION: 0.94.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItem.cs
+++ b/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItem.cs
@@ -37,6 +37,12 @@ namespace Stripe
         public long DiscountAmount { get; set; }
 
         /// <summary>
+        /// The amount of discount calculated per discount for this line item.
+        /// </summary>
+        [JsonProperty("discount_amounts")]
+        public List<CreditNoteLineItemDiscountAmount> DiscountAmounts { get; set; }
+
+        /// <summary>
         /// ID of the invoice line item being credited.
         /// </summary>
         [JsonProperty("invoice_line_item")]

--- a/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItemDiscountAmount.cs
+++ b/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItemDiscountAmount.cs
@@ -1,0 +1,41 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class CreditNoteLineItemDiscountAmount : StripeEntity<CreditNoteLineItemDiscountAmount>
+    {
+        /// <summary>
+        /// The amount, in cents, of the tax.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        #region Expandable Discount
+
+        /// <summary>
+        /// The ID of the discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscountId
+        {
+            get => this.InternalDiscount?.Id;
+            set => this.InternalDiscount = SetExpandableFieldId(value, this.InternalDiscount);
+        }
+
+        /// <summary>
+        /// The discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public Discount Discount
+        {
+            get => this.InternalDiscount?.ExpandedObject;
+            set => this.InternalDiscount = SetExpandableFieldObject(value, this.InternalDiscount);
+        }
+
+        [JsonProperty("discount")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Discount>))]
+        internal ExpandableField<Discount> InternalDiscount { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/CreditNotes/CreditNote.cs
+++ b/src/Stripe.net/Entities/CreditNotes/CreditNote.cs
@@ -92,6 +92,12 @@ namespace Stripe
         [JsonProperty("discount_amount")]
         public long DiscountAmount { get; set; }
 
+        /// <summary>
+        /// The aggregate amounts calculated per discount for all line items.
+        /// </summary>
+        [JsonProperty("discount_amounts")]
+        public List<CreditNoteDiscountAmount> DiscountAmounts { get; set; }
+
         #region Expandable Invoice
 
         /// <summary>

--- a/src/Stripe.net/Entities/CreditNotes/CreditNoteDiscountAmount.cs
+++ b/src/Stripe.net/Entities/CreditNotes/CreditNoteDiscountAmount.cs
@@ -1,0 +1,41 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class CreditNoteDiscountAmount : StripeEntity<CreditNoteDiscountAmount>
+    {
+        /// <summary>
+        /// The amount, in cents, of the tax.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        #region Expandable Discount
+
+        /// <summary>
+        /// The ID of the discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscountId
+        {
+            get => this.InternalDiscount?.Id;
+            set => this.InternalDiscount = SetExpandableFieldId(value, this.InternalDiscount);
+        }
+
+        /// <summary>
+        /// The discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public Discount Discount
+        {
+            get => this.InternalDiscount?.ExpandedObject;
+            set => this.InternalDiscount = SetExpandableFieldObject(value, this.InternalDiscount);
+        }
+
+        [JsonProperty("discount")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Discount>))]
+        internal ExpandableField<Discount> InternalDiscount { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -4,8 +4,11 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Discount : StripeEntity<Discount>, IHasObject
+    public class Discount : StripeEntity<Discount>, IHasId, IHasObject
     {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
         [JsonProperty("object")]
         public string Object { get; set; }
 

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -6,16 +6,29 @@ namespace Stripe
 
     public class Discount : StripeEntity<Discount>, IHasId, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object’s type. Objects of the same type share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <summary>
+        /// The coupon applied to create this discount if any.
+        /// </summary>
         [JsonProperty("coupon")]
         public Coupon Coupon { get; set; }
 
         #region Expandable Customer
+
+        /// <summary>
+        /// ID of the customer associated with this discount.
+        /// </summary>
         [JsonIgnore]
         public string CustomerId
         {
@@ -23,6 +36,9 @@ namespace Stripe
             set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
         }
 
+        /// <summary>
+        /// The customer associated with this discount (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public Customer Customer
         {
@@ -41,15 +57,41 @@ namespace Stripe
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
+        /// <summary>
+        /// If the coupon has a duration of repeating, the date that this discount will end. If the
+        /// coupon has a duration of once or forever, this attribute will be null.
+        /// </summary>
         [JsonProperty("end")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? End { get; set; }
 
+        /// <summary>
+        /// The invoice that the discount's coupon was applied to, if it was applied directly to a
+        /// particular invoice.
+        /// </summary>
+        [JsonProperty("invoice")]
+        public string Invoice { get; set; }
+
+        /// <summary>
+        /// The id of the invoice item or invoice line item that the discount's coupon was applied
+        /// to, if any.
+        /// </summary>
+        [JsonProperty("invoice_item")]
+        public string InvoiceItem { get; set; }
+
+        /// <summary>
+        /// Date that the coupon was applied.
+        /// </summary>
         [JsonProperty("start")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Start { get; set; }
 
         #region Expandable Subscription
+
+        /// <summary>
+        /// ID of the subscription that this coupon is applied to, if it is applied to a particular
+        /// subscription.
+        /// </summary>
         [JsonIgnore]
         public string SubscriptionId
         {
@@ -57,6 +99,10 @@ namespace Stripe
             set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
         }
 
+        /// <summary>
+        /// The subscription that this coupon is applied to, if it is applied to a particular
+        /// subscription (if it was expanded).
+        /// </summary>
         [JsonIgnore]
         public Subscription Subscription
         {

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -84,6 +85,34 @@ namespace Stripe
         /// </summary>
         [JsonProperty("discountable")]
         public bool Discountable { get; set; }
+
+        #region Expandable Discounts
+
+        /// <summary>
+        /// Ids of the discounts which apply to the invoice item. Item discounts are applied before
+        /// invoice discounts.
+        /// </summary>
+        [JsonIgnore]
+        public List<string> DiscountIds
+        {
+            get => this.InternalDiscounts?.Select((x) => x.Id).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
+        }
+
+        /// <summary>
+        /// The discounts which apply to the invoice item. Item discounts are applied before invoice
+        /// discounts.
+        /// </summary>
+        [JsonIgnore]
+        public List<Discount> Discounts
+        {
+            get => this.InternalDiscounts?.Select((x) => x.ExpandedObject).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayObjects(value);
+        }
+
+        [JsonProperty("discounts", ItemConverterType = typeof(ExpandableFieldConverter<Discount>))]
+        internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
+        #endregion
 
         #region Expandable Invoice
 

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -314,6 +315,26 @@ namespace Stripe
         /// </summary>
         [JsonProperty("discount")]
         public Discount Discount { get; set; }
+
+        #region Expandable Discounts
+
+        [JsonIgnore]
+        public List<string> DiscountIds
+        {
+            get => this.InternalDiscounts?.Select((x) => x.Id).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
+        }
+
+        [JsonIgnore]
+        public List<Discount> Discounts
+        {
+            get => this.InternalDiscounts?.Select((x) => x.ExpandedObject).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayObjects(value);
+        }
+
+        [JsonProperty("discounts", ItemConverterType = typeof(ExpandableFieldConverter<Discount>))]
+        internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
+        #endregion
 
         /// <summary>
         /// The date on which payment for this invoice is due. This value will be null for invoices

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -318,6 +318,10 @@ namespace Stripe
 
         #region Expandable Discounts
 
+        /// <summary>
+        /// Ids of the discounts applied to the invoice. Line item discounts are applied before
+        /// invoice discounts.
+        /// </summary>
         [JsonIgnore]
         public List<string> DiscountIds
         {
@@ -325,6 +329,10 @@ namespace Stripe
             set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
         }
 
+        /// <summary>
+        /// The discounts applied to the invoice. Line item discounts are applied before invoice
+        /// discounts.
+        /// </summary>
         [JsonIgnore]
         public List<Discount> Discounts
         {
@@ -565,6 +573,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("total")]
         public long Total { get; set; }
+
+        /// <summary>
+        /// The aggregate amounts calculated per discount for all line items.
+        /// </summary>
+        [JsonProperty("total_discount_amounts")]
+        public List<InvoiceDiscountAmount> TotalDiscountAmounts { get; set; }
 
         /// <summary>
         /// The aggregate amounts calculated per tax rate for all line items.

--- a/src/Stripe.net/Entities/Invoices/InvoiceDiscountAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceDiscountAmount.cs
@@ -1,0 +1,41 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceDiscountAmount : StripeEntity<InvoiceDiscountAmount>
+    {
+        /// <summary>
+        /// The amount, in cents, of the tax.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        #region Expandable Discount
+
+        /// <summary>
+        /// The ID of the discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscountId
+        {
+            get => this.InternalDiscount?.Id;
+            set => this.InternalDiscount = SetExpandableFieldId(value, this.InternalDiscount);
+        }
+
+        /// <summary>
+        /// The discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public Discount Discount
+        {
+            get => this.InternalDiscount?.ExpandedObject;
+            set => this.InternalDiscount = SetExpandableFieldObject(value, this.InternalDiscount);
+        }
+
+        [JsonProperty("discount")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Discount>))]
+        internal ExpandableField<Discount> InternalDiscount { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItem.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -28,6 +29,40 @@ namespace Stripe
 
         [JsonProperty("discountable")]
         public bool Discountable { get; set; }
+
+        #region Expandable Discounts
+
+        /// <summary>
+        /// Ids of the discounts applied to the invoice line item. Line item discounts are applied
+        /// before invoice discounts.
+        /// </summary>
+        [JsonIgnore]
+        public List<string> DiscountIds
+        {
+            get => this.InternalDiscounts?.Select((x) => x.Id).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
+        }
+
+        /// <summary>
+        /// The discounts applied to the invoice line item. Line item discounts are applied before
+        /// invoice discounts.
+        /// </summary>
+        [JsonIgnore]
+        public List<Discount> Discounts
+        {
+            get => this.InternalDiscounts?.Select((x) => x.ExpandedObject).ToList();
+            set => this.InternalDiscounts = SetExpandableArrayObjects(value);
+        }
+
+        [JsonProperty("discounts", ItemConverterType = typeof(ExpandableFieldConverter<Discount>))]
+        internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
+        #endregion
+
+        /// <summary>
+        /// The amount of discount calculated per discount for this line item.
+        /// </summary>
+        [JsonProperty("discount_amounts")]
+        public List<CreditNoteLineItemDiscountAmount> DiscountAmounts { get; set; }
 
         [JsonProperty("invoice_item")]
         public string InvoiceItem { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceLineItemDiscountAmount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceLineItemDiscountAmount.cs
@@ -1,0 +1,41 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceLineItemDiscountAmount : StripeEntity<InvoiceLineItemDiscountAmount>
+    {
+        /// <summary>
+        /// The amount, in cents, of the tax.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        #region Expandable Discount
+
+        /// <summary>
+        /// The ID of the discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscountId
+        {
+            get => this.InternalDiscount?.Id;
+            set => this.InternalDiscount = SetExpandableFieldId(value, this.InternalDiscount);
+        }
+
+        /// <summary>
+        /// The discount that was applied to get this discount amount.
+        /// </summary>
+        [JsonIgnore]
+        public Discount Discount
+        {
+            get => this.InternalDiscount?.ExpandedObject;
+            set => this.InternalDiscount = SetExpandableFieldObject(value, this.InternalDiscount);
+        }
+
+        [JsonProperty("discount")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Discount>))]
+        internal ExpandableField<Discount> InternalDiscount { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -1,6 +1,8 @@
 namespace Stripe
 {
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using Newtonsoft.Json;
@@ -150,6 +152,29 @@ namespace Stripe
             expandable.ExpandedObject = obj;
 
             return expandable;
+        }
+
+        protected static List<ExpandableField<T>> SetExpandableArrayIds<T>(List<string> ids)
+            where T : IHasId
+        {
+            return ids?.Select((id) =>
+            {
+                var expandable = new ExpandableField<T>();
+                expandable.Id = id;
+                return expandable;
+            }).ToList();
+        }
+
+        protected static List<ExpandableField<T>> SetExpandableArrayObjects<T>(List<T> objects)
+            where T : IHasId
+        {
+            return objects?.Select((obj) =>
+            {
+                var expandable = new ExpandableField<T>();
+                expandable.Id = obj.Id;
+                expandable.ExpandedObject = obj;
+                return expandable;
+            }).ToList();
         }
 
         private object GetIdString()

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemCreateOptions.cs
@@ -39,6 +39,14 @@ namespace Stripe
         public bool? Discountable { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice item. If not specified, inherits
+        /// the discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceItemDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// The ID of the invoice item to update in preview. If not specified, a new invoice item
         /// will be added to the preview of the upcoming invoice.
         /// </summary>

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemDiscountOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemDiscountOptions.cs
@@ -1,0 +1,19 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoiceItemDiscountOptions : INestedOptions
+    {
+        /// <summary>
+        /// ID of the coupon to create a new discount for.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        /// <summary>
+        /// ID of an existing discount on the object (or one of its ancestors) to reuse.
+        /// </summary>
+        [JsonProperty("discount")]
+        public string Discount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemUpdateOptions.cs
@@ -27,6 +27,14 @@ namespace Stripe
         public bool? Discountable { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice item. If not specified, inherits
+        /// the discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceItemDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// A set of key/value pairs that you can attach to an object. It can be useful for storing
         /// additional information about the object in a structured format.
         /// </summary>

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -67,6 +67,14 @@ namespace Stripe
         public string Description { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice. If not specified, inherits the
+        /// discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// The date on which payment for this invoice is due. Only valid for invoices where
         /// <c>billing=send_invoice</c>.
         /// </summary>

--- a/src/Stripe.net/Services/Invoices/InvoiceDiscountOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceDiscountOptions.cs
@@ -1,0 +1,19 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoiceDiscountOptions : INestedOptions
+    {
+        /// <summary>
+        /// ID of the coupon to create a new discount for.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        /// <summary>
+        /// ID of an existing discount on the object (or one of its ancestors) to reuse.
+        /// </summary>
+        [JsonProperty("discount")]
+        public string Discount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpcomingInvoiceItemOptions.cs
@@ -34,6 +34,14 @@ namespace Stripe
         public bool? Discountable { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice item. If not specified, inherits
+        /// the discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceItemDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// The ID of the invoice item to update in preview. If not specified, a new invoice item
         /// will be added to the preview of the upcoming invoice.
         /// </summary>

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -58,6 +58,14 @@ namespace Stripe
         public string Description { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice. If not specified, inherits the
+        /// discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// The date on which payment for this invoice is due. Only valid for invoices where
         /// <c>billing=send_invoice</c>.
         /// </summary>

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -24,6 +24,14 @@ namespace Stripe
         public string Customer { get; set; }
 
         /// <summary>
+        /// The coupons to redeem into discounts for the invoice. If not specified, inherits the
+        /// discount from the invoice's customer. Pass an empty string to avoid inheriting any
+        /// discounts.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<InvoiceDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// List of invoice items to add or update in the upcoming invoice preview.
         /// </summary>
         [JsonProperty("invoice_items")]

--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe;
     using Xunit;
@@ -56,6 +57,210 @@ namespace StripeTests
 
             Assert.NotNull(invoice.Subscription);
             Assert.Equal("subscription", invoice.Subscription.Object);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsNull()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": null}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.Null(invoice.DiscountIds);
+
+            Assert.Null(invoice.Discounts);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsEmpty()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": []}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Empty(invoice.DiscountIds);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Empty(invoice.Discounts);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsUnexpanded()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": [\"di_123\", \"di_456\"]}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Equal(2, invoice.DiscountIds.Count);
+            Assert.Equal("di_123", invoice.DiscountIds[0]);
+            Assert.Equal("di_456", invoice.DiscountIds[1]);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Equal(2, invoice.Discounts.Count);
+            Assert.Null(invoice.Discounts[0]);
+            Assert.Null(invoice.Discounts[1]);
+        }
+
+        [Fact]
+        public void DeserializeWithDiscountsExpanded()
+        {
+            string json = "{\"object\": \"invoice\", \"discounts\": [{\"id\": \"di_123\", \"object\": \"discount\"}, {\"id\": \"di_456\", \"object\": \"discount\"}]}";
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            Assert.NotNull(invoice);
+            Assert.IsType<Invoice>(invoice);
+            Assert.Equal("invoice", invoice.Object);
+
+            Assert.NotNull(invoice.DiscountIds);
+            Assert.Equal(2, invoice.DiscountIds.Count);
+            Assert.Equal("di_123", invoice.DiscountIds[0]);
+            Assert.Equal("di_456", invoice.DiscountIds[1]);
+
+            Assert.NotNull(invoice.Discounts);
+            Assert.Equal(2, invoice.Discounts.Count);
+            Assert.NotNull(invoice.Discounts[0]);
+            Assert.Equal("di_123", invoice.Discounts[0].Id);
+            Assert.Equal("discount", invoice.Discounts[0].Object);
+            Assert.NotNull(invoice.Discounts[1]);
+            Assert.Equal("di_456", invoice.Discounts[1].Id);
+            Assert.Equal("discount", invoice.Discounts[1].Object);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsNull()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = null;
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.Null(deserialized.DiscountIds);
+
+            Assert.Null(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsNull()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = null;
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.Null(deserialized.DiscountIds);
+
+            Assert.Null(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = new List<string>();
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Empty(deserialized.DiscountIds);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Empty(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = new List<Discount>();
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Empty(deserialized.DiscountIds);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Empty(deserialized.Discounts);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountIdsNotEmpty()
+        {
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.DiscountIds = new List<string> { "di_123", "di_456" };
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Equal(2, deserialized.DiscountIds.Count);
+            Assert.Equal("di_123", deserialized.DiscountIds[0]);
+            Assert.Equal("di_456", deserialized.DiscountIds[1]);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Equal(2, deserialized.Discounts.Count);
+            Assert.Null(deserialized.Discounts[0]);
+            Assert.Null(deserialized.Discounts[1]);
+        }
+
+        [Fact]
+        public void SerializeWithDiscountsNotEmpty()
+        {
+            var discount1 = new Discount();
+            discount1.Id = "di_123";
+            discount1.Object = "discount";
+
+            var discount2 = new Discount();
+            discount2.Id = "di_456";
+            discount2.Object = "discount";
+
+            string json = this.GetFixture("/v1/invoices/in_123");
+            var invoice = JsonConvert.DeserializeObject<Invoice>(json);
+            invoice.Discounts = new List<Discount> { discount1, discount2 };
+
+            var serialized = invoice.ToJson();
+            var deserialized = Invoice.FromJson(serialized);
+
+            Assert.NotNull(deserialized);
+
+            Assert.NotNull(deserialized.DiscountIds);
+            Assert.Equal(2, deserialized.DiscountIds.Count);
+            Assert.Equal("di_123", deserialized.DiscountIds[0]);
+            Assert.Equal("di_456", deserialized.DiscountIds[1]);
+
+            Assert.NotNull(deserialized.Discounts);
+            Assert.Equal(2, deserialized.Discounts.Count);
+            Assert.NotNull(deserialized.Discounts[0]);
+            Assert.Equal("di_123", deserialized.Discounts[0].Id);
+            Assert.Equal("discount", deserialized.Discounts[0].Object);
+            Assert.NotNull(deserialized.Discounts[1]);
+            Assert.Equal("di_456", deserialized.Discounts[1].Id);
+            Assert.Equal("discount", deserialized.Discounts[1].Object);
         }
     }
 }

--- a/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
+++ b/src/StripeTests/Services/AccountLinks/AccountLinkServiceTest.cs
@@ -25,7 +25,7 @@ namespace StripeTests
                 Collect = "eventually_due",
                 RefreshUrl = "https://stripe.com/refresh",
                 ReturnUrl = "https://stripe.com/return",
-                Type = "custom_account_verification",
+                Type = "account_onboarding",
             };
         }
 

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -34,6 +34,17 @@ namespace StripeTests
                     Name = "business name",
                 },
                 BusinessType = "company",
+                Capabilities = new AccountCapabilitiesOptions
+                {
+                    CardPayments = new AccountCapabilitiesCardPaymentsOptions
+                    {
+                        Requested = true,
+                    },
+                    Transfers = new AccountCapabilitiesTransfersOptions
+                    {
+                        Requested = true,
+                    },
+                },
                 Company = new AccountCompanyOptions
                 {
                     Address = new AddressOptions
@@ -56,11 +67,6 @@ namespace StripeTests
                     },
                 },
                 ExternalAccount = "tok_visa_debit",
-                RequestedCapabilities = new List<string>
-                {
-                    "card_payments",
-                    "transfers",
-                },
                 Settings = new AccountSettingsOptions
                 {
                     Branding = new AccountSettingsBrandingOptions

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.93.0";
+        private const string MockMinimumVersion = "0.94.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Add support for multiple coupons on Billing APIs
  * Add support for arrays of expandable API resources otherwise returning an array of strings by default
  * Add support for `Id`, `Invoice` and `InvoiceItem` on `Discount`.
  * Add support for `Discounts` on `Invoice`, `InvoiceItem`, `InvoiceLineItem`
  * Add support for `DiscountAmounts` on `CreditNote`, `CreditNoteLineItem`, `InvoiceLineItem`
  * Add support for `TotalDiscountAmounts` on `Invoice`

This PR supersedes https://github.com/stripe/stripe-dotnet/pull/2016 but used @ob-stripe's original commit as a base
It also mirrors https://github.com/stripe/stripe-java/pull/1070 in java

r? @richardm-stripe 
cc @stripe/api-libraries 
