### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
@@ -29,6 +29,9 @@ namespace Stripe
         [JsonProperty("bancontact")]
         public ChargePaymentMethodDetailsBancontact Bancontact { get; set; }
 
+        [JsonProperty("boleto")]
+        public ChargePaymentMethodDetailsBoleto Boleto { get; set; }
+
         [JsonProperty("card")]
         public ChargePaymentMethodDetailsCard Card { get; set; }
 

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsBoleto.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsBoleto.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class ChargePaymentMethodDetailsBoleto : StripeEntity<ChargePaymentMethodDetailsBoleto>
+    {
+        /// <summary>
+        /// Uniquely identifies this customer tax_id (CNPJ or CPF).
+        /// </summary>
+        [JsonProperty("tax_id")]
+        public string TaxId { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionCustomerDetailsTaxId.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionCustomerDetailsTaxId.cs
@@ -13,15 +13,15 @@ namespace Stripe.Checkout
         /// <c>jp_cn</c>, <c>jp_rn</c>, <c>li_uid</c>, <c>my_itn</c>, <c>us_ein</c>, <c>kr_brn</c>,
         /// <c>ca_qst</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>, <c>sa_vat</c>,
-        /// <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
+        /// <c>id_npwp</c>, <c>my_frp</c>, <c>il_vat</c>, or <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
-        /// <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>,
+        /// <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/Invoices/InvoiceCustomerTaxId.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceCustomerTaxId.cs
@@ -13,15 +13,15 @@ namespace Stripe
         /// <c>jp_cn</c>, <c>jp_rn</c>, <c>li_uid</c>, <c>my_itn</c>, <c>us_ein</c>, <c>kr_brn</c>,
         /// <c>ca_qst</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>my_sst</c>, <c>sg_gst</c>, <c>ae_trn</c>, <c>cl_tin</c>, <c>sa_vat</c>,
-        /// <c>id_npwp</c>, <c>my_frp</c>, or <c>unknown</c>.
+        /// <c>id_npwp</c>, <c>my_frp</c>, <c>il_vat</c>, or <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
-        /// <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>,
+        /// <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
@@ -8,6 +8,9 @@ namespace Stripe
         [JsonProperty("alipay_handle_redirect")]
         public PaymentIntentNextActionAlipayHandleRedirect AlipayHandleRedirect { get; set; }
 
+        [JsonProperty("boleto_display_details")]
+        public PaymentIntentNextActionBoletoDisplayDetails BoletoDisplayDetails { get; set; }
+
         [JsonProperty("oxxo_display_details")]
         public PaymentIntentNextActionOxxoDisplayDetails OxxoDisplayDetails { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionBoletoDisplayDetails.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionBoletoDisplayDetails.cs
@@ -1,0 +1,36 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentNextActionBoletoDisplayDetails : StripeEntity<PaymentIntentNextActionBoletoDisplayDetails>
+    {
+        /// <summary>
+        /// The timestamp after which the boleto expires.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// The URL to the hosted boleto voucher page, which allows customers to view the boleto
+        /// voucher.
+        /// </summary>
+        [JsonProperty("hosted_voucher_url")]
+        public string HostedVoucherUrl { get; set; }
+
+        /// <summary>
+        /// The boleto number.
+        /// </summary>
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        /// <summary>
+        /// The URL to the downloadable boleto voucher PDF.
+        /// </summary>
+        [JsonProperty("pdf")]
+        public string Pdf { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -17,6 +17,9 @@ namespace Stripe
         [JsonProperty("bancontact")]
         public PaymentIntentPaymentMethodOptionsBancontact Bancontact { get; set; }
 
+        [JsonProperty("boleto")]
+        public PaymentIntentPaymentMethodOptionsBoleto Boleto { get; set; }
+
         [JsonProperty("card")]
         public PaymentIntentPaymentMethodOptionsCard Card { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsBoleto.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsBoleto.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsBoleto : StripeEntity<PaymentIntentPaymentMethodOptionsBoleto>
+    {
+        /// <summary>
+        /// The number of calendar days before a Boleto voucher expires. For example, if you create
+        /// a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will
+        /// expire on Wednesday at 23:59 America/Sao_Paulo time.
+        /// </summary>
+        [JsonProperty("expires_after_days")]
+        public long ExpiresAfterDays { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -41,6 +41,9 @@ namespace Stripe
         [JsonProperty("billing_details")]
         public PaymentMethodBillingDetails BillingDetails { get; set; }
 
+        [JsonProperty("boleto")]
+        public PaymentMethodBoleto Boleto { get; set; }
+
         [JsonProperty("card")]
         public PaymentMethodCard Card { get; set; }
 
@@ -137,7 +140,7 @@ namespace Stripe
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
         /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
-        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>,
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>card</c>,
         /// <c>card_present</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>,
         /// <c>ideal</c>, <c>interac_present</c>, <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, or
         /// <c>sofort</c>.

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodBoleto.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodBoleto.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodBoleto : StripeEntity<PaymentMethodBoleto>
+    {
+        /// <summary>
+        /// Uniquely identifies the customer tax id (CNPJ or CPF).
+        /// </summary>
+        [JsonProperty("tax_id")]
+        public string TaxId { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/TaxIds/TaxId.cs
+++ b/src/Stripe.net/Entities/TaxIds/TaxId.cs
@@ -80,19 +80,19 @@ namespace Stripe
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
         /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
+        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>,
+        /// <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>. Note that some legacy tax IDs have type <c>unknown</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>, <c>us_ein</c>, or
-        /// <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>unknown</c>,
+        /// <c>us_ein</c>, or <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Customers/CustomerTaxIdDataOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerTaxIdDataOptions.cs
@@ -9,18 +9,19 @@ namespace Stripe
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
         /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
+        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>,
+        /// <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCustomerDetailsTaxIdOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCustomerDetailsTaxIdOptions.cs
@@ -9,18 +9,19 @@ namespace Stripe
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
         /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
+        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>,
+        /// <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceLineItemCustomerDetailsTaxIdOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceLineItemCustomerDetailsTaxIdOptions.cs
@@ -9,18 +9,19 @@ namespace Stripe
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
         /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
+        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>,
+        /// <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataBoletoOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataBoletoOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodDataBoletoOptions : INestedOptions
+    {
+        /// <summary>
+        /// Uniquely identifies this customer tax_id (CNPJ or CPF).
+        /// </summary>
+        [JsonProperty("tax_id")]
+        public string TaxId { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
@@ -56,6 +56,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodDataBillingDetailsOptions BillingDetails { get; set; }
 
         /// <summary>
+        /// If this is a <c>boleto</c> PaymentMethod, this hash contains details about the Boleto
+        /// payment method.
+        /// </summary>
+        [JsonProperty("boleto")]
+        public PaymentIntentPaymentMethodDataBoletoOptions Boleto { get; set; }
+
+        /// <summary>
         /// If this is an <c>eps</c> PaymentMethod, this hash contains details about the EPS payment
         /// method.
         /// </summary>
@@ -139,8 +146,8 @@ namespace Stripe
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
         /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
-        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>eps</c>, <c>fpx</c>,
-        /// <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>eps</c>,
+        /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
         /// <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsBoletoOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsBoletoOptions.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsBoletoOptions : INestedOptions
+    {
+        /// <summary>
+        /// The number of calendar days before a Boleto voucher expires. For example, if you create
+        /// a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will
+        /// expire on Wednesday at 23:59 America/Sao_Paulo time.
+        /// </summary>
+        [JsonProperty("expires_after_days")]
+        public long? ExpiresAfterDays { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -34,6 +34,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsBancontactOptions Bancontact { get; set; }
 
         /// <summary>
+        /// If this is a <c>boleto</c> PaymentMethod, this sub-hash contains details about the
+        /// Boleto payment method options.
+        /// </summary>
+        [JsonProperty("boleto")]
+        public PaymentIntentPaymentMethodOptionsBoletoOptions Boleto { get; set; }
+
+        /// <summary>
         /// Configuration for any card payments attempted on this PaymentIntent.
         /// </summary>
         [JsonProperty("card")]

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodBoletoOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodBoletoOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodBoletoOptions : INestedOptions
+    {
+        /// <summary>
+        /// Uniquely identifies this customer tax_id (CNPJ or CPF).
+        /// </summary>
+        [JsonProperty("tax_id")]
+        public string TaxId { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
@@ -55,6 +55,13 @@ namespace Stripe
         [JsonProperty("billing_details")]
         public PaymentMethodBillingDetailsOptions BillingDetails { get; set; }
 
+        /// <summary>
+        /// If this is a <c>boleto</c> PaymentMethod, this hash contains details about the Boleto
+        /// payment method.
+        /// </summary>
+        [JsonProperty("boleto")]
+        public PaymentMethodBoletoOptions Boleto { get; set; }
+
         [JsonProperty("card")]
         public PaymentMethodCardOptions Card { get; set; }
 
@@ -154,9 +161,9 @@ namespace Stripe
         /// a name matching this value. It contains additional information specific to the
         /// PaymentMethod type.
         /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
-        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>card</c>, <c>eps</c>,
-        /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>, <c>p24</c>,
-        /// <c>sepa_debit</c>, or <c>sofort</c>.
+        /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>card</c>,
+        /// <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>oxxo</c>,
+        /// <c>p24</c>, <c>sepa_debit</c>, or <c>sofort</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/TaxIds/TaxIdCreateOptions.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdCreateOptions.cs
@@ -9,18 +9,19 @@ namespace Stripe
         /// Type of the tax ID, one of <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>,
         /// <c>ca_bn</c>, <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>,
         /// <c>ca_qst</c>, <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>,
-        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>,
-        /// <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
+        /// <c>gb_vat</c>, <c>hk_br</c>, <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>,
+        /// <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>,
         /// <c>my_sst</c>, <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>,
         /// <c>sa_vat</c>, <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>,
         /// <c>us_ein</c>, or <c>za_vat</c>.
         /// One of: <c>ae_trn</c>, <c>au_abn</c>, <c>br_cnpj</c>, <c>br_cpf</c>, <c>ca_bn</c>,
         /// <c>ca_gst_hst</c>, <c>ca_pst_bc</c>, <c>ca_pst_mb</c>, <c>ca_pst_sk</c>, <c>ca_qst</c>,
         /// <c>ch_vat</c>, <c>cl_tin</c>, <c>es_cif</c>, <c>eu_vat</c>, <c>gb_vat</c>, <c>hk_br</c>,
-        /// <c>id_npwp</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>, <c>li_uid</c>,
-        /// <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>, <c>no_vat</c>,
-        /// <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>, <c>sg_gst</c>,
-        /// <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or <c>za_vat</c>.
+        /// <c>id_npwp</c>, <c>il_vat</c>, <c>in_gst</c>, <c>jp_cn</c>, <c>jp_rn</c>, <c>kr_brn</c>,
+        /// <c>li_uid</c>, <c>mx_rfc</c>, <c>my_frp</c>, <c>my_itn</c>, <c>my_sst</c>,
+        /// <c>no_vat</c>, <c>nz_gst</c>, <c>ru_inn</c>, <c>ru_kpp</c>, <c>sa_vat</c>,
+        /// <c>sg_gst</c>, <c>sg_uen</c>, <c>th_vat</c>, <c>tw_vat</c>, <c>us_ein</c>, or
+        /// <c>za_vat</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }


### PR DESCRIPTION
Codegen for openapi d12f3f1.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `boleto` on `ChargePaymentMethodDetails`, `PaymentIntentPaymentMethodOptions`, `PaymentMethod`, `PaymentIntentPaymentMethodDataOptions`, `PaymentIntentPaymentMethodOptionsOptions`, and `PaymentMethodCreateOptions`.
* Added support for `boleto_display_details` on `PaymentIntentNextAction`
