### PR TITLE
Add enum support for SubscriptionTrialEnd on the Upcoming Invoice API

### DIFF
--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceListLineItemsOptions.cs
@@ -54,8 +54,8 @@ namespace Stripe
         public DateTime? SubscriptionProrationDate { get; set; }
 
         [JsonProperty("subscription_trial_end")]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime? SubscriptionTrialEnd { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, SubscriptionTrialEnd> SubscriptionTrialEnd { get; set; }
 
         [JsonProperty("subscription_trial_from_plan")]
         public bool? SubscriptionTrialFromPlan { get; set; }

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -61,8 +61,8 @@ namespace Stripe
         public DateTime? SubscriptionStartDate { get; set; }
 
         [JsonProperty("subscription_trial_end")]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime? SubscriptionTrialEnd { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, SubscriptionTrialEnd> SubscriptionTrialEnd { get; set; }
 
         [JsonProperty("subscription_trial_from_plan")]
         public bool? SubscriptionTrialFromPlan { get; set; }

--- a/src/StripeTests/Services/Invoices/UpcomingInvoiceListLineItemsOptionsTest.cs
+++ b/src/StripeTests/Services/Invoices/UpcomingInvoiceListLineItemsOptionsTest.cs
@@ -36,6 +36,22 @@ namespace StripeTests
                     },
                     want = "subscription_billing_cycle_anchor=unchanged",
                 },
+                new
+                {
+                    options = new UpcomingInvoiceListLineItemsOptions
+                    {
+                        SubscriptionTrialEnd = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "subscription_trial_end=1234567890",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceListLineItemsOptions
+                    {
+                        SubscriptionTrialEnd = SubscriptionTrialEnd.Now,
+                    },
+                    want = "subscription_trial_end=now",
+                },
             };
 
             foreach (var testCase in testCases)

--- a/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
+++ b/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
@@ -36,6 +36,22 @@ namespace StripeTests
                     },
                     want = "subscription_billing_cycle_anchor=unchanged",
                 },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionTrialEnd = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "subscription_trial_end=1234567890",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionTrialEnd = SubscriptionTrialEnd.Now,
+                    },
+                    want = "subscription_trial_end=now",
+                },
             };
 
             foreach (var testCase in testCases)


### PR DESCRIPTION
Mirror of https://github.com/stripe/stripe-go/pull/1250

r? @richardm-stripe 
cc @stripe/api-libraries @ksinder-stripe