### PR TITLE
Add infrastructure for handling streaming binary responses

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/IHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/IHttpClient.cs
@@ -16,5 +16,9 @@ namespace Stripe
         Task<StripeResponse> MakeRequestAsync(
             StripeRequest request,
             CancellationToken cancellationToken = default);
+
+        Task<StripeStreamedResponse> MakeStreamingRequestAsync(
+            StripeRequest request,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/IStripeClient.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System.IO;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,5 +46,20 @@ namespace Stripe
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
             where T : IStripeEntity;
+
+        /// <summary>Sends a request to Stripe's API as an asynchronous operation and returns a <see cref="Stream"/> as the response.</summary>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="path">The path of the request.</param>
+        /// <param name="options">The parameters of the request.</param>
+        /// <param name="requestOptions">The special modifiers of the request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A task object with the Stream of the response body on success..</returns>
+        /// <exception cref="StripeException">Thrown if the request fails.</exception>
+        Task<Stream> RequestStreamingAsync(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeResponse.cs
@@ -1,72 +1,25 @@
 namespace Stripe
 {
-    using System;
-    using System.Linq;
     using System.Net;
     using System.Net.Http.Headers;
 
     /// <summary>
-    /// Represents a response from Stripe's API.
+    /// Represents a buffered textual response from Stripe's API.
     /// </summary>
-    public class StripeResponse
+    public class StripeResponse : StripeResponseBase
     {
         /// <summary>Initializes a new instance of the <see cref="StripeResponse"/> class.</summary>
         /// <param name="statusCode">The HTTP status code.</param>
         /// <param name="headers">The HTTP headers of the response.</param>
         /// <param name="content">The body of the response.</param>
         public StripeResponse(HttpStatusCode statusCode, HttpResponseHeaders headers, string content)
+            : base(statusCode, headers)
         {
-            this.StatusCode = statusCode;
-            this.Headers = headers;
             this.Content = content;
         }
-
-        /// <summary>Gets the HTTP status code of the response.</summary>
-        /// <value>The HTTP status code of the response.</value>
-        public HttpStatusCode StatusCode { get; }
-
-        /// <summary>Gets the HTTP headers of the response.</summary>
-        /// <value>The HTTP headers of the response.</value>
-        public HttpResponseHeaders Headers { get; }
 
         /// <summary>Gets the body of the response.</summary>
         /// <value>The body of the response.</value>
         public string Content { get; }
-
-        /// <summary>Gets the date of the request, as returned by Stripe.</summary>
-        /// <value>The date of the request, as returned by Stripe.</value>
-        public DateTimeOffset? Date => this.Headers?.Date;
-
-        /// <summary>Gets the idempotency key of the request, as returned by Stripe.</summary>
-        /// <value>The idempotency key of the request, as returned by Stripe.</value>
-        public string IdempotencyKey => MaybeGetHeader(this.Headers, "Idempotency-Key");
-
-        /// <summary>Gets the ID of the request, as returned by Stripe.</summary>
-        /// <value>The ID of the request, as returned by Stripe.</value>
-        public string RequestId => MaybeGetHeader(this.Headers, "Request-Id");
-
-        internal int NumRetries { get; set; }
-
-        /// <summary>Returns a string that represents the <see cref="StripeResponse"/>.</summary>
-        /// <returns>A string that represents the <see cref="StripeResponse"/>.</returns>
-        public override string ToString()
-        {
-            return string.Format(
-                "<{0} status={1} Request-Id={2} Date={3}>",
-                this.GetType().FullName,
-                (int)this.StatusCode,
-                this.RequestId,
-                this.Date?.ToString("s"));
-        }
-
-        private static string MaybeGetHeader(HttpHeaders headers, string name)
-        {
-            if ((headers == null) || (!headers.Contains(name)))
-            {
-                return null;
-            }
-
-            return headers.GetValues(name).First();
-        }
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeResponseBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeResponseBase.cs
@@ -1,0 +1,66 @@
+namespace Stripe
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http.Headers;
+
+    /// <summary>
+    /// Represents a response from Stripe's API.
+    /// </summary>
+    public abstract class StripeResponseBase
+    {
+        /// <summary>Initializes a new instance of the <see cref="StripeResponseBase"/> class.</summary>
+        /// <param name="statusCode">The HTTP status code.</param>
+        /// <param name="headers">The HTTP headers of the response.</param>
+        public StripeResponseBase(HttpStatusCode statusCode, HttpResponseHeaders headers)
+        {
+            this.StatusCode = statusCode;
+            this.Headers = headers;
+        }
+
+        /// <summary>Gets the HTTP status code of the response.</summary>
+        /// <value>The HTTP status code of the response.</value>
+        public HttpStatusCode StatusCode { get; }
+
+        /// <summary>Gets the HTTP headers of the response.</summary>
+        /// <value>The HTTP headers of the response.</value>
+        public HttpResponseHeaders Headers { get; }
+
+        /// <summary>Gets the date of the request, as returned by Stripe.</summary>
+        /// <value>The date of the request, as returned by Stripe.</value>
+        public DateTimeOffset? Date => this.Headers?.Date;
+
+        /// <summary>Gets the idempotency key of the request, as returned by Stripe.</summary>
+        /// <value>The idempotency key of the request, as returned by Stripe.</value>
+        public string IdempotencyKey => MaybeGetHeader(this.Headers, "Idempotency-Key");
+
+        /// <summary>Gets the ID of the request, as returned by Stripe.</summary>
+        /// <value>The ID of the request, as returned by Stripe.</value>
+        public string RequestId => MaybeGetHeader(this.Headers, "Request-Id");
+
+        internal int NumRetries { get; set; }
+
+        /// <summary>Returns a string that represents the <see cref="StripeResponse"/>.</summary>
+        /// <returns>A string that represents the <see cref="StripeResponse"/>.</returns>
+        public override string ToString()
+        {
+            return string.Format(
+                "<{0} status={1} Request-Id={2} Date={3}>",
+                this.GetType().FullName,
+                (int)this.StatusCode,
+                this.RequestId,
+                this.Date?.ToString("s"));
+        }
+
+        private static string MaybeGetHeader(HttpHeaders headers, string name)
+        {
+            if ((headers == null) || (!headers.Contains(name)))
+            {
+                return null;
+            }
+
+            return headers.GetValues(name).First();
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeStreamedResponse.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeStreamedResponse.cs
@@ -1,0 +1,51 @@
+namespace Stripe
+{
+    using System.IO;
+    using System.Net;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A streaming binary response. Body is not assumed to be text for successful responses.
+    /// </summary>
+    public class StripeStreamedResponse : StripeResponseBase
+    {
+        private Task<StripeResponse> fetchFullyTask;
+
+        public StripeStreamedResponse(HttpStatusCode statusCode, HttpResponseHeaders headers, Stream body)
+            : base(statusCode, headers)
+        {
+            this.Body = body;
+        }
+
+        /// <summary>
+        /// Binary response body as a <see cref="Stream"/>.
+        /// </summary>
+        public Stream Body { get; }
+
+        /// <summary>
+        /// Converts this response into a regular <see cref="StripeResponse"/> by
+        /// reading the body in full.
+        /// </summary>
+        /// This assumes that the response body is textual, which will be the case for
+        /// most API responses and for errors.
+        /// <returns>The response with body fully read.</returns>
+        public async Task<StripeResponse> ToStripeResponseAsync()
+        {
+            // We keep a reference to the task because we can only read the body once.
+            if (this.fetchFullyTask == null)
+            {
+                this.fetchFullyTask = this.FetchResponseAsTextAsync();
+            }
+
+            return await this.fetchFullyTask.ConfigureAwait(false);
+        }
+
+        private async Task<StripeResponse> FetchResponseAsTextAsync()
+        {
+            var reader = new StreamReader(this.Body);
+            var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+            return new StripeResponse(this.StatusCode, this.Headers, content);
+        }
+    }
+}

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Net;
     using System.Net.Http;
     using System.Reflection;
@@ -240,6 +241,16 @@ namespace Stripe
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
+        protected Stream RequestStreaming(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions)
+        {
+            return this.RequestStreamingAsync(method, path, options, requestOptions)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
         protected async Task<T> RequestAsync<T>(
             HttpMethod method,
             string path,
@@ -255,6 +266,24 @@ namespace Stripe
                 options,
                 requestOptions,
                 cancellationToken).ConfigureAwait(false);
+        }
+
+        protected async Task<Stream> RequestStreamingAsync(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default)
+        {
+            requestOptions = this.SetupRequestOptions(requestOptions);
+            var stream = await this.Client.RequestStreamingAsync(
+                    method,
+                    path,
+                    options,
+                    requestOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return stream;
         }
 
         protected IEnumerable<T> ListRequestAutoPaging<T>(

--- a/src/StripeTests/Services/_base/ServiceTest.cs
+++ b/src/StripeTests/Services/_base/ServiceTest.cs
@@ -2,6 +2,7 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -62,6 +63,17 @@ namespace StripeTests
             {
                 this.LastOptions = options;
                 return Task.FromResult(default(T));
+            }
+
+            public Task<Stream> RequestStreamingAsync(
+                HttpMethod method,
+                string path,
+                BaseOptions options,
+                RequestOptions requestOptions,
+                CancellationToken cancellationToken = default)
+            {
+                this.LastOptions = options;
+                return Task.FromResult(Stream.Null);
             }
         }
 


### PR DESCRIPTION
In support of upcoming API methods that return binary data, this PR adds versions of the request methods that return a `Stream` instead of assuming a JSON response.
