### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsCard.cs
@@ -93,6 +93,12 @@ namespace Stripe
         public string Last4 { get; set; }
 
         /// <summary>
+        /// ID of the mandate used to make this payment or created by it.
+        /// </summary>
+        [JsonProperty("mandate")]
+        public string Mandate { get; set; }
+
+        /// <summary>
         /// True if this payment was marked as MOTO and out of scope for SCA.
         /// </summary>
         [JsonProperty("moto")]

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
@@ -11,6 +11,9 @@ namespace Stripe
         [JsonProperty("boleto_display_details")]
         public PaymentIntentNextActionBoletoDisplayDetails BoletoDisplayDetails { get; set; }
 
+        [JsonProperty("card_await_notification")]
+        public PaymentIntentNextActionCardAwaitNotification CardAwaitNotification { get; set; }
+
         [JsonProperty("konbini_display_details")]
         public PaymentIntentNextActionKonbiniDisplayDetails KonbiniDisplayDetails { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionCardAwaitNotification.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionCardAwaitNotification.cs
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentNextActionCardAwaitNotification : StripeEntity<PaymentIntentNextActionCardAwaitNotification>
+    {
+        /// <summary>
+        /// The time that payment will be attempted. If customer approval is required, they need to
+        /// provide approval before this time.
+        /// </summary>
+        [JsonProperty("charge_attempt_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ChargeAttemptAt { get; set; }
+
+        /// <summary>
+        /// For payments greater than INR 5000, the customer must provide explicit approval of the
+        /// payment with their bank. For payments of lower amount, no customer action is required.
+        /// </summary>
+        [JsonProperty("customer_approval_required")]
+        public bool? CustomerApprovalRequired { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -15,6 +15,12 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsCardInstallments Installments { get; set; }
 
         /// <summary>
+        /// Configuration options for setting up an eMandate for cards issued in India.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public PaymentIntentPaymentMethodOptionsCardMandateOptions MandateOptions { get; set; }
+
+        /// <summary>
         /// Selected network to process this payment intent on. Depends on the available networks of
         /// the card attached to the payment intent. Can be only set confirm-time.
         /// One of: <c>amex</c>, <c>cartes_bancaires</c>, <c>diners</c>, <c>discover</c>,

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardMandateOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCardMandateOptions.cs
@@ -1,0 +1,78 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentPaymentMethodOptionsCardMandateOptions : StripeEntity<PaymentIntentPaymentMethodOptionsCardMandateOptions>
+    {
+        /// <summary>
+        /// Amount to be charged for future payments.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// One of <c>fixed</c> or <c>maximum</c>. If <c>fixed</c>, the <c>amount</c> param refers
+        /// to the exact amount to be charged in future payments. If <c>maximum</c>, the amount
+        /// charged can be up to the value passed for the <c>amount</c> param.
+        /// One of: <c>fixed</c>, or <c>maximum</c>.
+        /// </summary>
+        [JsonProperty("amount_type")]
+        public string AmountType { get; set; }
+
+        /// <summary>
+        /// A description of the mandate or subscription that is meant to be displayed to the
+        /// customer.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// End date of the mandate or subscription. If not provided, the mandate will be active
+        /// until canceled. If provided, end date should be after start date.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Specifies payment frequency. One of <c>day</c>, <c>week</c>, <c>month</c>, <c>year</c>,
+        /// or <c>sporadic</c>.
+        /// One of: <c>day</c>, <c>month</c>, <c>sporadic</c>, <c>week</c>, or <c>year</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// The number of intervals between payments. For example, <c>interval=month</c> and
+        /// <c>interval_count=3</c> indicates one payment every three months. Maximum of one year
+        /// interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when
+        /// <c>interval=sporadic</c>.
+        /// </summary>
+        [JsonProperty("interval_count")]
+        public long? IntervalCount { get; set; }
+
+        /// <summary>
+        /// Unique identifier for the mandate or subscription.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// Start date of the mandate or subscription. Start date should not be lesser than
+        /// yesterday.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime StartDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Specifies the type of mandates supported. Possible values are <c>india</c>.
+        /// </summary>
+        [JsonProperty("supported_types")]
+        public List<string> SupportedTypes { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentProcessingCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentProcessingCard.cs
@@ -1,7 +1,11 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using Newtonsoft.Json;
+
     public class PaymentIntentProcessingCard : StripeEntity<PaymentIntentProcessingCard>
     {
+        [JsonProperty("customer_notification")]
+        public PaymentIntentProcessingCardCustomerNotification CustomerNotification { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentProcessingCardCustomerNotification.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentProcessingCardCustomerNotification.cs
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentProcessingCardCustomerNotification : StripeEntity<PaymentIntentProcessingCardCustomerNotification>
+    {
+        /// <summary>
+        /// Whether customer approval has been requested for this payment. For payments greater than
+        /// INR 5000 or mandate amount, the customer must provide explicit approval of the payment
+        /// with their bank.
+        /// </summary>
+        [JsonProperty("approval_requested")]
+        public bool? ApprovalRequested { get; set; }
+
+        /// <summary>
+        /// If customer approval is required, they need to provide approval before this time.
+        /// </summary>
+        [JsonProperty("completes_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CompletesAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCard.cs
@@ -6,6 +6,12 @@ namespace Stripe
     public class SetupIntentPaymentMethodOptionsCard : StripeEntity<SetupIntentPaymentMethodOptionsCard>
     {
         /// <summary>
+        /// Configuration options for setting up an eMandate for cards issued in India.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsCardMandateOptions MandateOptions { get; set; }
+
+        /// <summary>
         /// We strongly recommend that you rely on our SCA Engine to automatically prompt your
         /// customers for authentication based on risk level and <a
         /// href="https://stripe.com/docs/strong-customer-authentication">other requirements</a>.

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCardMandateOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsCardMandateOptions.cs
@@ -1,0 +1,86 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SetupIntentPaymentMethodOptionsCardMandateOptions : StripeEntity<SetupIntentPaymentMethodOptionsCardMandateOptions>
+    {
+        /// <summary>
+        /// Amount to be charged for future payments.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// One of <c>fixed</c> or <c>maximum</c>. If <c>fixed</c>, the <c>amount</c> param refers
+        /// to the exact amount to be charged in future payments. If <c>maximum</c>, the amount
+        /// charged can be up to the value passed for the <c>amount</c> param.
+        /// One of: <c>fixed</c>, or <c>maximum</c>.
+        /// </summary>
+        [JsonProperty("amount_type")]
+        public string AmountType { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A description of the mandate or subscription that is meant to be displayed to the
+        /// customer.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// End date of the mandate or subscription. If not provided, the mandate will be active
+        /// until canceled. If provided, end date should be after start date.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Specifies payment frequency. One of <c>day</c>, <c>week</c>, <c>month</c>, <c>year</c>,
+        /// or <c>sporadic</c>.
+        /// One of: <c>day</c>, <c>month</c>, <c>sporadic</c>, <c>week</c>, or <c>year</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// The number of intervals between payments. For example, <c>interval=month</c> and
+        /// <c>interval_count=3</c> indicates one payment every three months. Maximum of one year
+        /// interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when
+        /// <c>interval=sporadic</c>.
+        /// </summary>
+        [JsonProperty("interval_count")]
+        public long? IntervalCount { get; set; }
+
+        /// <summary>
+        /// Unique identifier for the mandate or subscription.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// Start date of the mandate or subscription. Start date should not be lesser than
+        /// yesterday.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime StartDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Specifies the type of mandates supported. Possible values are <c>india</c>.
+        /// </summary>
+        [JsonProperty("supported_types")]
+        public List<string> SupportedTypes { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardMandateOptionsOptions.cs
@@ -1,0 +1,78 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentIntentPaymentMethodOptionsCardMandateOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Amount to be charged for future payments.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// One of <c>fixed</c> or <c>maximum</c>. If <c>fixed</c>, the <c>amount</c> param refers
+        /// to the exact amount to be charged in future payments. If <c>maximum</c>, the amount
+        /// charged can be up to the value passed for the <c>amount</c> param.
+        /// One of: <c>fixed</c>, or <c>maximum</c>.
+        /// </summary>
+        [JsonProperty("amount_type")]
+        public string AmountType { get; set; }
+
+        /// <summary>
+        /// A description of the mandate or subscription that is meant to be displayed to the
+        /// customer.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// End date of the mandate or subscription. If not provided, the mandate will be active
+        /// until canceled. If provided, end date should be after start date.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Specifies payment frequency. One of <c>day</c>, <c>week</c>, <c>month</c>, <c>year</c>,
+        /// or <c>sporadic</c>.
+        /// One of: <c>day</c>, <c>month</c>, <c>sporadic</c>, <c>week</c>, or <c>year</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// The number of intervals between payments. For example, <c>interval=month</c> and
+        /// <c>interval_count=3</c> indicates one payment every three months. Maximum of one year
+        /// interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when
+        /// <c>interval=sporadic</c>.
+        /// </summary>
+        [JsonProperty("interval_count")]
+        public long? IntervalCount { get; set; }
+
+        /// <summary>
+        /// Unique identifier for the mandate or subscription.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// Start date of the mandate or subscription. Start date should not be lesser than
+        /// yesterday.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>
+        /// Specifies the type of mandates supported. Possible values are <c>india</c>.
+        /// </summary>
+        [JsonProperty("supported_types")]
+        public List<string> SupportedTypes { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
@@ -23,6 +23,12 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsCardInstallmentsOptions Installments { get; set; }
 
         /// <summary>
+        /// Configuration options for setting up an eMandate for cards issued in India.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public PaymentIntentPaymentMethodOptionsCardMandateOptionsOptions MandateOptions { get; set; }
+
+        /// <summary>
         /// When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
         /// Order Telephone Order) and thus out of scope for SCA. This parameter can only be
         /// provided during confirmation.

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardMandateOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardMandateOptionsOptions.cs
@@ -1,0 +1,87 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class SetupIntentPaymentMethodOptionsCardMandateOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Amount to be charged for future payments.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// One of <c>fixed</c> or <c>maximum</c>. If <c>fixed</c>, the <c>amount</c> param refers
+        /// to the exact amount to be charged in future payments. If <c>maximum</c>, the amount
+        /// charged can be up to the value passed for the <c>amount</c> param.
+        /// One of: <c>fixed</c>, or <c>maximum</c>.
+        /// </summary>
+        [JsonProperty("amount_type")]
+        public string AmountType { get; set; }
+
+        /// <summary>
+        /// Currency in which future payments will be charged. Three-letter <a
+        /// href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in
+        /// lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A description of the mandate or subscription that is meant to be displayed to the
+        /// customer.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// End date of the mandate or subscription. If not provided, the mandate will be active
+        /// until canceled. If provided, end date should be after start date.
+        /// </summary>
+        [JsonProperty("end_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Specifies payment frequency. One of <c>day</c>, <c>week</c>, <c>month</c>, <c>year</c>,
+        /// or <c>sporadic</c>.
+        /// One of: <c>day</c>, <c>month</c>, <c>sporadic</c>, <c>week</c>, or <c>year</c>.
+        /// </summary>
+        [JsonProperty("interval")]
+        public string Interval { get; set; }
+
+        /// <summary>
+        /// The number of intervals between payments. For example, <c>interval=month</c> and
+        /// <c>interval_count=3</c> indicates one payment every three months. Maximum of one year
+        /// interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when
+        /// <c>interval=sporadic</c>.
+        /// </summary>
+        [JsonProperty("interval_count")]
+        public long? IntervalCount { get; set; }
+
+        /// <summary>
+        /// Unique identifier for the mandate or subscription.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>
+        /// Start date of the mandate or subscription. Start date should not be lesser than
+        /// yesterday.
+        /// </summary>
+        [JsonProperty("start_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>
+        /// Specifies the type of mandates supported. Possible values are <c>india</c>.
+        /// </summary>
+        [JsonProperty("supported_types")]
+        public List<string> SupportedTypes { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsCardOptions.cs
@@ -6,6 +6,12 @@ namespace Stripe
     public class SetupIntentPaymentMethodOptionsCardOptions : INestedOptions
     {
         /// <summary>
+        /// Configuration options for setting up an eMandate for cards issued in India.
+        /// </summary>
+        [JsonProperty("mandate_options")]
+        public SetupIntentPaymentMethodOptionsCardMandateOptionsOptions MandateOptions { get; set; }
+
+        /// <summary>
         /// When specified, this parameter signals that a card has been collected as MOTO (Mail
         /// Order Telephone Order) and thus out of scope for SCA. This parameter can only be
         /// provided during confirmation.


### PR DESCRIPTION
Codegen for openapi c671651.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `Mandate` on `ChargePaymentMethodDetailsCard`
* Add support for `MandateOptions` on `PaymentIntentPaymentMethodOptionsCardOptions`, `PaymentIntentPaymentMethodOptionsCardOptions`, `PaymentIntentPaymentMethodOptionsCardOptions`, `PaymentIntentPaymentMethodOptionsCard`, `SetupIntentPaymentMethodOptionsCardOptions`, `SetupIntentPaymentMethodOptionsCardOptions`, `SetupIntentPaymentMethodOptionsCardOptions`, and `SetupIntentPaymentMethodOptionsCard`
* Add support for `CardAwaitNotification` on `PaymentIntentNextAction`
* Add support for `CustomerNotification` on `PaymentIntentProcessingCard`

