### PR TITLE
Inherit from `INestedOptions` rather than `ShippingOptions` for `ChargeShippingOptions`

### DIFF
--- a/src/Stripe.net/Services/Charges/ChargeShippingOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeShippingOptions.cs
@@ -2,11 +2,37 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class ChargeShippingOptions : ShippingOptions
+    public class ChargeShippingOptions : INestedOptions
     {
+        /// <summary>
+        /// Shipping address.
+        /// </summary>
+        [JsonProperty("address")]
+        public AddressOptions Address { get; set; }
+
+        /// <summary>
+        /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
+        /// </summary>
         [JsonProperty("carrier")]
         public string Carrier { get; set; }
 
+        /// <summary>
+        /// Recipient name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Recipient phone (including extension).
+        /// </summary>
+        [JsonProperty("phone")]
+        public string Phone { get; set; }
+
+        /// <summary>
+        /// The tracking number for a physical product, obtained from the delivery service. If
+        /// multiple tracking numbers were generated for this purchase, please separate them with
+        /// commas.
+        /// </summary>
         [JsonProperty("tracking_number")]
         public string TrackingNumber { get; set; }
     }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 


ChargeShippingOptions was inheriting from ShippingOptions rather than INestedOptions. This is technically a breaking change because it's no longer using that parent, but I'm still going to share `ShippingOptions` because we're using that in several places already.