### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/Session.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Checkout
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
@@ -19,6 +20,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <summary>
+        /// When set, provides configuration for actions to take if this Checkout Session expires.
+        /// </summary>
+        [JsonProperty("after_expiration")]
+        public SessionAfterExpiration AfterExpiration { get; set; }
 
         /// <summary>
         /// Enables user redeemable promotion codes.
@@ -61,6 +68,19 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("client_reference_id")]
         public string ClientReferenceId { get; set; }
+
+        /// <summary>
+        /// Results of <c>consent_collection</c> for this session.
+        /// </summary>
+        [JsonProperty("consent")]
+        public SessionConsent Consent { get; set; }
+
+        /// <summary>
+        /// When set, provides configuration for the Checkout Session to gather active consent from
+        /// customers.
+        /// </summary>
+        [JsonProperty("consent_collection")]
+        public SessionConsentCollection ConsentCollection { get; set; }
 
         /// <summary>
         /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
@@ -122,6 +142,13 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("customer_email")]
         public string CustomerEmail { get; set; }
+
+        /// <summary>
+        /// The timestamp at which the Checkout Session will expire.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ExpiresAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
         /// The line items purchased by the customer.
@@ -217,6 +244,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("payment_status")]
         public string PaymentStatus { get; set; }
+
+        /// <summary>
+        /// The ID of the original expired Checkout Session that triggered the recovery flow.
+        /// </summary>
+        [JsonProperty("recovered_from")]
+        public string RecoveredFrom { get; set; }
 
         #region Expandable SetupIntent
 

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpiration.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpiration.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionAfterExpiration : StripeEntity<SessionAfterExpiration>
+    {
+        /// <summary>
+        /// When set, configuration used to recover the Checkout Session on expiry.
+        /// </summary>
+        [JsonProperty("recovery")]
+        public SessionAfterExpirationRecovery Recovery { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpirationRecovery.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpirationRecovery.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SessionAfterExpirationRecovery : StripeEntity<SessionAfterExpirationRecovery>
+    {
+        /// <summary>
+        /// Enables user redeemable promotion codes on the recovered Checkout Sessions. Defaults to
+        /// <c>false</c>.
+        /// </summary>
+        [JsonProperty("allow_promotion_codes")]
+        public bool? AllowPromotionCodes { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, a recovery url will be generated to recover this Checkout Session if it
+        /// expires before a transaction is completed. It will be attached to the Checkout Session
+        /// object upon expiration.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        /// <summary>
+        /// The timestamp at which the recovery URL will expire.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// URL that creates a new Checkout Session when clicked that is a copy of this expired
+        /// Checkout Session.
+        /// </summary>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpirationRecovery.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionAfterExpirationRecovery.cs
@@ -12,7 +12,7 @@ namespace Stripe.Checkout
         /// <c>false</c>.
         /// </summary>
         [JsonProperty("allow_promotion_codes")]
-        public bool? AllowPromotionCodes { get; set; }
+        public bool AllowPromotionCodes { get; set; }
 
         /// <summary>
         /// If <c>true</c>, a recovery url will be generated to recover this Checkout Session if it
@@ -20,7 +20,7 @@ namespace Stripe.Checkout
         /// object upon expiration.
         /// </summary>
         [JsonProperty("enabled")]
-        public bool? Enabled { get; set; }
+        public bool Enabled { get; set; }
 
         /// <summary>
         /// The timestamp at which the recovery URL will expire.

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionConsent.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionConsent.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionConsent : StripeEntity<SessionConsent>
+    {
+        /// <summary>
+        /// If <c>opt_in</c>, the customer consents to receiving promotional communications from the
+        /// merchant about this Checkout Session.
+        /// One of: <c>opt_in</c>, or <c>opt_out</c>.
+        /// </summary>
+        [JsonProperty("promotions")]
+        public string Promotions { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionConsentCollection.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionConsentCollection.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionConsentCollection : StripeEntity<SessionConsentCollection>
+    {
+        /// <summary>
+        /// If set to <c>auto</c>, enables the collection of customer consent for promotional
+        /// communications. The Checkout Session will determine whether to display an option to opt
+        /// into promotional communication from the merchant depending on the customer's locale.
+        /// Only available to US merchants.
+        /// </summary>
+        [JsonProperty("promotions")]
+        public string Promotions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionAfterExpirationOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionAfterExpirationOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionAfterExpirationOptions : INestedOptions
+    {
+        /// <summary>
+        /// Configure a Checkout Session that can be used to recover an expired session.
+        /// </summary>
+        [JsonProperty("recovery")]
+        public SessionAfterExpirationRecoveryOptions Recovery { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionAfterExpirationRecoveryOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionAfterExpirationRecoveryOptions.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionAfterExpirationRecoveryOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables user redeemable promotion codes on the recovered Checkout Sessions. Defaults to
+        /// <c>false</c>.
+        /// </summary>
+        [JsonProperty("allow_promotion_codes")]
+        public bool? AllowPromotionCodes { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, a recovery url will be generated to recover this Checkout Session if it
+        /// expires before a successful transaction is completed. It will be attached to the
+        /// Checkout Session object upon expiration.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionConsentCollectionOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionConsentCollectionOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionConsentCollectionOptions : INestedOptions
+    {
+        /// <summary>
+        /// If set to <c>auto</c>, enables the collection of customer consent for promotional
+        /// communications. The Checkout Session will determine whether to display an option to opt
+        /// into promotional communication from the merchant depending on the customer's locale.
+        /// Only available to US merchants.
+        /// </summary>
+        [JsonProperty("promotions")]
+        public string Promotions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -1,11 +1,19 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Checkout
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class SessionCreateOptions : BaseOptions, IHasMetadata
     {
+        /// <summary>
+        /// Configure actions after a Checkout Session has expired.
+        /// </summary>
+        [JsonProperty("after_expiration")]
+        public SessionAfterExpirationOptions AfterExpiration { get; set; }
+
         /// <summary>
         /// Enables user redeemable promotion codes.
         /// </summary>
@@ -39,6 +47,12 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("client_reference_id")]
         public string ClientReferenceId { get; set; }
+
+        /// <summary>
+        /// Configure fields for the Checkout Session to gather active consent from customers.
+        /// </summary>
+        [JsonProperty("consent_collection")]
+        public SessionConsentCollectionOptions ConsentCollection { get; set; }
 
         /// <summary>
         /// ID of an existing Customer, if one exists. In <c>payment</c> mode, the customer’s most
@@ -85,6 +99,15 @@ namespace Stripe.Checkout
         /// </summary>
         [JsonProperty("discounts")]
         public List<SessionDiscountOptions> Discounts { get; set; }
+
+        /// <summary>
+        /// The Epoch time in seconds at which the Checkout Session will expire. It can be anywhere
+        /// from 1 to 24 hours after Checkout Session creation. By default, this value is 24 hours
+        /// from creation.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// A list of items the customer is purchasing. Use this parameter to pass one-time or


### PR DESCRIPTION
Codegen for openapi 944e56f.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `AfterExpiration`, `ConsentCollection`, and `ExpiresAt` on `CheckoutSessionCreateOptions` and `CheckoutSession`
* Add support for `Consent` and `RecoveredFrom` on `CheckoutSession`

