### PR TITLE
Add `PreferredLocales` on `Charge` for payments made via Interac Present transactions

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsInteracPresent.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class ChargePaymentMethodDetailsInteracPresent : StripeEntity<ChargePaymentMethodDetailsInteracPresent>
@@ -102,6 +103,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("network")]
         public string Network { get; set; }
+
+        /// <summary>
+        /// EMV tag 5F2D. Preferred languages specified by the integrated circuit chip.
+        /// </summary>
+        [JsonProperty("preferred_locales")]
+        public List<string> PreferredLocales { get; set; }
 
         /// <summary>
         /// How card details were read in this transaction.

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -17,6 +17,9 @@ namespace Stripe
         [JsonProperty("oxxo")]
         public PaymentIntentPaymentMethodOptionsOxxo Oxxo { get; set; }
 
+        [JsonProperty("p24")]
+        public PaymentIntentPaymentMethodOptionsP24 P24 { get; set; }
+
         [JsonProperty("sofort")]
         public PaymentIntentPaymentMethodOptionsSofort Sofort { get; set; }
     }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsP24.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsP24.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsP24 : StripeEntity<PaymentIntentPaymentMethodOptionsP24>
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -33,6 +33,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsOxxoOptions Oxxo { get; set; }
 
         /// <summary>
+        /// If this is a <c>p24</c> PaymentMethod, this sub-hash contains details about the
+        /// Przelewy24 payment method options.
+        /// </summary>
+        [JsonProperty("p24")]
+        public PaymentIntentPaymentMethodOptionsP24Options P24 { get; set; }
+
+        /// <summary>
         /// If this is a <c>sofort</c> PaymentMethod, this sub-hash contains details about the
         /// SOFORT payment method options.
         /// </summary>

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsP24Options.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsP24Options.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsP24Options : INestedOptions
+    {
+    }
+}


### PR DESCRIPTION
This PR adds support for `payment_method_details[interac_present][preferred_locales]` on `Charge`. It also adds an empty-able hash `payment_method_options[p24]` on `PaymentIntent` for an upcoming feature but this change is a no op

Codegen for openapi 9f2a7bc

r? @richardm-stripe 
cc @stripe/api-libraries 