### PR TITLE
API Updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: T0PmP8uyzCseacBCDRBlti2y9Tz5DL6fknea0MKWvbPYrzADmLY2/5kOTfYIsPUk
   # If you bump this, don't forget to bump `MinimumMockVersion` in `StripeMockFixture.cs` as well.
-  STRIPE_MOCK_VERSION: 0.120.1
+  STRIPE_MOCK_VERSION: 0.122.0
 
 deploy:
 - provider: NuGet

--- a/src/Stripe.net/Entities/Products/Product.cs
+++ b/src/Stripe.net/Entities/Products/Product.cs
@@ -107,8 +107,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The product's name, meant to be displayable to the customer. Whenever this product is
-        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// The product's name, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/Reader.cs
@@ -26,6 +26,12 @@ namespace Stripe.Terminal
         public string Object { get; set; }
 
         /// <summary>
+        /// The most recent action performed by the reader.
+        /// </summary>
+        [JsonProperty("action")]
+        public ReaderAction Action { get; set; }
+
+        /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderAction.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderAction.cs
@@ -1,0 +1,53 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderAction : StripeEntity<ReaderAction>
+    {
+        /// <summary>
+        /// Failure code, only set if status is <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failure_code")]
+        public string FailureCode { get; set; }
+
+        /// <summary>
+        /// Detailed failure message, only set if status is <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failure_message")]
+        public string FailureMessage { get; set; }
+
+        /// <summary>
+        /// Represents a reader action to process a payment intent.
+        /// </summary>
+        [JsonProperty("process_payment_intent")]
+        public ReaderActionProcessPaymentIntent ProcessPaymentIntent { get; set; }
+
+        /// <summary>
+        /// Represents a reader action to process a setup intent.
+        /// </summary>
+        [JsonProperty("process_setup_intent")]
+        public ReaderActionProcessSetupIntent ProcessSetupIntent { get; set; }
+
+        /// <summary>
+        /// Represents a reader action to set the reader display.
+        /// </summary>
+        [JsonProperty("set_reader_display")]
+        public ReaderActionSetReaderDisplay SetReaderDisplay { get; set; }
+
+        /// <summary>
+        /// Status of the action performed by the reader.
+        /// One of: <c>failed</c>, <c>in_progress</c>, or <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Type of action performed by the reader.
+        /// One of: <c>process_payment_intent</c>, <c>process_setup_intent</c>, or
+        /// <c>set_reader_display</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderActionProcessPaymentIntent.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderActionProcessPaymentIntent.cs
@@ -1,0 +1,40 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class ReaderActionProcessPaymentIntent : StripeEntity<ReaderActionProcessPaymentIntent>
+    {
+        #region Expandable PaymentIntent
+
+        /// <summary>
+        /// (ID of the PaymentIntent)
+        /// Most recent PaymentIntent processed by the reader.
+        /// </summary>
+        [JsonIgnore]
+        public string PaymentIntentId
+        {
+            get => this.InternalPaymentIntent?.Id;
+            set => this.InternalPaymentIntent = SetExpandableFieldId(value, this.InternalPaymentIntent);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// Most recent PaymentIntent processed by the reader.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public PaymentIntent PaymentIntent
+        {
+            get => this.InternalPaymentIntent?.ExpandedObject;
+            set => this.InternalPaymentIntent = SetExpandableFieldObject(value, this.InternalPaymentIntent);
+        }
+
+        [JsonProperty("payment_intent")]
+        [JsonConverter(typeof(ExpandableFieldConverter<PaymentIntent>))]
+        internal ExpandableField<PaymentIntent> InternalPaymentIntent { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderActionProcessSetupIntent.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderActionProcessSetupIntent.cs
@@ -1,0 +1,43 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class ReaderActionProcessSetupIntent : StripeEntity<ReaderActionProcessSetupIntent>
+    {
+        [JsonProperty("generated_card")]
+        public string GeneratedCard { get; set; }
+
+        #region Expandable SetupIntent
+
+        /// <summary>
+        /// (ID of the SetupIntent)
+        /// Most recent SetupIntent processed by the reader.
+        /// </summary>
+        [JsonIgnore]
+        public string SetupIntentId
+        {
+            get => this.InternalSetupIntent?.Id;
+            set => this.InternalSetupIntent = SetExpandableFieldId(value, this.InternalSetupIntent);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// Most recent SetupIntent processed by the reader.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public SetupIntent SetupIntent
+        {
+            get => this.InternalSetupIntent?.ExpandedObject;
+            set => this.InternalSetupIntent = SetExpandableFieldObject(value, this.InternalSetupIntent);
+        }
+
+        [JsonProperty("setup_intent")]
+        [JsonConverter(typeof(ExpandableFieldConverter<SetupIntent>))]
+        internal ExpandableField<SetupIntent> InternalSetupIntent { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplay.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplay.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderActionSetReaderDisplay : StripeEntity<ReaderActionSetReaderDisplay>
+    {
+        /// <summary>
+        /// Cart object to be displayed by the reader.
+        /// </summary>
+        [JsonProperty("cart")]
+        public ReaderActionSetReaderDisplayCart Cart { get; set; }
+
+        /// <summary>
+        /// Type of information to be displayed by the reader.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplayCart.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplayCart.cs
@@ -1,0 +1,37 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ReaderActionSetReaderDisplayCart : StripeEntity<ReaderActionSetReaderDisplayCart>
+    {
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// List of line items in the cart.
+        /// </summary>
+        [JsonProperty("line_items")]
+        public List<ReaderActionSetReaderDisplayCartLineItem> LineItems { get; set; }
+
+        /// <summary>
+        /// Tax amount for the entire cart. A positive integer in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("tax")]
+        public long? Tax { get; set; }
+
+        /// <summary>
+        /// Total amount for the entire cart, including tax. A positive integer in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("total")]
+        public long Total { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplayCartLineItem.cs
+++ b/src/Stripe.net/Entities/Terminal/Readers/ReaderActionSetReaderDisplayCartLineItem.cs
@@ -1,0 +1,27 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderActionSetReaderDisplayCartLineItem : StripeEntity<ReaderActionSetReaderDisplayCartLineItem>
+    {
+        /// <summary>
+        /// The amount of the line item. A positive integer in the <a
+        /// href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Description of the line item.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The quantity of the line item.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long Quantity { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataProductDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionLineItemPriceDataProductDataOptions.cs
@@ -31,8 +31,7 @@ namespace Stripe.Checkout
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The product's name, meant to be displayable to the customer. Whenever this product is
-        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// The product's name, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Services/Prices/PriceProductDataOptions.cs
+++ b/src/Stripe.net/Services/Prices/PriceProductDataOptions.cs
@@ -29,8 +29,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The product's name, meant to be displayable to the customer. Whenever this product is
-        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// The product's name, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Services/Products/ProductCreateOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductCreateOptions.cs
@@ -64,8 +64,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The product's name, meant to be displayable to the customer. Whenever this product is
-        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// The product's name, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Services/Products/ProductUpdateOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductUpdateOptions.cs
@@ -60,8 +60,7 @@ namespace Stripe
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// The product's name, meant to be displayable to the customer. Whenever this product is
-        /// sold via a subscription, name will show up on associated invoice line item descriptions.
+        /// The product's name, meant to be displayable to the customer.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderCancelActionOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderCancelActionOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    public class ReaderCancelActionOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderCartLineItemOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderCartLineItemOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderCartLineItemOptions : INestedOptions
+    {
+        /// <summary>
+        /// The price of the item in cents.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// The description or name of the item.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The quantity of the line item being purchased.
+        /// </summary>
+        [JsonProperty("quantity")]
+        public long? Quantity { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderCartOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderCartOptions.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ReaderCartOptions : INestedOptions
+    {
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Array of line items that were purchased.
+        /// </summary>
+        [JsonProperty("line_items")]
+        public List<ReaderCartLineItemOptions> LineItems { get; set; }
+
+        /// <summary>
+        /// The amount of tax in cents.
+        /// </summary>
+        [JsonProperty("tax")]
+        public long? Tax { get; set; }
+
+        /// <summary>
+        /// Total balance of cart due in cents.
+        /// </summary>
+        [JsonProperty("total")]
+        public long? Total { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderProcessConfigOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderProcessConfigOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderProcessConfigOptions : INestedOptions
+    {
+        /// <summary>
+        /// Override showing a tipping selection screen on this transaction.
+        /// </summary>
+        [JsonProperty("skip_tipping")]
+        public bool? SkipTipping { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderProcessPaymentIntentOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderProcessPaymentIntentOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderProcessPaymentIntentOptions : BaseOptions
+    {
+        /// <summary>
+        /// PaymentIntent ID.
+        /// </summary>
+        [JsonProperty("payment_intent")]
+        public string PaymentIntent { get; set; }
+
+        /// <summary>
+        /// Configuration overrides.
+        /// </summary>
+        [JsonProperty("process_config")]
+        public ReaderProcessConfigOptions ProcessConfig { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderProcessSetupIntentOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderProcessSetupIntentOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderProcessSetupIntentOptions : BaseOptions
+    {
+        /// <summary>
+        /// Customer Consent Collected.
+        /// </summary>
+        [JsonProperty("customer_consent_collected")]
+        public bool? CustomerConsentCollected { get; set; }
+
+        /// <summary>
+        /// SetupIntent ID.
+        /// </summary>
+        [JsonProperty("setup_intent")]
+        public string SetupIntent { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Terminal
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,6 +24,16 @@ namespace Stripe.Terminal
         }
 
         public override string BasePath => "/v1/terminal/readers";
+
+        public virtual Reader CancelAction(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel_action", options, requestOptions);
+        }
+
+        public virtual Task<Reader> CancelActionAsync(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel_action", options, requestOptions, cancellationToken);
+        }
 
         public virtual Reader Create(ReaderCreateOptions options, RequestOptions requestOptions = null)
         {
@@ -72,6 +83,36 @@ namespace Stripe.Terminal
         public virtual IAsyncEnumerable<Reader> ListAutoPagingAsync(ReaderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual Reader ProcessPaymentIntent(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_payment_intent", options, requestOptions);
+        }
+
+        public virtual Task<Reader> ProcessPaymentIntentAsync(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_payment_intent", options, requestOptions, cancellationToken);
+        }
+
+        public virtual Reader ProcessSetupIntent(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_setup_intent", options, requestOptions);
+        }
+
+        public virtual Task<Reader> ProcessSetupIntentAsync(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_setup_intent", options, requestOptions, cancellationToken);
+        }
+
+        public virtual Reader SetReaderDisplay(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/set_reader_display", options, requestOptions);
+        }
+
+        public virtual Task<Reader> SetReaderDisplayAsync(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/set_reader_display", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Update(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderSetReaderDisplayOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderSetReaderDisplayOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderSetReaderDisplayOptions : BaseOptions
+    {
+        /// <summary>
+        /// Cart.
+        /// </summary>
+        [JsonProperty("cart")]
+        public ReaderCartOptions Cart { get; set; }
+
+        /// <summary>
+        /// Type.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderCardPresentOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderCardPresentOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderCardPresentOptions : INestedOptions
+    {
+        /// <summary>
+        /// Card Number.
+        /// </summary>
+        [JsonProperty("number")]
+        public string Number { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderPresentPaymentMethodOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderPresentPaymentMethodOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Terminal
+{
+    using Newtonsoft.Json;
+
+    public class ReaderPresentPaymentMethodOptions : BaseOptions
+    {
+        /// <summary>
+        /// Simulated card present data.
+        /// </summary>
+        [JsonProperty("card_present")]
+        public ReaderCardPresentOptions CardPresent { get; set; }
+
+        /// <summary>
+        /// Simulated payment type.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Terminal
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Terminal;
+
+    public class ReaderService : Service<Reader>
+    {
+        public ReaderService()
+            : base(null)
+        {
+        }
+
+        public ReaderService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/terminal/readers";
+
+        public virtual Reader PresentPaymentMethod(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/present_payment_method", options, requestOptions);
+        }
+
+        public virtual Task<Reader> PresentPaymentMethodAsync(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/present_payment_method", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/StripeTests/Services/TestHelpers/Terminal/Readers/ReaderServiceTest.cs
+++ b/src/StripeTests/Services/TestHelpers/Terminal/Readers/ReaderServiceTest.cs
@@ -1,0 +1,31 @@
+namespace StripeTests.TestHelpers.Terminal
+{
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Stripe.TestHelpers.Terminal;
+    using Xunit;
+
+    public class ReaderServiceTest : BaseStripeTest
+    {
+        private const string ReaderId = "ds_123";
+
+        private readonly ReaderService service;
+
+        public ReaderServiceTest(
+            StripeMockFixture stripeMockFixture,
+            MockHttpClientFixture mockHttpClientFixture)
+            : base(stripeMockFixture, mockHttpClientFixture)
+        {
+            this.service = new ReaderService(this.StripeClient);
+        }
+
+        [Fact]
+        public async Task PresentPaymentMethodAsync()
+        {
+            var reader = await this.service.PresentPaymentMethodAsync(ReaderId);
+            this.AssertRequest(HttpMethod.Post, "/v1/test_helpers/terminal/readers/ds_123/present_payment_method");
+            Assert.NotNull(reader);
+        }
+    }
+}


### PR DESCRIPTION
Codegen for openapi 1700e20.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `CancelAction`, `ProcessPaymentIntent`, `ProcessSetupIntent`, and `SetReaderDisplay` methods on resource `Terminal.Reader`
* Add support for `Action` on `TerminalReader`

