### PR TITLE
Add missing enums for File purpose

### DIFF
--- a/src/Stripe.net/Constants/FilePurpose.cs
+++ b/src/Stripe.net/Constants/FilePurpose.cs
@@ -2,6 +2,8 @@ namespace Stripe
 {
     public static class FilePurpose
     {
+        public const string AccountRequirement = "account_requirement";
+
         public const string AdditionalVerification = "additional_verification";
 
         public const string BusinessIcon = "business_icon";
@@ -18,6 +20,8 @@ namespace Stripe
 
         public const string IdentityDocument = "identity_document";
 
+        public const string IdentityDocumentDownloadable = "identity_document_downloadable";
+
         public const string IncorporationArticle = "incorporation_article";
 
         public const string IncorporationDocument = "incorporation_document";
@@ -25,6 +29,8 @@ namespace Stripe
         public const string PaymentProviderTransfer = "payment_provider_transfer";
 
         public const string PciDocument = "pci_document";
+
+        public const string Selfie = "selfie";
 
         public const string ProductFeed = "product_feed";
 


### PR DESCRIPTION
Adds enum values missing, extracted from the `purpose` [property](https://stripe.com/docs/api/files/object#file_object-purpose) and [parameter](https://stripe.com/docs/api/files/create#create_file-purpose)

r? @richardm-stripe 
cc @stripe/api-libraries 