### PR TITLE
Mark `SubscriptionProrate` as obsolete on `UpcomingInvoiceOptions`

### DIFF
--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -45,6 +45,7 @@ namespace Stripe
         [JsonProperty("subscription_items")]
         public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
 
+        [Obsolete("Use SubscriptionProrationBehavior instead.")]
         [JsonProperty("subscription_prorate")]
         public bool? SubscriptionProrate { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/2247

r? @richardm-stripe 
cc @stripe/api-libraries 