### PR TITLE
Move GetSelf down to bottom of AccountService

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -54,16 +54,6 @@ namespace Stripe
             return this.GetEntityAsync(accountId, options, requestOptions, cancellationToken);
         }
 
-        public virtual Account GetSelf(RequestOptions requestOptions = null)
-        {
-            return this.Request(HttpMethod.Get, "/v1/account", null, requestOptions);
-        }
-
-        public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
-        {
-            return this.RequestAsync(HttpMethod.Get, "/v1/account", null, requestOptions, cancellationToken);
-        }
-
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
             return this.ListEntities(options, requestOptions);
@@ -104,6 +94,16 @@ namespace Stripe
         public virtual Task<Account> UpdateAsync(string accountId, AccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.UpdateEntityAsync(accountId, options, requestOptions, cancellationToken);
+        }
+
+        public virtual Account GetSelf(RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Get, "/v1/account", null, requestOptions);
+        }
+
+        public virtual Task<Account> GetSelfAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Get, "/v1/account", null, requestOptions, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This is a no-op change, and it's a little odd, but we don't have a great way right now with autogen to have overridden methods correctly alphabetized with all of the other methods, so any overridden methods need to be grouped together.

This is something I'd like to address with @richardm-stripe but is a pretty core change to autogen infra to move _from_ all overridden methods are just strings _to_ overridden methods have specific names and the string content of the overridden method so that we can correctly alphabetize with the other methods. 

I put them at the bottom of the service, but we could put them at the top too. I could also add a standard comment if it would be helpful like "the methods below are not generated, but overridden" in the case that they are or we could just have them live at the bottom 🤷 

r? @remi-stripe 
cc @stripe/api-libraries 