### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyLicenseOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyLicenseOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AccountDocumentsCompanyLicenseOptions : INestedOptions
+    {
+        /// <summary>
+        /// One or more document ids returned by a <a
+        /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
+        /// value of <c>account_requirement</c>.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyMemorandumOfAssociationOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyMemorandumOfAssociationOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AccountDocumentsCompanyMemorandumOfAssociationOptions : INestedOptions
+    {
+        /// <summary>
+        /// One or more document ids returned by a <a
+        /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
+        /// value of <c>account_requirement</c>.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyMinisterialDecreeOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyMinisterialDecreeOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AccountDocumentsCompanyMinisterialDecreeOptions : INestedOptions
+    {
+        /// <summary>
+        /// One or more document ids returned by a <a
+        /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
+        /// value of <c>account_requirement</c>.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyRegistrationVerificationOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyRegistrationVerificationOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AccountDocumentsCompanyRegistrationVerificationOptions : INestedOptions
+    {
+        /// <summary>
+        /// One or more document ids returned by a <a
+        /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
+        /// value of <c>account_requirement</c>.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyTaxIdVerificationOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsCompanyTaxIdVerificationOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AccountDocumentsCompanyTaxIdVerificationOptions : INestedOptions
+    {
+        /// <summary>
+        /// One or more document ids returned by a <a
+        /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
+        /// value of <c>account_requirement</c>.
+        /// </summary>
+        [JsonProperty("files")]
+        public List<string> Files { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountDocumentsOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountDocumentsOptions.cs
@@ -14,5 +14,37 @@ namespace Stripe
         /// </summary>
         [JsonProperty("bank_account_ownership_verification")]
         public AccountDocumentsBankAccountOwnershipVerificationOptions BankAccountOwnershipVerification { get; set; }
+
+        /// <summary>
+        /// One or more documents that demonstrate proof of a company's license to operate.
+        /// </summary>
+        [JsonProperty("company_license")]
+        public AccountDocumentsCompanyLicenseOptions CompanyLicense { get; set; }
+
+        /// <summary>
+        /// One or more documents showing the company's Memorandum of Association.
+        /// </summary>
+        [JsonProperty("company_memorandum_of_association")]
+        public AccountDocumentsCompanyMemorandumOfAssociationOptions CompanyMemorandumOfAssociation { get; set; }
+
+        /// <summary>
+        /// (Certain countries only) One or more documents showing the ministerial decree legalizing
+        /// the company's establishment.
+        /// </summary>
+        [JsonProperty("company_ministerial_decree")]
+        public AccountDocumentsCompanyMinisterialDecreeOptions CompanyMinisterialDecree { get; set; }
+
+        /// <summary>
+        /// One or more documents that demonstrate proof of a company's registration with the
+        /// appropriate local authorities.
+        /// </summary>
+        [JsonProperty("company_registration_verification")]
+        public AccountDocumentsCompanyRegistrationVerificationOptions CompanyRegistrationVerification { get; set; }
+
+        /// <summary>
+        /// One or more documents that demonstrate proof of a company's tax ID.
+        /// </summary>
+        [JsonProperty("company_tax_id_verification")]
+        public AccountDocumentsCompanyTaxIdVerificationOptions CompanyTaxIdVerification { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -19,7 +19,8 @@ namespace Stripe
         /// A fee in %s that will be applied to the invoice and transferred to the application
         /// owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account
         /// header in order to take an application fee. For more information, see the application
-        /// fees <a href="https://stripe.com/docs/connect/subscriptions#invoices">documentation</a>.
+        /// fees <a
+        /// href="https://stripe.com/docs/billing/invoices/connect#collecting-fees">documentation</a>.
         /// </summary>
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceUpdateOptions.cs
@@ -19,7 +19,8 @@ namespace Stripe
         /// A fee in %s that will be applied to the invoice and transferred to the application
         /// owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account
         /// header in order to take an application fee. For more information, see the application
-        /// fees <a href="https://stripe.com/docs/connect/subscriptions#invoices">documentation</a>.
+        /// fees <a
+        /// href="https://stripe.com/docs/billing/invoices/connect#collecting-fees">documentation</a>.
         /// </summary>
         [JsonProperty("application_fee_amount")]
         public long? ApplicationFeeAmount { get; set; }


### PR DESCRIPTION
Codegen for openapi 383c876.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `company_registration_verification`, `company_ministerial_decree`, `company_memorandum_of_association`, `company_license` and `company_tax_id_verification` on `Account#update.documents` and `Account#create.documents`

