### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -632,6 +632,7 @@ namespace Stripe
 
         /// <summary>
         /// The status of the payment is either <c>succeeded</c>, <c>pending</c>, or <c>failed</c>.
+        /// One of: <c>failed</c>, <c>pending</c>, or <c>succeeded</c>.
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionWechatPayDisplayQrCode.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionWechatPayDisplayQrCode.cs
@@ -16,5 +16,17 @@ namespace Stripe
         /// </summary>
         [JsonProperty("image_data_url")]
         public string ImageDataUrl { get; set; }
+
+        /// <summary>
+        /// The image_url_png string used to render QR code, can be used as &lt;img src="…" /&gt;.
+        /// </summary>
+        [JsonProperty("image_url_png")]
+        public string ImageUrlPng { get; set; }
+
+        /// <summary>
+        /// The image_url_svg string used to render QR code, can be used as &lt;img src="…" /&gt;.
+        /// </summary>
+        [JsonProperty("image_url_svg")]
+        public string ImageUrlSvg { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -17,6 +17,9 @@ namespace Stripe
         [JsonProperty("au_becs_debit")]
         public PaymentIntentPaymentMethodOptionsAuBecsDebit AuBecsDebit { get; set; }
 
+        [JsonProperty("bacs_debit")]
+        public PaymentIntentPaymentMethodOptionsBacsDebit BacsDebit { get; set; }
+
         [JsonProperty("bancontact")]
         public PaymentIntentPaymentMethodOptionsBancontact Bancontact { get; set; }
 
@@ -28,6 +31,9 @@ namespace Stripe
 
         [JsonProperty("card_present")]
         public PaymentIntentPaymentMethodOptionsCardPresent CardPresent { get; set; }
+
+        [JsonProperty("eps")]
+        public PaymentIntentPaymentMethodOptionsEps Eps { get; set; }
 
         [JsonProperty("fpx")]
         public PaymentIntentPaymentMethodOptionsFpx Fpx { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsBacsDebit.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsBacsDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsBacsDebit : StripeEntity<PaymentIntentPaymentMethodOptionsBacsDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsEps.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsEps.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsEps : StripeEntity<PaymentIntentPaymentMethodOptionsEps>
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsBacsDebitOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsBacsDebitOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsBacsDebitOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsEpsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsEpsOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodOptionsEpsOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -34,6 +34,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsAuBecsDebitOptions AuBecsDebit { get; set; }
 
         /// <summary>
+        /// If this is a <c>bacs_debit</c> PaymentMethod, this sub-hash contains details about the
+        /// BACS Debit payment method options.
+        /// </summary>
+        [JsonProperty("bacs_debit")]
+        public PaymentIntentPaymentMethodOptionsBacsDebitOptions BacsDebit { get; set; }
+
+        /// <summary>
         /// If this is a <c>bancontact</c> PaymentMethod, this sub-hash contains details about the
         /// Bancontact payment method options.
         /// </summary>
@@ -59,6 +66,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("card_present")]
         public PaymentIntentPaymentMethodOptionsCardPresentOptions CardPresent { get; set; }
+
+        /// <summary>
+        /// If this is a <c>eps</c> PaymentMethod, this sub-hash contains details about the EPS
+        /// payment method options.
+        /// </summary>
+        [JsonProperty("eps")]
+        public PaymentIntentPaymentMethodOptionsEpsOptions Eps { get; set; }
 
         /// <summary>
         /// If this is a <c>fpx</c> PaymentMethod, this sub-hash contains details about the FPX


### PR DESCRIPTION
Codegen for openapi 7734045.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `BacsDebit` and `Eps` on `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodOptionsOptions`, and `PaymentIntentPaymentMethodOptions`
* Add support for `ImageUrlPng` and `ImageUrlSvg` on `PaymentIntentNextActionWechatPayDisplayQrCode`

