### PR TITLE
Unshare `Period` Objects

### DIFF
--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -158,7 +158,7 @@ namespace Stripe
         /// Period this invoice item was created for.
         /// </summary>
         [JsonProperty("period")]
-        public Period Period { get; set; }
+        public InvoiceItemPeriod Period { get; set; }
 
         /// <summary>
         /// If the invoice item is a proration, the plan of the subscription that the proration was

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItemPeriod.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItemPeriod.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoiceItemPeriod : StripeEntity<InvoiceItemPeriod>
+    {
+        [JsonProperty("end")]
+        public long End { get; set; }
+
+        [JsonProperty("start")]
+        public long Start { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItem.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Newtonsoft.Json;
@@ -20,22 +19,17 @@ namespace Stripe
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        [JsonProperty("date")]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime Date { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
-
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        [JsonProperty("discount_amounts")]
+        public List<InvoiceLineItemDiscountAmount> DiscountAmounts { get; set; }
 
         [JsonProperty("discountable")]
         public bool Discountable { get; set; }
 
         #region Expandable Discounts
 
-        /// <summary>
-        /// Ids of the discounts applied to the invoice line item. Line item discounts are applied
-        /// before invoice discounts.
-        /// </summary>
         [JsonIgnore]
         public List<string> DiscountIds
         {
@@ -43,10 +37,6 @@ namespace Stripe
             set => this.InternalDiscounts = SetExpandableArrayIds<Discount>(value);
         }
 
-        /// <summary>
-        /// The discounts applied to the invoice line item. Line item discounts are applied before
-        /// invoice discounts.
-        /// </summary>
         [JsonIgnore]
         public List<Discount> Discounts
         {
@@ -58,12 +48,6 @@ namespace Stripe
         internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
         #endregion
 
-        /// <summary>
-        /// The amount of discount calculated per discount for this line item.
-        /// </summary>
-        [JsonProperty("discount_amounts")]
-        public List<CreditNoteLineItemDiscountAmount> DiscountAmounts { get; set; }
-
         [JsonProperty("invoice_item")]
         public string InvoiceItem { get; set; }
 
@@ -74,14 +58,11 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         [JsonProperty("period")]
-        public Period Period { get; set; }
+        public InvoiceLineItemPeriod Period { get; set; }
 
         [JsonProperty("plan")]
         public Plan Plan { get; set; }
 
-        /// <summary>
-        /// The price associated with the invoice line item.
-        /// </summary>
         [JsonProperty("price")]
         public Price Price { get; set; }
 
@@ -97,25 +78,15 @@ namespace Stripe
         [JsonProperty("subscription_item")]
         public string SubscriptionItem { get; set; }
 
-        /// <summary>
-        /// The tax amounts which apply to this line item.
-        /// </summary>
         [JsonProperty("tax_amounts")]
-        public List<InvoiceTaxAmount> TaxAmounts { get; set; }
+        public List<InvoiceLineItemTaxAmount> TaxAmounts { get; set; }
 
-        /// <summary>
-        /// Tax rates applied to this line item.
-        /// </summary>
         [JsonProperty("tax_rates")]
         public List<TaxRate> TaxRates { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; set; }
 
-        /// <summary>
-        /// Set to <c>true</c> if we grouped proration items into one,
-        /// <c>false</c> if not.
-        /// </summary>
         [JsonProperty("unified_proration")]
         public bool UnifiedProration { get; set; }
     }

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemDiscountAmount.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemDiscountAmount.cs
@@ -5,17 +5,11 @@ namespace Stripe
 
     public class InvoiceLineItemDiscountAmount : StripeEntity<InvoiceLineItemDiscountAmount>
     {
-        /// <summary>
-        /// The amount, in cents, of the tax.
-        /// </summary>
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
         #region Expandable Discount
 
-        /// <summary>
-        /// The ID of the discount that was applied to get this discount amount.
-        /// </summary>
         [JsonIgnore]
         public string DiscountId
         {
@@ -23,9 +17,6 @@ namespace Stripe
             set => this.InternalDiscount = SetExpandableFieldId(value, this.InternalDiscount);
         }
 
-        /// <summary>
-        /// The discount that was applied to get this discount amount.
-        /// </summary>
         [JsonIgnore]
         public Discount Discount
         {

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemPeriod.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemPeriod.cs
@@ -1,0 +1,13 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoiceLineItemPeriod : StripeEntity<InvoiceLineItemPeriod>
+    {
+        [JsonProperty("end")]
+        public long End { get; set; }
+
+        [JsonProperty("start")]
+        public long Start { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemTaxAmount.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemTaxAmount.cs
@@ -1,0 +1,35 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InvoiceLineItemTaxAmount : StripeEntity<InvoiceLineItemTaxAmount>
+    {
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        [JsonProperty("inclusive")]
+        public bool Inclusive { get; set; }
+
+        #region Expandable TaxRate
+
+        [JsonIgnore]
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
+        }
+
+        [JsonIgnore]
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
+        }
+
+        [JsonProperty("tax_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
+        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummary.cs
+++ b/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummary.cs
@@ -17,7 +17,7 @@ namespace Stripe
         public bool Livemode { get; set; }
 
         [JsonProperty("period")]
-        public Period Period { get; set; }
+        public UsageRecordSummaryPeriod Period { get; set; }
 
         [JsonProperty("subscription_item")]
         public string SubscriptionItem { get; set; }

--- a/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummaryPeriod.cs
+++ b/src/Stripe.net/Entities/UsageRecordSummaries/UsageRecordSummaryPeriod.cs
@@ -4,14 +4,14 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Period : StripeEntity<Period>
+    public class UsageRecordSummaryPeriod : StripeEntity<UsageRecordSummaryPeriod>
     {
-        [JsonProperty("start")]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime? Start { get; set; }
-
         [JsonProperty("end")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
         public DateTime? End { get; set; }
+
+        [JsonProperty("start")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? Start { get; set; }
     }
 }


### PR DESCRIPTION
- [x] ⚠️ Unshare `Period` Objects
- [x] ⚠️ Renames `InvoiceTaxAmount` to `InvoiceLineItemTaxAmount` on `InvoiceLineItem`
- [x] ⚠️ Removes `date` from `InvoiceLineItem`
- [x] ⚠️ Unshared `CreditNoteLineItemDiscountAmount` and uses a new `InvoiceLineItemDiscountAmount` on `InvoiceLineItem`


I _think_ that `date` removal from `InvoiceLineItem` is correct, but if you can double check.

r? @remi-stripe 
cc @stripe/api-libraries 
