### PR TITLE
Add support for `BankName` on `ChargePaymentMethodDetailsAcssDebit`

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsAcssDebit.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsAcssDebit.cs
@@ -5,6 +5,12 @@ namespace Stripe
     public class ChargePaymentMethodDetailsAcssDebit : StripeEntity<ChargePaymentMethodDetailsAcssDebit>
     {
         /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
         /// Uniquely identifies this particular bank account. You can use this attribute to check
         /// whether two bank accounts are the same.
         /// </summary>


### PR DESCRIPTION
r? @remi-stripe (feel free to change reviewer)
cc @stripe/api-libraries

Added support for `bank_name` on ChargePaymentMethodDetailsAcssDebit
