### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountCompany.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCompany.cs
@@ -83,7 +83,7 @@ namespace Stripe
         /// <c>incorporated_non_profit</c>, <c>limited_liability_partnership</c>,
         /// <c>multi_member_llc</c>, <c>private_company</c>, <c>private_corporation</c>,
         /// <c>private_partnership</c>, <c>public_company</c>, <c>public_corporation</c>,
-        /// <c>public_partnership</c>, <c>sole_proprietorship</c>,
+        /// <c>public_partnership</c>, <c>single_member_llc</c>, <c>sole_proprietorship</c>,
         /// <c>tax_exempt_government_instrumentality</c>, <c>unincorporated_association</c>, or
         /// <c>unincorporated_non_profit</c>.
         /// </summary>

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebit.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAcssDebit.cs
@@ -5,6 +5,9 @@ namespace Stripe.Checkout
 
     public class SessionPaymentMethodOptionsAcssDebit : StripeEntity<SessionPaymentMethodOptionsAcssDebit>
     {
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
         [JsonProperty("mandate_options")]
         public SessionPaymentMethodOptionsAcssDebitMandateOptions MandateOptions { get; set; }
 
@@ -14,8 +17,5 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("verification_method")]
         public string VerificationMethod { get; set; }
-
-        [JsonProperty("currency")]
-        public string Currency { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/CardShipping.cs
@@ -12,7 +12,7 @@ namespace Stripe.Issuing
 
         /// <summary>
         /// The delivery company that shipped a card.
-        /// One of: <c>fedex</c>, or <c>usps</c>.
+        /// One of: <c>dhl</c>, <c>fedex</c>, <c>royal_mail</c>, or <c>usps</c>.
         /// </summary>
         [JsonProperty("carrier")]
         public string Carrier { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -17,6 +17,9 @@ namespace Stripe
         [JsonProperty("card")]
         public PaymentIntentPaymentMethodOptionsCard Card { get; set; }
 
+        [JsonProperty("card_present")]
+        public PaymentIntentPaymentMethodOptionsCardPresent CardPresent { get; set; }
+
         [JsonProperty("oxxo")]
         public PaymentIntentPaymentMethodOptionsOxxo Oxxo { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -15,8 +15,8 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsCardInstallments Installments { get; set; }
 
         /// <summary>
-        /// Selected network to process this PaymentIntent on. Depends on the available networks of
-        /// the card attached to the PaymentIntent. Can be only set confirm-time.
+        /// Selected network to process this payment intent on. Depends on the available networks of
+        /// the card attached to the payment intent. Can be only set confirm-time.
         /// One of: <c>amex</c>, <c>cartes_bancaires</c>, <c>diners</c>, <c>discover</c>,
         /// <c>interac</c>, <c>jcb</c>, <c>mastercard</c>, <c>unionpay</c>, <c>unknown</c>, or
         /// <c>visa</c>.

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardPresent.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardPresent.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsCardPresent : StripeEntity<PaymentIntentPaymentMethodOptionsCardPresent>
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardPresentOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardPresentOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsCardPresentOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -33,6 +33,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsCardOptions Card { get; set; }
 
         /// <summary>
+        /// If this is a <c>card_present</c> PaymentMethod, this sub-hash contains details about the
+        /// Card Present payment method options.
+        /// </summary>
+        [JsonProperty("card_present")]
+        public PaymentIntentPaymentMethodOptionsCardPresentOptions CardPresent { get; set; }
+
+        /// <summary>
         /// If this is a <c>oxxo</c> PaymentMethod, this sub-hash contains details about the OXXO
         /// payment method options.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemCreateOptions.cs
@@ -33,6 +33,13 @@ namespace Stripe
         /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
         /// Migration Guide</a> for Billing to learn more. This is the default behavior.
         ///
+        /// Use <c>default_incomplete</c> to transition the subscription to <c>status=past_due</c>
+        /// when payment is required and await explicit confirmation of the invoice's payment
+        /// intent. This allows simpler management of scenarios where additional user actions are
+        /// needed to pay a subscription’s invoice. Such as failed payments, <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// regulation</a>, or collecting a mandate for a bank debit payment method.
+        ///
         /// Use <c>pending_if_incomplete</c> to update the subscription using <a
         /// href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending
         /// updates</a>. When you use <c>pending_if_incomplete</c> you can only pass the parameters
@@ -46,8 +53,8 @@ namespace Stripe
         /// does not update the subscription and returns an error instead. This was the default
         /// behavior for API versions prior to 2019-03-14. See the <a
         /// href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
-        /// One of: <c>allow_incomplete</c>, <c>error_if_incomplete</c>, or
-        /// <c>pending_if_incomplete</c>.
+        /// One of: <c>allow_incomplete</c>, <c>default_incomplete</c>, <c>error_if_incomplete</c>,
+        /// or <c>pending_if_incomplete</c>.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemUpdateOptions.cs
@@ -39,6 +39,13 @@ namespace Stripe
         /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
         /// Migration Guide</a> for Billing to learn more. This is the default behavior.
         ///
+        /// Use <c>default_incomplete</c> to transition the subscription to <c>status=past_due</c>
+        /// when payment is required and await explicit confirmation of the invoice's payment
+        /// intent. This allows simpler management of scenarios where additional user actions are
+        /// needed to pay a subscription’s invoice. Such as failed payments, <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// regulation</a>, or collecting a mandate for a bank debit payment method.
+        ///
         /// Use <c>pending_if_incomplete</c> to update the subscription using <a
         /// href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending
         /// updates</a>. When you use <c>pending_if_incomplete</c> you can only pass the parameters
@@ -52,8 +59,8 @@ namespace Stripe
         /// does not update the subscription and returns an error instead. This was the default
         /// behavior for API versions prior to 2019-03-14. See the <a
         /// href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
-        /// One of: <c>allow_incomplete</c>, <c>error_if_incomplete</c>, or
-        /// <c>pending_if_incomplete</c>.
+        /// One of: <c>allow_incomplete</c>, <c>default_incomplete</c>, <c>error_if_incomplete</c>,
+        /// or <c>pending_if_incomplete</c>.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -160,6 +160,16 @@ namespace Stripe
         /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
         /// Migration Guide</a> for Billing to learn more. This is the default behavior.
         ///
+        /// Use <c>default_incomplete</c> to create Subscriptions with <c>status=incomplete</c> when
+        /// the first invoice requires payment, otherwise start as active. Subscriptions transition
+        /// to <c>status=active</c> when successfully confirming the payment intent on the first
+        /// invoice. This allows simpler management of scenarios where additional user actions are
+        /// needed to pay a subscription’s invoice. Such as failed payments, <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// regulation</a>, or collecting a mandate for a bank debit payment method. If the payment
+        /// intent is not confirmed within 23 hours subscriptions transition to
+        /// <c>status=expired_incomplete</c>, which is a terminal state.
+        ///
         /// Use <c>error_if_incomplete</c> if you want Stripe to return an HTTP 402 status code if a
         /// subscription's first invoice cannot be paid. For example, if a payment method requires
         /// 3DS authentication due to SCA regulation and further user action is needed, this
@@ -169,8 +179,8 @@ namespace Stripe
         ///
         /// <c>pending_if_incomplete</c> is only used with updates and cannot be passed when
         /// creating a subscription.
-        /// One of: <c>allow_incomplete</c>, <c>error_if_incomplete</c>, or
-        /// <c>pending_if_incomplete</c>.
+        /// One of: <c>allow_incomplete</c>, <c>default_incomplete</c>, <c>error_if_incomplete</c>,
+        /// or <c>pending_if_incomplete</c>.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -151,6 +151,13 @@ namespace Stripe
         /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
         /// Migration Guide</a> for Billing to learn more. This is the default behavior.
         ///
+        /// Use <c>default_incomplete</c> to transition the subscription to <c>status=past_due</c>
+        /// when payment is required and await explicit confirmation of the invoice's payment
+        /// intent. This allows simpler management of scenarios where additional user actions are
+        /// needed to pay a subscription’s invoice. Such as failed payments, <a
+        /// href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+        /// regulation</a>, or collecting a mandate for a bank debit payment method.
+        ///
         /// Use <c>pending_if_incomplete</c> to update the subscription using <a
         /// href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending
         /// updates</a>. When you use <c>pending_if_incomplete</c> you can only pass the parameters
@@ -164,8 +171,8 @@ namespace Stripe
         /// does not update the subscription and returns an error instead. This was the default
         /// behavior for API versions prior to 2019-03-14. See the <a
         /// href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
-        /// One of: <c>allow_incomplete</c>, <c>error_if_incomplete</c>, or
-        /// <c>pending_if_incomplete</c>.
+        /// One of: <c>allow_incomplete</c>, <c>default_incomplete</c>, <c>error_if_incomplete</c>,
+        /// or <c>pending_if_incomplete</c>.
         /// </summary>
         [JsonProperty("payment_behavior")]
         public string PaymentBehavior { get; set; }


### PR DESCRIPTION
Codegen for openapi 9c11715.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `card_present` on `PaymentIntentPaymentMethodOptionsOptions`, and `PaymentIntentMethodOptions`
* Added `default_incomplete` as a new `payment_behavior` of `SubscriptionOptions` and `SubscriptionItemOptions`.
