### PR TITLE
Add support for `promotion_code.created` and `promotion_code.updated` on `Event`

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -603,6 +603,16 @@ namespace Stripe
         public const string ProductUpdated = "product.updated";
 
         /// <summary>
+        /// Occurs whenever a promotion code is created.
+        /// </summary>
+        public const string PromotionCodeCreated = "promotion_code.created";
+
+        /// <summary>
+        /// Occurs whenever a promotion code is updated.
+        /// </summary>
+        public const string PromotionCodeUpdated = "promotion_code.updated";
+
+        /// <summary>
         /// Occurs whenever an early fraud warning is created.
         /// </summary>
         public const string RadarEarlyFraudWarningCreated = "radar.early_fraud_warning.created";

--- a/src/Stripe.net/Entities/TaxRates/TaxRate.cs
+++ b/src/Stripe.net/Entities/TaxRates/TaxRate.cs
@@ -55,7 +55,8 @@ namespace Stripe
         public bool Inclusive { get; set; }
 
         /// <summary>
-        /// The jurisdiction for the tax rate.
+        /// The jurisdiction for the tax rate. You can use this label field for tax reporting
+        /// purposes. It also appears on your customer’s invoice.
         /// </summary>
         [JsonProperty("jurisdiction")]
         public string Jurisdiction { get; set; }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe.Issuing
     public class DisputeCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// A hash containing all the evidence related to the dispute.
+        /// Evidence provided for the dispute.
         /// </summary>
         [JsonProperty("evidence")]
         public DisputeEvidenceOptions Evidence { get; set; }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeUpdateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeUpdateOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe.Issuing
     public class DisputeUpdateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
-        /// A hash containing all the evidence related to the dispute.
+        /// Evidence provided for the dispute.
         /// </summary>
         [JsonProperty("evidence")]
         public DisputeEvidenceOptions Evidence { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsSofortOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsSofortOptions.cs
@@ -4,6 +4,10 @@ namespace Stripe
 
     public class PaymentIntentPaymentMethodOptionsSofortOptions : INestedOptions
     {
+        /// <summary>
+        /// Language shown to the payer on redirect.
+        /// One of: <c>de</c>, <c>en</c>, <c>es</c>, <c>fr</c>, <c>it</c>, <c>nl</c>, or <c>pl</c>.
+        /// </summary>
         [JsonProperty("preferred_language")]
         public string PreferredLanguage { get; set; }
     }

--- a/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateCreateOptions.cs
@@ -33,7 +33,8 @@ namespace Stripe
         public bool? Inclusive { get; set; }
 
         /// <summary>
-        /// The jurisdiction for the tax rate.
+        /// The jurisdiction for the tax rate. You can use this label field for tax reporting
+        /// purposes. It also appears on your customer’s invoice.
         /// </summary>
         [JsonProperty("jurisdiction")]
         public string Jurisdiction { get; set; }

--- a/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateUpdateOptions.cs
@@ -27,7 +27,8 @@ namespace Stripe
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// The jurisdiction for the tax rate.
+        /// The jurisdiction for the tax rate. You can use this label field for tax reporting
+        /// purposes. It also appears on your customer’s invoice.
         /// </summary>
         [JsonProperty("jurisdiction")]
         public string Jurisdiction { get; set; }


### PR DESCRIPTION
Codegen for openapi 92265b4

r? @cjavilla-stripe 
cc @stripe/api-libraries 