### PR TITLE
Fix VSCode C# extension name

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp",
+        "EditorConfig.editorconfig"
     ]
 }


### PR DESCRIPTION
r? @ob-stripe 

Fix name for C# extension in VSCode extension recommendation.

Also adds recommendation for EditorConfig extension.
