### PR TITLE
Makes `Price` and `Rate` included by default on `LineItem` and `LineItemTax` respectively

### DIFF
--- a/src/Stripe.net/Entities/LineItems/LineItem.cs
+++ b/src/Stripe.net/Entities/LineItems/LineItem.cs
@@ -2,7 +2,6 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class LineItem : StripeEntity<LineItem>, IHasId, IHasObject
     {
@@ -55,32 +54,11 @@ namespace Stripe
         [JsonProperty("discounts")]
         public List<LineItemDiscount> Discounts { get; set; }
 
-        #region Expandable Price
-
         /// <summary>
-        /// ID of the price linked to this line item.
+        /// The price used to generate the line item.
         /// </summary>
-        [JsonIgnore]
-        public string PriceId
-        {
-            get => this.InternalPrice?.Id;
-            set => this.InternalPrice = SetExpandableFieldId(value, this.InternalPrice);
-        }
-
-        /// <summary>
-        /// (Expanded) The price linked to this line item (if it was expanded).
-        /// </summary>
-        [JsonIgnore]
-        public Price Price
-        {
-            get => this.InternalPrice?.ExpandedObject;
-            set => this.InternalPrice = SetExpandableFieldObject(value, this.InternalPrice);
-        }
-
         [JsonProperty("price")]
-        [JsonConverter(typeof(ExpandableFieldConverter<Price>))]
-        internal ExpandableField<Price> InternalPrice { get; set; }
-        #endregion
+        public Price Price { get; set; }
 
         /// <summary>
         /// Quantity associated with the line item.

--- a/src/Stripe.net/Entities/LineItems/LineItemTax.cs
+++ b/src/Stripe.net/Entities/LineItems/LineItemTax.cs
@@ -1,7 +1,6 @@
 namespace Stripe
 {
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class LineItemTax : StripeEntity<LineItemTax>
     {
@@ -11,31 +10,10 @@ namespace Stripe
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
-        #region Expandable TaxRate
-
         /// <summary>
-        /// ID of the tax rate applied to this line item.
+        /// The tax rate applied.
         /// </summary>
-        [JsonIgnore]
-        public string TaxRateId
-        {
-            get => this.InternalTaxRate?.Id;
-            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
-        }
-
-        /// <summary>
-        /// (Expanded) The tax rate applied to this line item. (if it was expanded).
-        /// </summary>
-        [JsonIgnore]
-        public TaxRate TaxRate
-        {
-            get => this.InternalTaxRate?.ExpandedObject;
-            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
-        }
-
-        [JsonProperty("tax_rate")]
-        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
-        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
-        #endregion
+        [JsonProperty("rate")]
+        public TaxRate Rate { get; set; }
     }
 }


### PR DESCRIPTION
- [x] ⚠️ Makes `Price` and `Rate` included by default on `LineItem` and `LineItemTax` respectively

r? @remi-stripe 
cc @stripe/api-libraries 