### PR TITLE
Multiple API changes

### DIFF
--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -424,6 +424,13 @@ namespace Stripe
         public string InvoicePdf { get; set; }
 
         /// <summary>
+        /// The error encountered during the previous attempt to finalize the invoice. This field is
+        /// cleared when the invoice is successfully finalized.
+        /// </summary>
+        [JsonProperty("last_finalization_error")]
+        public StripeError LastFinalizationError { get; set; }
+
+        /// <summary>
         /// The individual line items that make up the invoice. <c>lines</c> is sorted as follows:
         /// invoice items in reverse chronological order, followed by the subscription, if any.
         /// </summary>

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -6,7 +6,7 @@ namespace Stripe.Issuing
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class Dispute : StripeEntity<Dispute>, IHasId, IHasMetadata, IHasObject
+    public class Dispute : StripeEntity<Dispute>, IHasId, IHasMetadata, IHasObject, IBalanceTransactionSource
     {
         /// <summary>
         /// Unique identifier for the object.

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -64,6 +64,13 @@ namespace Stripe
         public PaymentMethod PaymentMethod { get; set; }
 
         /// <summary>
+        /// If the error is specific to the type of payment method, the payment method type that had
+        /// a problem. This field is only populated for invoice-related errors.
+        /// </summary>
+        [JsonProperty("payment_method_type")]
+        public string PaymentMethodType { get; set; }
+
+        /// <summary>
         /// The <see cref="Stripe.SetupIntent"/> object for errors returned on a request
         /// involving a <see cref="Stripe.SetupIntent"/>.
         /// </summary>


### PR DESCRIPTION
Multiple API changes:
  * Add support for `LastFinalizationError` on `Invoice`
  * Add support for Issuing `Dispute` to `IBalanceTransactionSource` to support proper deserialization on the `BalanceTransaction.Source`
  * Add support for `PaymentMethodType` on `StripeError`

Codegen for openapi 83680bb + manual changes

r? @ctrudeau-stripe 
cc @stripe/api-libraries