### PR TITLE
Multiple API changes

### DIFF
--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -62,8 +62,8 @@ namespace Stripe
         /// <summary>
         /// If the subscription has been canceled, the date of that cancellation. If the
         /// subscription was canceled with <c>cancel_at_period_end</c>, <c>canceled_at</c> will
-        /// still reflect the date of the initial cancellation request, not the end of the
-        /// subscription period when the subscription is automatically moved to a canceled state.
+        /// reflect the time of the most recent update request, not the end of the subscription
+        /// period when the subscription is automatically moved to a canceled state.
         /// </summary>
         [JsonProperty("canceled_at")]
         [JsonConverter(typeof(UnixDateTimeConverter))]

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
@@ -6,6 +6,14 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsCardOptions : INestedOptions
     {
         /// <summary>
+        /// A single-use <c>cvc_update</c> Token that represents a card CVC value. When provided,
+        /// the CVC value will be verified during the card payment attempt. This parameter can only
+        /// be provided during confirmation.
+        /// </summary>
+        [JsonProperty("cvc_token")]
+        public string CvcToken { get; set; }
+
+        /// <summary>
         /// Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
         ///
         /// For more information, see the <a

--- a/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenCreateOptions.cs
@@ -33,6 +33,12 @@ namespace Stripe
         public string Customer { get; set; }
 
         /// <summary>
+        /// The updated CVC value this token will represent.
+        /// </summary>
+        [JsonProperty("cvc_update")]
+        public TokenCvcUpdateOptions CvcUpdate { get; set; }
+
+        /// <summary>
         /// Information for the person this token will represent.
         /// </summary>
         [JsonProperty("person")]

--- a/src/Stripe.net/Services/Tokens/TokenCvcUpdateOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenCvcUpdateOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class TokenCvcUpdateOptions : INestedOptions
+    {
+        /// <summary>
+        /// The CVC value, in string form.
+        /// </summary>
+        [JsonProperty("cvc")]
+        public string Cvc { get; set; }
+    }
+}


### PR DESCRIPTION
Multiple API changes:
  * Add support for passing `CvcToken` in `PaymentIntentPaymentMethodOptionsCardOptions ` on `PaymentIntent`
  * Add support for creating a CVC Token on `Token`.

Codegen for openapi e215279

r? @richardm-stripe 
cc @stripe/api-libraries 