### PR TITLE
API Updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.118.0
+  STRIPE_MOCK_VERSION: 0.119.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -223,5 +223,36 @@ namespace Stripe
         /// </summary>
         [JsonProperty("tax_ids")]
         public StripeList<TaxId> TaxIds { get; set; }
+
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this customer belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this customer belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
     }
 }

--- a/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
+++ b/src/Stripe.net/Entities/InvoiceItems/InvoiceItem.cs
@@ -254,6 +254,37 @@ namespace Stripe
         [JsonProperty("tax_rates")]
         public List<TaxRate> TaxRates { get; set; }
 
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this invoice item belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this invoice item belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
+
         /// <summary>
         /// Unit amount (in the <c>currency</c> specified) of the invoice item.
         /// </summary>

--- a/src/Stripe.net/Entities/Invoices/Invoice.cs
+++ b/src/Stripe.net/Entities/Invoices/Invoice.cs
@@ -769,6 +769,37 @@ namespace Stripe
         [JsonProperty("tax")]
         public long? Tax { get; set; }
 
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this invoice belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this invoice belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
+
         [JsonProperty("threshold_reason")]
         public InvoiceThresholdReason ThresholdReason { get; set; }
 

--- a/src/Stripe.net/Entities/Quotes/Quote.cs
+++ b/src/Stripe.net/Entities/Quotes/Quote.cs
@@ -388,6 +388,37 @@ namespace Stripe
         internal ExpandableField<SubscriptionSchedule> InternalSubscriptionSchedule { get; set; }
         #endregion
 
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this quote belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this quote belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
+
         [JsonProperty("total_details")]
         public QuoteTotalDetails TotalDetails { get; set; }
 

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -165,6 +165,9 @@ namespace Stripe
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; }
 
+        [JsonProperty("next_action")]
+        public RefundNextAction NextAction { get; set; }
+
         #region Expandable PaymentIntent
 
         /// <summary>

--- a/src/Stripe.net/Entities/Refunds/RefundNextAction.cs
+++ b/src/Stripe.net/Entities/Refunds/RefundNextAction.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class RefundNextAction : StripeEntity<RefundNextAction>
+    {
+        /// <summary>
+        /// Contains the refund details.
+        /// </summary>
+        [JsonProperty("display_details")]
+        public RefundNextActionDisplayDetails DisplayDetails { get; set; }
+
+        /// <summary>
+        /// Type of the next action to perform.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Refunds/RefundNextActionDisplayDetails.cs
+++ b/src/Stripe.net/Entities/Refunds/RefundNextActionDisplayDetails.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class RefundNextActionDisplayDetails : StripeEntity<RefundNextActionDisplayDetails>
+    {
+        [JsonProperty("email_sent")]
+        public RefundNextActionDisplayDetailsEmailSent EmailSent { get; set; }
+
+        /// <summary>
+        /// The expiry timestamp.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ExpiresAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+    }
+}

--- a/src/Stripe.net/Entities/Refunds/RefundNextActionDisplayDetailsEmailSent.cs
+++ b/src/Stripe.net/Entities/Refunds/RefundNextActionDisplayDetailsEmailSent.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class RefundNextActionDisplayDetailsEmailSent : StripeEntity<RefundNextActionDisplayDetailsEmailSent>
+    {
+        /// <summary>
+        /// The timestamp when the email was sent.
+        /// </summary>
+        [JsonProperty("email_sent_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime EmailSentAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The recipient's email address.
+        /// </summary>
+        [JsonProperty("email_sent_to")]
+        public string EmailSentTo { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedule.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedule.cs
@@ -177,5 +177,36 @@ namespace Stripe
         [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]
         internal ExpandableField<Subscription> InternalSubscription { get; set; }
         #endregion
+
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this subscription schedule belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this subscription schedule belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
     }
 }

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -454,6 +454,37 @@ namespace Stripe
         [JsonProperty("status")]
         public string Status { get; set; }
 
+        #region Expandable TestClock
+
+        /// <summary>
+        /// (ID of the TestHelpers.TestClock)
+        /// ID of the test clock this subscription belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public string TestClockId
+        {
+            get => this.InternalTestClock?.Id;
+            set => this.InternalTestClock = SetExpandableFieldId(value, this.InternalTestClock);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the test clock this subscription belongs to.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public TestHelpers.TestClock TestClock
+        {
+            get => this.InternalTestClock?.ExpandedObject;
+            set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
+        }
+
+        [JsonProperty("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+        internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
+        #endregion
+
         /// <summary>
         /// The account (if any) the subscription's payments will be attributed to for tax
         /// reporting, and where funds from each payment will be transferred to for each of the

--- a/src/Stripe.net/Entities/TestHelpers/TestClocks/TestClock.cs
+++ b/src/Stripe.net/Entities/TestHelpers/TestClocks/TestClock.cs
@@ -1,0 +1,70 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// A test clock enables deterministic control over objects in testmode. With a test clock,
+    /// you can create objects at a frozen time in the past or future, and advance to a specific
+    /// future time to observe webhooks and state changes. After the clock advances, you can
+    /// either validate the current state of your scenario (and test your assumptions), change
+    /// the current state of your scenario (and test more complex scenarios), or keep advancing
+    /// forward in time.
+    /// </summary>
+    public class TestClock : StripeEntity<TestClock>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Whether this object is deleted or not.
+        /// </summary>
+        [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Deleted { get; set; }
+
+        /// <summary>
+        /// Time at which all objects belonging to this clock are frozen.
+        /// </summary>
+        [JsonProperty("frozen_time")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime FrozenTime { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// The custom name supplied at creation.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The status of the Test Clock.
+        /// One of: <c>advancing</c>, <c>internal_failure</c>, or <c>ready</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -112,6 +112,7 @@ namespace Stripe
                 },
                 { "terminal.location", typeof(Terminal.Location) },
                 { "terminal.reader", typeof(Terminal.Reader) },
+                { "test_helpers.test_clock", typeof(TestHelpers.TestClock) },
                 { "token", typeof(Token) },
                 { "topup", typeof(Topup) },
                 { "transfer", typeof(Transfer) },

--- a/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerCreateOptions.cs
@@ -130,6 +130,12 @@ namespace Stripe
         [JsonProperty("tax_id_data")]
         public List<CustomerTaxIdDataOptions> TaxIdData { get; set; }
 
+        /// <summary>
+        /// ID of the test clock to attach to the customer.
+        /// </summary>
+        [JsonProperty("test_clock")]
+        public string TestClock { get; set; }
+
         [JsonProperty("trial_end")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, SubscriptionTrialEnd> TrialEnd { get; set; }

--- a/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceCreateOptions.cs
@@ -146,6 +146,19 @@ namespace Stripe
         public InvoicePaymentSettingsOptions PaymentSettings { get; set; }
 
         /// <summary>
+        /// How to handle pending invoice items on invoice creation. One of <c>include</c>,
+        /// <c>include_and_require</c>, or <c>exclude</c>. <c>include</c> will include any pending
+        /// invoice items, and will create an empty draft invoice if no pending invoice items exist.
+        /// <c>include_and_require</c> will include any pending invoice items, if no pending invoice
+        /// items exist then the request will fail. <c>exclude</c> will always create an empty
+        /// invoice draft regardless if there are pending invoice items or not. Defaults to
+        /// <c>include_and_require</c> if the parameter is omitted.
+        /// One of: <c>exclude</c>, <c>include</c>, or <c>include_and_require</c>.
+        /// </summary>
+        [JsonProperty("pending_invoice_items_behavior")]
+        public string PendingInvoiceItemsBehavior { get; set; }
+
+        /// <summary>
         /// Extra information about a charge for the customer's credit card statement. It must
         /// contain at least one letter. If not specified and this invoice is part of a
         /// subscription, the default <c>statement_descriptor</c> will be set to the first

--- a/src/Stripe.net/Services/Quotes/QuoteCreateOptions.cs
+++ b/src/Stripe.net/Services/Quotes/QuoteCreateOptions.cs
@@ -147,6 +147,12 @@ namespace Stripe
         public QuoteSubscriptionDataOptions SubscriptionData { get; set; }
 
         /// <summary>
+        /// ID of the test clock to attach to the quote.
+        /// </summary>
+        [JsonProperty("test_clock")]
+        public string TestClock { get; set; }
+
+        /// <summary>
         /// The data with which to automatically create a Transfer for each of the invoices.
         /// </summary>
         [JsonProperty("transfer_data")]

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockAdvanceOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockAdvanceOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TestClockAdvanceOptions : BaseOptions
+    {
+        /// <summary>
+        /// The time to advance the test clock. Must be after the test clock's current frozen time.
+        /// Cannot be more than two intervals in the future from the shortest subscription in this
+        /// test clock. If there are no subscriptions in this test clock, it cannot be more than two
+        /// years in the future.
+        /// </summary>
+        [JsonProperty("frozen_time")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? FrozenTime { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockCreateOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockCreateOptions.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TestClockCreateOptions : BaseOptions
+    {
+        /// <summary>
+        /// The initial frozen time for this test clock.
+        /// </summary>
+        [JsonProperty("frozen_time")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? FrozenTime { get; set; }
+
+        /// <summary>
+        /// The name for this test clock.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockDeleteOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockDeleteOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    public class TestClockDeleteOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockGetOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    public class TestClockGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockListOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockListOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    public class TestClockListOptions : ListOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
@@ -1,0 +1,87 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class TestClockService : Service<TestClock>,
+        ICreatable<TestClock, TestClockCreateOptions>,
+        IDeletable<TestClock, TestClockDeleteOptions>,
+        IListable<TestClock, TestClockListOptions>,
+        IRetrievable<TestClock, TestClockGetOptions>
+    {
+        public TestClockService()
+            : base(null)
+        {
+        }
+
+        public TestClockService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/test_clocks";
+
+        public virtual TestClock Advance(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/advance", options, requestOptions);
+        }
+
+        public virtual Task<TestClock> AdvanceAsync(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/advance", options, requestOptions, cancellationToken);
+        }
+
+        public virtual TestClock Create(TestClockCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<TestClock> CreateAsync(TestClockCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual TestClock Delete(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.DeleteEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<TestClock> DeleteAsync(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual TestClock Get(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<TestClock> GetAsync(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<TestClock> List(TestClockListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<TestClock>> ListAsync(TestClockListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<TestClock> ListAutoPaging(TestClockListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<TestClock> ListAutoPagingAsync(TestClockListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -2487,6 +2487,57 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTestHelpersTestClockServiceAdvance()
+        {
+            var options = new Stripe.TestHelpers.TestClockAdvanceOptions
+            {
+                FrozenTime = DateTimeOffset.FromUnixTimeSeconds(142)
+                    .UtcDateTime,
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Advance("clock_xyz", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceCreate()
+        {
+            var options = new Stripe.TestHelpers.TestClockCreateOptions
+            {
+                FrozenTime = DateTimeOffset.FromUnixTimeSeconds(123)
+                    .UtcDateTime,
+                Name = "cogsworth",
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceDelete()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Delete("clock_xyz");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceList()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            StripeList<Stripe.TestHelpers.TestClock> testclocks = service.List();
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceRetrieve()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Get("clock_xyz");
+        }
+
+        [Fact]
         public void TestTokenServiceRetrieve()
         {
             var service = new TokenService(this.StripeClient);

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -13,7 +13,7 @@ namespace StripeTests
         /// If you bump this, don't forget to bump <c>STRIPE_MOCK_VERSION</c> in <c>appveyor.yml</c>
         /// as well.
         /// </remarks>
-        private const string MockMinimumVersion = "0.118.0";
+        private const string MockMinimumVersion = "0.119.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Codegen for openapi 1707cb8.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `TestHelpers.TestClock`
* Add support for `TestClock` on `CustomerCreateOptions`, `Customer`, `Invoice`, `InvoiceItem`, `QuoteCreateOptions`, `Quote`, `Subscription`, and `SubscriptionSchedule`
* Add support for `PendingInvoiceItemsBehavior` on `InvoiceCreateOptions`
* Change type of `ProductUrlOptions` from `string` to `emptyStringable(string)`
* Add support for `NextAction` on `Refund`

