### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionCustomerDetailsTaxId.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionCustomerDetailsTaxId.cs
@@ -11,15 +11,17 @@ namespace Stripe.Checkout
         /// <c>za_vat</c>, <c>ch_vat</c>, <c>mx_rfc</c>, <c>sg_uen</c>, <c>ru_inn</c>,
         /// <c>ru_kpp</c>, <c>ca_bn</c>, <c>hk_br</c>, <c>es_cif</c>, <c>tw_vat</c>, <c>th_vat</c>,
         /// <c>jp_cn</c>, <c>jp_rn</c>, <c>li_uid</c>, <c>my_itn</c>, <c>us_ein</c>, <c>kr_brn</c>,
-        /// <c>ca_qst</c>, <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>,
-        /// <c>sa_vat</c>, <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
+        /// <c>ca_qst</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
+        /// <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>, <c>sa_vat</c>,
+        /// <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
-        /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>unknown</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceCustomerTaxId.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceCustomerTaxId.cs
@@ -11,15 +11,17 @@ namespace Stripe
         /// <c>za_vat</c>, <c>ch_vat</c>, <c>mx_rfc</c>, <c>sg_uen</c>, <c>ru_inn</c>,
         /// <c>ru_kpp</c>, <c>ca_bn</c>, <c>hk_br</c>, <c>es_cif</c>, <c>tw_vat</c>, <c>th_vat</c>,
         /// <c>jp_cn</c>, <c>jp_rn</c>, <c>li_uid</c>, <c>my_itn</c>, <c>us_ein</c>, <c>kr_brn</c>,
-        /// <c>ca_qst</c>, <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>,
-        /// <c>sa_vat</c>, <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
+        /// <c>ca_qst</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
+        /// <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>, <c>sa_vat</c>,
+        /// <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
-        /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>unknown</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/TaxIds/TaxId.cs
+++ b/src/Stripe.net/Entities/TaxIds/TaxId.cs
@@ -78,19 +78,21 @@ namespace Stripe
 
         /// <summary>
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
-        /// <c>ca_bn</c>, <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
+        /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
+        /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
         /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
         /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>. Note that some legacy tax IDs have type <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
-        /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>unknown</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerTaxIdDataOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerTaxIdDataOptions.cs
@@ -7,19 +7,20 @@ namespace Stripe
     {
         /// <summary>
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
-        /// <c>ca_bn</c>, <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>us_ein</c>, or <c>za_vat</c>.
-        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
         /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
         /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
+        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCustomerDetailsTaxIdOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCustomerDetailsTaxIdOptions.cs
@@ -7,19 +7,20 @@ namespace Stripe
     {
         /// <summary>
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
-        /// <c>ca_bn</c>, <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>us_ein</c>, or <c>za_vat</c>.
-        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
         /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
         /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
+        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceLineItemCustomerDetailsTaxIdOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceLineItemCustomerDetailsTaxIdOptions.cs
@@ -7,19 +7,20 @@ namespace Stripe
     {
         /// <summary>
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
-        /// <c>ca_bn</c>, <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>us_ein</c>, or <c>za_vat</c>.
-        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
         /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
         /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
+        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/TaxIds/TaxIdCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdCreateOptions.cs
@@ -7,19 +7,20 @@ namespace Stripe
     {
         /// <summary>
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
-        /// <c>ca_bn</c>, <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
-        /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
-        /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
-        /// <c>us_ein</c>, or <c>za_vat</c>.
-        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
         /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
         /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
+        /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
+        /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
+        /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
+        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
+        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
+        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
+        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }


### PR DESCRIPTION
Codegen for openapi 2550077.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* `TaxId#create.type`, `Invoice.customer_tax_ids[].type`, `Invoice#upcomingLines.customer_details.tax_ids[].type`, `Invoice#upcoming.customer_details.tax_ids[].type`, `Customer#create.tax_id_data[].type`, `Checkout.Session.customer_details.tax_ids[].type` and `TaxId.type` added new enum members: `ca_pst_mb, ca_pst_bc, ca_gst_hst and ca_pst_sk` (breaking change)

