### PR TITLE
Multiple API Changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.94.0
+  STRIPE_MOCK_VERSION: 0.95.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -7,7 +7,8 @@ namespace Stripe.Checkout
     public class Session : StripeEntity<Session>, IHasId, IHasMetadata, IHasObject
     {
         /// <summary>
-        /// Unique identifier for the object.
+        /// Unique identifier for the object. Used to pass to <c>redirectToCheckout</c> in
+        /// Stripe.js.
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -17,6 +18,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <summary>
+        /// Enables user redeemable promotion codes.
+        /// </summary>
+        [JsonProperty("allow_promotion_codes")]
+        public bool? AllowPromotionCodes { get; set; }
 
         /// <summary>
         /// Total of all items before discounts or taxes are applied.
@@ -31,30 +38,29 @@ namespace Stripe.Checkout
         public long? AmountTotal { get; set; }
 
         /// <summary>
-        /// Specify whether Checkout should collect the customer's billing address. If set to
-        /// <c>required</c>, Checkout will always collect the customer's billing address. If left
-        /// blank or set to <c>auto</c> Checkout will only collect the billing address when
-        /// necessary.
+        /// Describes whether Checkout should collect the customer's billing address.
         /// </summary>
         [JsonProperty("billing_address_collection")]
         public string BillingAddressCollection { get; set; }
 
         /// <summary>
-        /// The URL the customer will be directed to if they decide to go back to your website.
+        /// The URL the customer will be directed to if they decide to cancel payment and return to
+        /// your website.
         /// </summary>
         [JsonProperty("cancel_url")]
         public string CancelUrl { get; set; }
 
         /// <summary>
-        /// A unique string to reference the Checkout Session. This can be a customer ID, a cart
-        /// ID, or similar. It is included in the <c>checkout.session.completed</c> webhook and can
-        /// be used to fulfill the purchase.
+        /// A unique string to reference the Checkout Session. This can be a customer ID, a cart ID,
+        /// or similar, and can be used to reconcile the session with your internal systems.
         /// </summary>
         [JsonProperty("client_reference_id")]
         public string ClientReferenceId { get; set; }
 
         /// <summary>
-        /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
         /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }
@@ -62,7 +68,11 @@ namespace Stripe.Checkout
         #region Expandable Customer
 
         /// <summary>
-        /// ID of the customer this Session is for if one exists.
+        /// (ID of the Customer)
+        /// The ID of the customer for this session. For Checkout Sessions in <c>payment</c> or
+        /// <c>subscription</c> mode, Checkout will create a new customer object based on
+        /// information provided during the session unless an existing customer was provided when
+        /// the session was created.
         /// </summary>
         [JsonIgnore]
         public string CustomerId
@@ -72,7 +82,13 @@ namespace Stripe.Checkout
         }
 
         /// <summary>
-        /// Customer this Session is for (if it was expanded).
+        /// (Expanded)
+        /// The ID of the customer for this session. For Checkout Sessions in <c>payment</c> or
+        /// <c>subscription</c> mode, Checkout will create a new customer object based on
+        /// information provided during the session unless an existing customer was provided when
+        /// the session was created.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
         [JsonIgnore]
         public Customer Customer
@@ -87,26 +103,30 @@ namespace Stripe.Checkout
         #endregion
 
         /// <summary>
-        /// The email address used to create the customer object.
+        /// If provided, this value will be used when the Customer object is created. If not
+        /// provided, customers will be asked to enter their email address. Use this parameter to
+        /// prefill customer data if you already have an email on file. To access information about
+        /// the customer once a session is complete, use the <c>customer</c> attribute.
         /// </summary>
         [JsonProperty("customer_email")]
         public string CustomerEmail { get; set; }
 
         /// <summary>
-        /// The line items, plans, or SKUs that were purchased by the customer.
+        /// The line items, plans, or SKUs purchased by the customer. Prefer using
+        /// <c>line_items</c>.
         /// </summary>
         [JsonProperty("display_items")]
         public List<SessionDisplayItem> DisplayItems { get; set; }
 
         /// <summary>
-        /// The line items associated with this session.
+        /// The line items purchased by the customer.
         /// </summary>
         [JsonProperty("line_items")]
         public StripeList<LineItem> LineItems { get; set; }
 
         /// <summary>
-        /// Has the value <c>true</c> if the object exists in live mode or the value
-        /// <c>false</c> if the object exists in test mode.
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
         /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
@@ -119,15 +139,15 @@ namespace Stripe.Checkout
         public string Locale { get; set; }
 
         /// <summary>
-        /// A set of key/value pairs that you can attach to an object. It can
-        /// be useful for storing additional information about the object in a
-        /// structured format.
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The mode of the Checkout Session which can be <c>payment</c>, <c>setup</c>, or
+        /// The mode of the Checkout Session, one of <c>payment</c>, <c>setup</c>, or
         /// <c>subscription</c>.
         /// </summary>
         [JsonProperty("mode")]
@@ -136,7 +156,8 @@ namespace Stripe.Checkout
         #region Expandable PaymentIntent
 
         /// <summary>
-        /// The ID of the PaymentIntent created if SKUs or line items were provided.
+        /// (ID of the PaymentIntent)
+        /// The ID of the PaymentIntent for Checkout Sessions in <c>payment</c> mode.
         /// </summary>
         [JsonIgnore]
         public string PaymentIntentId
@@ -146,7 +167,10 @@ namespace Stripe.Checkout
         }
 
         /// <summary>
-        /// PaymentIntent created if SKUs or line items were provided (if it was expanded).
+        /// (Expanded)
+        /// The ID of the PaymentIntent for Checkout Sessions in <c>payment</c> mode.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
         [JsonIgnore]
         public PaymentIntent PaymentIntent
@@ -161,8 +185,8 @@ namespace Stripe.Checkout
         #endregion
 
         /// <summary>
-        /// The list of payment method types (e.g. card) that this Checkout Session is allowed to
-        /// use.
+        /// A list of the types of payment methods (e.g. card) this Checkout Session is allowed to
+        /// accept.
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
@@ -170,7 +194,8 @@ namespace Stripe.Checkout
         #region Expandable SetupIntent
 
         /// <summary>
-        /// The ID of the SetupIntent created if mode was set to <c>setup</c>.
+        /// (ID of the SetupIntent)
+        /// The ID of the SetupIntent for Checkout Sessions in <c>setup</c> mode.
         /// </summary>
         [JsonIgnore]
         public string SetupIntentId
@@ -180,7 +205,10 @@ namespace Stripe.Checkout
         }
 
         /// <summary>
-        /// The SetupIntent created if mode was set to <c>setup</c> (if it was expanded).
+        /// (Expanded)
+        /// The ID of the SetupIntent for Checkout Sessions in <c>setup</c> mode.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
         [JsonIgnore]
         public SetupIntent SetupIntent
@@ -208,12 +236,10 @@ namespace Stripe.Checkout
         public SessionShippingAddressCollection ShippingAddressCollection { get; set; }
 
         /// <summary>
-        /// Describes the type of transaction being performed by Checkout in
-        /// order to customize relevant text on the page, such as the Submit
-        /// button. <c>submit_type</c> can only be specified on checkout
-        /// sessions using line items or a SKU, and not checkout sessions for
-        /// subscriptions. Supported values are <c>auto</c>, <c>book</c>,
-        /// <c>donate</c>, or <c>pay</c>.
+        /// Describes the type of transaction being performed by Checkout in order to customize
+        /// relevant text on the page, such as the submit button. <c>submit_type</c> can only be
+        /// specified on Checkout Sessions in <c>payment</c> mode, but not Checkout Sessions in
+        /// <c>subscription</c> or <c>setup</c> mode.
         /// </summary>
         [JsonProperty("submit_type")]
         public string SubmitType { get; set; }
@@ -221,7 +247,8 @@ namespace Stripe.Checkout
         #region Expandable Subscription
 
         /// <summary>
-        /// The ID of the subscription created if one or more plans were provided.
+        /// (ID of the Subscription)
+        /// The ID of the subscription for Checkout Sessions in <c>subscription</c> mode.
         /// </summary>
         [JsonIgnore]
         public string SubscriptionId
@@ -231,7 +258,10 @@ namespace Stripe.Checkout
         }
 
         /// <summary>
-        /// The subscription created if one or more plans were provided (if it was expanded).
+        /// (Expanded)
+        /// The ID of the subscription for Checkout Sessions in <c>subscription</c> mode.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
         [JsonIgnore]
         public Subscription Subscription
@@ -246,7 +276,8 @@ namespace Stripe.Checkout
         #endregion
 
         /// <summary>
-        /// The URL the customer will be directed to after a successful payment.
+        /// The URL the customer will be directed to after the payment or subscription creation is
+        /// successful.
         /// </summary>
         [JsonProperty("success_url")]
         public string SuccessUrl { get; set; }

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -7,56 +7,113 @@ namespace Stripe
 
     public class Coupon : StripeEntity<Coupon>, IHasId, IHasMetadata, IHasObject
     {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <summary>
+        /// Amount (in the <c>currency</c> specified) that will be taken off the subtotal of any
+        /// invoices for this customer.
+        /// </summary>
         [JsonProperty("amount_off")]
         public long? AmountOff { get; set; }
 
+        [JsonProperty("applies_to")]
+        public CouponAppliesTo AppliesTo { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Created { get; set; }
 
+        /// <summary>
+        /// If <c>amount_off</c> has been set, the three-letter <a
+        /// href="https://stripe.com/docs/currencies">ISO code for the currency</a> of the amount to
+        /// take off.
+        /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <summary>
-        /// Whether this object is deleted or not.
-        /// </summary>
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 
+        /// <summary>
+        /// One of <c>forever</c>, <c>once</c>, and <c>repeating</c>. Describes how long a customer
+        /// who applies this coupon will get the discount.
+        /// </summary>
         [JsonProperty("duration")]
         public string Duration { get; set; }
 
+        /// <summary>
+        /// If <c>duration</c> is <c>repeating</c>, the number of months the coupon applies. Null if
+        /// coupon <c>duration</c> is <c>forever</c> or <c>once</c>.
+        /// </summary>
         [JsonProperty("duration_in_months")]
         public long? DurationInMonths { get; set; }
 
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
 
+        /// <summary>
+        /// Maximum number of times this coupon can be redeemed, in total, across all customers,
+        /// before it is no longer valid.
+        /// </summary>
         [JsonProperty("max_redemptions")]
         public long? MaxRedemptions { get; set; }
 
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// Name of the coupon displayed to customers on for instance invoices or receipts.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Percent that will be taken off the subtotal of any invoices for this customer for the
+        /// duration of the coupon. For example, a coupon with percent_off of 50 will make a %s100
+        /// invoice %s50 instead.
+        /// </summary>
         [JsonProperty("percent_off")]
         public decimal? PercentOff { get; set; }
 
+        /// <summary>
+        /// Date after which the coupon can no longer be redeemed.
+        /// </summary>
         [JsonProperty("redeem_by")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? RedeemBy { get; set; }
 
+        /// <summary>
+        /// Number of times this coupon has been applied to a customer.
+        /// </summary>
         [JsonProperty("times_redeemed")]
         public long TimesRedeemed { get; set; }
 
+        /// <summary>
+        /// Taking account of the above properties, whether this coupon can still be applied to a
+        /// customer.
+        /// </summary>
         [JsonProperty("valid")]
         public bool Valid { get; set; }
     }

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -44,6 +44,9 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <summary>
+        /// Whether this object is deleted or not.
+        /// </summary>
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Deleted { get; set; }
 

--- a/src/Stripe.net/Entities/Coupons/CouponAppliesTo.cs
+++ b/src/Stripe.net/Entities/Coupons/CouponAppliesTo.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class CouponAppliesTo : StripeEntity<CouponAppliesTo>
+    {
+        /// <summary>
+        /// A list of product IDs this coupon applies to.
+        /// </summary>
+        [JsonProperty("products")]
+        public List<string> Products { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -79,6 +79,37 @@ namespace Stripe
         [JsonProperty("invoice_item")]
         public string InvoiceItem { get; set; }
 
+        #region Expandable PromotionCode
+
+        /// <summary>
+        /// (ID of the PromotionCode)
+        /// The promotion code applied to create this discount.
+        /// </summary>
+        [JsonIgnore]
+        public string PromotionCodeId
+        {
+            get => this.InternalPromotionCode?.Id;
+            set => this.InternalPromotionCode = SetExpandableFieldId(value, this.InternalPromotionCode);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The promotion code applied to create this discount.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public PromotionCode PromotionCode
+        {
+            get => this.InternalPromotionCode?.ExpandedObject;
+            set => this.InternalPromotionCode = SetExpandableFieldObject(value, this.InternalPromotionCode);
+        }
+
+        [JsonProperty("promotion_code")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PromotionCode>))]
+        internal ExpandableField<PromotionCode> InternalPromotionCode { get; set; }
+        #endregion
+
         /// <summary>
         /// Date that the coupon was applied.
         /// </summary>

--- a/src/Stripe.net/Entities/PromotionCodes/PromotionCode.cs
+++ b/src/Stripe.net/Entities/PromotionCodes/PromotionCode.cs
@@ -1,0 +1,122 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PromotionCode : StripeEntity<PromotionCode>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Whether the promotion code is currently active. A promotion code is only active if the
+        /// coupon is also valid.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// The customer-facing code. Regardless of case, this code must be unique across all active
+        /// promotion codes for each customer.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// A coupon contains information about a percent-off or amount-off discount you might want
+        /// to apply to a customer. Coupons may be applied to <a
+        /// href="https://stripe.com/docs/api#invoices">invoices</a> or <a
+        /// href="https://stripe.com/docs/api#create_order-coupon">orders</a>. Coupons do not work
+        /// with conventional one-off <a
+        /// href="https://stripe.com/docs/api#create_charge">charges</a>.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public Coupon Coupon { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime Created { get; set; }
+
+        #region Expandable Customer
+
+        /// <summary>
+        /// (ID of the Customer)
+        /// The customer that this promotion code can be used by.
+        /// </summary>
+        [JsonIgnore]
+        public string CustomerId
+        {
+            get => this.InternalCustomer?.Id;
+            set => this.InternalCustomer = SetExpandableFieldId(value, this.InternalCustomer);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The customer that this promotion code can be used by.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Customer Customer
+        {
+            get => this.InternalCustomer?.ExpandedObject;
+            set => this.InternalCustomer = SetExpandableFieldObject(value, this.InternalCustomer);
+        }
+
+        [JsonProperty("customer")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Customer>))]
+        internal ExpandableField<Customer> InternalCustomer { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Date at which the promotion code can no longer be redeemed.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Maximum number of times this promotion code can be redeemed.
+        /// </summary>
+        [JsonProperty("max_redemptions")]
+        public long? MaxRedemptions { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        [JsonProperty("restrictions")]
+        public PromotionCodeRestrictions Restrictions { get; set; }
+
+        /// <summary>
+        /// Number of times this promotion code has been used.
+        /// </summary>
+        [JsonProperty("times_redeemed")]
+        public long TimesRedeemed { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PromotionCodes/PromotionCodeRestrictions.cs
+++ b/src/Stripe.net/Entities/PromotionCodes/PromotionCodeRestrictions.cs
@@ -1,0 +1,28 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PromotionCodeRestrictions : StripeEntity<PromotionCodeRestrictions>
+    {
+        /// <summary>
+        /// A Boolean indicating if the Promotion Code should only be redeemed for Customers without
+        /// any successful payments or invoices.
+        /// </summary>
+        [JsonProperty("first_time_transaction")]
+        public bool FirstTimeTransaction { get; set; }
+
+        /// <summary>
+        /// Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase
+        /// must be $100 or more to work).
+        /// </summary>
+        [JsonProperty("minimum_amount")]
+        public long? MinimumAmount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://stripe.com/docs/currencies">ISO code</a> for
+        /// minimum_amount.
+        /// </summary>
+        [JsonProperty("minimum_amount_currency")]
+        public string MinimumAmountCurrency { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -60,6 +60,7 @@ namespace Stripe
             { "plan", typeof(Plan) },
             { "price", typeof(Price) },
             { "product", typeof(Product) },
+            { "promotion_code", typeof(PromotionCode) },
             { "radar.early_fraud_warning", typeof(Radar.EarlyFraudWarning) },
             { "radar.value_list", typeof(Radar.ValueList) },
             { "radar.value_list_item", typeof(Radar.ValueListItem) },

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -6,44 +6,57 @@ namespace Stripe.Checkout
     public class SessionCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// Specify whether Checkout should collect the customer's billing address. If set to
-        /// <c>required</c>, Checkout will always collect the customer's billing address. If left
-        /// blank or set to <c>auto</c> Checkout will only collect the billing address when
-        /// necessary.
+        /// Enables user redeemable promotion codes.
+        /// </summary>
+        [JsonProperty("allow_promotion_codes")]
+        public bool? AllowPromotionCodes { get; set; }
+
+        /// <summary>
+        /// Specify whether Checkout should collect the customer's billing address.
         /// </summary>
         [JsonProperty("billing_address_collection")]
         public string BillingAddressCollection { get; set; }
 
         /// <summary>
-        /// The URL the customer will be directed to if they decide to go back to your website.
+        /// The URL the customer will be directed to if they decide to cancel payment and return to
+        /// your website.
         /// </summary>
         [JsonProperty("cancel_url")]
         public string CancelUrl { get; set; }
 
         /// <summary>
-        /// A unique string to reference the Checkout Session. This can be a customer ID, a cart
-        /// ID, or similar. It is included in the <c>checkout.session.completed</c> webhook and can
-        /// be used to fulfill the purchase.
+        /// A unique string to reference the Checkout Session. This can be a customer ID, a cart ID,
+        /// or similar, and can be used to reconcile the session with your internal systems.
         /// </summary>
         [JsonProperty("client_reference_id")]
         public string ClientReferenceId { get; set; }
 
         /// <summary>
-        /// ID of the customer this Checkout Session is for if one exists. May only be used with
-        /// <c>LineItems</c>. Usage with <c>SubscriptionData</c> is not yet available.
+        /// ID of an existing customer, if one exists. The email stored on the customer will be used
+        /// to prefill the email field on the Checkout page. If the customer changes their email on
+        /// the Checkout page, the Customer object will be updated with the new email. If blank for
+        /// Checkout Sessions in <c>payment</c> or <c>subscription</c> mode, Checkout will create a
+        /// new customer object based on information provided during the session.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
 
         /// <summary>
-        /// The email address used to create the customer object. If you already know your
-        /// customer's email address, use this attribute to prefill it on Checkout.
+        /// If provided, this value will be used when the Customer object is created. If not
+        /// provided, customers will be asked to enter their email address. Use this parameter to
+        /// prefill customer data if you already have an email on file. To access information about
+        /// the customer once a session is complete, use the <c>customer</c> field.
         /// </summary>
         [JsonProperty("customer_email")]
         public string CustomerEmail { get; set; }
 
         /// <summary>
-        /// A list of items your customer is purchasing.
+        /// A list of items the customer is purchasing. Use this parameter to pass one-time or
+        /// recurring <a href="https://stripe.com/docs/api/prices">Prices</a>. One-time Prices in
+        /// <c>subscription</c> mode will be on the initial invoice only.
+        ///
+        /// There is a maximum of 100 line items, however it is recommended to consolidate line
+        /// items if there are more than a few dozen.
         /// </summary>
         [JsonProperty("line_items")]
         public List<SessionLineItemOptions> LineItems { get; set; }
@@ -56,34 +69,47 @@ namespace Stripe.Checkout
         public string Locale { get; set; }
 
         /// <summary>
-        /// Set of key-value pairs that you can attach to an object. This can be useful for storing
-        /// additional information about the object in a structured format.
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The mode of the Checkout Session which can be <c>payment</c>, <c>setup</c>, or
-        /// <c>subscription</c>.
+        /// The mode of the Checkout Session, one of <c>payment</c>, <c>setup</c>, or
+        /// <c>subscription</c>. Required when using prices or <c>setup</c> mode. Pass
+        /// <c>subscription</c> if Checkout session includes at least one recurring item.
         /// </summary>
         [JsonProperty("mode")]
         public string Mode { get; set; }
 
         /// <summary>
-        /// A subset of parameters to be passed to PaymentIntent creation.
+        /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in
+        /// <c>payment</c> mode.
         /// </summary>
         [JsonProperty("payment_intent_data")]
         public SessionPaymentIntentDataOptions PaymentIntentData { get; set; }
 
         /// <summary>
-        /// The list of payment method types (e.g. card) that this Checkout Session is allowed to
-        /// use.
+        /// A list of the types of payment methods (e.g., <c>card</c>) this Checkout session can
+        /// accept.
+        ///
+        /// Read more about the supported payment methods and their requirements in our <a
+        /// href="https://stripe.com/docs/payments/checkout/payment-methods">payment method details
+        /// guide</a>.
+        ///
+        /// If multiple payment methods are passed, Checkout will dynamically reorder them to
+        /// prioritize the most relevant payment methods based on the customer's location and other
+        /// characteristics.
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
         /// <summary>
-        /// A subset of parameters to be passed to SetupIntent creation.
+        /// A subset of parameters to be passed to SetupIntent creation for Checkout Sessions in
+        /// <c>setup</c> mode.
         /// </summary>
         [JsonProperty("setup_intent_data")]
         public SessionSetupIntentDataOptions SetupIntentData { get; set; }
@@ -96,24 +122,27 @@ namespace Stripe.Checkout
         public SessionShippingAddressCollectionOptions ShippingAddressCollection { get; set; }
 
         /// <summary>
-        /// Describes the type of transaction being performed by Checkout in
-        /// order to customize relevant text on the page, such as the Submit
-        /// button. <c>submit_type</c> can only be specified on checkout
-        /// sessions using line items or a SKU, and not checkout sessions for
-        /// subscriptions.  Supported values are <c>auto</c>, <c>book</c>,
-        /// <c>donate</c>, or <c>pay</c>.
+        /// Describes the type of transaction being performed by Checkout in order to customize
+        /// relevant text on the page, such as the submit button. <c>submit_type</c> can only be
+        /// specified on Checkout Sessions in <c>payment</c> mode, but not Checkout Sessions in
+        /// <c>subscription</c> or <c>setup</c> mode.
         /// </summary>
         [JsonProperty("submit_type")]
         public string SubmitType { get; set; }
 
         /// <summary>
-        /// A subset of parameters to be passed to subscription creation.
+        /// A subset of parameters to be passed to subscription creation for Checkout Sessions in
+        /// <c>subscription</c> mode.
         /// </summary>
         [JsonProperty("subscription_data")]
         public SessionSubscriptionDataOptions SubscriptionData { get; set; }
 
         /// <summary>
-        /// The URL the customer will be directed to after a successful payment.
+        /// The URL to which Stripe should send customers when payment or setup is complete. If
+        /// you’d like access to the Checkout Session for the successful payment, read more about it
+        /// in our guide on <a
+        /// href="https://stripe.com/docs/payments/checkout/accept-a-payment#payment-success">fulfilling
+        /// your payments with webhooks</a>.
         /// </summary>
         [JsonProperty("success_url")]
         public string SuccessUrl { get; set; }

--- a/src/Stripe.net/Services/Coupons/CouponAppliesToOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponAppliesToOptions.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class CouponAppliesToOptions : INestedOptions
+    {
+        /// <summary>
+        /// An array of Product IDs that this Coupon will apply to.
+        /// </summary>
+        [JsonProperty("products")]
+        public List<string> Products { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponCreateOptions.cs
@@ -7,33 +7,83 @@ namespace Stripe
 
     public class CouponCreateOptions : BaseOptions, IHasId, IHasMetadata
     {
+        /// <summary>
+        /// A positive integer representing the amount to subtract from an invoice total (required
+        /// if <c>percent_off</c> is not passed).
+        /// </summary>
         [JsonProperty("amount_off")]
         public long? AmountOff { get; set; }
 
+        /// <summary>
+        /// A hash containing directions for what this Coupon will apply discounts to.
+        /// </summary>
+        [JsonProperty("applies_to")]
+        public CouponAppliesToOptions AppliesTo { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://stripe.com/docs/currencies">ISO code for the currency</a>
+        /// of the <c>amount_off</c> parameter (required if <c>amount_off</c> is passed).
+        /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <summary>
+        /// Specifies how long the discount will be in effect. Can be <c>forever</c>, <c>once</c>,
+        /// or <c>repeating</c>.
+        /// </summary>
         [JsonProperty("duration")]
         public string Duration { get; set; }
 
+        /// <summary>
+        /// Required only if <c>duration</c> is <c>repeating</c>, in which case it must be a
+        /// positive integer that specifies the number of months the discount will be in effect.
+        /// </summary>
         [JsonProperty("duration_in_months")]
         public long? DurationInMonths { get; set; }
 
+        /// <summary>
+        /// Unique string of your choice that will be used to identify this coupon when applying it
+        /// to a customer. If you don't want to specify a particular code, you can leave the ID
+        /// blank and we'll generate a random code for you.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// A positive integer specifying the number of times the coupon can be redeemed before it's
+        /// no longer valid. For example, you might have a 50% off coupon that the first 20 readers
+        /// of your blog can use.
+        /// </summary>
         [JsonProperty("max_redemptions")]
         public long? MaxRedemptions { get; set; }
 
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        /// <summary>
+        /// Name of the coupon displayed to customers on, for instance invoices, or receipts. By
+        /// default the <c>id</c> is shown if <c>name</c> is not set.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// A positive float larger than 0, and smaller or equal to 100, that represents the
+        /// discount the coupon will apply (required if <c>amount_off</c> is not passed).
+        /// </summary>
         [JsonProperty("percent_off")]
         public decimal? PercentOff { get; set; }
 
+        /// <summary>
+        /// Unix timestamp specifying the last time at which the coupon can be redeemed. After the
+        /// redeem_by date, the coupon can no longer be applied to new customers.
+        /// </summary>
         [JsonProperty("redeem_by")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? RedeemBy { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -14,11 +14,9 @@ namespace Stripe
         public AddressOptions Address { get; set; }
 
         /// <summary>
-        /// Current balance, if any, being stored on the customer. If negative, the customer has
-        /// credit to apply to their next invoice. If positive, the customer has an amount owed that
-        /// will be added to their next invoice. The balance does not refer to any unpaid invoices;
-        /// it solely takes into account amounts that have yet to be successfully applied to any
-        /// invoice. This balance is only taken into account as invoices are finalized.
+        /// An integer amount in %s that represents the customer's current balance, which affect the
+        /// customer's future invoices. A negative amount represents a credit that decreases the
+        /// amount due on an invoice; a positive amount increases the amount due on an invoice.
         /// </summary>
         [JsonProperty("balance")]
         public long? Balance { get; set; }
@@ -26,18 +24,39 @@ namespace Stripe
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 
+        /// <summary>
+        /// An arbitrary string that you can attach to a customer object. It is displayed alongside
+        /// the customer in the dashboard.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <summary>
+        /// Customer's email address. It's displayed alongside the customer in your dashboard and
+        /// can be useful for searching and tracking. This may be up to <em>512 characters</em>.
+        /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// The prefix for the customer used to generate unique invoice numbers. Must be 3–12
+        /// uppercase letters or numbers.
+        /// </summary>
         [JsonProperty("invoice_prefix")]
         public string InvoicePrefix { get; set; }
 
+        /// <summary>
+        /// Default invoice settings for this customer.
+        /// </summary>
         [JsonProperty("invoice_settings")]
         public CustomerInvoiceSettingsOptions InvoiceSettings { get; set; }
 
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -48,7 +67,7 @@ namespace Stripe
         public string Name { get; set; }
 
         /// <summary>
-        /// The suffix of the customer's next invoice number.
+        /// The sequence to be used on the customer's next invoice. Defaults to 1.
         /// </summary>
         [JsonProperty("next_invoice_sequence")]
         public long? NextInvoiceSequence { get; set; }
@@ -66,38 +85,34 @@ namespace Stripe
         public string Plan { get; set; }
 
         /// <summary>
-        /// The customer's preferred locales (languages), ordered by preference.
+        /// Customer's preferred languages, ordered by preference.
         /// </summary>
         [JsonProperty("preferred_locales")]
         public List<string> PreferredLocales { get; set; }
 
+        /// <summary>
+        /// The API ID of a promotion code to apply to the customer. The customer will have a
+        /// discount applied on all recurring payments. Charges you create through the API will not
+        /// have the discount.
+        /// </summary>
+        [JsonProperty("promotion_code")]
+        public string PromotionCode { get; set; }
+
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
+        /// <summary>
+        /// The customer's shipping information. Appears on invoices emailed to this customer.
+        /// </summary>
         [JsonProperty("shipping")]
         public ShippingOptions Shipping { get; set; }
 
-        /// <summary>
-        /// The source can either be a Token or a Source, as returned by
-        /// <a href="https://stripe.com/docs/elements">Elements</a>, or a
-        /// <see cref="CardCreateNestedOptions"/> containing a user's credit card details. You must
-        /// provide a source if the customer does not already have a valid source attached, and you
-        /// are subscribing the customer to be charged automatically for a plan that is not free.
-        /// Passing <c>source</c> will create a new source object, make it the customer default
-        /// source, and delete the old customer default if one exists. If you want to add an
-        /// additional source, instead use
-        /// <see cref="CardService.Create(string, CardCreateOptions, RequestOptions)"/> to add the
-        /// card and then <see cref="CustomerService.Update(string, CustomerUpdateOptions, RequestOptions)"/>
-        /// to set it as the default. Whenever you attach a card to a customer, Stripe will
-        /// automatically validate the card.
-        /// </summary>
         [JsonProperty("source")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         /// <summary>
-        /// Describes the customer's tax exemption status. One of <c>none</c>, <c>exempt</c>, or
-        /// <c>reverse</c>.
+        /// The customer's tax exemption. One of <c>none</c>, <c>exempt</c>, or <c>reverse</c>.
         /// </summary>
         [JsonProperty("tax_exempt")]
         public string TaxExempt { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerUpdateOptions.cs
@@ -13,11 +13,9 @@ namespace Stripe
         public AddressOptions Address { get; set; }
 
         /// <summary>
-        /// Current balance, if any, being stored on the customer. If negative, the customer has
-        /// credit to apply to their next invoice. If positive, the customer has an amount owed that
-        /// will be added to their next invoice. The balance does not refer to any unpaid invoices;
-        /// it solely takes into account amounts that have yet to be successfully applied to any
-        /// invoice. This balance is only taken into account as invoices are finalized.
+        /// An integer amount in %s that represents the customer's current balance, which affect the
+        /// customer's future invoices. A negative amount represents a credit that decreases the
+        /// amount due on an invoice; a positive amount increases the amount due on an invoice.
         /// </summary>
         [JsonProperty("balance")]
         public long? Balance { get; set; }
@@ -25,21 +23,54 @@ namespace Stripe
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 
+        /// <summary>
+        /// If you are using payment methods created via the PaymentMethods API, see the <a
+        /// href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">invoice_settings.default_payment_method</a>
+        /// parameter.
+        ///
+        /// Provide the ID of a payment source already attached to this customer to make it this
+        /// customer's default payment source.
+        ///
+        /// If you want to add a new payment source and make it the default, see the <a
+        /// href="https://stripe.com/docs/api/customers/update#update_customer-source">source</a>
+        /// property.
+        /// </summary>
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 
+        /// <summary>
+        /// An arbitrary string that you can attach to a customer object. It is displayed alongside
+        /// the customer in the dashboard.
+        /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <summary>
+        /// Customer's email address. It's displayed alongside the customer in your dashboard and
+        /// can be useful for searching and tracking. This may be up to <em>512 characters</em>.
+        /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
 
+        /// <summary>
+        /// The prefix for the customer used to generate unique invoice numbers. Must be 3–12
+        /// uppercase letters or numbers.
+        /// </summary>
         [JsonProperty("invoice_prefix")]
         public string InvoicePrefix { get; set; }
 
+        /// <summary>
+        /// Default invoice settings for this customer.
+        /// </summary>
         [JsonProperty("invoice_settings")]
         public CustomerInvoiceSettingsOptions InvoiceSettings { get; set; }
 
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
@@ -50,7 +81,7 @@ namespace Stripe
         public string Name { get; set; }
 
         /// <summary>
-        /// The suffix of the customer's next invoice number.
+        /// The sequence to be used on the customer's next invoice. Defaults to 1.
         /// </summary>
         [JsonProperty("next_invoice_sequence")]
         public long? NextInvoiceSequence { get; set; }
@@ -62,30 +93,31 @@ namespace Stripe
         public string Phone { get; set; }
 
         /// <summary>
-        /// The customer's preferred locales (languages), ordered by preference.
+        /// Customer's preferred languages, ordered by preference.
         /// </summary>
         [JsonProperty("preferred_locales")]
         public List<string> PreferredLocales { get; set; }
 
+        /// <summary>
+        /// The API ID of a promotion code to apply to the customer. The customer will have a
+        /// discount applied on all recurring payments. Charges you create through the API will not
+        /// have the discount.
+        /// </summary>
+        [JsonProperty("promotion_code")]
+        public string PromotionCode { get; set; }
+
+        /// <summary>
+        /// The customer's shipping information. Appears on invoices emailed to this customer.
+        /// </summary>
         [JsonProperty("shipping")]
         public ShippingOptions Shipping { get; set; }
 
-        /// <summary>
-        /// A Token's or a Source's ID, as returned by
-        /// <a href="https://stripe.com/docs/elements">Elements</a>. Passing <c>source</c> will
-        /// create a new source object, make it the new customer default source, and delete the old\
-        /// customer default if one exists. If you want to add additional sources instead of
-        /// replacing the existing default, use
-        /// <see cref="CardService.Create(string, CardCreateOptions, RequestOptions)"/>. Whenever
-        /// you attach a card to a customer, Stripe will automatically validate the card.
-        /// </summary>
         [JsonProperty("source")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<string, CardCreateNestedOptions> Source { get; set; }
 
         /// <summary>
-        /// Describes the customer's tax exemption status. One of <c>none</c>,  <c>exempt</c>, or
-        /// <c>reverse</c>.
+        /// The customer's tax exemption. One of <c>none</c>, <c>exempt</c>, or <c>reverse</c>.
         /// </summary>
         [JsonProperty("tax_exempt")]
         public string TaxExempt { get; set; }

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeCreateOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeCreateOptions.cs
@@ -1,0 +1,68 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PromotionCodeCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Whether the promotion code is currently active.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// The customer-facing code. Regardless of case, this code must be unique across all active
+        /// promotion codes for a specific customer. If left blank, we will generate one
+        /// automatically.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// The coupon for this promotion code.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        /// <summary>
+        /// The customer that this promotion code can be used by. If not set, the promotion code can
+        /// be used by all customers.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+
+        /// <summary>
+        /// The timestamp at which this promotion code will expire. If the coupon has specified a
+        /// <c>redeems_by</c>, then this value cannot be after the coupon's <c>redeems_by</c>.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(DateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// A positive integer specifying the number of times the promotion code can be redeemed. If
+        /// the coupon has specified a <c>max_redemptions</c>, then this value cannot be greater
+        /// than the coupon's <c>max_redemptions</c>.
+        /// </summary>
+        [JsonProperty("max_redemptions")]
+        public long? MaxRedemptions { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Settings that restrict the redemption of the promotion code.
+        /// </summary>
+        [JsonProperty("restrictions")]
+        public PromotionCodeRestrictionsOptions Restrictions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeGetOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeGetOptions.cs
@@ -1,0 +1,6 @@
+namespace Stripe
+{
+    public class PromotionCodeGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeListOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeListOptions.cs
@@ -1,0 +1,19 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PromotionCodeListOptions : ListOptionsWithCreated
+    {
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeRestrictionsOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeRestrictionsOptions.cs
@@ -1,0 +1,28 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PromotionCodeRestrictionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// A Boolean indicating if the Promotion Code should only be redeemed for Customers without
+        /// any successful payments or invoices.
+        /// </summary>
+        [JsonProperty("first_time_transaction")]
+        public bool? FirstTimeTransaction { get; set; }
+
+        /// <summary>
+        /// Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase
+        /// must be $100 or more to work).
+        /// </summary>
+        [JsonProperty("minimum_amount")]
+        public long? MinimumAmount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://stripe.com/docs/currencies">ISO code</a> for
+        /// minimum_amount.
+        /// </summary>
+        [JsonProperty("minimum_amount_currency")]
+        public string MinimumAmountCurrency { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
@@ -1,0 +1,77 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class PromotionCodeService : Service<PromotionCode>,
+        ICreatable<PromotionCode, PromotionCodeCreateOptions>,
+        IListable<PromotionCode, PromotionCodeListOptions>,
+        IRetrievable<PromotionCode, PromotionCodeGetOptions>,
+        IUpdatable<PromotionCode, PromotionCodeUpdateOptions>
+    {
+        public PromotionCodeService()
+            : base(null)
+        {
+        }
+
+        public PromotionCodeService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/promotion_codes";
+
+        public virtual PromotionCode Create(PromotionCodeCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<PromotionCode> CreateAsync(PromotionCodeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual PromotionCode Get(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<PromotionCode> GetAsync(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<PromotionCode> List(PromotionCodeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<PromotionCode>> ListAsync(PromotionCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<PromotionCode> ListAutoPaging(PromotionCodeListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+#if !NET45
+        public virtual IAsyncEnumerable<PromotionCode> ListAutoPagingAsync(PromotionCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+#endif
+
+        public virtual PromotionCode Update(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<PromotionCode> UpdateAsync(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeUpdateOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeUpdateOptions.cs
@@ -3,8 +3,15 @@ namespace Stripe
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class CouponUpdateOptions : BaseOptions, IHasMetadata
+    public class PromotionCodeUpdateOptions : BaseOptions, IHasMetadata
     {
+        /// <summary>
+        /// Whether the promotion code is currently active. A promotion code can only be reactivated
+        /// when the coupon is still valid and the promotion code is otherwise redeemable.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
         /// <summary>
         /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
         /// attach to an object. This can be useful for storing additional information about the
@@ -13,12 +20,5 @@ namespace Stripe
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
-
-        /// <summary>
-        /// Name of the coupon displayed to customers on, for instance invoices, or receipts. By
-        /// default the <c>id</c> is shown if <c>name</c> is not set.
-        /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -15,230 +15,242 @@ namespace Stripe
         public List<SubscriptionAddInvoiceItemOptions> AddInvoiceItems { get; set; }
 
         /// <summary>
-        /// A non-negative decimal between 0 and 100, with at most two decimal
-        /// places. This represents the percentage of the subscription invoice
-        /// subtotal that will be transferred to the application owner's Stripe
-        /// account. The request must be made with an OAuth key in order to set
-        /// an application fee percentage. For more information, see the
-        /// application fees <see href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</see>.
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner's Stripe account. The request must be made by a platform
+        /// account on a connected account in order to set an application fee percentage. For more
+        /// information, see the application fees <a
+        /// href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</a>.
         /// </summary>
         [JsonProperty("application_fee_percent")]
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
-        /// For new subscriptions, a past timestamp to backdate the
-        /// subscription's start date to.  If set, the first invoice will
-        /// contain a proration for the timespan between the start date and the
-        /// current time. Can be combined with trials and the billing cycle
-        /// anchor.
+        /// For new subscriptions, a past timestamp to backdate the subscription's start date to. If
+        /// set, the first invoice will contain a proration for the timespan between the start date
+        /// and the current time. Can be combined with trials and the billing cycle anchor.
         /// </summary>
         [JsonProperty("backdate_start_date")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? BackdateStartDate { get; set; }
 
         /// <summary>
-        /// A future date to anchor the subscription's <see href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</see>.
-        /// This is used to determine the date of the first full invoice, and, for plans with
-        /// <c>month</c> or <c>year</c> intervals, the day of the month for subsequent invoices.
+        /// A future timestamp to anchor the subscription's <a
+        /// href="https://stripe.com/docs/subscriptions/billing-cycle">billing cycle</a>. This is
+        /// used to determine the date of the first full invoice, and, for plans with <c>month</c>
+        /// or <c>year</c> intervals, the day of the month for subsequent invoices.
         /// </summary>
         [JsonProperty("billing_cycle_anchor")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? BillingCycleAnchor { get; set; }
 
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the
-        /// subscription advanced to a new billing period. Pass an empty string
-        /// to remove previously-defined thresholds.
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
         /// </summary>
         [JsonProperty("billing_thresholds")]
         public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
 
         /// <summary>
-        /// A timestamp at which the subscription should cancel. If set to a date before the
-        /// current period ends this will cause a proration if <c>prorate=true</c>.
+        /// A timestamp at which the subscription should cancel. If set to a date before the current
+        /// period ends, this will cause a proration if prorations have been enabled using
+        /// <c>proration_behavior</c>. If set during a future period, this will always cause a
+        /// proration for that period.
         /// </summary>
         [JsonProperty("cancel_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CancelAt { get; set; }
 
         /// <summary>
-        /// Boolean indicating whether this subscription should cancel at the
-        /// end of the current period.
+        /// Boolean indicating whether this subscription should cancel at the end of the current
+        /// period.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]
         public bool? CancelAtPeriodEnd { get; set; }
 
         /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
-        /// charging automatically, Stripe will attempt to pay this invoice
-        /// using the default source attached to the customer. When sending an
-        /// invoice, Stripe will email invoices for this subscription to the
-        /// customer with payment instructions. Defaults to
-        /// <c>charge_automatically</c>.
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging automatically,
+        /// Stripe will attempt to pay this subscription at the end of the cycle using the default
+        /// source attached to the customer. When sending an invoice, Stripe will email your
+        /// customer an invoice with payment instructions. Defaults to <c>charge_automatically</c>.
         /// </summary>
         [JsonProperty("collection_method")]
         public string CollectionMethod { get; set; }
 
         /// <summary>
-        /// The code of the coupon to apply to this subscription. A coupon
-        /// applied to a subscription will only affect invoices created for
-        /// that particular subscription.
+        /// The code of the coupon to apply to this subscription. A coupon applied to a subscription
+        /// will only affect invoices created for that particular subscription.
         /// </summary>
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 
         /// <summary>
-        /// REQUIRED: The identifier of the customer to subscribe.
+        /// The identifier of the customer to subscribe.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
 
         /// <summary>
-        /// Number of days a customer has to pay invoices generated by this
-        /// subscription. Only valid for subscriptions where
-        /// <c>billing=send_invoice</c>.
+        /// Number of days a customer has to pay invoices generated by this subscription. Valid only
+        /// for subscriptions where <c>collection_method</c> is set to <c>send_invoice</c>.
         /// </summary>
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
         /// <summary>
-        /// ID of the default payment method for the subscription.
+        /// ID of the default payment method for the subscription. It must belong to the customer
+        /// associated with the subscription. If not set, invoices will use the default payment
+        /// method in the customer's invoice settings.
         /// </summary>
         [JsonProperty("default_payment_method")]
         public string DefaultPaymentMethod { get; set; }
 
         /// <summary>
-        /// ID of the default payment source for the subscription. It must
-        /// belong to the customer associated with the subscription and be in a
-        /// chargeable state. If not set, defaults to the customer's default
-        /// source.
+        /// ID of the default payment source for the subscription. It must belong to the customer
+        /// associated with the subscription and be in a chargeable state. If not set, defaults to
+        /// the customer's default source.
         /// </summary>
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 
         /// <summary>
-        /// IDs of the tax rates to apply to this subscription.
+        /// The tax rates that will apply to any subscription item that does not have
+        /// <c>tax_rates</c> set. Invoices created will have their <c>default_tax_rates</c>
+        /// populated from the subscription.
         /// </summary>
         [JsonProperty("default_tax_rates")]
         public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
-        /// List of subscription items, each with an attached plan.
+        /// A list of up to 20 subscription items, each with an attached price.
         /// </summary>
         [JsonProperty("items")]
         public List<SubscriptionItemOptions> Items { get; set; }
 
         /// <summary>
-        /// A set of key/value pairs that you can attach to a subscription
-        /// object. It can be useful for storing additional information about
-        /// the subscription in a structured format.
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// Indicates if a customer is on session while an invoice payment is
-        /// attempted.
+        /// Indicates if a customer is on or off-session while an invoice payment is attempted.
         /// </summary>
         [JsonProperty("off_session")]
         public bool? OffSession { get; set; }
 
         /// <summary>
-        /// <para>
-        /// Use <c>allow_incomplete</c> to create subscriptions with
-        /// <c>status=incomplete</c> if its first invoice cannot be paid.
-        /// Creating subscriptions with this status allows you to manage
-        /// scenarios where additional user actions are needed to pay a
-        /// subscription's invoice. For example, SCA regulation may require 3DS
-        /// authentication to complete payment.  See the
-        /// <a href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration Guide</a>
-        /// for Billing to learn more. This is the default behavior.
-        /// </para>
-        /// <para>
-        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP
-        /// 402 status code if a subscription's first invoice cannot be paid.
-        /// For example, if a payment method requires 3DS authentication due to
-        /// SCA regulation and further user action is needed, this parameter
-        /// does not create a subscription and returns an error instead.
-        /// </para>
+        /// Use <c>allow_incomplete</c> to create subscriptions with <c>status=incomplete</c> if the
+        /// first invoice cannot be paid. Creating subscriptions with this status allows you to
+        /// manage scenarios where additional user actions are needed to pay a subscription's
+        /// invoice. For example, SCA regulation may require 3DS authentication to complete payment.
+        /// See the <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// Migration Guide</a> for Billing to learn more. This is the default behavior.
+        ///
+        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if a
+        /// subscription's first invoice cannot be paid. For example, if a payment method requires
+        /// 3DS authentication due to SCA regulation and further user action is needed, this
+        /// parameter does not create a subscription and returns an error instead. This was the
+        /// default behavior for API versions prior to 2019-03-14. See the <a
+        /// href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
+        ///
+        /// <c>pending_if_incomplete</c> is only used with updates and cannot be passed when
+        /// creating a subscription.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }
 
         /// <summary>
-        /// Specifies an interval for how often to bill for any pending invoice
-        /// items. It is analogous to creating an invoice for the given
-        /// subscription at the specified interval.
+        /// Specifies an interval for how often to bill for any pending invoice items. It is
+        /// analogous to calling <a href="https://stripe.com/docs/api#create_invoice">Create an
+        /// invoice</a> for the given subscription at the specified interval.
         /// </summary>
         [JsonProperty("pending_invoice_item_interval")]
         public SubscriptionPendingInvoiceItemIntervalOptions PendingInvoiceItemInterval { get; set; }
 
-        [Obsolete("Use Items")]
+        [Obsolete("Use Items instead.")]
         [JsonProperty("plan")]
         public string Plan { get; set; }
 
         /// <summary>
-        /// Boolean (default <c>true</c>). Use with a
-        /// <c>billing_cycle_anchor</c> timestamp to determine whether the
-        /// customer will be invoiced a prorated amount until the anchor date.
-        /// If <c>false</c>, the anchor period will be free (similar to a
-        /// trial).
+        /// The API ID of a promotion code to apply to this subscription. A promotion code applied
+        /// to a subscription will only affect invoices created for that particular subscription.
+        /// </summary>
+        [JsonProperty("promotion_code")]
+        public string PromotionCode { get; set; }
+
+        /// <summary>
+        /// This field has been renamed to <c>proration_behavior</c>. <c>prorate=true</c> can be
+        /// replaced with <c>proration_behavior=create_prorations</c> and <c>prorate=false</c> can
+        /// be replaced with <c>proration_behavior=none</c>.
         /// </summary>
         [JsonProperty("prorate")]
         public bool? Prorate { get; set; }
 
         /// <summary>
-        /// Determines how to handle
-        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
-        /// when the billing cycle changes. The value defaults to
-        /// <c>create_prorations</c>, indicating that proration invoice items
-        /// should be created. Prorations can be disabled by setting the value
-        /// to <c>none</c>.
+        /// Determines how to handle <a
+        /// href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a>
+        /// resulting from the <c>billing_cycle_anchor</c>. Valid values are
+        /// <c>create_prorations</c> or <c>none</c>.
+        ///
+        /// Passing <c>create_prorations</c> will cause proration invoice items to be created when
+        /// applicable. Prorations can be disabled by passing <c>none</c>. If no value is passed,
+        /// the default is <c>create_prorations</c>.
         /// </summary>
         [JsonProperty("proration_behavior")]
         public string ProrationBehavior { get; set; }
 
-        [Obsolete("Use Items")]
+        [Obsolete("Use Items instead.")]
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
         /// <summary>
-        /// A non-negative decimal (with at most four decimal places) between 0
-        /// and 100. This represents the percentage of the subscription invoice
-        /// subtotal that will be calculated and added as tax to the final
-        /// amount each billing period. For example, a plan which charges
-        /// $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per
-        /// invoice.
+        /// A non-negative decimal (with at most four decimal places) between 0 and 100. This
+        /// represents the percentage of the subscription invoice subtotal that will be calculated
+        /// and added as tax to the final amount each billing period. For example, a plan which
+        /// charges $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per invoice.
         /// </summary>
         [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+        /// <summary>
+        /// If specified, the funds from the subscription's invoices will be transferred to the
+        /// destination and the ID of the resulting transfers will be found on the resulting
+        /// charges.
+        /// </summary>
         [JsonProperty("transfer_data")]
         public SubscriptionTransferDataOptions TransferData { get; set; }
 
         /// <summary>
-        /// <see cref="DateTime"/> representing the end of the trial period the customer will get
-        /// before being charged for the first time. This will always overwrite any trials that
-        /// might apply via a subscribed plan. If set, <see cref="TrialEnd"/> will override the
-        /// default trial period of the plan the customer is being subscribed to. The special value
-        /// <see cref="SubscriptionTrialEnd.Now"/> can be provided to end the customer's trial
-        /// immediately.
+        /// Unix timestamp representing the end of the trial period the customer will get before
+        /// being charged for the first time. This will always overwrite any trials that might apply
+        /// via a subscribed plan. If set, trial_end will override the default trial period of the
+        /// plan the customer is being subscribed to. The special value <c>now</c> can be provided
+        /// to end the customer's trial immediately. Can be at most two years from
+        /// <c>billing_cycle_anchor</c>.
         /// </summary>
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, SubscriptionTrialEnd> TrialEnd { get; set; }
 
         /// <summary>
-        /// Boolean. Decide whether to use the default trial on the plan when
-        /// creating a subscription.
+        /// Indicates if a plan's <c>trial_period_days</c> should be applied to the subscription.
+        /// Setting <c>trial_end</c> per subscription is preferred, and this defaults to
+        /// <c>false</c>. Setting this flag to <c>true</c> together with <c>trial_end</c> is not
+        /// allowed.
         /// </summary>
         [JsonProperty("trial_from_plan")]
         public bool? TrialFromPlan { get; set; }
 
         /// <summary>
-        /// Integer representing the number of trial period days before the
-        /// customer is charged for the first time.
+        /// Integer representing the number of trial period days before the customer is charged for
+        /// the first time. This will always overwrite any trials that might apply via a subscribed
+        /// plan.
         /// </summary>
         [JsonProperty("trial_period_days")]
         public long? TrialPeriodDays { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -15,113 +15,114 @@ namespace Stripe
         public List<SubscriptionAddInvoiceItemOptions> AddInvoiceItems { get; set; }
 
         /// <summary>
-        /// A non-negative decimal between 0 and 100, with at most two decimal
-        /// places. This represents the percentage of the subscription invoice
-        /// subtotal that will be transferred to the application owner's Stripe
-        /// account. The request must be made with an OAuth key in order to set
-        /// an application fee percentage. For more information, see the
-        /// application fees <see
-        /// href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</see>.
+        /// A non-negative decimal between 0 and 100, with at most two decimal places. This
+        /// represents the percentage of the subscription invoice subtotal that will be transferred
+        /// to the application owner's Stripe account. The request must be made by a platform
+        /// account on a connected account in order to set an application fee percentage. For more
+        /// information, see the application fees <a
+        /// href="https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions">documentation</a>.
         /// </summary>
         [JsonProperty("application_fee_percent")]
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
-        /// One of <see cref="SubscriptionBillingCycleAnchor"/>. Setting the value to
-        /// <see cref="SubscriptionBillingCycleAnchor.Now"/> resets the subscription's billing
-        /// cycle anchor to the current time. For more information, see the billing cycle
-        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+        /// Either <c>now</c> or <c>unchanged</c>. Setting the value to <c>now</c> resets the
+        /// subscription's billing cycle anchor to the current time. For more information, see the
+        /// billing cycle <a
+        /// href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
         /// </summary>
         [JsonProperty("billing_cycle_anchor")]
         public SubscriptionBillingCycleAnchor BillingCycleAnchor { get; set; }
 
         /// <summary>
-        /// Define thresholds at which an invoice will be sent, and the
-        /// subscription advanced to a new billing period. Pass an empty string
-        /// to remove previously-defined thresholds.
+        /// Define thresholds at which an invoice will be sent, and the subscription advanced to a
+        /// new billing period. Pass an empty string to remove previously-defined thresholds.
         /// </summary>
         [JsonProperty("billing_thresholds")]
         public SubscriptionBillingThresholdsOptions BillingThresholds { get; set; }
 
         /// <summary>
-        /// A timestamp at which the subscription should cancel. If set to a date before the
-        /// current period ends this will cause a proration if <c>prorate=true</c>.
+        /// A timestamp at which the subscription should cancel. If set to a date before the current
+        /// period ends, this will cause a proration if prorations have been enabled using
+        /// <c>proration_behavior</c>. If set during a future period, this will always cause a
+        /// proration for that period.
         /// </summary>
         [JsonProperty("cancel_at")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? CancelAt { get; set; }
 
         /// <summary>
-        /// Boolean indicating whether this subscription should cancel at the
-        /// end of the current period.
+        /// Boolean indicating whether this subscription should cancel at the end of the current
+        /// period.
         /// </summary>
         [JsonProperty("cancel_at_period_end")]
         public bool? CancelAtPeriodEnd { get; set; }
 
         /// <summary>
-        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When
-        /// charging automatically, Stripe will attempt to pay this invoice
-        /// using the default source attached to the customer. When sending an
-        /// invoice, Stripe will email invoices for this subscription to the
-        /// customer with payment instructions. Defaults to
-        /// <c>charge_automatically</c>.
+        /// Either <c>charge_automatically</c>, or <c>send_invoice</c>. When charging automatically,
+        /// Stripe will attempt to pay this subscription at the end of the cycle using the default
+        /// source attached to the customer. When sending an invoice, Stripe will email your
+        /// customer an invoice with payment instructions. Defaults to <c>charge_automatically</c>.
         /// </summary>
         [JsonProperty("collection_method")]
         public string CollectionMethod { get; set; }
 
         /// <summary>
-        /// The code of the coupon to apply to this subscription. A coupon
-        /// applied to a subscription will only affect invoices created for
-        /// that particular subscription.
+        /// The code of the coupon to apply to this subscription. A coupon applied to a subscription
+        /// will only affect invoices created for that particular subscription.
         /// </summary>
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 
         /// <summary>
-        /// Number of days a customer has to pay invoices generated by this
-        /// subscription. Only valid for subscriptions where
-        /// <c>billing=send_invoice</c>.
+        /// Number of days a customer has to pay invoices generated by this subscription. Valid only
+        /// for subscriptions where <c>collection_method</c> is set to <c>send_invoice</c>.
         /// </summary>
         [JsonProperty("days_until_due")]
         public long? DaysUntilDue { get; set; }
 
         /// <summary>
-        /// ID of the default payment method for the subscription.
+        /// ID of the default payment method for the subscription. It must belong to the customer
+        /// associated with the subscription. If not set, invoices will use the default payment
+        /// method in the customer's invoice settings.
         /// </summary>
         [JsonProperty("default_payment_method")]
         public string DefaultPaymentMethod { get; set; }
 
         /// <summary>
-        /// ID of the default payment source for the subscription. It must
-        /// belong to the customer associated with the subscription and be in a
-        /// chargeable state. If not set, defaults to the customer's default
-        /// source.
+        /// ID of the default payment source for the subscription. It must belong to the customer
+        /// associated with the subscription and be in a chargeable state. If not set, defaults to
+        /// the customer's default source.
         /// </summary>
         [JsonProperty("default_source")]
         public string DefaultSource { get; set; }
 
         /// <summary>
-        /// Ids of the tax rates to apply to this subscription.
+        /// The tax rates that will apply to any subscription item that does not have
+        /// <c>tax_rates</c> set. Invoices created will have their <c>default_tax_rates</c>
+        /// populated from the subscription. Pass an empty string to remove previously-defined tax
+        /// rates.
         /// </summary>
         [JsonProperty("default_tax_rates")]
         public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
-        /// List of subscription items, each with an attached plan.
+        /// A list of up to 20 subscription items, each with an attached price.
         /// </summary>
         [JsonProperty("items")]
         public List<SubscriptionItemOptions> Items { get; set; }
 
         /// <summary>
-        /// A set of key/value pairs that you can attach to a subscription
-        /// object. It can be useful for storing additional information about
-        /// the subscription in a structured format.
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// Indicates if a customer is on session while an invoice payment is attempted.
+        /// Indicates if a customer is on or off-session while an invoice payment is attempted.
         /// </summary>
         [JsonProperty("off_session")]
         public bool? OffSession { get; set; }
@@ -133,105 +134,127 @@ namespace Stripe
         public SubscriptionPauseCollectionOptions PauseCollection { get; set; }
 
         /// <summary>
-        /// <para>
-        /// Use <c>allow_incomplete</c> to create subscriptions with <c>status=incomplete</c> if its
-        /// first invoice cannot be paid. Creating subscriptions with this status allows you to
-        /// manage scenarios where additional user actions are needed to pay a subscription's
-        /// invoice. For example, SCA regulation may require 3DS authentication to complete payment.
-        /// See the <a href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration Guide</a>
-        /// for Billing to learn more. This is the default behavior.
-        /// </para>
-        /// <para>
-        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if
-        /// a subscription's first invoice cannot be paid. For example, if a payment method requires
-        /// 3DS authentication due to SCA regulation and further user action is needed, this
-        /// parameter does not create a subscription and returns an error instead.
-        /// </para>
+        /// Use <c>allow_incomplete</c> to transition the subscription to <c>status=past_due</c> if
+        /// a payment is required but cannot be paid. This allows you to manage scenarios where
+        /// additional user actions are needed to pay a subscription's invoice. For example, SCA
+        /// regulation may require 3DS authentication to complete payment. See the <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// Migration Guide</a> for Billing to learn more. This is the default behavior.
+        ///
+        /// Use <c>pending_if_incomplete</c> to update the subscription using <a
+        /// href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending
+        /// updates</a>. When you use <c>pending_if_incomplete</c> you can only pass the parameters
+        /// <a
+        /// href="https://stripe.com/docs/billing/pending-updates-reference#supported-attributes">supported
+        /// by pending updates</a>.
+        ///
+        /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if a
+        /// subscription's invoice cannot be paid. For example, if a payment method requires 3DS
+        /// authentication due to SCA regulation and further user action is needed, this parameter
+        /// does not update the subscription and returns an error instead. This was the default
+        /// behavior for API versions prior to 2019-03-14. See the <a
+        /// href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }
 
         /// <summary>
-        /// Specifies an interval for how often to bill for any pending invoice
-        /// items. It is analogous to creating an invoice for the given
-        /// subscription at the specified interval.
+        /// Specifies an interval for how often to bill for any pending invoice items. It is
+        /// analogous to calling <a href="https://stripe.com/docs/api#create_invoice">Create an
+        /// invoice</a> for the given subscription at the specified interval.
         /// </summary>
         [JsonProperty("pending_invoice_item_interval")]
         public SubscriptionPendingInvoiceItemIntervalOptions PendingInvoiceItemInterval { get; set; }
 
-        [Obsolete("Use Items")]
+        [Obsolete("Use Items instead.")]
         [JsonProperty("plan")]
         public string Plan { get; set; }
 
         /// <summary>
-        /// Boolean (default <c>true</c>). Use with a
-        /// <c>billing_cycle_anchor</c> timestamp to determine whether the
-        /// customer will be invoiced a prorated amount until the anchor date.
-        /// If <c>false</c>, the anchor period will be free (similar to a
-        /// trial).
+        /// The promotion code to apply to this subscription. A promotion code applied to a
+        /// subscription will only affect invoices created for that particular subscription.
+        /// </summary>
+        [JsonProperty("promotion_code")]
+        public string PromotionCode { get; set; }
+
+        /// <summary>
+        /// This field has been renamed to <c>proration_behavior</c>. <c>prorate=true</c> can be
+        /// replaced with <c>proration_behavior=create_prorations</c> and <c>prorate=false</c> can
+        /// be replaced with <c>proration_behavior=none</c>.
         /// </summary>
         [JsonProperty("prorate")]
         public bool? Prorate { get; set; }
 
         /// <summary>
-        /// Determines how to handle
-        /// <a href="https://stripe.com/docs/billing/subscriptions/billing-cycle#prorations">prorations</a>
-        /// when the billing cycle changes. The value defaults to
-        /// <c>create_prorations</c>, indicating that proration invoice items
-        /// should be created. Prorations can be disabled by setting the value
-        /// to <c>none</c>.
+        /// Determines how to handle <a
+        /// href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a>
+        /// when the billing cycle changes (e.g., when switching plans, resetting
+        /// <c>billing_cycle_anchor=now</c>, or starting a trial), or if an item's <c>quantity</c>
+        /// changes. Valid values are <c>create_prorations</c>, <c>none</c>, or
+        /// <c>always_invoice</c>.
+        ///
+        /// Passing <c>create_prorations</c> will cause proration invoice items to be created when
+        /// applicable. These proration items will only be invoiced immediately under <a
+        /// href="https://stripe.com/docs/subscriptions/upgrading-downgrading#immediate-payment">certain
+        /// conditions</a>. In order to always invoice immediately for prorations, pass
+        /// <c>always_invoice</c>.
+        ///
+        /// Prorations can be disabled by passing <c>none</c>.
         /// </summary>
         [JsonProperty("proration_behavior")]
         public string ProrationBehavior { get; set; }
 
         /// <summary>
-        /// If set, the proration will be calculated as though the subscription
-        /// was updated at the given time. This can be used to apply exactly
-        /// the same proration that was previewed with
-        /// <see href="https://stripe.com/docs/api#upcoming_invoice">upcoming invoice</see>
-        /// endpoint. It can also be used to implement custom
-        /// proration logic, such as prorating by day instead of by second, by
-        /// providing the time that you wish to use for proration calculations.
+        /// If set, the proration will be calculated as though the subscription was updated at the
+        /// given time. This can be used to apply exactly the same proration that was previewed with
+        /// <a href="https://stripe.com/docs/api#retrieve_customer_invoice">upcoming invoice</a>
+        /// endpoint. It can also be used to implement custom proration logic, such as prorating by
+        /// day instead of by second, by providing the time that you wish to use for proration
+        /// calculations.
         /// </summary>
         [JsonProperty("proration_date")]
         [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? ProrationDate { get; set; }
 
-        [Obsolete("Use Items")]
+        [Obsolete("Use Items instead.")]
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
         /// <summary>
-        /// A non-negative decimal (with at most four decimal places) between 0
-        /// and 100. This represents the percentage of the subscription invoice
-        /// subtotal that will be calculated and added as tax to the final
-        /// amount each billing period. For example, a plan which charges
-        /// $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per
-        /// invoice.
+        /// A non-negative decimal (with at most four decimal places) between 0 and 100. This
+        /// represents the percentage of the subscription invoice subtotal that will be calculated
+        /// and added as tax to the final amount each billing period. For example, a plan which
+        /// charges $10/month with a <c>tax_percent</c> of 20.0 will charge $12 per invoice.
         /// </summary>
         [Obsolete("Use DefaultTaxRates")]
         [JsonProperty("tax_percent")]
         public decimal? TaxPercent { get; set; }
 
+        /// <summary>
+        /// If specified, the funds from the subscription's invoices will be transferred to the
+        /// destination and the ID of the resulting transfers will be found on the resulting
+        /// charges. This will be unset if you POST an empty value.
+        /// </summary>
         [JsonProperty("transfer_data")]
         public SubscriptionTransferDataOptions TransferData { get; set; }
 
         /// <summary>
-        /// <see cref="DateTime"/> representing the end of the trial period the
-        /// customer will get before being charged for the first time. This
-        /// will always overwrite any trials that might apply via a subscribed
-        /// plan. If set, <see cref="TrialEnd"/> will override the default
-        /// trial period of the plan the customer is being subscribed to. The
-        /// special value <see cref="SubscriptionTrialEnd.Now"/> can be
-        /// provided to end the customer's trial immediately.
+        /// Unix timestamp representing the end of the trial period the customer will get before
+        /// being charged for the first time. This will always overwrite any trials that might apply
+        /// via a subscribed plan. If set, trial_end will override the default trial period of the
+        /// plan the customer is being subscribed to. The special value <c>now</c> can be provided
+        /// to end the customer's trial immediately. Can be at most two years from
+        /// <c>billing_cycle_anchor</c>.
         /// </summary>
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, SubscriptionTrialEnd> TrialEnd { get; set; }
 
         /// <summary>
-        /// Boolean. Decide whether to use the default trial on the plan when
-        /// creating a subscription.
+        /// Indicates if a plan's <c>trial_period_days</c> should be applied to the subscription.
+        /// Setting <c>trial_end</c> per subscription is preferred, and this defaults to
+        /// <c>false</c>. Setting this flag to <c>true</c> together with <c>trial_end</c> is not
+        /// allowed.
         /// </summary>
         [JsonProperty("trial_from_plan")]
         public bool? TrialFromPlan { get; set; }

--- a/src/StripeTests/Entities/PromotionCodes/PromotionCodeTest.cs
+++ b/src/StripeTests/Entities/PromotionCodes/PromotionCodeTest.cs
@@ -21,5 +21,25 @@ namespace StripeTests
             Assert.NotNull(promoCode.Id);
             Assert.Equal("promotion_code", promoCode.Object);
         }
+
+        [Fact]
+        public void DeserializeWithExpansionsCustomer()
+        {
+            string[] expansions =
+            {
+              "customer",
+            };
+
+            string json = this.GetFixture("/v1/promotion_codes/co_123", expansions);
+            var promoCode = JsonConvert.DeserializeObject<PromotionCode>(json);
+            Assert.NotNull(promoCode);
+            Assert.IsType<PromotionCode>(promoCode);
+            Assert.NotNull(promoCode.Id);
+            Assert.Equal("promotion_code", promoCode.Object);
+
+            Assert.NotNull(promoCode.Customer);
+            Assert.IsType<Customer>(promoCode.Customer);
+            Assert.Equal("customer", promoCode.Customer.Object);
+        }
     }
 }

--- a/src/StripeTests/Entities/PromotionCodes/PromotionCodeTest.cs
+++ b/src/StripeTests/Entities/PromotionCodes/PromotionCodeTest.cs
@@ -1,0 +1,25 @@
+namespace StripeTests
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class PromotionCodeTest : BaseStripeTest
+    {
+        public PromotionCodeTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            string json = this.GetFixture("/v1/promotion_codes/co_123");
+            var promoCode = JsonConvert.DeserializeObject<PromotionCode>(json);
+            Assert.NotNull(promoCode);
+            Assert.IsType<PromotionCode>(promoCode);
+            Assert.NotNull(promoCode.Id);
+            Assert.Equal("promotion_code", promoCode.Object);
+        }
+    }
+}

--- a/src/StripeTests/Entities/_base/StripeEntityTest.cs
+++ b/src/StripeTests/Entities/_base/StripeEntityTest.cs
@@ -161,9 +161,6 @@ namespace StripeTests
             // Access `created`, a number element
             Assert.Equal(subscription.Created, subscription.RawJObject["created"]);
 
-            // Access `plan[id]`, a nested string element
-            Assert.Equal(subscription.Plan.Id, subscription.RawJObject["plan"]["id"]);
-
             // Access `items[data][0][id]`, a deeply nested string element
             Assert.Equal(
                 subscription.Items.Data[0].Id,

--- a/src/StripeTests/Services/PromotionCodes/PromotionCodeServiceTest.cs
+++ b/src/StripeTests/Services/PromotionCodes/PromotionCodeServiceTest.cs
@@ -1,0 +1,141 @@
+namespace StripeTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Xunit;
+
+    public class PromotionCodeServiceTest : BaseStripeTest
+    {
+        private const string PromotionCodeId = "promo_123";
+
+        private readonly PromotionCodeService service;
+        private readonly PromotionCodeCreateOptions createOptions;
+        private readonly PromotionCodeUpdateOptions updateOptions;
+        private readonly PromotionCodeListOptions listOptions;
+
+        public PromotionCodeServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+        {
+            this.service = new PromotionCodeService(this.StripeClient);
+
+            this.createOptions = new PromotionCodeCreateOptions
+            {
+                Coupon = "co_123",
+                Code = "TESTCODE",
+            };
+
+            this.updateOptions = new PromotionCodeUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
+            };
+
+            this.listOptions = new PromotionCodeListOptions
+            {
+                Limit = 1,
+            };
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var promotionCode = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/promotion_codes");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var promotionCode = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/promotion_codes");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var promotionCode = this.service.Get(PromotionCodeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/promotion_codes/promo_123");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var promotionCode = await this.service.GetAsync(PromotionCodeId);
+            this.AssertRequest(HttpMethod.Get, "/v1/promotion_codes/promo_123");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+        [Fact]
+        public void List()
+        {
+            var promotionCodes = this.service.List(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/promotion_codes");
+            Assert.NotNull(promotionCodes);
+            Assert.Equal("list", promotionCodes.Object);
+            Assert.Single(promotionCodes.Data);
+            Assert.Equal("promotion_code", promotionCodes.Data[0].Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var promotionCodes = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/promotion_codes");
+            Assert.NotNull(promotionCodes);
+            Assert.Equal("list", promotionCodes.Object);
+            Assert.Single(promotionCodes.Data);
+            Assert.Equal("promotion_code", promotionCodes.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var promotionCode = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+#if !NET45
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var promotionCode = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+#endif
+
+        [Fact]
+        public void Update()
+        {
+            var promotionCode = this.service.Update(PromotionCodeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/promotion_codes/promo_123");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+
+        [Fact]
+        public async Task UpdateAsync()
+        {
+            var promotionCode = await this.service.UpdateAsync(PromotionCodeId, this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/promotion_codes/promo_123");
+            Assert.NotNull(promotionCode);
+            Assert.Equal("promotion_code", promotionCode.Object);
+        }
+    }
+}

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.94.0";
+        private const string MockMinimumVersion = "0.95.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Multiple API changes:
  * Add the `PromotionCode` resource and APIs
  * Add support for `AllowPromotionCodes` on Checkout `Session`
  * Add support for `AppliesTo` on `Coupon`
  * Add support for `PromotionCode` on `Customer` and `Subscription` creation or update

r? @remi-stripe
cc @stripe/api-libraries