### PR TITLE
Add support for `AmountDetails` on Issuing `Authorization` and `Transaction`

### DIFF
--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -26,6 +26,14 @@ namespace Stripe.Issuing
         public long Amount { get; set; }
 
         /// <summary>
+        /// Detailed breakdown of amount components. These amounts are denominated in
+        /// <c>currency</c> and in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("amount_details")]
+        public AuthorizationAmountDetails AmountDetails { get; set; }
+
+        /// <summary>
         /// Whether the authorization has been approved.
         /// </summary>
         [JsonProperty("approved")]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationAmountDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationAmountDetails.cs
@@ -1,0 +1,13 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class AuthorizationAmountDetails : StripeEntity<AuthorizationAmountDetails>
+    {
+        /// <summary>
+        /// The fee charged by the ATM for the cash withdrawal.
+        /// </summary>
+        [JsonProperty("atm_fee")]
+        public long? AtmFee { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequest.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequest.cs
@@ -12,7 +12,17 @@ namespace Stripe.Issuing
         public long Amount { get; set; }
 
         /// <summary>
-        /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+        /// Detailed breakdown of amount components. These amounts are denominated in
+        /// <c>currency</c> and in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("amount_details")]
+        public AuthorizationPendingRequestAmountDetails AmountDetails { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
         /// </summary>
         [JsonProperty("currency")]
         public string Currency { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequestAmountDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationPendingRequestAmountDetails.cs
@@ -1,0 +1,13 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class AuthorizationPendingRequestAmountDetails : StripeEntity<AuthorizationPendingRequestAmountDetails>
+    {
+        /// <summary>
+        /// The fee charged by the ATM for the cash withdrawal.
+        /// </summary>
+        [JsonProperty("atm_fee")]
+        public long? AtmFee { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistory.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistory.cs
@@ -13,6 +13,14 @@ namespace Stripe.Issuing
         public long Amount { get; set; }
 
         /// <summary>
+        /// Detailed breakdown of amount components. These amounts are denominated in
+        /// <c>currency</c> and in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("amount_details")]
+        public AuthorizationRequestHistoryAmountDetails AmountDetails { get; set; }
+
+        /// <summary>
         /// Whether this request was approved.
         /// </summary>
         [JsonProperty("approved")]

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistoryAmountDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistoryAmountDetails.cs
@@ -1,0 +1,13 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class AuthorizationRequestHistoryAmountDetails : StripeEntity<AuthorizationRequestHistoryAmountDetails>
+    {
+        /// <summary>
+        /// The fee charged by the ATM for the cash withdrawal.
+        /// </summary>
+        [JsonProperty("atm_fee")]
+        public long? AtmFee { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -25,6 +25,14 @@ namespace Stripe.Issuing
         [JsonProperty("amount")]
         public long Amount { get; set; }
 
+        /// <summary>
+        /// Detailed breakdown of amount components. These amounts are denominated in
+        /// <c>currency</c> and in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("amount_details")]
+        public TransactionAmountDetails AmountDetails { get; set; }
+
         #region Expandable Authorization
 
         /// <summary>

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionAmountDetails.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionAmountDetails.cs
@@ -1,0 +1,13 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class TransactionAmountDetails : StripeEntity<TransactionAmountDetails>
+    {
+        /// <summary>
+        /// The fee charged by the ATM for the cash withdrawal.
+        /// </summary>
+        [JsonProperty("atm_fee")]
+        public long? AtmFee { get; set; }
+    }
+}


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 