### PR TITLE
Add support for `description`, `iin` and `issuer` in `payment_method_details[card_present]` and `payment_method_details[interac_present]` on `Charge`

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCardPresent.cs
@@ -28,6 +28,13 @@ namespace Stripe
         public string Country { get; set; }
 
         /// <summary>
+        /// Card description. (For internal use only and not typically available in standard API
+        /// requests.).
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// Authorization response cryptogram.
         /// </summary>
         [JsonProperty("emv_auth_data")]
@@ -68,6 +75,20 @@ namespace Stripe
         /// </summary>
         [JsonProperty("generated_card")]
         public string GeneratedCard { get; set; }
+
+        /// <summary>
+        /// Issuer identification number of the card. (For internal use only and not typically
+        /// available in standard API requests.).
+        /// </summary>
+        [JsonProperty("iin")]
+        public string Iin { get; set; }
+
+        /// <summary>
+        /// Issuer bank name of the card. (For internal use only and not typically available in
+        /// standard API requests.).
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
 
         /// <summary>
         /// The last four digits of the card.

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
@@ -27,6 +27,13 @@ namespace Stripe
         public string Country { get; set; }
 
         /// <summary>
+        /// Card description. (For internal use only and not typically available in standard API
+        /// requests.).
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// Authorization response cryptogram.
         /// </summary>
         [JsonProperty("emv_auth_data")]
@@ -67,6 +74,20 @@ namespace Stripe
         /// </summary>
         [JsonProperty("generated_card")]
         public string GeneratedCard { get; set; }
+
+        /// <summary>
+        /// Issuer identification number of the card. (For internal use only and not typically
+        /// available in standard API requests.).
+        /// </summary>
+        [JsonProperty("iin")]
+        public string Iin { get; set; }
+
+        /// <summary>
+        /// Issuer bank name of the card. (For internal use only and not typically available in
+        /// standard API requests.).
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
 
         /// <summary>
         /// The last four digits of the card.

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -349,7 +349,8 @@ namespace Stripe
         public string Description { get; set; }
 
         /// <summary>
-        /// Describes the current discount applied to this invoice, if there is one.
+        /// Describes the current discount applied to this invoice, if there is one. Not populated
+        /// if there are multiple discounts.
         /// </summary>
         [JsonProperty("discount")]
         public Discount Discount { get; set; }


### PR DESCRIPTION
Codegen for openapi e8e2ba1

r? @paulasjes-stripe 
cc @stripe/api-libraries 