### PR TITLE
Add missing transfer event types

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -847,6 +847,16 @@ namespace Stripe
         public const string TransferUpdated = "transfer.updated";
 
         /// <summary>
+        /// Occurs after a transfer is paid. For Instant Payouts, the event will typically be sent within 30 minutes.
+        /// </summary>
+        public const string TransferPaid = "transfer.paid";
+
+        /// <summary>
+        /// Occurs whenever a transfer failed.
+        /// </summary>
+        public const string TransferFailed = "transfer.failed";
+
+        /// <summary>
         /// May be sent by Stripe at any time to see if a provided webhook URL is working.
         /// </summary>
         public const string Ping = "ping";


### PR DESCRIPTION
Working on integrating Stripe webhooks and I noticed the below events were missing from the constants defined in the Events class, not sure if this is intentional but if it isn't this PR rectifies this.

Events added:
- `transfer.paid`
- `transfer.failed`
