### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
@@ -14,6 +14,9 @@ namespace Stripe
         [JsonProperty("acss_debit")]
         public ChargePaymentMethodDetailsAcssDebit AcssDebit { get; set; }
 
+        [JsonProperty("afterpay_clearpay")]
+        public ChargePaymentMethodDetailsAfterpayClearpay AfterpayClearpay { get; set; }
+
         [JsonProperty("alipay")]
         public ChargePaymentMethodDetailsAlipay Alipay { get; set; }
 

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsAfterpayClearpay.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsAfterpayClearpay.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class ChargePaymentMethodDetailsAfterpayClearpay : StripeEntity<ChargePaymentMethodDetailsAfterpayClearpay>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -152,12 +152,12 @@ namespace Stripe.Issuing
         public AuthorizationPendingRequest PendingRequest { get; set; }
 
         /// <summary>
-        /// History of every time the authorization was approved/denied (whether approved/denied by
-        /// you directly or by Stripe based on your <c>spending_controls</c>). If the merchant
-        /// changes the authorization by performing an <a
+        /// History of every time <c>pending_request</c> was approved/denied, either by you directly
+        /// or by Stripe (e.g. based on your <c>spending_controls</c>). If the merchant changes the
+        /// authorization by performing an <a
         /// href="https://stripe.com/docs/issuing/purchases/authorizations">incremental
-        /// authorization or partial capture</a>, you can look at this field to see the previous
-        /// states of the authorization.
+        /// authorization</a>, you can look at this field to see the previous requests for the
+        /// authorization.
         /// </summary>
         [JsonProperty("request_history")]
         public List<AuthorizationRequestHistory> RequestHistory { get; set; }

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistory.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationRequestHistory.cs
@@ -8,10 +8,10 @@ namespace Stripe.Issuing
     public class AuthorizationRequestHistory : StripeEntity<AuthorizationRequestHistory>
     {
         /// <summary>
-        /// The authorization amount in your card's currency and in the <a
-        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
-        /// Stripe held this amount from your account to fund the authorization if the request was
-        /// approved.
+        /// The <c>pending_request.amount</c> at the time of the request, presented in your card's
+        /// currency and in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
+        /// currency unit</a>. Stripe held this amount from your account to fund the authorization
+        /// if the request was approved.
         /// </summary>
         [JsonProperty("amount")]
         public long Amount { get; set; }
@@ -46,7 +46,7 @@ namespace Stripe.Issuing
         public string Currency { get; set; }
 
         /// <summary>
-        /// The amount that was authorized at the time of this request. This amount is in the
+        /// The <c>pending_request.merchant_amount</c> at the time of the request, presented in the
         /// <c>merchant_currency</c> and in the <a
         /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
         /// </summary>

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        [JsonProperty("afterpay_clearpay")]
+        public PaymentMethodAfterpayClearpay AfterpayClearpay { get; set; }
+
         [JsonProperty("alipay")]
         public PaymentMethodAlipay Alipay { get; set; }
 
@@ -130,10 +133,10 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>alipay</c>, <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>,
-        /// <c>card</c>, <c>card_present</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>,
-        /// <c>grabpay</c>, <c>ideal</c>, <c>interac_present</c>, <c>oxxo</c>, <c>p24</c>,
-        /// <c>sepa_debit</c>, or <c>sofort</c>.
+        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
+        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>card_present</c>, <c>eps</c>,
+        /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>interac_present</c>,
+        /// <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodAfterpayClearpay.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodAfterpayClearpay.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentMethodAfterpayClearpay : StripeEntity<PaymentMethodAfterpayClearpay>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
@@ -5,6 +5,12 @@ namespace Stripe
 
     public class SetupAttemptPaymentMethodDetails : StripeEntity<SetupAttemptPaymentMethodDetails>
     {
+        [JsonProperty("au_becs_debit")]
+        public SetupAttemptPaymentMethodDetailsAuBecsDebit AuBecsDebit { get; set; }
+
+        [JsonProperty("bacs_debit")]
+        public SetupAttemptPaymentMethodDetailsBacsDebit BacsDebit { get; set; }
+
         [JsonProperty("bancontact")]
         public SetupAttemptPaymentMethodDetailsBancontact Bancontact { get; set; }
 
@@ -16,6 +22,9 @@ namespace Stripe
 
         [JsonProperty("ideal")]
         public SetupAttemptPaymentMethodDetailsIdeal Ideal { get; set; }
+
+        [JsonProperty("sepa_debit")]
+        public SetupAttemptPaymentMethodDetailsSepaDebit SepaDebit { get; set; }
 
         [JsonProperty("sofort")]
         public SetupAttemptPaymentMethodDetailsSofort Sofort { get; set; }

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsAuBecsDebit.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsAuBecsDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupAttemptPaymentMethodDetailsAuBecsDebit : StripeEntity<SetupAttemptPaymentMethodDetailsAuBecsDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsBacsDebit.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsBacsDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupAttemptPaymentMethodDetailsBacsDebit : StripeEntity<SetupAttemptPaymentMethodDetailsBacsDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsSepaDebit.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsSepaDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupAttemptPaymentMethodDetailsSepaDebit : StripeEntity<SetupAttemptPaymentMethodDetailsSepaDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Services/AccountLinks/AccountLinkCreateOptions.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkCreateOptions.cs
@@ -20,9 +20,12 @@ namespace Stripe
         public string Collect { get; set; }
 
         /// <summary>
-        /// The URL that the user will be redirected to if the account link is no longer valid. Your
-        /// <c>refresh_url</c> should trigger a method on your server to create a new account link
-        /// using this API, with the same parameters, and redirect the user to the new account link.
+        /// The URL the user will be redirected to if the account link is expired, has been
+        /// previously-visited, or is otherwise invalid. The URL you specify should attempt to
+        /// generate a new account link with the same parameters used to create the original account
+        /// link, then redirect the user to the new account link's URL so they can continue with
+        /// Connect Onboarding. If a new account link cannot be generated or the redirect fails you
+        /// should display a useful error to the user.
         /// </summary>
         [JsonProperty("refresh_url")]
         public string RefreshUrl { get; set; }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemAdjustableQuantityOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemAdjustableQuantityOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionLineItemAdjustableQuantityOptions : INestedOptions
+    {
+        /// <summary>
+        /// Set to true if the quantity can be adjusted to any non-negative integer. By default
+        /// customers will be able to remove the line item by setting the quantity to 0.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        /// <summary>
+        /// The maximum quantity the customer can purchase for the Checkout Session. By default this
+        /// value is 99.
+        /// </summary>
+        [JsonProperty("maximum")]
+        public long? Maximum { get; set; }
+
+        /// <summary>
+        /// The minimum quantity the customer must purchase for the Checkout Session. By default
+        /// this value is 0.
+        /// </summary>
+        [JsonProperty("minimum")]
+        public long? Minimum { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe.Checkout
     public class SessionLineItemOptions : INestedOptions
     {
         /// <summary>
+        /// When set, provides configuration for this item’s quantity to be adjusted by the customer
+        /// during Checkout.
+        /// </summary>
+        [JsonProperty("adjustable_quantity")]
+        public SessionLineItemAdjustableQuantityOptions AdjustableQuantity { get; set; }
+
+        /// <summary>
         /// The amount to be collected per unit of the line item. If specified, must also pass
         /// <c>currency</c> and <c>name</c>.
         /// </summary>

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataAfterpayClearpayOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataAfterpayClearpayOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodDataAfterpayClearpayOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe
     public class PaymentIntentPaymentMethodDataOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
+        /// If this is an <c>AfterpayClearpay</c> PaymentMethod, this hash contains details about
+        /// the AfterpayClearpay payment method.
+        /// </summary>
+        [JsonProperty("afterpay_clearpay")]
+        public PaymentIntentPaymentMethodDataAfterpayClearpayOptions AfterpayClearpay { get; set; }
+
+        /// <summary>
         /// If this is an <c>Alipay</c> PaymentMethod, this hash contains details about the Alipay
         /// payment method.
         /// </summary>
@@ -124,9 +131,10 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>alipay</c>, <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>,
-        /// <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>,
-        /// <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
+        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
+        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>,
+        /// <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or
+        /// <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodAfterpayClearpayOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodAfterpayClearpayOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentMethodAfterpayClearpayOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe
     public class PaymentMethodCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
+        /// If this is an <c>AfterpayClearpay</c> PaymentMethod, this hash contains details about
+        /// the AfterpayClearpay payment method.
+        /// </summary>
+        [JsonProperty("afterpay_clearpay")]
+        public PaymentMethodAfterpayClearpayOptions AfterpayClearpay { get; set; }
+
+        /// <summary>
         /// If this is an <c>Alipay</c> PaymentMethod, this hash contains details about the Alipay
         /// payment method.
         /// </summary>
@@ -139,9 +146,10 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>alipay</c>, <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>,
-        /// <c>card</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>,
-        /// <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
+        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
+        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>eps</c>, <c>fpx</c>,
+        /// <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
+        /// <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }


### PR DESCRIPTION
Codegen for openapi 546b28b.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `afterpay_clearpay` on `PaymentMethod`, `PaymentIntentPaymentMethodData`, and `ChargePaymentMethodDetails`.
* Added support for `adjustable_quantity` on `SessionLineItemOptions`
* Added support for `bacs_debit`, `au_becs_debit` and `sepa_debit` on `SetupAttempt.payment_method_details`


