### PR TITLE
Codegen for openapi 3723465

### DIFF
--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -131,8 +131,9 @@ namespace Stripe
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
         /// One of: <c>alipay</c>, <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>,
-        /// <c>card</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>,
-        /// <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
+        /// <c>card</c>, <c>card_present</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>,
+        /// <c>grabpay</c>, <c>ideal</c>, <c>interac_present</c>, <c>oxxo</c>, <c>p24</c>,
+        /// <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebit.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebit.cs
@@ -1,7 +1,11 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using Newtonsoft.Json;
+
     public class SetupIntentPaymentMethodOptionsSepaDebit : StripeEntity<SetupIntentPaymentMethodOptionsSepaDebit>
     {
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsSepaDebitMandateOptions MandateOptions { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitMandateOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitMandateOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupIntentPaymentMethodOptionsSepaDebitMandateOptions : StripeEntity<SetupIntentPaymentMethodOptionsSepaDebitMandateOptions>
+    {
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitMandateOptionsOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupIntentPaymentMethodOptionsSepaDebitMandateOptionsOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsSepaDebitOptions.cs
@@ -1,7 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using Newtonsoft.Json;
+
     public class SetupIntentPaymentMethodOptionsSepaDebitOptions : INestedOptions
     {
+        /// <summary>
+        /// Additional fields for Mandate creation.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsSepaDebitMandateOptionsOptions MandateOptions { get; set; }
     }
 }


### PR DESCRIPTION
Codegen for openapi 3723465.
r? @ctrudeau-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `mandate_options` on `SetupIntent.payment_method_options.sepa_debit`.

