### PR TITLE
Rename custom methods on InvoiceService

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceFinalizeOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceFinalizeOptions.cs
@@ -1,9 +1,6 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
 
     public class InvoiceFinalizeOptions : BaseOptions
     {

--- a/src/Stripe.net/Services/Invoices/InvoiceSendOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceSendOptions.cs
@@ -1,10 +1,5 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-    using Stripe.Infrastructure;
-
     public class InvoiceSendOptions : BaseOptions
     {
     }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -44,12 +44,12 @@ namespace Stripe
             return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice FinalizeInvoice(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null)
+        public virtual Invoice Finalize(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions);
         }
 
-        public virtual Task<Invoice> FinalizeInvoiceAsync(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Invoice> FinalizeAsync(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions, cancellationToken);
         }
@@ -144,12 +144,12 @@ namespace Stripe
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/pay", options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice SendInvoice(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null)
+        public virtual Invoice Send(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/send", options, requestOptions);
         }
 
-        public virtual Task<Invoice> SendInvoiceAsync(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Invoice> SendAsync(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/send", options, requestOptions, cancellationToken);
         }
@@ -174,12 +174,12 @@ namespace Stripe
             return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
         }
 
-        public virtual Invoice VoidInvoice(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null)
+        public virtual Invoice Void(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions);
         }
 
-        public virtual Task<Invoice> VoidInvoiceAsync(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Invoice> VoidAsync(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions, cancellationToken);
         }

--- a/src/Stripe.net/Services/Invoices/InvoiceVoidOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceVoidOptions.cs
@@ -1,10 +1,5 @@
 namespace Stripe
 {
-    using System;
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-    using Stripe.Infrastructure;
-
     public class InvoiceVoidOptions : BaseOptions
     {
     }

--- a/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
+++ b/src/StripeTests/Services/Invoices/InvoiceServiceTest.cs
@@ -130,7 +130,7 @@ namespace StripeTests
         [Fact]
         public void FinalizeInvoice()
         {
-            var invoice = this.service.FinalizeInvoice(InvoiceId, this.finalizeOptions);
+            var invoice = this.service.Finalize(InvoiceId, this.finalizeOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/finalize");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
@@ -139,7 +139,7 @@ namespace StripeTests
         [Fact]
         public async Task FinalizeInvoiceAsync()
         {
-            var invoice = await this.service.FinalizeInvoiceAsync(InvoiceId, this.finalizeOptions);
+            var invoice = await this.service.FinalizeAsync(InvoiceId, this.finalizeOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/finalize");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
@@ -314,18 +314,18 @@ namespace StripeTests
         }
 
         [Fact]
-        public void SendInvoice()
+        public void Send()
         {
-            var invoice = this.service.SendInvoice(InvoiceId, this.sendOptions);
+            var invoice = this.service.Send(InvoiceId, this.sendOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/send");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
 
         [Fact]
-        public async Task SendInvoiceAsync()
+        public async Task SendAsync()
         {
-            var invoice = await this.service.SendInvoiceAsync(InvoiceId, this.sendOptions);
+            var invoice = await this.service.SendAsync(InvoiceId, this.sendOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/send");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
@@ -368,18 +368,18 @@ namespace StripeTests
         }
 
         [Fact]
-        public void VoidInvoice()
+        public void Void()
         {
-            var invoice = this.service.VoidInvoice(InvoiceId, this.voidOptions);
+            var invoice = this.service.Void(InvoiceId, this.voidOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/void");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);
         }
 
         [Fact]
-        public async Task VoidInvoiceAsync()
+        public async Task VoidAsync()
         {
-            var invoice = await this.service.VoidInvoiceAsync(InvoiceId, this.voidOptions);
+            var invoice = await this.service.VoidAsync(InvoiceId, this.voidOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/invoices/in_123/void");
             Assert.NotNull(invoice);
             Assert.Equal("invoice", invoice.Object);


### PR DESCRIPTION
This is one of the proposed approaches for the naming of custom methods on the InvoiceService.

We need to decide whether to

:one: Keep the method named `FinalizeInvoice` and change the options class to `InvoiceFinalizeInvoiceOptions`
:two: Keep the options class as `InvoiceFinalizeOptions` and  rename the method `FinalizeInvoice` to `Finalize`.

r? @remi-stripe 
cc @stripe/api-libraries 
cc @richardm-stripe @ob-stripe 
