### PR TITLE
Fix the release of stripe-dotnet to push a *.snupkg archive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ after_test:
       }
 
 artifacts:
-  - path: 'src\Stripe.net\bin\Release\*.nupkg'
+  - path: 'src\Stripe.net\bin\Release\*.snupkg'
 
 # these commands tell appveyor to open an RDP session for debugging
 #init:


### PR DESCRIPTION
The release of 38.0.0, 39.0.0 and 39.1.0 failed. The issue is due to us pushing `*.nupkg` but as of 38.0.0 we now generate a `*.snupkg`. This is likely due to us dropping support for .NET Framework 4.5 in [this PR](https://github.com/stripe/stripe-dotnet/pull/2101).

Digging into it further with @cjavilla-stripe and @brandur-stripe it seems to be that `*.snupkg` are the right ones and we had `*.nupkg` for legacy reasons. More info [here](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) and [here](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages).

r? @brandur-stripe 
cc @stripe/api-libraries 