### PR TITLE
API Updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.101.0
+  STRIPE_MOCK_VERSION: 0.103.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/Configuration.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/Configuration.cs
@@ -1,0 +1,78 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class Configuration : StripeEntity<Configuration>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Whether the configuration is active and can be used to create portal sessions.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// ID of the Connect Application that created the configuration.
+        /// </summary>
+        [JsonProperty("application")]
+        public string Application { get; set; }
+
+        [JsonProperty("business_profile")]
+        public ConfigurationBusinessProfile BusinessProfile { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The default URL to redirect customers to when they click on the portal's link to return
+        /// to your website. This can be <a
+        /// href="https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url">overriden</a>
+        /// when creating the session.
+        /// </summary>
+        [JsonProperty("default_return_url")]
+        public string DefaultReturnUrl { get; set; }
+
+        [JsonProperty("features")]
+        public ConfigurationFeatures Features { get; set; }
+
+        /// <summary>
+        /// Whether the configuration is the default. If <c>true</c>, this configuration can be
+        /// managed in the Dashboard and portal sessions will use this configuration unless it is
+        /// overriden when creating the session.
+        /// </summary>
+        [JsonProperty("is_default")]
+        public bool IsDefault { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Time at which the object was last updated. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("updated")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Updated { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationBusinessProfile.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationBusinessProfile.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationBusinessProfile : StripeEntity<ConfigurationBusinessProfile>
+    {
+        /// <summary>
+        /// The messaging shown to customers in the portal.
+        /// </summary>
+        [JsonProperty("headline")]
+        public string Headline { get; set; }
+
+        /// <summary>
+        /// A link to the business’s publicly available privacy policy.
+        /// </summary>
+        [JsonProperty("privacy_policy_url")]
+        public string PrivacyPolicyUrl { get; set; }
+
+        /// <summary>
+        /// A link to the business’s publicly available terms of service.
+        /// </summary>
+        [JsonProperty("terms_of_service_url")]
+        public string TermsOfServiceUrl { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeatures.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeatures.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeatures : StripeEntity<ConfigurationFeatures>
+    {
+        [JsonProperty("customer_update")]
+        public ConfigurationFeaturesCustomerUpdate CustomerUpdate { get; set; }
+
+        [JsonProperty("invoice_history")]
+        public ConfigurationFeaturesInvoiceHistory InvoiceHistory { get; set; }
+
+        [JsonProperty("payment_method_update")]
+        public ConfigurationFeaturesPaymentMethodUpdate PaymentMethodUpdate { get; set; }
+
+        [JsonProperty("subscription_cancel")]
+        public ConfigurationFeaturesSubscriptionCancel SubscriptionCancel { get; set; }
+
+        [JsonProperty("subscription_update")]
+        public ConfigurationFeaturesSubscriptionUpdate SubscriptionUpdate { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesCustomerUpdate.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesCustomerUpdate.cs
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesCustomerUpdate : StripeEntity<ConfigurationFeaturesCustomerUpdate>
+    {
+        /// <summary>
+        /// The types of customer updates that are supported. When empty, customers are not
+        /// updateable.
+        /// </summary>
+        [JsonProperty("allowed_updates")]
+        public List<string> AllowedUpdates { get; set; }
+
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesInvoiceHistory.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesInvoiceHistory.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesInvoiceHistory : StripeEntity<ConfigurationFeaturesInvoiceHistory>
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesPaymentMethodUpdate.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesPaymentMethodUpdate.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesPaymentMethodUpdate : StripeEntity<ConfigurationFeaturesPaymentMethodUpdate>
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionCancel.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionCancel.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionCancel : StripeEntity<ConfigurationFeaturesSubscriptionCancel>
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Whether to cancel subscriptions immediately or at the end of the billing period.
+        /// One of: <c>at_period_end</c>, or <c>immediately</c>.
+        /// </summary>
+        [JsonProperty("mode")]
+        public string Mode { get; set; }
+
+        /// <summary>
+        /// Whether to create prorations when canceling subscriptions. Possible values are
+        /// <c>none</c> and <c>create_prorations</c>.
+        /// One of: <c>always_invoice</c>, <c>create_prorations</c>, or <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdate.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdate.cs
@@ -1,0 +1,36 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionUpdate : StripeEntity<ConfigurationFeaturesSubscriptionUpdate>
+    {
+        /// <summary>
+        /// The types of subscription updates that are supported for items listed in the
+        /// <c>products</c> attribute. When empty, subscriptions are not updateable.
+        /// </summary>
+        [JsonProperty("default_allowed_updates")]
+        public List<string> DefaultAllowedUpdates { get; set; }
+
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The list of products that support subscription updates.
+        /// </summary>
+        [JsonProperty("products")]
+        public List<ConfigurationFeaturesSubscriptionUpdateProduct> Products { get; set; }
+
+        /// <summary>
+        /// Determines how to handle prorations resulting from subscription updates. Valid values
+        /// are <c>none</c>, <c>create_prorations</c>, and <c>always_invoice</c>.
+        /// One of: <c>always_invoice</c>, <c>create_prorations</c>, or <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProduct.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProduct.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionUpdateProduct : StripeEntity<ConfigurationFeaturesSubscriptionUpdateProduct>
+    {
+        /// <summary>
+        /// The product ID.
+        /// </summary>
+        [JsonProperty("product")]
+        public string Product { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProduct.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProduct.cs
@@ -1,10 +1,17 @@
 // File generated from our OpenAPI spec
 namespace Stripe.BillingPortal
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     public class ConfigurationFeaturesSubscriptionUpdateProduct : StripeEntity<ConfigurationFeaturesSubscriptionUpdateProduct>
     {
+        /// <summary>
+        /// The list of price IDs which, when subscribed to, a subscription can be updated.
+        /// </summary>
+        [JsonProperty("prices")]
+        public List<string> Prices { get; set; }
+
         /// <summary>
         /// The product ID.
         /// </summary>

--- a/src/Stripe.net/Entities/BillingPortal/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/BillingPortal/Sessions/Session.cs
@@ -19,6 +19,37 @@ namespace Stripe.BillingPortal
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        #region Expandable Configuration
+
+        /// <summary>
+        /// (ID of the Configuration)
+        /// The configuration used by this session, describing the features available.
+        /// </summary>
+        [JsonIgnore]
+        public string ConfigurationId
+        {
+            get => this.InternalConfiguration?.Id;
+            set => this.InternalConfiguration = SetExpandableFieldId(value, this.InternalConfiguration);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The configuration used by this session, describing the features available.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Configuration Configuration
+        {
+            get => this.InternalConfiguration?.ExpandedObject;
+            set => this.InternalConfiguration = SetExpandableFieldObject(value, this.InternalConfiguration);
+        }
+
+        [JsonProperty("configuration")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Configuration>))]
+        internal ExpandableField<Configuration> InternalConfiguration { get; set; }
+        #endregion
+
         /// <summary>
         /// Time at which the object was created. Measured in seconds since the Unix epoch.
         /// </summary>
@@ -40,14 +71,27 @@ namespace Stripe.BillingPortal
         public bool Livemode { get; set; }
 
         /// <summary>
-        /// The URL to which Stripe should send customers when they click on the link to return to
-        /// your website.
+        /// The account for which the session was created on behalf of. When specified, only
+        /// subscriptions and invoices with this <c>on_behalf_of</c> account appear in the portal.
+        /// For more information, see the <a
+        /// href="https://stripe.com/docs/connect/charges-transfers#on-behalf-of">docs</a>. Use the
+        /// <a
+        /// href="https://stripe.com/docs/api/accounts/object#account_object-settings-branding">Accounts
+        /// API</a> to modify the <c>on_behalf_of</c> account's branding settings, which the portal
+        /// displays.
+        /// </summary>
+        [JsonProperty("on_behalf_of")]
+        public string OnBehalfOf { get; set; }
+
+        /// <summary>
+        /// The URL to redirect customers to when they click on the portal's link to return to your
+        /// website.
         /// </summary>
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }
 
         /// <summary>
-        /// The short-lived URL of the session giving customers access to the customer portal.
+        /// The short-lived URL of the session that gives customers access to the customer portal.
         /// </summary>
         [JsonProperty("url")]
         public string Url { get; set; }

--- a/src/Stripe.net/Entities/Plans/Plan.cs
+++ b/src/Stripe.net/Entities/Plans/Plan.cs
@@ -39,14 +39,15 @@ namespace Stripe
         public string AggregateUsage { get; set; }
 
         /// <summary>
-        /// The unit amount in %s to be charged, represented as a whole integer if possible.
+        /// The unit amount in %s to be charged, represented as a whole integer if possible. Only
+        /// set if <c>billing_scheme=per_unit</c>.
         /// </summary>
         [JsonProperty("amount")]
         public long? Amount { get; set; }
 
         /// <summary>
         /// The unit amount in %s to be charged, represented as a decimal string with at most 12
-        /// decimal places.
+        /// decimal places. Only set if <c>billing_scheme=per_unit</c>.
         /// </summary>
         [JsonProperty("amount_decimal")]
         public decimal? AmountDecimal { get; set; }

--- a/src/Stripe.net/Entities/Prices/Price.cs
+++ b/src/Stripe.net/Entities/Prices/Price.cs
@@ -156,14 +156,15 @@ namespace Stripe
         public string Type { get; set; }
 
         /// <summary>
-        /// The unit amount in %s to be charged, represented as a whole integer if possible.
+        /// The unit amount in %s to be charged, represented as a whole integer if possible. Only
+        /// set if <c>billing_scheme=per_unit</c>.
         /// </summary>
         [JsonProperty("unit_amount")]
         public long? UnitAmount { get; set; }
 
         /// <summary>
         /// The unit amount in %s to be charged, represented as a decimal string with at most 12
-        /// decimal places.
+        /// decimal places. Only set if <c>billing_scheme=per_unit</c>.
         /// </summary>
         [JsonProperty("unit_amount_decimal")]
         public decimal? UnitAmountDecimal { get; set; }

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -22,6 +22,7 @@ namespace Stripe
             { "balance_transaction", typeof(BalanceTransaction) },
             { "bank_account", typeof(BankAccount) },
             { "billing_portal.session", typeof(BillingPortal.Session) },
+            { "billing_portal.configuration", typeof(BillingPortal.Configuration) },
             { "capability", typeof(Capability) },
             { "card", typeof(Card) },
             { "charge", typeof(Charge) },

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationBusinessProfileOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationBusinessProfileOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationBusinessProfileOptions : INestedOptions
+    {
+        /// <summary>
+        /// The messaging shown to customers in the portal.
+        /// </summary>
+        [JsonProperty("headline")]
+        public string Headline { get; set; }
+
+        /// <summary>
+        /// A link to the business’s publicly available privacy policy.
+        /// </summary>
+        [JsonProperty("privacy_policy_url")]
+        public string PrivacyPolicyUrl { get; set; }
+
+        /// <summary>
+        /// A link to the business’s publicly available terms of service.
+        /// </summary>
+        [JsonProperty("terms_of_service_url")]
+        public string TermsOfServiceUrl { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationCreateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationCreateOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationCreateOptions : BaseOptions
+    {
+        /// <summary>
+        /// The business information shown to customers in the portal.
+        /// </summary>
+        [JsonProperty("business_profile")]
+        public ConfigurationBusinessProfileOptions BusinessProfile { get; set; }
+
+        /// <summary>
+        /// The default URL to redirect customers to when they click on the portal's link to return
+        /// to your website. This can be <a
+        /// href="https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url">overriden</a>
+        /// when creating the session.
+        /// </summary>
+        [JsonProperty("default_return_url")]
+        public string DefaultReturnUrl { get; set; }
+
+        /// <summary>
+        /// Information about the features available in the portal.
+        /// </summary>
+        [JsonProperty("features")]
+        public ConfigurationFeaturesOptions Features { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesCustomerUpdateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesCustomerUpdateOptions.cs
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesCustomerUpdateOptions : INestedOptions
+    {
+        /// <summary>
+        /// The types of customer updates that are supported. When empty, customers are not
+        /// updateable.
+        /// </summary>
+        [JsonProperty("allowed_updates")]
+        public List<string> AllowedUpdates { get; set; }
+
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesInvoiceHistoryOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesInvoiceHistoryOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesInvoiceHistoryOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesOptions.cs
@@ -1,0 +1,38 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Information about updating the customer details in the portal.
+        /// </summary>
+        [JsonProperty("customer_update")]
+        public ConfigurationFeaturesCustomerUpdateOptions CustomerUpdate { get; set; }
+
+        /// <summary>
+        /// Information about showing the billing history in the portal.
+        /// </summary>
+        [JsonProperty("invoice_history")]
+        public ConfigurationFeaturesInvoiceHistoryOptions InvoiceHistory { get; set; }
+
+        /// <summary>
+        /// Information about updating payment methods in the portal.
+        /// </summary>
+        [JsonProperty("payment_method_update")]
+        public ConfigurationFeaturesPaymentMethodUpdateOptions PaymentMethodUpdate { get; set; }
+
+        /// <summary>
+        /// Information about canceling subscriptions in the portal.
+        /// </summary>
+        [JsonProperty("subscription_cancel")]
+        public ConfigurationFeaturesSubscriptionCancelOptions SubscriptionCancel { get; set; }
+
+        /// <summary>
+        /// Information about updating subscriptions in the portal.
+        /// </summary>
+        [JsonProperty("subscription_update")]
+        public ConfigurationFeaturesSubscriptionUpdateOptions SubscriptionUpdate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesPaymentMethodUpdateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesPaymentMethodUpdateOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesPaymentMethodUpdateOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionCancelOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionCancelOptions.cs
@@ -1,0 +1,31 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionCancelOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        /// <summary>
+        /// Whether to cancel subscriptions immediately or at the end of the billing period.
+        /// One of: <c>at_period_end</c>, or <c>immediately</c>.
+        /// </summary>
+        [JsonProperty("mode")]
+        public string Mode { get; set; }
+
+        /// <summary>
+        /// Whether to create prorations when canceling subscriptions. Possible values are
+        /// <c>none</c> and <c>create_prorations</c>, which is only compatible with
+        /// <c>mode=immediately</c>. No prorations are generated when canceling a subscription at
+        /// the end of its natural billing period.
+        /// One of: <c>always_invoice</c>, <c>create_prorations</c>, or <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateOptions.cs
@@ -1,0 +1,36 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionUpdateOptions : INestedOptions
+    {
+        /// <summary>
+        /// The types of subscription updates that are supported. When empty, subscriptions are not
+        /// updateable.
+        /// </summary>
+        [JsonProperty("default_allowed_updates")]
+        public List<string> DefaultAllowedUpdates { get; set; }
+
+        /// <summary>
+        /// Whether the feature is enabled.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        /// <summary>
+        /// The list of products that support subscription updates.
+        /// </summary>
+        [JsonProperty("products")]
+        public List<ConfigurationFeaturesSubscriptionUpdateProductOptions> Products { get; set; }
+
+        /// <summary>
+        /// Determines how to handle prorations resulting from subscription updates. Valid values
+        /// are <c>none</c>, <c>create_prorations</c>, and <c>always_invoice</c>.
+        /// One of: <c>always_invoice</c>, <c>create_prorations</c>, or <c>none</c>.
+        /// </summary>
+        [JsonProperty("proration_behavior")]
+        public string ProrationBehavior { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProductOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationFeaturesSubscriptionUpdateProductOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationFeaturesSubscriptionUpdateProductOptions : INestedOptions
+    {
+        /// <summary>
+        /// The list of prices IDs that a subscription can be updated to.
+        /// </summary>
+        [JsonProperty("prices")]
+        public List<string> Prices { get; set; }
+
+        /// <summary>
+        /// The product id.
+        /// </summary>
+        [JsonProperty("product")]
+        public string Product { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationGetOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    public class ConfigurationGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationListOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationListOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationListOptions : ListOptions
+    {
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        [JsonProperty("is_default")]
+        public bool? IsDefault { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
@@ -1,0 +1,76 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class ConfigurationService : Service<Configuration>,
+        ICreatable<Configuration, ConfigurationCreateOptions>,
+        IListable<Configuration, ConfigurationListOptions>,
+        IRetrievable<Configuration, ConfigurationGetOptions>,
+        IUpdatable<Configuration, ConfigurationUpdateOptions>
+    {
+        public ConfigurationService()
+            : base(null)
+        {
+        }
+
+        public ConfigurationService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/billing_portal/configurations";
+
+        public virtual Configuration Create(ConfigurationCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<Configuration> CreateAsync(ConfigurationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual Configuration Get(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<Configuration> GetAsync(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<Configuration> List(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<Configuration>> ListAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Configuration> ListAutoPaging(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<Configuration> ListAutoPagingAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual Configuration Update(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<Configuration> UpdateAsync(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationUpdateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationUpdateOptions.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.BillingPortal
+{
+    using Newtonsoft.Json;
+
+    public class ConfigurationUpdateOptions : BaseOptions
+    {
+        /// <summary>
+        /// Whether the configuration is active and can be used to create portal sessions.
+        /// </summary>
+        [JsonProperty("active")]
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// The business information shown to customers in the portal.
+        /// </summary>
+        [JsonProperty("business_profile")]
+        public ConfigurationBusinessProfileOptions BusinessProfile { get; set; }
+
+        /// <summary>
+        /// The default URL to redirect customers to when they click on the portal's link to return
+        /// to your website. This can be <a
+        /// href="https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url">overriden</a>
+        /// when creating the session.
+        /// </summary>
+        [JsonProperty("default_return_url")]
+        public string DefaultReturnUrl { get; set; }
+
+        /// <summary>
+        /// Information about the features available in the portal.
+        /// </summary>
+        [JsonProperty("features")]
+        public ConfigurationFeaturesOptions Features { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
@@ -35,9 +35,7 @@ namespace Stripe.BillingPortal
 
         /// <summary>
         /// The default URL to redirect customers to when they click on the portal's link to return
-        /// to your website. This field is required if the configuration's <a
-        /// href="https://stripe.com/docs/api/customer_portal/configuration#portal_configuration_object-default_return_url"><c>default_return_url</c></a>
-        /// is not set.
+        /// to your website.
         /// </summary>
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionCreateOptions.cs
@@ -6,15 +6,38 @@ namespace Stripe.BillingPortal
     public class SessionCreateOptions : BaseOptions
     {
         /// <summary>
+        /// The <a
+        /// href="https://stripe.com/docs/api/customer_portal/configuration">configuration</a> to
+        /// use for this session, describing its functionality and features. If not specified, the
+        /// session uses the default configuration.
+        /// </summary>
+        [JsonProperty("configuration")]
+        public string Configuration { get; set; }
+
+        /// <summary>
         /// The ID of an existing customer.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
 
         /// <summary>
-        /// The URL to which Stripe should send customers when they click on the link to return to
-        /// your website. This field is required if a default return URL has not been configured for
-        /// the portal.
+        /// The <c>on_behalf_of</c> account to use for this session. When specified, only
+        /// subscriptions and invoices with this <c>on_behalf_of</c> account appear in the portal.
+        /// For more information, see the <a
+        /// href="https://stripe.com/docs/connect/charges-transfers#on-behalf-of">docs</a>. Use the
+        /// <a
+        /// href="https://stripe.com/docs/api/accounts/object#account_object-settings-branding">Accounts
+        /// API</a> to modify the <c>on_behalf_of</c> account's branding settings, which the portal
+        /// displays.
+        /// </summary>
+        [JsonProperty("on_behalf_of")]
+        public string OnBehalfOf { get; set; }
+
+        /// <summary>
+        /// The default URL to redirect customers to when they click on the portal's link to return
+        /// to your website. This field is required if the configuration's <a
+        /// href="https://stripe.com/docs/api/customer_portal/configuration#portal_configuration_object-default_return_url"><c>default_return_url</c></a>
+        /// is not set.
         /// </summary>
         [JsonProperty("return_url")]
         public string ReturnUrl { get; set; }

--- a/src/StripeTests/Entities/BillingPortal/Sessions/ConfigurationTest.cs
+++ b/src/StripeTests/Entities/BillingPortal/Sessions/ConfigurationTest.cs
@@ -1,0 +1,26 @@
+namespace StripeTests.BillingPortal
+{
+    using Newtonsoft.Json;
+    using Stripe;
+    using Stripe.BillingPortal;
+    using Xunit;
+
+    public class ConfigurationTest : BaseStripeTest
+    {
+        public ConfigurationTest(StripeMockFixture stripeMockFixture)
+            : base(stripeMockFixture)
+        {
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var json = GetResourceAsString("api_fixtures.billing_portal.configuration.json");
+            var configuration = JsonConvert.DeserializeObject<Configuration>(json);
+            Assert.NotNull(configuration);
+            Assert.IsType<Configuration>(configuration);
+            Assert.NotNull(configuration.Id);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+    }
+}

--- a/src/StripeTests/Resources/api_fixtures/billing_portal/configuration.json
+++ b/src/StripeTests/Resources/api_fixtures/billing_portal/configuration.json
@@ -1,0 +1,40 @@
+{
+  "active": true,
+  "application": null,
+  "business_profile": {
+    "headline": null,
+    "privacy_policy_url": "https://example.com",
+    "terms_of_service_url": "https://example.com"
+  },
+  "created": 1234567890,
+  "default_return_url": null,
+  "features": {
+    "customer_update": {
+      "allowed_updates": [
+        "address"
+      ],
+      "enabled": true
+    },
+    "invoice_history": {
+      "enabled": true
+    },
+    "payment_method_update": {
+      "enabled": false
+    },
+    "subscription_cancel": {
+      "enabled": false,
+      "mode": "at_period_end",
+      "proration_behavior": "none"
+    },
+    "subscription_update": {
+      "default_allowed_updates": [],
+      "enabled": false,
+      "proration_behavior": "none"
+    }
+  },
+  "id": "bpc_GDJCj6v0s7LYkbm",
+  "is_default": true,
+  "livemode": true,
+  "object": "billing_portal.configuration",
+  "updated": 1234567890
+}

--- a/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
+++ b/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
@@ -28,25 +28,25 @@ namespace StripeTests.BillingPortal
             {
                 BusinessProfile = new ConfigurationBusinessProfileOptions
                 {
-                  PrivacyPolicyUrl = "https://example.com/privacy",
-                  TermsOfServiceUrl = "https://example.com/tos",
+                    PrivacyPolicyUrl = "https://example.com/privacy",
+                    TermsOfServiceUrl = "https://example.com/tos",
                 },
                 Features = new ConfigurationFeaturesOptions
                 {
-                  CustomerUpdate = new ConfigurationFeaturesCustomerUpdateOptions
-                  {
-                    AllowedUpdates = new List<string> { "address" },
-                    Enabled = true,
-                  },
+                    CustomerUpdate = new ConfigurationFeaturesCustomerUpdateOptions
+                    {
+                        AllowedUpdates = new List<string> { "address" },
+                        Enabled = true,
+                    },
                 },
             };
             this.updateOptions = new ConfigurationUpdateOptions
             {
-              Active = false,
+                Active = false,
             };
             this.listOptions = new ConfigurationListOptions
             {
-              Active = true,
+                Active = true,
             };
         }
 

--- a/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
+++ b/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
@@ -11,9 +11,10 @@ namespace StripeTests.BillingPortal
 
     public class ConfigurationServiceTest : BaseStripeTest
     {
-        private const string ConfigurationId = "pts_123";
+        private const string ConfigurationId = "bpc_123";
         private readonly ConfigurationService service;
         private readonly ConfigurationCreateOptions createOptions;
+        private readonly ConfigurationUpdateOptions updateOptions;
 
         public ConfigurationServiceTest(
             StripeMockFixture stripeMockFixture,
@@ -33,10 +34,14 @@ namespace StripeTests.BillingPortal
                 {
                   CustomerUpdate = new ConfigurationFeaturesCustomerUpdateOptions
                   {
-                    AllowedUpdates = ["address"],
+                    AllowedUpdates = new List<string> { "address" },
                     Enabled = true,
-                  }
+                  },
                 },
+            };
+            this.updateOptions = new ConfigurationUpdateOptions
+            {
+              Active = false,
             };
         }
 
@@ -45,6 +50,15 @@ namespace StripeTests.BillingPortal
         {
             var configuration = this.service.Create(this.createOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/billing_portal/configurations");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var configuration = this.service.Update("bpc_123", this.updateOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/billing_portal/configurations/bpc_123");
             Assert.NotNull(configuration);
             Assert.Equal("billing_portal.configuration", configuration.Object);
         }

--- a/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
+++ b/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
@@ -15,6 +15,7 @@ namespace StripeTests.BillingPortal
         private readonly ConfigurationService service;
         private readonly ConfigurationCreateOptions createOptions;
         private readonly ConfigurationUpdateOptions updateOptions;
+        private readonly ConfigurationListOptions listOptions;
 
         public ConfigurationServiceTest(
             StripeMockFixture stripeMockFixture,
@@ -43,6 +44,10 @@ namespace StripeTests.BillingPortal
             {
               Active = false,
             };
+            this.listOptions = new ConfigurationListOptions
+            {
+              Active = true,
+            };
         }
 
         [Fact]
@@ -68,6 +73,51 @@ namespace StripeTests.BillingPortal
         {
             var configuration = await this.service.CreateAsync(this.createOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/billing_portal/configurations");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public void Get()
+        {
+            var configuration = this.service.Get(ConfigurationId);
+            this.AssertRequest(HttpMethod.Get, "/v1/billing_portal/configurations/bpc_123");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public async Task GetAsync()
+        {
+            var configuration = await this.service.GetAsync(ConfigurationId);
+            this.AssertRequest(HttpMethod.Get, "/v1/billing_portal/configurations/bpc_123");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public async Task ListAsync()
+        {
+            var configurations = await this.service.ListAsync(this.listOptions);
+            this.AssertRequest(HttpMethod.Get, "/v1/billing_portal/configurations");
+            Assert.NotNull(configurations);
+            Assert.Equal("list", configurations.Object);
+            Assert.Single(configurations.Data);
+            Assert.Equal("billing_portal.configuration", configurations.Data[0].Object);
+        }
+
+        [Fact]
+        public void ListAutoPaging()
+        {
+            var configuration = this.service.ListAutoPaging(this.listOptions).First();
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public async Task ListAutoPagingAsync()
+        {
+            var configuration = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
             Assert.NotNull(configuration);
             Assert.Equal("billing_portal.configuration", configuration.Object);
         }

--- a/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
+++ b/src/StripeTests/Services/BillingPortal/Sessions/ConfigurationServiceTest.cs
@@ -1,0 +1,61 @@
+namespace StripeTests.BillingPortal
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Stripe;
+    using Stripe.BillingPortal;
+    using Xunit;
+
+    public class ConfigurationServiceTest : BaseStripeTest
+    {
+        private const string ConfigurationId = "pts_123";
+        private readonly ConfigurationService service;
+        private readonly ConfigurationCreateOptions createOptions;
+
+        public ConfigurationServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+        {
+            this.service = new ConfigurationService(this.StripeClient);
+
+            this.createOptions = new ConfigurationCreateOptions
+            {
+                BusinessProfile = new ConfigurationBusinessProfileOptions
+                {
+                  PrivacyPolicyUrl = "https://example.com/privacy",
+                  TermsOfServiceUrl = "https://example.com/tos",
+                },
+                Features = new ConfigurationFeaturesOptions
+                {
+                  CustomerUpdate = new ConfigurationFeaturesCustomerUpdateOptions
+                  {
+                    AllowedUpdates = ["address"],
+                    Enabled = true,
+                  }
+                },
+            };
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var configuration = this.service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/billing_portal/configurations");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+
+        [Fact]
+        public async Task CreateAsync()
+        {
+            var configuration = await this.service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/v1/billing_portal/configurations");
+            Assert.NotNull(configuration);
+            Assert.Equal("billing_portal.configuration", configuration.Object);
+        }
+    }
+}

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.101.0";
+        private const string MockMinimumVersion = "0.103.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Codegen for openapi 403fdb8.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for new resource `BillingPortal.Configuration`
* Added support for `configuration` and `on_behalf_of` on `Session#create` and `BillingPortal.Session`
* `WebhookEndpoint#create.enabled_events[]` and `WebhookEndpoint#update.enabled_events[]` added new enum members: `billing_portal.configuration.created and billing_portal.configuration.updated`

