### PR TITLE
Multiple API changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.97.0
+  STRIPE_MOCK_VERSION: 0.98.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
+++ b/src/Stripe.net/Entities/BankAccounts/BankAccount.cs
@@ -63,6 +63,13 @@ namespace Stripe
         public string AccountHolderType { get; set; }
 
         /// <summary>
+        /// A set of available payout methods for this bank account. Only values from this set
+        /// should be passed as the <c>method</c> when creating a payout.
+        /// </summary>
+        [JsonProperty("available_payout_methods")]
+        public List<string> AvailablePayoutMethods { get; set; }
+
+        /// <summary>
         /// Name of the bank associated with the routing number (e.g., <c>WELLS FARGO</c>).
         /// </summary>
         [JsonProperty("bank_name")]

--- a/src/Stripe.net/Entities/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Cards/Card.cs
@@ -102,9 +102,8 @@ namespace Stripe
         public string AddressZipCheck { get; set; }
 
         /// <summary>
-        /// A set of available payout methods for this card. Will be either <c>["standard"]</c> or
-        /// <c>["standard", "instant"]</c>. Only values from this set should be passed as the
-        /// <c>method</c> when creating a transfer.
+        /// A set of available payout methods for this card. Only values from this set should be
+        /// passed as the <c>method</c> when creating a payout.
         /// </summary>
         [JsonProperty("available_payout_methods")]
         public List<string> AvailablePayoutMethods { get; set; }

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -191,6 +191,15 @@ namespace Stripe.Checkout
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
 
+        /// <summary>
+        /// The payment status of the Checkout Session, one of <c>paid</c>, <c>unpaid</c>, or
+        /// <c>no_payment_required</c>. You can use this value to decide when to fulfill your
+        /// customer's order.
+        /// One of: <c>no_payment_required</c>, <c>paid</c>, or <c>unpaid</c>.
+        /// </summary>
+        [JsonProperty("payment_status")]
+        public string PaymentStatus { get; set; }
+
         #region Expandable SetupIntent
 
         /// <summary>

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -1,10 +1,11 @@
 namespace Stripe.Issuing
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Dispute : StripeEntity<Dispute>, IHasId, IHasObject
+    public class Dispute : StripeEntity<Dispute>, IHasId, IHasMetadata, IHasObject
     {
         /// <summary>
         /// Unique identifier for the object.
@@ -19,10 +20,33 @@ namespace Stripe.Issuing
         public string Object { get; set; }
 
         /// <summary>
+        /// Disputed amount. Usually the amount of the <c>disputed_transaction</c>, but can differ
+        /// (usually because of currency fluctuation).
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
         /// List of balance transactions associated with the dispute.
         /// </summary>
         [JsonProperty("balance_transactions")]
         public List<BalanceTransaction> BalanceTransactions { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The currency the <c>disputed_transaction</c> was made in.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("evidence")]
+        public DisputeEvidence Evidence { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
@@ -30,6 +54,22 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("livemode")]
         public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Current status of the dispute.
+        /// One of: <c>expired</c>, <c>lost</c>, <c>submitted</c>, <c>unsubmitted</c>, or
+        /// <c>won</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
 
         #region Expandable Transaction
 

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidence.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidence.cs
@@ -1,0 +1,38 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeEvidence : StripeEntity<DisputeEvidence>
+    {
+        [JsonProperty("canceled")]
+        public DisputeEvidenceCanceled Canceled { get; set; }
+
+        [JsonProperty("duplicate")]
+        public DisputeEvidenceDuplicate Duplicate { get; set; }
+
+        [JsonProperty("fraudulent")]
+        public DisputeEvidenceFraudulent Fraudulent { get; set; }
+
+        [JsonProperty("merchandise_not_as_described")]
+        public DisputeEvidenceMerchandiseNotAsDescribed MerchandiseNotAsDescribed { get; set; }
+
+        [JsonProperty("not_received")]
+        public DisputeEvidenceNotReceived NotReceived { get; set; }
+
+        [JsonProperty("other")]
+        public DisputeEvidenceOther Other { get; set; }
+
+        /// <summary>
+        /// The reason for filing the dispute. Its value will match the field containing the
+        /// evidence.
+        /// One of: <c>canceled</c>, <c>duplicate</c>, <c>fraudulent</c>,
+        /// <c>merchandise_not_as_described</c>, <c>not_received</c>, <c>other</c>, or
+        /// <c>service_not_as_described</c>.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        [JsonProperty("service_not_as_described")]
+        public DisputeEvidenceServiceNotAsDescribed ServiceNotAsDescribed { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceCanceled.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceCanceled.cs
@@ -1,0 +1,101 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceCanceled : StripeEntity<DisputeEvidenceCanceled>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Date when order was canceled.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Whether the cardholder was provided with a cancellation policy.
+        /// </summary>
+        [JsonProperty("cancellation_policy_provided")]
+        public bool? CancellationPolicyProvided { get; set; }
+
+        /// <summary>
+        /// Reason for canceling the order.
+        /// </summary>
+        [JsonProperty("cancellation_reason")]
+        public string CancellationReason { get; set; }
+
+        /// <summary>
+        /// Date when the cardholder expected to receive the product.
+        /// </summary>
+        [JsonProperty("expected_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpectedAt { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// One of: <c>merchandise</c>, or <c>service</c>.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+
+        /// <summary>
+        /// Result of cardholder's attempt to return the product.
+        /// One of: <c>merchant_rejected</c>, or <c>successful</c>.
+        /// </summary>
+        [JsonProperty("return_status")]
+        public string ReturnStatus { get; set; }
+
+        /// <summary>
+        /// Date when the product was returned or attempted to be returned.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceDuplicate.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceDuplicate.cs
@@ -1,0 +1,153 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceDuplicate : StripeEntity<DisputeEvidenceDuplicate>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        #region Expandable CardStatement
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the card statement showing that the product had already been paid for.
+        /// </summary>
+        [JsonIgnore]
+        public string CardStatementId
+        {
+            get => this.InternalCardStatement?.Id;
+            set => this.InternalCardStatement = SetExpandableFieldId(value, this.InternalCardStatement);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the card statement showing that the product had already been paid for.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File CardStatement
+        {
+            get => this.InternalCardStatement?.ExpandedObject;
+            set => this.InternalCardStatement = SetExpandableFieldObject(value, this.InternalCardStatement);
+        }
+
+        [JsonProperty("card_statement")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalCardStatement { get; set; }
+        #endregion
+
+        #region Expandable CashReceipt
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the receipt showing that the product had been paid for in cash.
+        /// </summary>
+        [JsonIgnore]
+        public string CashReceiptId
+        {
+            get => this.InternalCashReceipt?.Id;
+            set => this.InternalCashReceipt = SetExpandableFieldId(value, this.InternalCashReceipt);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the receipt showing that the product had been paid for in cash.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File CashReceipt
+        {
+            get => this.InternalCashReceipt?.ExpandedObject;
+            set => this.InternalCashReceipt = SetExpandableFieldObject(value, this.InternalCashReceipt);
+        }
+
+        [JsonProperty("cash_receipt")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalCashReceipt { get; set; }
+        #endregion
+
+        #region Expandable CheckImage
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+        /// the front and back of the check that was used to pay for the product.
+        /// </summary>
+        [JsonIgnore]
+        public string CheckImageId
+        {
+            get => this.InternalCheckImage?.Id;
+            set => this.InternalCheckImage = SetExpandableFieldId(value, this.InternalCheckImage);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+        /// the front and back of the check that was used to pay for the product.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File CheckImage
+        {
+            get => this.InternalCheckImage?.ExpandedObject;
+            set => this.InternalCheckImage = SetExpandableFieldObject(value, this.InternalCheckImage);
+        }
+
+        [JsonProperty("check_image")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalCheckImage { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two
+        /// or more transactions that are copies of each other, this is original undisputed one.
+        /// </summary>
+        [JsonProperty("original_transaction")]
+        public string OriginalTransaction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceFraudulent.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceFraudulent.cs
@@ -1,0 +1,47 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceFraudulent : StripeEntity<DisputeEvidenceFraudulent>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceMerchandiseNotAsDescribed.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceMerchandiseNotAsDescribed.cs
@@ -1,0 +1,75 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceMerchandiseNotAsDescribed : StripeEntity<DisputeEvidenceMerchandiseNotAsDescribed>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Date when the product was received.
+        /// </summary>
+        [JsonProperty("received_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReceivedAt { get; set; }
+
+        /// <summary>
+        /// Description of the cardholder's attempt to return the product.
+        /// </summary>
+        [JsonProperty("return_description")]
+        public string ReturnDescription { get; set; }
+
+        /// <summary>
+        /// Result of cardholder's attempt to return the product.
+        /// One of: <c>merchant_rejected</c>, or <c>successful</c>.
+        /// </summary>
+        [JsonProperty("return_status")]
+        public string ReturnStatus { get; set; }
+
+        /// <summary>
+        /// Date when the product was returned or attempted to be returned.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceNotReceived.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceNotReceived.cs
@@ -1,0 +1,68 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceNotReceived : StripeEntity<DisputeEvidenceNotReceived>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Date when the cardholder expected to receive the product.
+        /// </summary>
+        [JsonProperty("expected_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpectedAt { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// One of: <c>merchandise</c>, or <c>service</c>.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceOther.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceOther.cs
@@ -1,0 +1,60 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceOther : StripeEntity<DisputeEvidenceOther>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// One of: <c>merchandise</c>, or <c>service</c>.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceServiceNotAsDescribed.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeEvidenceServiceNotAsDescribed.cs
@@ -1,0 +1,68 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceServiceNotAsDescribed : StripeEntity<DisputeEvidenceServiceNotAsDescribed>
+    {
+        #region Expandable AdditionalDocumentation
+
+        /// <summary>
+        /// (ID of the File)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string AdditionalDocumentationId
+        {
+            get => this.InternalAdditionalDocumentation?.Id;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldId(value, this.InternalAdditionalDocumentation);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public File AdditionalDocumentation
+        {
+            get => this.InternalAdditionalDocumentation?.ExpandedObject;
+            set => this.InternalAdditionalDocumentation = SetExpandableFieldObject(value, this.InternalAdditionalDocumentation);
+        }
+
+        [JsonProperty("additional_documentation")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+        internal ExpandableField<File> InternalAdditionalDocumentation { get; set; }
+        #endregion
+
+        /// <summary>
+        /// Date when order was canceled.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Reason for canceling the order.
+        /// </summary>
+        [JsonProperty("cancellation_reason")]
+        public string CancellationReason { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Date when the product was received.
+        /// </summary>
+        [JsonProperty("received_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReceivedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -176,6 +176,37 @@ namespace Stripe.Issuing
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        #region Expandable Dispute
+
+        /// <summary>
+        /// (ID of the Dispute)
+        /// If you've disputed the transaction, the ID of the dispute.
+        /// </summary>
+        [JsonIgnore]
+        public string DisputeId
+        {
+            get => this.InternalDispute?.Id;
+            set => this.InternalDispute = SetExpandableFieldId(value, this.InternalDispute);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// If you've disputed the transaction, the ID of the dispute.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Dispute Dispute
+        {
+            get => this.InternalDispute?.ExpandedObject;
+            set => this.InternalDispute = SetExpandableFieldObject(value, this.InternalDispute);
+        }
+
+        [JsonProperty("dispute")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Dispute>))]
+        internal ExpandableField<Dispute> InternalDispute { get; set; }
+        #endregion
+
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
         /// the object exists in test mode.
@@ -217,7 +248,7 @@ namespace Stripe.Issuing
 
         /// <summary>
         /// The nature of the transaction.
-        /// One of: <c>capture</c>, or <c>refund</c>.
+        /// One of: <c>capture</c>, <c>dispute</c>, or <c>refund</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
+++ b/src/Stripe.net/Entities/Reporting/ReportRuns/ReportRun.cs
@@ -42,8 +42,7 @@ namespace Stripe.Reporting
         public ReportRunParameters Parameters { get; set; }
 
         /// <summary>
-        /// The ID of the <a
-        /// href="https://stripe.com/docs/reporting/statements/api#report-types">report type</a> to
+        /// The ID of the <a href="https://stripe.com/docs/reports/report-types">report type</a> to
         /// run, such as <c>"balance.summary.1"</c>.
         /// </summary>
         [JsonProperty("report_type")]

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
@@ -6,6 +6,12 @@ namespace Stripe.Issuing
     public class DisputeCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
+        /// A hash containing all the evidence related to the dispute.
+        /// </summary>
+        [JsonProperty("evidence")]
+        public DisputeEvidenceOptions Evidence { get; set; }
+
+        /// <summary>
         /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
         /// attach to an object. This can be useful for storing additional information about the
         /// object in a structured format. Individual keys can be unset by posting an empty value to
@@ -13,5 +19,11 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The ID of the issuing transaction to create a dispute for.
+        /// </summary>
+        [JsonProperty("transaction")]
+        public string Transaction { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceCanceledOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceCanceledOptions.cs
@@ -1,0 +1,73 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceCanceledOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Date when order was canceled.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Whether the cardholder was provided with a cancellation policy.
+        /// </summary>
+        [JsonProperty("cancellation_policy_provided")]
+        public bool? CancellationPolicyProvided { get; set; }
+
+        /// <summary>
+        /// Reason for canceling the order.
+        /// </summary>
+        [JsonProperty("cancellation_reason")]
+        public string CancellationReason { get; set; }
+
+        /// <summary>
+        /// Date when the cardholder expected to receive the product.
+        /// </summary>
+        [JsonProperty("expected_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpectedAt { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+
+        /// <summary>
+        /// Result of cardholder's attempt to return the product.
+        /// </summary>
+        [JsonProperty("return_status")]
+        public string ReturnStatus { get; set; }
+
+        /// <summary>
+        /// Date when the product was returned or attempted to be returned.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceDuplicateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceDuplicateOptions.cs
@@ -1,0 +1,48 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeEvidenceDuplicateOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the card statement showing that the product had already been paid for.
+        /// </summary>
+        [JsonProperty("card_statement")]
+        public string CardStatement { get; set; }
+
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+        /// the receipt showing that the product had been paid for in cash.
+        /// </summary>
+        [JsonProperty("cash_receipt")]
+        public string CashReceipt { get; set; }
+
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+        /// the front and back of the check that was used to pay for the product.
+        /// </summary>
+        [JsonProperty("check_image")]
+        public string CheckImage { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two
+        /// or more transactions that are copies of each other, this is original undisputed one.
+        /// </summary>
+        [JsonProperty("original_transaction")]
+        public string OriginalTransaction { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceFraudulentOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceFraudulentOptions.cs
@@ -1,0 +1,20 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeEvidenceFraudulentOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceMerchandiseNotAsDescribedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceMerchandiseNotAsDescribedOptions.cs
@@ -1,0 +1,48 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceMerchandiseNotAsDescribedOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Date when the product was received.
+        /// </summary>
+        [JsonProperty("received_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReceivedAt { get; set; }
+
+        /// <summary>
+        /// Description of the cardholder's attempt to return the product.
+        /// </summary>
+        [JsonProperty("return_description")]
+        public string ReturnDescription { get; set; }
+
+        /// <summary>
+        /// Result of cardholder's attempt to return the product.
+        /// </summary>
+        [JsonProperty("return_status")]
+        public string ReturnStatus { get; set; }
+
+        /// <summary>
+        /// Date when the product was returned or attempted to be returned.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceNotReceivedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceNotReceivedOptions.cs
@@ -1,0 +1,41 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceNotReceivedOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Date when the cardholder expected to receive the product.
+        /// </summary>
+        [JsonProperty("expected_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpectedAt { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceOptions.cs
@@ -1,0 +1,59 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeEvidenceOptions : INestedOptions
+    {
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'canceled'.
+        /// </summary>
+        [JsonProperty("canceled")]
+        public DisputeEvidenceCanceledOptions Canceled { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'duplicate'.
+        /// </summary>
+        [JsonProperty("duplicate")]
+        public DisputeEvidenceDuplicateOptions Duplicate { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'fraudulent'.
+        /// </summary>
+        [JsonProperty("fraudulent")]
+        public DisputeEvidenceFraudulentOptions Fraudulent { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'merchandise_not_as_described'.
+        /// </summary>
+        [JsonProperty("merchandise_not_as_described")]
+        public DisputeEvidenceMerchandiseNotAsDescribedOptions MerchandiseNotAsDescribed { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'not_received'.
+        /// </summary>
+        [JsonProperty("not_received")]
+        public DisputeEvidenceNotReceivedOptions NotReceived { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'other'.
+        /// </summary>
+        [JsonProperty("other")]
+        public DisputeEvidenceOtherOptions Other { get; set; }
+
+        /// <summary>
+        /// The reason for filing the dispute. The evidence should be submitted in the field of the
+        /// same name.
+        /// One of: <c>canceled</c>, <c>duplicate</c>, <c>fraudulent</c>,
+        /// <c>merchandise_not_as_described</c>, <c>not_received</c>, <c>other</c>, or
+        /// <c>service_not_as_described</c>.
+        /// </summary>
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+
+        /// <summary>
+        /// Evidence provided when <c>reason</c> is 'service_not_as_described'.
+        /// </summary>
+        [JsonProperty("service_not_as_described")]
+        public DisputeEvidenceServiceNotAsDescribedOptions ServiceNotAsDescribed { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceOtherOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceOtherOptions.cs
@@ -1,0 +1,32 @@
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeEvidenceOtherOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Description of the merchandise or service that was purchased.
+        /// </summary>
+        [JsonProperty("product_description")]
+        public string ProductDescription { get; set; }
+
+        /// <summary>
+        /// Whether the product was a merchandise or service.
+        /// </summary>
+        [JsonProperty("product_type")]
+        public string ProductType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceServiceNotAsDescribedOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeEvidenceServiceNotAsDescribedOptions.cs
@@ -1,0 +1,42 @@
+namespace Stripe.Issuing
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DisputeEvidenceServiceNotAsDescribedOptions : INestedOptions
+    {
+        /// <summary>
+        /// (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>)
+        /// Additional documentation supporting the dispute.
+        /// </summary>
+        [JsonProperty("additional_documentation")]
+        public string AdditionalDocumentation { get; set; }
+
+        /// <summary>
+        /// Date when order was canceled.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Reason for canceling the order.
+        /// </summary>
+        [JsonProperty("cancellation_reason")]
+        public string CancellationReason { get; set; }
+
+        /// <summary>
+        /// Explanation of why the cardholder is disputing this transaction.
+        /// </summary>
+        [JsonProperty("explanation")]
+        public string Explanation { get; set; }
+
+        /// <summary>
+        /// Date when the product was received.
+        /// </summary>
+        [JsonProperty("received_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReceivedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeListOptions.cs
@@ -1,6 +1,13 @@
 namespace Stripe.Issuing
 {
-    public class DisputeListOptions : ListOptions
+    using Newtonsoft.Json;
+
+    public class DisputeListOptions : ListOptionsWithCreated
     {
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("transaction")]
+        public string Transaction { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -1,6 +1,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -60,6 +61,16 @@ namespace Stripe.Issuing
         public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual Dispute Submit(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/submit", options, requestOptions);
+        }
+
+        public virtual Task<Dispute> SubmitAsync(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/submit", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeSubmitOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeSubmitOptions.cs
@@ -3,14 +3,8 @@ namespace Stripe.Issuing
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class DisputeUpdateOptions : BaseOptions, IHasMetadata
+    public class DisputeSubmitOptions : BaseOptions, IHasMetadata
     {
-        /// <summary>
-        /// A hash containing all the evidence related to the dispute.
-        /// </summary>
-        [JsonProperty("evidence")]
-        public DisputeEvidenceOptions Evidence { get; set; }
-
         /// <summary>
         /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
         /// attach to an object. This can be useful for storing additional information about the

--- a/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
+++ b/src/StripeTests/Services/Issuing/Disputes/IssuingDisputeServiceTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests.Issuing
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
@@ -14,6 +15,7 @@ namespace StripeTests.Issuing
 
         private readonly DisputeService service;
         private readonly DisputeCreateOptions createOptions;
+        private readonly DisputeSubmitOptions submitOptions;
         private readonly DisputeUpdateOptions updateOptions;
         private readonly DisputeListOptions listOptions;
 
@@ -26,10 +28,35 @@ namespace StripeTests.Issuing
 
             this.createOptions = new DisputeCreateOptions
             {
+                Evidence = new DisputeEvidenceOptions
+                {
+                    NotReceived = new DisputeEvidenceNotReceivedOptions
+                    {
+                        AdditionalDocumentation = "file_123",
+                        ExpectedAt = DateTime.Now,
+                        Explanation = "Dispute explanation",
+                        ProductDescription = "Product description",
+                        ProductType = "merchandise",
+                    },
+                    Reason = "not_received",
+                },
+                Transaction = "ipi_123",
+            };
+
+            this.submitOptions = new DisputeSubmitOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
             };
 
             this.updateOptions = new DisputeUpdateOptions
             {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "key", "value" },
+                },
             };
 
             this.listOptions = new DisputeListOptions
@@ -100,6 +127,22 @@ namespace StripeTests.Issuing
             var dispute = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
             Assert.NotNull(dispute);
             Assert.Equal("issuing.dispute", dispute.Object);
+        }
+
+        [Fact]
+        public void Submit()
+        {
+            var dispute = this.service.Submit(DisputeId, this.submitOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes/idp_123/submit");
+            Assert.NotNull(dispute);
+        }
+
+        [Fact]
+        public async Task SubmitAsync()
+        {
+            var dispute = await this.service.SubmitAsync(DisputeId, this.submitOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/issuing/disputes/idp_123/submit");
+            Assert.NotNull(dispute);
         }
 
         [Fact]

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.97.0";
+        private const string MockMinimumVersion = "0.98.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Multiple API changes
  * Improve support for the Issuing `Dispute` APIs. Added the Submit API, missing parameters on creation, update and list and returned evidence details
  * Add support for `dispute` on Issuing `Transaction`
  * Add `AvailablePayoutMethods` on `BankAccount`
  * Add `PaymentStatus` on Checkout `Session`

Codegen for openapi dd28064

r? @cjavilla-stripe 
cc @stripe/api-libraries 