### PR TITLE
Add missing events to Events.cs

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -55,6 +55,16 @@ namespace Stripe
         public const string BalanceAvailable = "balance.available";
 
         /// <summary>
+        /// Occurs whenever a portal configuration is created.
+        /// </summary>
+        public const string BillingPortalConfigurationCreated = "billing_portal.configuration.created";
+
+        /// <summary>
+        /// Occurs whenever a portal configuration is updated.
+        /// </summary>
+        public const string BillingPortalConfigurationUpdated = "billing_portal.configuration.updated";
+
+        /// <summary>
         /// Occurs whenever a capability has new requirements or a new status.
         /// </summary>
         public const string CapabilityUpdated = "capability.updated";
@@ -141,6 +151,11 @@ namespace Stripe
         /// Occurs when a Checkout Session has been successfully completed.
         /// </summary>
         public const string CheckoutSessionCompleted = "checkout.session.completed";
+
+        /// <summary>
+        /// Occurs when a Checkout Session is expired.
+        /// </summary>
+        public const string CheckoutSessionExpired = "checkout.session.expired";
 
         /// <summary>
         /// Occurs whenever a coupon is created.
@@ -319,9 +334,14 @@ namespace Stripe
         public const string InvoiceDeleted = "invoice.deleted";
 
         /// <summary>
-        /// Occurs whenever a draft invoice cannot be finalized.
+        /// Deprecated, use InvoiceFinalizationFailed.
         /// </summary>
         public const string InvoiceFinalizationError = "invoice.finalization_error";
+
+        /// <summary>
+        /// Occurs whenever a draft invoice cannot be finalized.
+        /// </summary>
+        public const string InvoiceFinalizationFailed = "invoice.finalization_failed";
 
         /// <summary>
         ///  Occurs whenever a draft invoice is finalized and updated to be an open invoice.
@@ -658,6 +678,26 @@ namespace Stripe
         public const string PromotionCodeUpdated = "promotion_code.updated";
 
         /// <summary>
+        /// Occurs whenever a quote is accepted.
+        /// </summary>
+        public const string QuoteAccepted = "quote.accepted";
+
+        /// <summary>
+        /// Occurs whenever a quote is canceled.
+        /// </summary>
+        public const string QuoteCanceled = "quote.canceled";
+
+        /// <summary>
+        /// Occurs whenever a quote is created.
+        /// </summary>
+        public const string QuoteCreated = "quote.created";
+
+        /// <summary>
+        /// Occurs whenever a quote is finalized.
+        /// </summary>
+        public const string QuoteFinalized = "quote.finalized";
+
+        /// <summary>
         /// Occurs whenever an early fraud warning is created.
         /// </summary>
         public const string RadarEarlyFraudWarningCreated = "radar.early_fraud_warning.created";
@@ -865,6 +905,16 @@ namespace Stripe
         /// Occurs whenever a new transfer is created.
         /// </summary>
         public const string TransferCreated = "transfer.created";
+
+        /// <summary>
+        /// Occurs whenever a transfer failed.
+        /// </summary>
+        public const string TransferFailed = "transfer.failed";
+
+        /// <summary>
+        /// Occurs after a transfer is paid. For Instant Payouts, the event will typically be sent within 30 minutes.
+        /// </summary>
+        public const string TransferPaid = "transfer.paid";
 
         /// <summary>
         /// Occurs whenever a transfer is reversed, including partial reversals.

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -915,7 +915,6 @@ namespace Stripe
         /// Occurs after a transfer is paid. For Instant Payouts, the event will typically be sent within 30 minutes.
         /// </summary>
         public const string TransferPaid = "transfer.paid";
-
         /// <summary>
         /// Occurs whenever a transfer is reversed, including partial reversals.
         /// </summary>

--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -907,15 +907,6 @@ namespace Stripe
         public const string TransferCreated = "transfer.created";
 
         /// <summary>
-        /// Occurs whenever a transfer failed.
-        /// </summary>
-        public const string TransferFailed = "transfer.failed";
-
-        /// <summary>
-        /// Occurs after a transfer is paid. For Instant Payouts, the event will typically be sent within 30 minutes.
-        /// </summary>
-        public const string TransferPaid = "transfer.paid";
-        /// <summary>
         /// Occurs whenever a transfer is reversed, including partial reversals.
         /// </summary>
         public const string TransferReversed = "transfer.reversed";


### PR DESCRIPTION
## Notify
r? @remi-stripe 
cc @stripe/api-libraries 

## Changelog
* Add support for `BillingPortalConfigurationCreated`, `BillingPortalConfigurationUpdated`, `CheckoutSessionExpired`, `InvoiceFinalizationFailed`, `QuoteAccepted`, `QuoteCanceled`, `QuoteCreated`, `QuoteFinalized`, `TransferFailed`, and `TransferPaid` on `Events`

* Marks `InvoiceFinalizationError` as deprecated. This has been `InvoiceFinalizationFailed` in recent versions of the Stripe API.