### PR TITLE
`subscription_prorate` is no longer supported on UpcomingInvoiceListL…

### DIFF
--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -42,8 +42,8 @@ namespace Stripe
         [JsonProperty("subscription_items")]
         public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
 
-        [JsonProperty("subscription_prorate")]
-        public bool? SubscriptionProrate { get; set; }
+        [JsonProperty("subscription_proration_behavior")]
+        public string SubscriptionProrationBehavior { get; set; }
 
         [JsonProperty("subscription_proration_date")]
         [JsonConverter(typeof(UnixDateTimeConverter))]

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -42,6 +42,10 @@ namespace Stripe
         [JsonProperty("subscription_items")]
         public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
 
+        [Obsolete("Use SubscriptionProrationBehavior instead.")]
+        [JsonProperty("subscription_prorate")]
+        public bool? SubscriptionProrate { get; set; }
+
         [JsonProperty("subscription_proration_behavior")]
         public string SubscriptionProrationBehavior { get; set; }
 


### PR DESCRIPTION
`subscription_prorate` is no longer supported on UpcomingInvoiceListLineItemsOptions

This has been replaced with `subscription_proration_behavior`. This is updated here.