### PR TITLE
[wip] API Updates

### DIFF
--- a/src/Stripe.net/Services/UsageRecords/UsageRecordCreateOptions.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordCreateOptions.cs
@@ -1,7 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    using System;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
@@ -27,10 +26,12 @@ namespace Stripe
 
         /// <summary>
         /// The timestamp for the usage event. This timestamp must be within the current billing
-        /// period of the subscription of the provided <c>subscription_item</c>.
+        /// period of the subscription of the provided <c>subscription_item</c>, and must not be in
+        /// the future. When passing <c>"now"</c>, Stripe records usage for the current time.
+        /// Default is <c>"now"</c> if a value is not provided.
         /// </summary>
         [JsonProperty("timestamp")]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime? Timestamp { get; set; }
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<long?, UsageRecordTimestamp> Timestamp { get; set; }
     }
 }


### PR DESCRIPTION
Codegen for openapi 1f5d304.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Change type of `UsageRecordTimestampOptions` from `integer` to `literal('now') | integer`

