### PR TITLE
Set service method options parameter defaults

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -84,12 +84,12 @@ namespace Stripe
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Account Reject(string id, AccountRejectOptions options, RequestOptions requestOptions = null)
+        public virtual Account Reject(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/reject", options, requestOptions);
         }
 
-        public virtual Task<Account> RejectAsync(string id, AccountRejectOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Account> RejectAsync(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/reject", options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -63,24 +63,24 @@ namespace Stripe
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<CreditNoteLineItem> ListLineItems(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
+        public virtual StripeList<CreditNoteLineItem> ListLineItems(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions);
+            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions);
         }
 
-        public virtual Task<StripeList<CreditNoteLineItem>> ListLineItemsAsync(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<StripeList<CreditNoteLineItem>> ListLineItemsAsync(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
         }
 
-        public virtual IEnumerable<CreditNoteLineItem> ListLineItemsAutoPaging(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
+        public virtual IEnumerable<CreditNoteLineItem> ListLineItemsAutoPaging(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions);
         }
 
-        public virtual IAsyncEnumerable<CreditNoteLineItem> ListLineItemsAutoPagingAsync(string creditnoteId, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual IAsyncEnumerable<CreditNoteLineItem> ListLineItemsAutoPagingAsync(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl(creditnoteId)}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditNoteLineItem> ListPreviewLineItems(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -23,12 +23,12 @@ namespace Stripe
 
         public override string BasePath => "/v1/accounts/{PARENT_ID}/external_accounts";
 
-        public virtual IExternalAccount Create(string parentId, ExternalAccountCreateOptions options, RequestOptions requestOptions = null)
+        public virtual IExternalAccount Create(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null)
         {
             return this.CreateNestedEntity(parentId, options, requestOptions);
         }
 
-        public virtual Task<IExternalAccount> CreateAsync(string parentId, ExternalAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<IExternalAccount> CreateAsync(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -154,12 +154,12 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/send", options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice Upcoming(UpcomingInvoiceOptions options, RequestOptions requestOptions = null)
+        public virtual Invoice Upcoming(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions);
         }
 
-        public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -2,7 +2,6 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class PaymentIntentCreateOptions : BaseOptions, IHasMetadata
     {

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -23,12 +23,12 @@ namespace Stripe
 
         public override string BasePath => "/v1/payment_methods";
 
-        public virtual PaymentMethod Attach(string id, PaymentMethodAttachOptions options, RequestOptions requestOptions = null)
+        public virtual PaymentMethod Attach(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/attach", options, requestOptions);
         }
 
-        public virtual Task<PaymentMethod> AttachAsync(string id, PaymentMethodAttachOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<PaymentMethod> AttachAsync(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/attach", options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/Sources/SourceDetachOptions.cs
+++ b/src/Stripe.net/Services/Sources/SourceDetachOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class SourceDetachOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -23,14 +23,14 @@ namespace Stripe
 
         public override string BasePath => "/v1/sources";
 
-        public virtual Source Attach(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null)
+        public virtual Source Attach(string parentId, SourceAttachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Source>(HttpMethod.Post, $"/v1/customers/{customerId}/sources", options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions);
         }
 
-        public virtual Task<Source> AttachAsync(string customerId, SourceAttachOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Source> AttachAsync(string parentId, SourceAttachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/customers/{customerId}/sources", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Create(SourceCreateOptions options, RequestOptions requestOptions = null)
@@ -43,14 +43,14 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual Source Detach(string customerId, string id, RequestOptions requestOptions = null)
+        public virtual Source Detach(string parentId, string id, SourceDetachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Source>(HttpMethod.Delete, $"/v1/customers/{customerId}/sources/{id}", null, requestOptions);
+            return this.Request<Source>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", null, requestOptions);
         }
 
-        public virtual Task<Source> DetachAsync(string customerId, string id, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Source> DetachAsync(string parentId, string id, SourceDetachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Source>(HttpMethod.Delete, $"/v1/customers/{customerId}/sources/{id}", null, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", null, requestOptions, cancellationToken);
         }
 
         public virtual Source Get(string id, SourceGetOptions options = null, RequestOptions requestOptions = null)
@@ -63,24 +63,24 @@ namespace Stripe
             return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
         }
 
-        public virtual StripeList<Source> List(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
+        public virtual StripeList<Source> List(string parentId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions);
+            return this.Request<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new SourceListOptions(), requestOptions);
         }
 
-        public virtual Task<StripeList<Source>> ListAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<StripeList<Source>> ListAsync(string parentId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Source>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
         }
 
-        public virtual IEnumerable<Source> ListAutoPaging(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null)
+        public virtual IEnumerable<Source> ListAutoPaging(string parentId, SourceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions);
+            return this.ListRequestAutoPaging<Source>($"/v1/customers/{parentId}/sources", options ?? new SourceListOptions(), requestOptions);
         }
 
-        public virtual IAsyncEnumerable<Source> ListAutoPagingAsync(string customerId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual IAsyncEnumerable<Source> ListAutoPagingAsync(string parentId, SourceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<Source>($"/v1/customers/{customerId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Source>($"/v1/customers/{parentId}/sources", options ?? new SourceListOptions(), requestOptions, cancellationToken);
         }
 
         public virtual Source Update(string id, SourceUpdateOptions options, RequestOptions requestOptions = null)
@@ -93,12 +93,12 @@ namespace Stripe
             return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
         }
 
-        public virtual Source Verify(string id, SourceVerifyOptions options, RequestOptions requestOptions = null)
+        public virtual Source Verify(string id, SourceVerifyOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<Source>(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify", options, requestOptions);
         }
 
-        public virtual Task<Source> VerifyAsync(string id, SourceVerifyOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Source> VerifyAsync(string id, SourceVerifyOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync<Source>(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify", options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -33,12 +33,12 @@ namespace Stripe
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
 
-        public virtual SubscriptionItem Delete(string id, SubscriptionItemDeleteOptions options, RequestOptions requestOptions = null)
+        public virtual SubscriptionItem Delete(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
             return this.DeleteEntity(id, options, requestOptions);
         }
 
-        public virtual Task<SubscriptionItem> DeleteAsync(string id, SubscriptionItemDeleteOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<SubscriptionItem> DeleteAsync(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -22,12 +22,12 @@ namespace Stripe
 
         public override string BasePath => "/v1/subscriptions";
 
-        public virtual Subscription Cancel(string id, SubscriptionCancelOptions options, RequestOptions requestOptions = null)
+        public virtual Subscription Cancel(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null)
         {
             return this.DeleteEntity(id, options, requestOptions);
         }
 
-        public virtual Task<Subscription> CancelAsync(string id, SubscriptionCancelOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Subscription> CancelAsync(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
+++ b/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
@@ -18,12 +18,12 @@ namespace Stripe.Terminal
 
         public override string BasePath => "/v1/terminal/connection_tokens";
 
-        public virtual ConnectionToken Create(ConnectionTokenCreateOptions options = null, RequestOptions requestOptions = null)
+        public virtual ConnectionToken Create(ConnectionTokenCreateOptions options, RequestOptions requestOptions = null)
         {
             return this.CreateEntity(options, requestOptions);
         }
 
-        public virtual Task<ConnectionToken> CreateAsync(ConnectionTokenCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<ConnectionToken> CreateAsync(ConnectionTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }


### PR DESCRIPTION
  * ⚠️ Set service method options parameter defaults to `null`
  * ⚠️ Use `parentId` and `id` instead of `customerId` and `creditnoteId` for `SourceService` and `CreditNoteService`
  * ⚠️ Add `SourceDetachOptions` empty class

r? @remi-stripe 
cc @stripe/api-libraries 