### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
@@ -6,6 +6,14 @@ namespace Stripe
     public class AccountCapabilities : StripeEntity<AccountCapabilities>
     {
         /// <summary>
+        /// The status of the ACSS Direct Debits payments capability of the account, or whether the
+        /// account can directly process ACSS Direct Debits charges.
+        /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
+        /// </summary>
+        [JsonProperty("acss_debit_payments")]
+        public string AcssDebitPayments { get; set; }
+
+        /// <summary>
         /// The status of the Afterpay Clearpay capability of the account, or whether the account
         /// can directly process Afterpay Clearpay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.

--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -193,6 +193,13 @@ namespace Stripe.Checkout
         #endregion
 
         /// <summary>
+        /// Payment-method-specific configuration for the PaymentIntent or SetupIntent of this
+        /// CheckoutSession.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public SessionPaymentMethodOptions PaymentMethodOptions { get; set; }
+
+        /// <summary>
         /// A list of the types of payment methods (e.g. card) this Checkout Session is allowed to
         /// accept.
         /// </summary>

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
@@ -1,0 +1,11 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptions : StripeEntity<SessionPaymentMethodOptions>
+    {
+        [JsonProperty("acss_debit")]
+        public SessionPaymentMethodOptionsAcssDebit AcssDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebit.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebit.cs
@@ -1,0 +1,18 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsAcssDebit : StripeEntity<SessionPaymentMethodOptionsAcssDebit>
+    {
+        [JsonProperty("mandate_options")]
+        public SessionPaymentMethodOptionsAcssDebitMandateOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitMandateOptions.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitMandateOptions.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsAcssDebitMandateOptions : StripeEntity<SessionPaymentMethodOptionsAcssDebitMandateOptions>
+    {
+        /// <summary>
+        /// A URL for custom mandate text.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the interval. Only required if 'payment_schedule' parmeter is 'interval'
+        /// or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class MandatePaymentMethodDetails : StripeEntity<MandatePaymentMethodDetails>
     {
+        [JsonProperty("acss_debit")]
+        public MandatePaymentMethodDetailsAcssDebit AcssDebit { get; set; }
+
         [JsonProperty("au_becs_debit")]
         public MandatePaymentMethodDetailsAuBecsDebit AuBecsDebit { get; set; }
 

--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsAcssDebit.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsAcssDebit.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class MandatePaymentMethodDetailsAcssDebit : StripeEntity<MandatePaymentMethodDetailsAcssDebit>
+    {
+        /// <summary>
+        /// Description of the interval. Only required if 'payment_schedule' parmeter is 'interval'
+        /// or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
@@ -20,5 +20,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("verify_with_microdeposits")]
+        public PaymentIntentNextActionVerifyWithMicrodeposits VerifyWithMicrodeposits { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionVerifyWithMicrodeposits.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionVerifyWithMicrodeposits.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentNextActionVerifyWithMicrodeposits : StripeEntity<PaymentIntentNextActionVerifyWithMicrodeposits>
+    {
+        /// <summary>
+        /// The timestamp when the microdeposits are expected to land.
+        /// </summary>
+        [JsonProperty("arrival_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ArrivalDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The URL for the hosted verification page, which allows customers to verify their bank
+        /// account.
+        /// </summary>
+        [JsonProperty("hosted_verification_url")]
+        public string HostedVerificationUrl { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class PaymentIntentPaymentMethodOptions : StripeEntity<PaymentIntentPaymentMethodOptions>
     {
+        [JsonProperty("acss_debit")]
+        public PaymentIntentPaymentMethodOptionsAcssDebit AcssDebit { get; set; }
+
         [JsonProperty("alipay")]
         public PaymentIntentPaymentMethodOptionsAlipay Alipay { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebit.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebit.cs
@@ -1,0 +1,18 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsAcssDebit : StripeEntity<PaymentIntentPaymentMethodOptionsAcssDebit>
+    {
+        [JsonProperty("mandate_options")]
+        public PaymentIntentPaymentMethodOptionsAcssDebitMandateOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitMandateOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitMandateOptions.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsAcssDebitMandateOptions : StripeEntity<PaymentIntentPaymentMethodOptionsAcssDebitMandateOptions>
+    {
+        /// <summary>
+        /// A URL for custom mandate text.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the interval. Only required if 'payment_schedule' parmeter is 'interval'
+        /// or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        [JsonProperty("acss_debit")]
+        public PaymentMethodAcssDebit AcssDebit { get; set; }
+
         [JsonProperty("afterpay_clearpay")]
         public PaymentMethodAfterpayClearpay AfterpayClearpay { get; set; }
 
@@ -133,10 +136,11 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
-        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>card_present</c>, <c>eps</c>,
-        /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>interac_present</c>,
-        /// <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
+        /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>,
+        /// <c>card_present</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>,
+        /// <c>ideal</c>, <c>interac_present</c>, <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or
+        /// <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodAcssDebit.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodAcssDebit.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodAcssDebit : StripeEntity<PaymentMethodAcssDebit>
+    {
+        /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Institution number of the bank account.
+        /// </summary>
+        [JsonProperty("institution_number")]
+        public string InstitutionNumber { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// Transit number of the bank account.
+        /// </summary>
+        [JsonProperty("transit_number")]
+        public string TransitNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class SetupAttemptPaymentMethodDetails : StripeEntity<SetupAttemptPaymentMethodDetails>
     {
+        [JsonProperty("acss_debit")]
+        public SetupAttemptPaymentMethodDetailsAcssDebit AcssDebit { get; set; }
+
         [JsonProperty("au_becs_debit")]
         public SetupAttemptPaymentMethodDetailsAuBecsDebit AuBecsDebit { get; set; }
 

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsAcssDebit.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsAcssDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupAttemptPaymentMethodDetailsAcssDebit : StripeEntity<SetupAttemptPaymentMethodDetailsAcssDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentNextAction.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentNextAction.cs
@@ -14,5 +14,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("verify_with_microdeposits")]
+        public SetupIntentNextActionVerifyWithMicrodeposits VerifyWithMicrodeposits { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionVerifyWithMicrodeposits.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionVerifyWithMicrodeposits.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SetupIntentNextActionVerifyWithMicrodeposits : StripeEntity<SetupIntentNextActionVerifyWithMicrodeposits>
+    {
+        /// <summary>
+        /// The timestamp when the microdeposits are expected to land.
+        /// </summary>
+        [JsonProperty("arrival_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ArrivalDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The URL for the hosted verification page, which allows customers to verify their bank
+        /// account.
+        /// </summary>
+        [JsonProperty("hosted_verification_url")]
+        public string HostedVerificationUrl { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
@@ -5,6 +5,9 @@ namespace Stripe
 
     public class SetupIntentPaymentMethodOptions : StripeEntity<SetupIntentPaymentMethodOptions>
     {
+        [JsonProperty("acss_debit")]
+        public SetupIntentPaymentMethodOptionsAcssDebit AcssDebit { get; set; }
+
         [JsonProperty("card")]
         public SetupIntentPaymentMethodOptionsCard Card { get; set; }
 

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebit.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebit.cs
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsAcssDebit : StripeEntity<SetupIntentPaymentMethodOptionsAcssDebit>
+    {
+        /// <summary>
+        /// Currency supported by the bank account.
+        /// One of: <c>cad</c>, or <c>usd</c>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsAcssDebitMandateOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitMandateOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitMandateOptions.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsAcssDebitMandateOptions : StripeEntity<SetupIntentPaymentMethodOptionsAcssDebitMandateOptions>
+    {
+        /// <summary>
+        /// A URL for custom mandate text.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the interval. Only required if 'payment_schedule' parmeter is 'interval'
+        /// or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountCapabilitiesAcssDebitPaymentsOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCapabilitiesAcssDebitPaymentsOptions.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class AccountCapabilitiesAcssDebitPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Passing true requests the capability for the account, if it is not already requested. A
+        /// requested capability may not immediately become active. Any requirements to activate the
+        /// capability are returned in the <c>requirements</c> arrays.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountCapabilitiesOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCapabilitiesOptions.cs
@@ -6,6 +6,12 @@ namespace Stripe
     public class AccountCapabilitiesOptions : INestedOptions
     {
         /// <summary>
+        /// The acss_debit_payments capability.
+        /// </summary>
+        [JsonProperty("acss_debit_payments")]
+        public AccountCapabilitiesAcssDebitPaymentsOptions AcssDebitPayments { get; set; }
+
+        /// <summary>
         /// The afterpay_clearpay_payments capability.
         /// </summary>
         [JsonProperty("afterpay_clearpay_payments")]

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -34,11 +34,24 @@ namespace Stripe.Checkout
         public string ClientReferenceId { get; set; }
 
         /// <summary>
-        /// ID of an existing customer, if one exists. The email stored on the customer will be used
-        /// to prefill the email field on the Checkout page. If the customer changes their email on
-        /// the Checkout page, the Customer object will be updated with the new email. If blank for
-        /// Checkout Sessions in <c>payment</c> or <c>subscription</c> mode, Checkout will create a
-        /// new customer object based on information provided during the payment flow.
+        /// ID of an existing Customer, if one exists. In <c>payment</c> mode, the customer’s most
+        /// recent card payment method will be used to prefill the email, name, card details, and
+        /// billing address on the Checkout page. In <c>subscription</c> mode, the customer’s <a
+        /// href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">default
+        /// payment method</a> will be used if it’s a card, and otherwise the most recent card will
+        /// be used. A valid billing address is required for Checkout to prefill the customer's card
+        /// details.
+        ///
+        /// If the customer changes their email on the Checkout page, the Customer object will be
+        /// updated with the new email.
+        ///
+        /// If blank for Checkout Sessions in <c>payment</c> or <c>subscription</c> mode, Checkout
+        /// will create a new Customer object based on information provided during the payment flow.
+        ///
+        /// You can set <a
+        /// href="https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_intent_data-setup_future_usage"><c>payment_intent_data.setup_future_usage</c></a>
+        /// to have Checkout automatically attach the payment method to the Customer you pass in for
+        /// future reuse.
         /// </summary>
         [JsonProperty("customer")]
         public string Customer { get; set; }
@@ -109,6 +122,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("payment_intent_data")]
         public SessionPaymentIntentDataOptions PaymentIntentData { get; set; }
+
+        /// <summary>
+        /// Payment-method-specific configuration.
+        /// </summary>
+        [JsonProperty("payment_method_options")]
+        public SessionPaymentMethodOptionsOptions PaymentMethodOptions { get; set; }
 
         /// <summary>
         /// A list of the types of payment methods (e.g., <c>card</c>) this Checkout Session can

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsAcssDebitMandateOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// A URL for custom mandate text to render during confirmation step. The URL will be
+        /// rendered with additional GET parameters <c>payment_intent</c> and
+        /// <c>payment_intent_client_secret</c> when confirming a Payment Intent, or
+        /// <c>setup_intent</c> and <c>setup_intent_client_secret</c> when confirming a Setup
+        /// Intent.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the mandate interval. Only required if 'payment_schedule' parameter is
+        /// 'interval' or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebitOptions.cs
@@ -1,0 +1,30 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsAcssDebitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// One of: <c>cad</c>, or <c>usd</c>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Additional fields for Mandate creation.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public SessionPaymentMethodOptionsAcssDebitMandateOptionsOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// contains details about the ACSS Debit payment method options.
+        /// </summary>
+        [JsonProperty("acss_debit")]
+        public SessionPaymentMethodOptionsAcssDebitOptions AcssDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataAcssDebitOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataAcssDebitOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodDataAcssDebitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Customer's bank account number.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// Institution number of the customer's bank.
+        /// </summary>
+        [JsonProperty("institution_number")]
+        public string InstitutionNumber { get; set; }
+
+        /// <summary>
+        /// Transit number of the customer's bank.
+        /// </summary>
+        [JsonProperty("transit_number")]
+        public string TransitNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe
     public class PaymentIntentPaymentMethodDataOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
+        /// If this is an <c>acss_debit</c> PaymentMethod, this hash contains details about the ACSS
+        /// Debit payment method.
+        /// </summary>
+        [JsonProperty("acss_debit")]
+        public PaymentIntentPaymentMethodDataAcssDebitOptions AcssDebit { get; set; }
+
+        /// <summary>
         /// If this is an <c>AfterpayClearpay</c> PaymentMethod, this hash contains details about
         /// the AfterpayClearpay payment method.
         /// </summary>
@@ -131,10 +138,10 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
-        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>,
-        /// <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or
-        /// <c>sofort</c>.
+        /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>eps</c>, <c>fpx</c>,
+        /// <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
+        /// <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// A URL for custom mandate text to render during confirmation step. The URL will be
+        /// rendered with additional GET parameters <c>payment_intent</c> and
+        /// <c>payment_intent_client_secret</c> when confirming a Payment Intent, or
+        /// <c>setup_intent</c> and <c>setup_intent_client_secret</c> when confirming a Setup
+        /// Intent.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the mandate interval. Only required if 'payment_schedule' parameter is
+        /// 'interval' or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsAcssDebitOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsAcssDebitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Additional fields for Mandate creation.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public PaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -6,6 +6,13 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsOptions : INestedOptions
     {
         /// <summary>
+        /// If this is a <c>acss_debit</c> PaymentMethod, this sub-hash contains details about the
+        /// ACSS Debit payment method options.
+        /// </summary>
+        [JsonProperty("acss_debit")]
+        public PaymentIntentPaymentMethodOptionsAcssDebitOptions AcssDebit { get; set; }
+
+        /// <summary>
         /// If this is a <c>alipay</c> PaymentMethod, this sub-hash contains details about the
         /// Alipay payment method options.
         /// </summary>

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodAcssDebitOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodAcssDebitOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodAcssDebitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Customer's bank account number.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// Institution number of the customer's bank.
+        /// </summary>
+        [JsonProperty("institution_number")]
+        public string InstitutionNumber { get; set; }
+
+        /// <summary>
+        /// Transit number of the customer's bank.
+        /// </summary>
+        [JsonProperty("transit_number")]
+        public string TransitNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
@@ -7,6 +7,13 @@ namespace Stripe
     public class PaymentMethodCreateOptions : BaseOptions, IHasMetadata
     {
         /// <summary>
+        /// If this is an <c>acss_debit</c> PaymentMethod, this hash contains details about the ACSS
+        /// Debit payment method.
+        /// </summary>
+        [JsonProperty("acss_debit")]
+        public PaymentMethodAcssDebitOptions AcssDebit { get; set; }
+
+        /// <summary>
         /// If this is an <c>AfterpayClearpay</c> PaymentMethod, this hash contains details about
         /// the AfterpayClearpay payment method.
         /// </summary>
@@ -146,9 +153,9 @@ namespace Stripe
         /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
-        /// One of: <c>afterpay_clearpay</c>, <c>alipay</c>, <c>au_becs_debit</c>,
-        /// <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>eps</c>, <c>fpx</c>,
-        /// <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
+        /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>eps</c>,
+        /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
         /// <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// A URL for custom mandate text to render during confirmation step. The URL will be
+        /// rendered with additional GET parameters <c>payment_intent</c> and
+        /// <c>payment_intent_client_secret</c> when confirming a Payment Intent, or
+        /// <c>setup_intent</c> and <c>setup_intent_client_secret</c> when confirming a Setup
+        /// Intent.
+        /// </summary>
+        [JsonProperty("custom_mandate_url")]
+        public string CustomMandateUrl { get; set; }
+
+        /// <summary>
+        /// Description of the mandate interval. Only required if 'payment_schedule' parameter is
+        /// 'interval' or 'combined'.
+        /// </summary>
+        [JsonProperty("interval_description")]
+        public string IntervalDescription { get; set; }
+
+        /// <summary>
+        /// Payment schedule for the mandate.
+        /// One of: <c>combined</c>, <c>interval</c>, or <c>sporadic</c>.
+        /// </summary>
+        [JsonProperty("payment_schedule")]
+        public string PaymentSchedule { get; set; }
+
+        /// <summary>
+        /// Transaction type of the mandate.
+        /// One of: <c>business</c>, or <c>personal</c>.
+        /// </summary>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsAcssDebitOptions.cs
@@ -1,0 +1,30 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsAcssDebitOptions : INestedOptions
+    {
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// One of: <c>cad</c>, or <c>usd</c>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Additional fields for Mandate creation.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsAcssDebitMandateOptionsOptions MandateOptions { get; set; }
+
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
@@ -6,6 +6,13 @@ namespace Stripe
     public class SetupIntentPaymentMethodOptionsOptions : INestedOptions
     {
         /// <summary>
+        /// If this is a <c>acss_debit</c> SetupIntent, this sub-hash contains details about the
+        /// ACSS Debit payment method options.
+        /// </summary>
+        [JsonProperty("acss_debit")]
+        public SetupIntentPaymentMethodOptionsAcssDebitOptions AcssDebit { get; set; }
+
+        /// <summary>
         /// Configuration for any card setup attempted on this SetupIntent.
         /// </summary>
         [JsonProperty("card")]


### PR DESCRIPTION
Codegen for openapi 3e77877.

cc @stripe/api-libraries

## Changelog
* Added support for `acss_debit_payments` on `AccountCapabilities`
* Added support for `acss_debit` on `SetupIntentPaymentMethodOptionsOptions`, `SetupAttemptPaymentMethodDetailsOptions`, `PaymentMethod`, `PaymentMethodOptions`, `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodDataOptions`, and `MandatePaymentMethodDetails`, and `Checkout.SessionPaymentMethodOptions`.
* Add `acss_debit` to the `type` enum of `PaymentMethod`, `PaymentIntent` and `Checkout.SessionCreateOptions.payment_method_types`.
* Added support for `verify_with_microdeposits` on `PaymentIntentNextAction` and `SetupIntentNextAction`
