### PR TITLE
Create PaymentIntentPaymentMethodCard.cs

### DIFF
--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodCard.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodCard.cs
@@ -1,0 +1,10 @@
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    
+    public class PaymentIntentPaymentMethodCard : INestedOptions
+    {
+        [JsonProperty("token")]
+        public string Token { get; set; }
+    }
+}


### PR DESCRIPTION
 A token may not be passed in as a PaymentMethod. Instead, use payment_method_data with type=card and card[token]=tok_xxxxxxxxxx