### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -65,7 +65,7 @@ namespace Stripe
         public string Country { get; set; }
 
         /// <summary>
-        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// Time at which the account was connected. Measured in seconds since the Unix epoch.
         /// </summary>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixDateTimeConverter))]

--- a/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
@@ -165,6 +165,14 @@ namespace Stripe
         public string P24Payments { get; set; }
 
         /// <summary>
+        /// The status of the paynow payments capability of the account, or whether the account can
+        /// directly process paynow charges.
+        /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
+        /// </summary>
+        [JsonProperty("paynow_payments")]
+        public string PaynowPayments { get; set; }
+
+        /// <summary>
         /// The status of the SEPA Direct Debits payments capability of the account, or whether the
         /// account can directly process SEPA Direct Debits charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
@@ -201,5 +209,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("transfers")]
         public string Transfers { get; set; }
+
+        /// <summary>
+        /// The status of the US bank account ACH payments capability of the account, or whether the
+        /// account can directly process US bank account charges.
+        /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account_ach_payments")]
+        public string UsBankAccountAchPayments { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Charges/Charge.cs
+++ b/src/Stripe.net/Entities/Charges/Charge.cs
@@ -308,6 +308,39 @@ namespace Stripe
         [JsonProperty("disputed")]
         public bool Disputed { get; set; }
 
+        #region Expandable FailureBalanceTransaction
+
+        /// <summary>
+        /// (ID of the BalanceTransaction)
+        /// ID of the balance transaction that describes the reversal of the balance on your account
+        /// due to payment failure.
+        /// </summary>
+        [JsonIgnore]
+        public string FailureBalanceTransactionId
+        {
+            get => this.InternalFailureBalanceTransaction?.Id;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldId(value, this.InternalFailureBalanceTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the balance transaction that describes the reversal of the balance on your account
+        /// due to payment failure.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public BalanceTransaction FailureBalanceTransaction
+        {
+            get => this.InternalFailureBalanceTransaction?.ExpandedObject;
+            set => this.InternalFailureBalanceTransaction = SetExpandableFieldObject(value, this.InternalFailureBalanceTransaction);
+        }
+
+        [JsonProperty("failure_balance_transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<BalanceTransaction>))]
+        internal ExpandableField<BalanceTransaction> InternalFailureBalanceTransaction { get; set; }
+        #endregion
+
         /// <summary>
         /// Error code explaining reason for charge failure if available (see <a
         /// href="https://stripe.com/docs/api#errors">the errors section</a> for a list of codes).

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetails.cs
@@ -71,6 +71,9 @@ namespace Stripe
         [JsonProperty("p24")]
         public ChargePaymentMethodDetailsP24 P24 { get; set; }
 
+        [JsonProperty("paynow")]
+        public ChargePaymentMethodDetailsPaynow Paynow { get; set; }
+
         [JsonProperty("sepa_debit")]
         public ChargePaymentMethodDetailsSepaDebit SepaDebit { get; set; }
 
@@ -91,6 +94,9 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public ChargePaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
 
         [JsonProperty("wechat")]
         public ChargePaymentMethodDetailsWechat Wechat { get; set; }

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsPaynow.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsPaynow.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class ChargePaymentMethodDetailsPaynow : StripeEntity<ChargePaymentMethodDetailsPaynow>
+    {
+        /// <summary>
+        /// Reference number associated with this PayNow payment.
+        /// </summary>
+        [JsonProperty("reference")]
+        public string Reference { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Charges/ChargePaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class ChargePaymentMethodDetailsUsBankAccount : StripeEntity<ChargePaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
@@ -16,5 +16,8 @@ namespace Stripe.Checkout
 
         [JsonProperty("oxxo")]
         public SessionPaymentMethodOptionsOxxo Oxxo { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public SessionPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsUsBankAccount.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsUsBankAccount : StripeEntity<SessionPaymentMethodOptionsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, or <c>instant</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Invoices/InvoicePaymentSettingsPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoicePaymentSettingsPaymentMethodOptions.cs
@@ -32,5 +32,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("konbini")]
         public InvoicePaymentSettingsPaymentMethodOptionsKonbini Konbini { get; set; }
+
+        /// <summary>
+        /// If paying by <c>us_bank_account</c>, this sub-hash contains details about the ACH direct
+        /// debit payment method options to pass to the invoice’s PaymentIntent.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Invoices/InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount : StripeEntity<InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetails.cs
@@ -27,5 +27,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public MandatePaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Mandates/MandatePaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class MandatePaymentMethodDetailsUsBankAccount : StripeEntity<MandatePaymentMethodDetailsUsBankAccount>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
@@ -20,6 +20,9 @@ namespace Stripe
         [JsonProperty("oxxo_display_details")]
         public PaymentIntentNextActionOxxoDisplayDetails OxxoDisplayDetails { get; set; }
 
+        [JsonProperty("paynow_display_qr_code")]
+        public PaymentIntentNextActionPaynowDisplayQrCode PaynowDisplayQrCode { get; set; }
+
         [JsonProperty("redirect_to_url")]
         public PaymentIntentNextActionRedirectToUrl RedirectToUrl { get; set; }
 

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionPaynowDisplayQrCode.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionPaynowDisplayQrCode.cs
@@ -1,0 +1,27 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentNextActionPaynowDisplayQrCode : StripeEntity<PaymentIntentNextActionPaynowDisplayQrCode>
+    {
+        /// <summary>
+        /// The raw data string used to generate QR code, it should be used together with QR code
+        /// library.
+        /// </summary>
+        [JsonProperty("data")]
+        public string Data { get; set; }
+
+        /// <summary>
+        /// The image_url_png string used to render QR code.
+        /// </summary>
+        [JsonProperty("image_url_png")]
+        public string ImageUrlPng { get; set; }
+
+        /// <summary>
+        /// The image_url_svg string used to render QR code.
+        /// </summary>
+        [JsonProperty("image_url_svg")]
+        public string ImageUrlSvg { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionVerifyWithMicrodeposits.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionVerifyWithMicrodeposits.cs
@@ -20,5 +20,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("hosted_verification_url")]
         public string HostedVerificationUrl { get; set; }
+
+        /// <summary>
+        /// The type of the microdeposit sent to the customer. Used to distinguish between different
+        /// verification methods.
+        /// One of: <c>amounts</c>, or <c>descriptor_code</c>.
+        /// </summary>
+        [JsonProperty("microdeposit_type")]
+        public string MicrodepositType { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptions.cs
@@ -62,11 +62,17 @@ namespace Stripe
         [JsonProperty("p24")]
         public PaymentIntentPaymentMethodOptionsP24 P24 { get; set; }
 
+        [JsonProperty("paynow")]
+        public PaymentIntentPaymentMethodOptionsPaynow Paynow { get; set; }
+
         [JsonProperty("sepa_debit")]
         public PaymentIntentPaymentMethodOptionsSepaDebit SepaDebit { get; set; }
 
         [JsonProperty("sofort")]
         public PaymentIntentPaymentMethodOptionsSofort Sofort { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public PaymentIntentPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }
 
         [JsonProperty("wechat_pay")]
         public PaymentIntentPaymentMethodOptionsWechatPay WechatPay { get; set; }

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAfterpayClearpay.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsAfterpayClearpay.cs
@@ -6,6 +6,12 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsAfterpayClearpay : StripeEntity<PaymentIntentPaymentMethodOptionsAfterpayClearpay>
     {
         /// <summary>
+        /// Controls when the funds will be captured from the customer's account.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
         /// Order identifier shown to the customer in Afterpay’s online portal. We recommend using a
         /// value that helps you answer any questions a customer might have about the payment. The
         /// identifier is limited to 128 characters and may contain only letters, digits,

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsCard.cs
@@ -6,6 +6,12 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsCard : StripeEntity<PaymentIntentPaymentMethodOptionsCard>
     {
         /// <summary>
+        /// Controls when the funds will be captured from the customer's account.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
         /// Installment details for this payment (Mexico only).
         ///
         /// For more information, see the <a

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsPaynow.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsPaynow.cs
@@ -3,20 +3,8 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class PaymentIntentPaymentMethodOptionsKlarna : StripeEntity<PaymentIntentPaymentMethodOptionsKlarna>
+    public class PaymentIntentPaymentMethodOptionsPaynow : StripeEntity<PaymentIntentPaymentMethodOptionsPaynow>
     {
-        /// <summary>
-        /// Controls when the funds will be captured from the customer's account.
-        /// </summary>
-        [JsonProperty("capture_method")]
-        public string CaptureMethod { get; set; }
-
-        /// <summary>
-        /// Preferred locale of the Klarna checkout page that the customer is redirected to.
-        /// </summary>
-        [JsonProperty("preferred_locale")]
-        public string PreferredLocale { get; set; }
-
         /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment
         /// method.

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccount.cs
@@ -3,20 +3,8 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class PaymentIntentPaymentMethodOptionsKlarna : StripeEntity<PaymentIntentPaymentMethodOptionsKlarna>
+    public class PaymentIntentPaymentMethodOptionsUsBankAccount : StripeEntity<PaymentIntentPaymentMethodOptionsUsBankAccount>
     {
-        /// <summary>
-        /// Controls when the funds will be captured from the customer's account.
-        /// </summary>
-        [JsonProperty("capture_method")]
-        public string CaptureMethod { get; set; }
-
-        /// <summary>
-        /// Preferred locale of the Klarna checkout page that the customer is redirected to.
-        /// </summary>
-        [JsonProperty("preferred_locale")]
-        public string PreferredLocale { get; set; }
-
         /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment
         /// method.
@@ -32,8 +20,16 @@ namespace Stripe
         /// When processing card payments, Stripe also uses <c>setup_future_usage</c> to dynamically
         /// optimize your payment flow and comply with regional legislation and network rules, such
         /// as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+        /// One of: <c>none</c>, <c>off_session</c>, or <c>on_session</c>.
         /// </summary>
         [JsonProperty("setup_future_usage")]
         public string SetupFutureUsage { get; set; }
+
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethod.cs
@@ -145,6 +145,9 @@ namespace Stripe
         [JsonProperty("p24")]
         public PaymentMethodP24 P24 { get; set; }
 
+        [JsonProperty("paynow")]
+        public PaymentMethodPaynow Paynow { get; set; }
+
         [JsonProperty("sepa_debit")]
         public PaymentMethodSepaDebit SepaDebit { get; set; }
 
@@ -159,10 +162,14 @@ namespace Stripe
         /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>card</c>,
         /// <c>card_present</c>, <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>,
         /// <c>ideal</c>, <c>interac_present</c>, <c>klarna</c>, <c>konbini</c>, <c>oxxo</c>,
-        /// <c>p24</c>, <c>sepa_debit</c>, <c>sofort</c>, or <c>wechat_pay</c>.
+        /// <c>p24</c>, <c>paynow</c>, <c>sepa_debit</c>, <c>sofort</c>, <c>us_bank_account</c>, or
+        /// <c>wechat_pay</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public PaymentMethodUsBankAccount UsBankAccount { get; set; }
 
         [JsonProperty("wechat_pay")]
         public PaymentMethodWechatPay WechatPay { get; set; }

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodPaynow.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodPaynow.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentMethodPaynow : StripeEntity<PaymentMethodPaynow>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccount.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccount.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodUsBankAccount : StripeEntity<PaymentMethodUsBankAccount>
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// The name of the bank.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetails.cs
@@ -42,5 +42,8 @@ namespace Stripe
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public SetupAttemptPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/SetupAttempts/SetupAttemptPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class SetupAttemptPaymentMethodDetailsUsBankAccount : StripeEntity<SetupAttemptPaymentMethodDetailsUsBankAccount>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionVerifyWithMicrodeposits.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentNextActionVerifyWithMicrodeposits.cs
@@ -20,5 +20,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("hosted_verification_url")]
         public string HostedVerificationUrl { get; set; }
+
+        /// <summary>
+        /// The type of the microdeposit sent to the customer. Used to distinguish between different
+        /// verification methods.
+        /// One of: <c>amounts</c>, or <c>descriptor_code</c>.
+        /// </summary>
+        [JsonProperty("microdeposit_type")]
+        public string MicrodepositType { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptions.cs
@@ -13,5 +13,8 @@ namespace Stripe
 
         [JsonProperty("sepa_debit")]
         public SetupIntentPaymentMethodOptionsSepaDebit SepaDebit { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public SetupIntentPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccount.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsUsBankAccount : StripeEntity<SetupIntentPaymentMethodOptionsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptions.cs
@@ -32,5 +32,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("konbini")]
         public SubscriptionPaymentSettingsPaymentMethodOptionsKonbini Konbini { get; set; }
+
+        /// <summary>
+        /// This sub-hash contains details about the ACH direct debit payment method options to pass
+        /// to invoices created by the subscription.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount : StripeEntity<SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank account verification method.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountCapabilitiesOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCapabilitiesOptions.cs
@@ -126,6 +126,12 @@ namespace Stripe
         public AccountCapabilitiesP24PaymentsOptions P24Payments { get; set; }
 
         /// <summary>
+        /// The paynow_payments capability.
+        /// </summary>
+        [JsonProperty("paynow_payments")]
+        public AccountCapabilitiesPaynowPaymentsOptions PaynowPayments { get; set; }
+
+        /// <summary>
         /// The sepa_debit_payments capability.
         /// </summary>
         [JsonProperty("sepa_debit_payments")]
@@ -154,5 +160,11 @@ namespace Stripe
         /// </summary>
         [JsonProperty("transfers")]
         public AccountCapabilitiesTransfersOptions Transfers { get; set; }
+
+        /// <summary>
+        /// The us_bank_account_ach_payments capability.
+        /// </summary>
+        [JsonProperty("us_bank_account_ach_payments")]
+        public AccountCapabilitiesUsBankAccountAchPaymentsOptions UsBankAccountAchPayments { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Accounts/AccountCapabilitiesPaynowPaymentsOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCapabilitiesPaynowPaymentsOptions.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class AccountCapabilitiesPaynowPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Passing true requests the capability for the account, if it is not already requested. A
+        /// requested capability may not immediately become active. Any requirements to activate the
+        /// capability are returned in the <c>requirements</c> arrays.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Accounts/AccountCapabilitiesUsBankAccountAchPaymentsOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCapabilitiesUsBankAccountAchPaymentsOptions.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class AccountCapabilitiesUsBankAccountAchPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Passing true requests the capability for the account, if it is not already requested. A
+        /// requested capability may not immediately become active. Any requirements to activate the
+        /// capability are returned in the <c>requirements</c> arrays.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsOptions.cs
@@ -30,6 +30,12 @@ namespace Stripe.Checkout
         public SessionPaymentMethodOptionsOxxoOptions Oxxo { get; set; }
 
         /// <summary>
+        /// contains details about the Us Bank Account payment method options.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public SessionPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
+
+        /// <summary>
         /// contains details about the WeChat Pay payment method options.
         /// </summary>
         [JsonProperty("wechat_pay")]

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    using Newtonsoft.Json;
+
+    public class SessionPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, or <c>instant</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Invoices/InvoicePaymentSettingsPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoicePaymentSettingsPaymentMethodOptionsOptions.cs
@@ -32,5 +32,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("konbini")]
         public InvoicePaymentSettingsPaymentMethodOptionsKonbiniOptions Konbini { get; set; }
+
+        /// <summary>
+        /// If paying by <c>us_bank_account</c>, this sub-hash contains details about the ACH direct
+        /// debit payment method options to pass to the invoice’s PaymentIntent.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public InvoicePaymentSettingsPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoicePaymentSettingsPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoicePaymentSettingsPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class InvoicePaymentSettingsPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataOptions.cs
@@ -142,6 +142,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodDataP24Options P24 { get; set; }
 
         /// <summary>
+        /// If this is a <c>paynow</c> PaymentMethod, this hash contains details about the PayNow
+        /// payment method.
+        /// </summary>
+        [JsonProperty("paynow")]
+        public PaymentIntentPaymentMethodDataPaynowOptions Paynow { get; set; }
+
+        /// <summary>
         /// If this is a <c>sepa_debit</c> PaymentMethod, this hash contains details about the SEPA
         /// debit bank account.
         /// </summary>
@@ -162,10 +169,18 @@ namespace Stripe
         /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
         /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>eps</c>,
         /// <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>klarna</c>, <c>konbini</c>,
-        /// <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, <c>sofort</c>, or <c>wechat_pay</c>.
+        /// <c>oxxo</c>, <c>p24</c>, <c>paynow</c>, <c>sepa_debit</c>, <c>sofort</c>,
+        /// <c>us_bank_account</c>, or <c>wechat_pay</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        /// <summary>
+        /// If this is an <c>us_bank_account</c> PaymentMethod, this hash contains details about the
+        /// US bank account payment method.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public PaymentIntentPaymentMethodDataUsBankAccountOptions UsBankAccount { get; set; }
 
         /// <summary>
         /// If this is an <c>wechat_pay</c> PaymentMethod, this hash contains details about the

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataPaynowOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataPaynowOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentIntentPaymentMethodDataPaynowOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodDataUsBankAccountOptions.cs
@@ -1,0 +1,34 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodDataUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account number of the bank account.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsCardOptions.cs
@@ -6,6 +6,18 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsCardOptions : INestedOptions
     {
         /// <summary>
+        /// Controls when the funds will be captured from the customer's account.
+        ///
+        /// If provided, this parameter will override the top-level <c>capture_method</c> when
+        /// finalizing the payment with this payment method type.
+        ///
+        /// If <c>capture_method</c> is already set on the PaymentIntent, providing an empty value
+        /// for this parameter will unset the stored value for this payment method type.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
         /// A single-use <c>cvc_update</c> Token that represents a card CVC value. When provided,
         /// the CVC value will be verified during the card payment attempt. This parameter can only
         /// be provided during confirmation.

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsKlarnaOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsKlarnaOptions.cs
@@ -6,6 +6,18 @@ namespace Stripe
     public class PaymentIntentPaymentMethodOptionsKlarnaOptions : INestedOptions
     {
         /// <summary>
+        /// Controls when the funds will be captured from the customer's account.
+        ///
+        /// If provided, this parameter will override the top-level <c>capture_method</c> when
+        /// finalizing the payment with this payment method type.
+        ///
+        /// If <c>capture_method</c> is already set on the PaymentIntent, providing an empty value
+        /// for this parameter will unset the stored value for this payment method type.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
         /// Preferred language of the Klarna authorization page that the customer is redirected to.
         /// One of: <c>da-DK</c>, <c>de-AT</c>, <c>de-DE</c>, <c>en-AT</c>, <c>en-BE</c>,
         /// <c>en-DE</c>, <c>en-DK</c>, <c>en-ES</c>, <c>en-FI</c>, <c>en-FR</c>, <c>en-GB</c>,

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsOptions.cs
@@ -138,6 +138,13 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsP24Options P24 { get; set; }
 
         /// <summary>
+        /// If this is a <c>paynow</c> PaymentMethod, this sub-hash contains details about the
+        /// PayNow payment method options.
+        /// </summary>
+        [JsonProperty("paynow")]
+        public PaymentIntentPaymentMethodOptionsPaynowOptions Paynow { get; set; }
+
+        /// <summary>
         /// If this is a <c>sepa_debit</c> PaymentIntent, this sub-hash contains details about the
         /// SEPA Debit payment method options.
         /// </summary>
@@ -150,6 +157,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("sofort")]
         public PaymentIntentPaymentMethodOptionsSofortOptions Sofort { get; set; }
+
+        /// <summary>
+        /// If this is a <c>us_bank_account</c> PaymentMethod, this sub-hash contains details about
+        /// the US bank account payment method options.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public PaymentIntentPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
 
         /// <summary>
         /// If this is a <c>wechat_pay</c> PaymentMethod, this sub-hash contains details about the

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsPaynowOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsPaynowOptions.cs
@@ -3,29 +3,8 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class PaymentIntentPaymentMethodOptionsAfterpayClearpayOptions : INestedOptions
+    public class PaymentIntentPaymentMethodOptionsPaynowOptions : INestedOptions
     {
-        /// <summary>
-        /// Controls when the funds will be captured from the customer's account.
-        ///
-        /// If provided, this parameter will override the top-level <c>capture_method</c> when
-        /// finalizing the payment with this payment method type.
-        ///
-        /// If <c>capture_method</c> is already set on the PaymentIntent, providing an empty value
-        /// for this parameter will unset the stored value for this payment method type.
-        /// </summary>
-        [JsonProperty("capture_method")]
-        public string CaptureMethod { get; set; }
-
-        /// <summary>
-        /// Order identifier shown to the customer in Afterpay’s online portal. We recommend using a
-        /// value that helps you answer any questions a customer might have about the payment. The
-        /// identifier is limited to 128 characters and may contain only letters, digits,
-        /// underscores, backslashes and dashes.
-        /// </summary>
-        [JsonProperty("reference")]
-        public string Reference { get; set; }
-
         /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment
         /// method.

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountOptions.cs
@@ -3,29 +3,8 @@ namespace Stripe
 {
     using Newtonsoft.Json;
 
-    public class PaymentIntentPaymentMethodOptionsAfterpayClearpayOptions : INestedOptions
+    public class PaymentIntentPaymentMethodOptionsUsBankAccountOptions : INestedOptions
     {
-        /// <summary>
-        /// Controls when the funds will be captured from the customer's account.
-        ///
-        /// If provided, this parameter will override the top-level <c>capture_method</c> when
-        /// finalizing the payment with this payment method type.
-        ///
-        /// If <c>capture_method</c> is already set on the PaymentIntent, providing an empty value
-        /// for this parameter will unset the stored value for this payment method type.
-        /// </summary>
-        [JsonProperty("capture_method")]
-        public string CaptureMethod { get; set; }
-
-        /// <summary>
-        /// Order identifier shown to the customer in Afterpay’s online portal. We recommend using a
-        /// value that helps you answer any questions a customer might have about the payment. The
-        /// identifier is limited to 128 characters and may contain only letters, digits,
-        /// underscores, backslashes and dashes.
-        /// </summary>
-        [JsonProperty("reference")]
-        public string Reference { get; set; }
-
         /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment
         /// method.
@@ -48,5 +27,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("setup_future_usage")]
         public string SetupFutureUsage { get; set; }
+
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
     }
 }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentVerifyMicrodepositsOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentVerifyMicrodepositsOptions.cs
@@ -12,5 +12,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("amounts")]
         public List<long?> Amounts { get; set; }
+
+        /// <summary>
+        /// A six-character code starting with SM present in the microdeposit sent to the bank
+        /// account.
+        /// </summary>
+        [JsonProperty("descriptor_code")]
+        public string DescriptorCode { get; set; }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodCreateOptions.cs
@@ -157,6 +157,13 @@ namespace Stripe
         public string PaymentMethod { get; set; }
 
         /// <summary>
+        /// If this is a <c>paynow</c> PaymentMethod, this hash contains details about the PayNow
+        /// payment method.
+        /// </summary>
+        [JsonProperty("paynow")]
+        public PaymentMethodPaynowOptions Paynow { get; set; }
+
+        /// <summary>
         /// If this is a <c>sepa_debit</c> PaymentMethod, this hash contains details about the SEPA
         /// debit bank account.
         /// </summary>
@@ -177,11 +184,18 @@ namespace Stripe
         /// One of: <c>acss_debit</c>, <c>afterpay_clearpay</c>, <c>alipay</c>,
         /// <c>au_becs_debit</c>, <c>bacs_debit</c>, <c>bancontact</c>, <c>boleto</c>, <c>card</c>,
         /// <c>eps</c>, <c>fpx</c>, <c>giropay</c>, <c>grabpay</c>, <c>ideal</c>, <c>klarna</c>,
-        /// <c>konbini</c>, <c>oxxo</c>, <c>p24</c>, <c>sepa_debit</c>, <c>sofort</c>, or
-        /// <c>wechat_pay</c>.
+        /// <c>konbini</c>, <c>oxxo</c>, <c>p24</c>, <c>paynow</c>, <c>sepa_debit</c>,
+        /// <c>sofort</c>, <c>us_bank_account</c>, or <c>wechat_pay</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
+
+        /// <summary>
+        /// If this is an <c>us_bank_account</c> PaymentMethod, this hash contains details about the
+        /// US bank account payment method.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public PaymentMethodUsBankAccountOptions UsBankAccount { get; set; }
 
         /// <summary>
         /// If this is an <c>wechat_pay</c> PaymentMethod, this hash contains details about the

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodPaynowOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodPaynowOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class PaymentMethodPaynowOptions : INestedOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodUpdateOptions.cs
@@ -55,5 +55,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("sepa_debit")]
         public PaymentMethodSepaDebitOptions SepaDebit { get; set; }
+
+        /// <summary>
+        /// If this is an <c>us_bank_account</c> PaymentMethod, this hash contains details about the
+        /// US bank account payment method.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public PaymentMethodUsBankAccountOptions UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodUsBankAccountOptions.cs
@@ -1,0 +1,34 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentMethodUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account number of the bank account.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsOptions.cs
@@ -24,5 +24,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("sepa_debit")]
         public SetupIntentPaymentMethodOptionsSepaDebitOptions SepaDebit { get; set; }
+
+        /// <summary>
+        /// If this is a <c>us_bank_account</c> SetupIntent, this sub-hash contains details about
+        /// the US bank account payment method options.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public SetupIntentPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentVerifyMicrodepositsOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentVerifyMicrodepositsOptions.cs
@@ -12,5 +12,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("amounts")]
         public List<long?> Amounts { get; set; }
+
+        /// <summary>
+        /// A six-character code starting with SM present in the microdeposit sent to the bank
+        /// account.
+        /// </summary>
+        [JsonProperty("descriptor_code")]
+        public string DescriptorCode { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
@@ -29,5 +29,8 @@ namespace Stripe
 
         [JsonProperty("status")]
         public string Status { get; set; }
+
+        [JsonProperty("test_clock")]
+        public string TestClock { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsOptions.cs
@@ -32,5 +32,12 @@ namespace Stripe
         /// </summary>
         [JsonProperty("konbini")]
         public SubscriptionPaymentSettingsPaymentMethodOptionsKonbiniOptions Konbini { get; set; }
+
+        /// <summary>
+        /// This sub-hash contains details about the ACH direct debit payment method options to pass
+        /// to the invoice’s PaymentIntent.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Verification method for the intent.
+        /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}


### PR DESCRIPTION
Codegen for openapi dc3ef48.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for PayNow and US Bank Accounts Debits payments
    * **Charge** ([API ref](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details))
        * Add support for `Paynow` and `UsBankAccount` on `ChargePaymentMethodDetails`
    * **Mandate** ([API ref](https://stripe.com/docs/api/mandates/object#mandate_object-payment_method_details))
        * Add support for `UsBankAccount` on `MandatePaymentMethodDetails`
    * **Payment Intent** ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options))
        * Add support for `Paynow` and `UsBankAccount` on `PaymentIntentPaymentMethodOptions`, `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodDataOptions`
        * Add support for `PaynowDisplayQrCode` on `PaymentIntentNextAction`
    * **Setup Intent** ([API ref](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options))
        * Add support for `UsBankAccount` on `SetupIntentPaymentMethodOptionsOptions` and `SetupIntentPaymentMethodOptions`
    * **Setup Attempt** ([API ref](https://stripe.com/docs/api/setup_attempts/object#setup_attempt_object-payment_method_details))
        * Add support for `UsBankAccount` on `SetupAttemptPaymentMethodDetails`
    * **Payment Method** ([API ref](https://stripe.com/docs/api/payment_methods/object#payment_method_object-paynow))
        * Add support for `Paynow` and `UsBankAccount` on `PaymentMethod` and `PaymentMethodCreateOptions`
        * Add support for `UsBankAccount` on `PaymentMethodUpdateOptions`
    * **Checkout Session** ([API ref](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types))
        * Add support for `UsBankAccount` on `CheckoutSessionPaymentMethodOptions` and `CheckoutSessionPaymentMethodOptionsOptions`
    * **Invoice** ([API ref](https://stripe.com/docs/api/invoices/object#invoice_object-payment_settings-payment_method_types))
        * Add support for `UsBankAccount` on `InvoicePaymentSettingsPaymentMethodOptions` and `InvoicePaymentSettingsPaymentMethodOptionsOptions`
    * **Subscription** ([API ref](https://stripe.com/docs/api/subscriptions/object#subscription_object-payment_settings-payment_method_types))
        * Add support for `UsBankAccount` on `SubscriptionPaymentSettingsPaymentMethodOptions` and `SubscriptionPaymentSettingsPaymentMethodOptionsOptions`
    * **Account capabilities** ([API ref](https://stripe.com/docs/api/accounts/object#account_object-capabilities))
    * Add support for `PaynowPayments` and `UsBankAccountAchPayments` on `AccountCapabilities` and `AccountCapabilitiesParams`
* Add support for `FailureBalanceTransaction` on `Charge`
* Add support for `TestClock` on `SubscriptionListOptions`
* Add support for `CaptureMethod` on `PaymentIntentPaymentMethodOptionsAfterpayClearpayOptions`, `PaymentIntentPaymentMethodOptionsAfterpayClearpay`, `PaymentIntentPaymentMethodOptionsCardOptions`, `PaymentIntentPaymentMethodOptionsCard`, `PaymentIntentPaymentMethodOptionsKlarnaOptions`, `PaymentIntentPaymentMethodOptionsKlarna`, and `PaymentIntentTypeSpecificPaymentMethodOptionsClient`
* Add additional support for verify microdeposits on Payment Intent and Setup Intent ([API ref](https://stripe.com/docs/api/payment_intents/verify_microdeposits))
    * Add support for `DescriptorCode` on `PaymentIntentVerifyMicrodepositsOptions` and `SetupIntentVerifyMicrodepositsOptions`
    * Add support for `MicrodepositType` on `PaymentIntentNextActionVerifyWithMicrodeposits` and `SetupIntentNextActionVerifyWithMicrodeposits`
