### PR TITLE
Push NuGet package from Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
   pull_request:
     branches:
       - master
 
 jobs:
-  tests:
-    name: Tests
+  build:
+    name: Build and test
 
     runs-on: ubuntu-latest
 
@@ -57,3 +59,27 @@ jobs:
         env:
           CI_NAME: github-actions
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Pack
+        run: dotnet pack src -c Release --no-build --output nuget
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: nuget
+          path: nuget/
+
+  publish:
+    #if: (github.event_name == 'push') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe'))
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: nuget
+        path: nuget
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Publish NuGet packages to NuGet
+      run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org" --skip-duplicate --no-symbols true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,4 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Publish NuGet packages to NuGet
-      run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org" --skip-duplicate --no-symbols true
+      run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           path: nuget/
 
   publish:
-    if: (github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe'))
+    if: (github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe')
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           path: nuget/
 
   publish:
-    if: (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/master') && (endsWith(github.actor, '-stripe')
+    if: ((github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/master') && endsWith(github.actor, '-stripe'))
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           path: nuget/
 
   publish:
-    if: (github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe')
+    if: (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/master') && (endsWith(github.actor, '-stripe')
     needs: [build]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           path: nuget/
 
   publish:
-    #if: (github.event_name == 'push') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe'))
+    if: (github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') && (endsWith(github.actor, '-stripe'))
     needs: [build]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a manual-dispatch workflow step to release nuget packages to Nuget.org.

The testing plan:
1. Try to push an old tag (to see a version already exists message from the package manager).
2. Disable the appveyor and release a new package manually
3. Flip workflow to automatic on tag pushes

r? @dcr-stripe 