### PR TITLE
Add support for `discounts` to `SessionCreateOptions`

### DIFF
--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -53,6 +53,13 @@ namespace Stripe.Checkout
         public string CustomerEmail { get; set; }
 
         /// <summary>
+        /// The coupon or promotion code to apply to this session. Currently, only up to one may be
+        /// specified.
+        /// </summary>
+        [JsonProperty("discounts")]
+        public List<SessionDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
         /// A list of items the customer is purchasing. Use this parameter to pass one-time or
         /// recurring <a href="https://stripe.com/docs/api/prices">Prices</a>. One-time Prices in
         /// <c>subscription</c> mode will be on the initial invoice only.

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionDiscountOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionDiscountOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionDiscountOptions : INestedOptions
+    {
+        /// <summary>
+        /// The ID of the coupon to apply to this session.
+        /// </summary>
+        [JsonProperty("coupon")]
+        public string Coupon { get; set; }
+
+        /// <summary>
+        /// The ID of a promotion code to apply to this session.
+        /// </summary>
+        [JsonProperty("promotion_code")]
+        public string PromotionCode { get; set; }
+    }
+}


### PR DESCRIPTION
Codegen for openapi aacc1c6.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `discounts` on `SessionCreateOptions`

