### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownDiscount.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionTotalDetailsBreakdownDiscount.cs
@@ -12,8 +12,10 @@ namespace Stripe.Checkout
         public long Amount { get; set; }
 
         /// <summary>
-        /// A discount represents the actual application of a coupon to a particular customer. It
-        /// contains information about when the discount began and when it will end.
+        /// A discount represents the actual application of a <a
+        /// href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+        /// href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+        /// information about when the discount began, when it will end, and what it is applied to.
         ///
         /// Related guide: <a
         /// href="https://stripe.com/docs/billing/subscriptions/discounts">Applying Discounts to

--- a/src/Stripe.net/Entities/Coupons/Coupon.cs
+++ b/src/Stripe.net/Entities/Coupons/Coupon.cs
@@ -9,10 +9,12 @@ namespace Stripe
     /// <summary>
     /// A coupon contains information about a percent-off or amount-off discount you might want
     /// to apply to a customer. Coupons may be applied to <a
-    /// href="https://stripe.com/docs/api#invoices">invoices</a> or <a
-    /// href="https://stripe.com/docs/api#create_order_legacy-coupon">orders</a>. Coupons do not
-    /// work with conventional one-off <a
-    /// href="https://stripe.com/docs/api#create_charge">charges</a>.
+    /// href="https://stripe.com/docs/api#subscriptions">subscriptions</a>, <a
+    /// href="https://stripe.com/docs/api#invoices">invoices</a>, <a
+    /// href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a>, <a
+    /// href="https://stripe.com/docs/api#quotes">quotes</a>, and more. Coupons do not work with
+    /// conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a> or
+    /// <a href="https://stripe.com/docs/api/payment_intents">payment intents</a>.
     /// </summary>
     public class Coupon : StripeEntity<Coupon>, IHasId, IHasMetadata, IHasObject
     {

--- a/src/Stripe.net/Entities/LineItems/LineItemDiscount.cs
+++ b/src/Stripe.net/Entities/LineItems/LineItemDiscount.cs
@@ -12,8 +12,10 @@ namespace Stripe
         public long Amount { get; set; }
 
         /// <summary>
-        /// A discount represents the actual application of a coupon to a particular customer. It
-        /// contains information about when the discount began and when it will end.
+        /// A discount represents the actual application of a <a
+        /// href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+        /// href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+        /// information about when the discount began, when it will end, and what it is applied to.
         ///
         /// Related guide: <a
         /// href="https://stripe.com/docs/billing/subscriptions/discounts">Applying Discounts to

--- a/src/Stripe.net/Entities/PaymentLinks/PaymentLink.cs
+++ b/src/Stripe.net/Entities/PaymentLinks/PaymentLink.cs
@@ -73,6 +73,19 @@ namespace Stripe
         public string BillingAddressCollection { get; set; }
 
         /// <summary>
+        /// When set, provides configuration to gather active consent from customers.
+        /// </summary>
+        [JsonProperty("consent_collection")]
+        public PaymentLinkConsentCollection ConsentCollection { get; set; }
+
+        /// <summary>
+        /// Configuration for Customer creation during checkout.
+        /// One of: <c>always</c>, or <c>if_required</c>.
+        /// </summary>
+        [JsonProperty("customer_creation")]
+        public string CustomerCreation { get; set; }
+
+        /// <summary>
         /// The line items representing what is being sold.
         /// </summary>
         [JsonProperty("line_items")]
@@ -129,6 +142,12 @@ namespace Stripe
         #endregion
 
         /// <summary>
+        /// Indicates the parameters to be passed to PaymentIntent creation during checkout.
+        /// </summary>
+        [JsonProperty("payment_intent_data")]
+        public PaymentLinkPaymentIntentData PaymentIntentData { get; set; }
+
+        /// <summary>
         /// The list of payment method types that customers can use. When <c>null</c>, Stripe will
         /// dynamically show relevant payment methods you've enabled in your <a
         /// href="https://dashboard.stripe.com/settings/payment_methods">payment method
@@ -147,11 +166,28 @@ namespace Stripe
         public PaymentLinkShippingAddressCollection ShippingAddressCollection { get; set; }
 
         /// <summary>
+        /// The shipping rate options applied to the session.
+        /// </summary>
+        [JsonProperty("shipping_options")]
+        public List<PaymentLinkShippingOption> ShippingOptions { get; set; }
+
+        /// <summary>
+        /// Indicates the type of transaction being performed which customizes relevant text on the
+        /// page, such as the submit button.
+        /// One of: <c>auto</c>, <c>book</c>, <c>donate</c>, or <c>pay</c>.
+        /// </summary>
+        [JsonProperty("submit_type")]
+        public string SubmitType { get; set; }
+
+        /// <summary>
         /// When creating a subscription, the specified configuration data will be used. There must
         /// be at least one line item with a recurring price to use <c>subscription_data</c>.
         /// </summary>
         [JsonProperty("subscription_data")]
         public PaymentLinkSubscriptionData SubscriptionData { get; set; }
+
+        [JsonProperty("tax_id_collection")]
+        public PaymentLinkTaxIdCollection TaxIdCollection { get; set; }
 
         /// <summary>
         /// The account (if any) the payments will be attributed to for tax reporting, and where

--- a/src/Stripe.net/Entities/PaymentLinks/PaymentLinkConsentCollection.cs
+++ b/src/Stripe.net/Entities/PaymentLinks/PaymentLinkConsentCollection.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkConsentCollection : StripeEntity<PaymentLinkConsentCollection>
+    {
+        /// <summary>
+        /// If set to <c>auto</c>, enables the collection of customer consent for promotional
+        /// communications.
+        /// </summary>
+        [JsonProperty("promotions")]
+        public string Promotions { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentLinks/PaymentLinkPaymentIntentData.cs
+++ b/src/Stripe.net/Entities/PaymentLinks/PaymentLinkPaymentIntentData.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkPaymentIntentData : StripeEntity<PaymentLinkPaymentIntentData>
+    {
+        /// <summary>
+        /// Indicates when the funds will be captured from the customer's account.
+        /// One of: <c>automatic</c>, or <c>manual</c>.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
+        /// Indicates that you intend to make future payments with the payment method collected
+        /// during checkout.
+        /// One of: <c>off_session</c>, or <c>on_session</c>.
+        /// </summary>
+        [JsonProperty("setup_future_usage")]
+        public string SetupFutureUsage { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentLinks/PaymentLinkShippingOption.cs
+++ b/src/Stripe.net/Entities/PaymentLinks/PaymentLinkShippingOption.cs
@@ -1,0 +1,46 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class PaymentLinkShippingOption : StripeEntity<PaymentLinkShippingOption>
+    {
+        /// <summary>
+        /// A non-negative integer in cents representing how much to charge.
+        /// </summary>
+        [JsonProperty("shipping_amount")]
+        public long ShippingAmount { get; set; }
+
+        #region Expandable ShippingRate
+
+        /// <summary>
+        /// (ID of the ShippingRate)
+        /// The ID of the Shipping Rate to use for this shipping option.
+        /// </summary>
+        [JsonIgnore]
+        public string ShippingRateId
+        {
+            get => this.InternalShippingRate?.Id;
+            set => this.InternalShippingRate = SetExpandableFieldId(value, this.InternalShippingRate);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The ID of the Shipping Rate to use for this shipping option.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public ShippingRate ShippingRate
+        {
+            get => this.InternalShippingRate?.ExpandedObject;
+            set => this.InternalShippingRate = SetExpandableFieldObject(value, this.InternalShippingRate);
+        }
+
+        [JsonProperty("shipping_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<ShippingRate>))]
+        internal ExpandableField<ShippingRate> InternalShippingRate { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/PaymentLinks/PaymentLinkTaxIdCollection.cs
+++ b/src/Stripe.net/Entities/PaymentLinks/PaymentLinkTaxIdCollection.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkTaxIdCollection : StripeEntity<PaymentLinkTaxIdCollection>
+    {
+        /// <summary>
+        /// Indicates whether tax ID collection is enabled for the session.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PromotionCodes/PromotionCode.cs
+++ b/src/Stripe.net/Entities/PromotionCodes/PromotionCode.cs
@@ -7,8 +7,9 @@ namespace Stripe
     using Stripe.Infrastructure;
 
     /// <summary>
-    /// A Promotion Code represents a customer-redeemable code for a coupon. It can be used to
-    /// create multiple codes for a single coupon.
+    /// A Promotion Code represents a customer-redeemable code for a <a
+    /// href="https://stripe.com/docs/api#coupons">coupon</a>. It can be used to create multiple
+    /// codes for a single coupon.
     /// </summary>
     public class PromotionCode : StripeEntity<PromotionCode>, IHasId, IHasMetadata, IHasObject
     {
@@ -41,10 +42,12 @@ namespace Stripe
         /// <summary>
         /// A coupon contains information about a percent-off or amount-off discount you might want
         /// to apply to a customer. Coupons may be applied to <a
-        /// href="https://stripe.com/docs/api#invoices">invoices</a> or <a
-        /// href="https://stripe.com/docs/api#create_order_legacy-coupon">orders</a>. Coupons do not
-        /// work with conventional one-off <a
-        /// href="https://stripe.com/docs/api#create_charge">charges</a>.
+        /// href="https://stripe.com/docs/api#subscriptions">subscriptions</a>, <a
+        /// href="https://stripe.com/docs/api#invoices">invoices</a>, <a
+        /// href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a>, <a
+        /// href="https://stripe.com/docs/api#quotes">quotes</a>, and more. Coupons do not work with
+        /// conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a> or
+        /// <a href="https://stripe.com/docs/api/payment_intents">payment intents</a>.
         /// </summary>
         [JsonProperty("coupon")]
         public Coupon Coupon { get; set; }

--- a/src/Stripe.net/Entities/Quotes/QuoteComputedRecurringTotalDetailsBreakdownDiscount.cs
+++ b/src/Stripe.net/Entities/Quotes/QuoteComputedRecurringTotalDetailsBreakdownDiscount.cs
@@ -12,8 +12,10 @@ namespace Stripe
         public long Amount { get; set; }
 
         /// <summary>
-        /// A discount represents the actual application of a coupon to a particular customer. It
-        /// contains information about when the discount began and when it will end.
+        /// A discount represents the actual application of a <a
+        /// href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+        /// href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+        /// information about when the discount began, when it will end, and what it is applied to.
         ///
         /// Related guide: <a
         /// href="https://stripe.com/docs/billing/subscriptions/discounts">Applying Discounts to

--- a/src/Stripe.net/Entities/Quotes/QuoteComputedUpfrontTotalDetailsBreakdownDiscount.cs
+++ b/src/Stripe.net/Entities/Quotes/QuoteComputedUpfrontTotalDetailsBreakdownDiscount.cs
@@ -12,8 +12,10 @@ namespace Stripe
         public long Amount { get; set; }
 
         /// <summary>
-        /// A discount represents the actual application of a coupon to a particular customer. It
-        /// contains information about when the discount began and when it will end.
+        /// A discount represents the actual application of a <a
+        /// href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+        /// href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+        /// information about when the discount began, when it will end, and what it is applied to.
         ///
         /// Related guide: <a
         /// href="https://stripe.com/docs/billing/subscriptions/discounts">Applying Discounts to

--- a/src/Stripe.net/Entities/Quotes/QuoteTotalDetailsBreakdownDiscount.cs
+++ b/src/Stripe.net/Entities/Quotes/QuoteTotalDetailsBreakdownDiscount.cs
@@ -12,8 +12,10 @@ namespace Stripe
         public long Amount { get; set; }
 
         /// <summary>
-        /// A discount represents the actual application of a coupon to a particular customer. It
-        /// contains information about when the discount began and when it will end.
+        /// A discount represents the actual application of a <a
+        /// href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+        /// href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+        /// information about when the discount began, when it will end, and what it is applied to.
         ///
         /// Related guide: <a
         /// href="https://stripe.com/docs/billing/subscriptions/discounts">Applying Discounts to

--- a/src/Stripe.net/Entities/Refunds/Refund.cs
+++ b/src/Stripe.net/Entities/Refunds/Refund.cs
@@ -257,7 +257,8 @@ namespace Stripe
         /// <summary>
         /// Status of the refund. For credit card refunds, this can be <c>pending</c>,
         /// <c>succeeded</c>, or <c>failed</c>. For other types of refunds, it can be
-        /// <c>pending</c>, <c>succeeded</c>, <c>failed</c>, or <c>canceled</c>. Refer to our <a
+        /// <c>pending</c>, <c>requires_action</c>, <c>succeeded</c>, <c>failed</c>, or
+        /// <c>canceled</c>. Refer to our <a
         /// href="https://stripe.com/docs/refunds#failed-refunds">refunds</a> documentation for more
         /// details.
         /// </summary>

--- a/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
+++ b/src/Stripe.net/Entities/SubscriptionSchedules/SubscriptionSchedulePhase.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class SubscriptionSchedulePhase : StripeEntity<SubscriptionSchedulePhase>
+    public class SubscriptionSchedulePhase : StripeEntity<SubscriptionSchedulePhase>, IHasMetadata
     {
         /// <summary>
         /// A list of prices and quantities that will generate invoice items appended to the first
@@ -146,6 +146,16 @@ namespace Stripe
         /// </summary>
         [JsonProperty("items")]
         public List<SubscriptionSchedulePhaseItem> Items { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to a phase. Metadata on a schedule's phase will update the underlying
+        /// subscription's <c>metadata</c> when the phase is entered. Updating the underlying
+        /// subscription's <c>metadata</c> directly will not affect the current phase's
+        /// <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// If the subscription schedule will prorate when transitioning to this phase. Possible

--- a/src/Stripe.net/Entities/Subscriptions/Subscription.cs
+++ b/src/Stripe.net/Entities/Subscriptions/Subscription.cs
@@ -273,6 +273,13 @@ namespace Stripe
         public List<TaxRate> DefaultTaxRates { get; set; }
 
         /// <summary>
+        /// The subscription's description, meant to be displayable to the customer. Use this field
+        /// to optionally store an explanation of the subscription for rendering in Stripe surfaces.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// Describes the current discount applied to this subscription, if there is one. When
         /// billing, a discount applied to a subscription overrides a discount applied on a
         /// customer-wide basis.

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionSubscriptionDataOptions.cs
@@ -35,6 +35,14 @@ namespace Stripe.Checkout
         public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
+        /// The subscription's description, meant to be displayable to the customer. Use this field
+        /// to optionally store an explanation of the subscription for rendering in Stripe hosted
+        /// surfaces.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// A list of items, each with an attached plan, that the customer is subscribing to. Prefer
         /// using <c>line_items</c>.
         /// </summary>

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkConsentCollectionOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkConsentCollectionOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkConsentCollectionOptions : INestedOptions
+    {
+        /// <summary>
+        /// If set to <c>auto</c>, enables the collection of customer consent for promotional
+        /// communications. The Checkout Session will determine whether to display an option to opt
+        /// into promotional communication from the merchant depending on the customer's locale.
+        /// Only available to US merchants.
+        /// </summary>
+        [JsonProperty("promotions")]
+        public string Promotions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkCreateOptions.cs
@@ -49,6 +49,21 @@ namespace Stripe
         public string BillingAddressCollection { get; set; }
 
         /// <summary>
+        /// Configure fields to gather active consent from customers.
+        /// </summary>
+        [JsonProperty("consent_collection")]
+        public PaymentLinkConsentCollectionOptions ConsentCollection { get; set; }
+
+        /// <summary>
+        /// Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+        /// sessions</a> created by this payment link create a <a
+        /// href="https://stripe.com/docs/api/customers">Customer</a>.
+        /// One of: <c>always</c>, or <c>if_required</c>.
+        /// </summary>
+        [JsonProperty("customer_creation")]
+        public string CustomerCreation { get; set; }
+
+        /// <summary>
         /// The line items representing what is being sold. Each line item represents an item being
         /// sold. Up to 20 line items are supported.
         /// </summary>
@@ -72,6 +87,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("on_behalf_of")]
         public string OnBehalfOf { get; set; }
+
+        /// <summary>
+        /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in
+        /// <c>payment</c> mode.
+        /// </summary>
+        [JsonProperty("payment_intent_data")]
+        public PaymentLinkPaymentIntentDataOptions PaymentIntentData { get; set; }
 
         /// <summary>
         /// The list of payment method types that customers can use. Only <c>card</c> is supported.
@@ -98,11 +120,33 @@ namespace Stripe
         public PaymentLinkShippingAddressCollectionOptions ShippingAddressCollection { get; set; }
 
         /// <summary>
+        /// The shipping rate options to apply to <a
+        /// href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a> created by
+        /// this payment link.
+        /// </summary>
+        [JsonProperty("shipping_options")]
+        public List<PaymentLinkShippingOptionOptions> ShippingOptions { get; set; }
+
+        /// <summary>
+        /// Describes the type of transaction being performed in order to customize relevant text on
+        /// the page, such as the submit button.
+        /// One of: <c>auto</c>, <c>book</c>, <c>donate</c>, or <c>pay</c>.
+        /// </summary>
+        [JsonProperty("submit_type")]
+        public string SubmitType { get; set; }
+
+        /// <summary>
         /// When creating a subscription, the specified configuration data will be used. There must
         /// be at least one line item with a recurring price to use <c>subscription_data</c>.
         /// </summary>
         [JsonProperty("subscription_data")]
         public PaymentLinkSubscriptionDataOptions SubscriptionData { get; set; }
+
+        /// <summary>
+        /// Controls tax ID collection during checkout.
+        /// </summary>
+        [JsonProperty("tax_id_collection")]
+        public PaymentLinkTaxIdCollectionOptions TaxIdCollection { get; set; }
 
         /// <summary>
         /// The account (if any) the payments will be attributed to for tax reporting, and where

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkPaymentIntentDataOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkPaymentIntentDataOptions.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkPaymentIntentDataOptions : INestedOptions
+    {
+        /// <summary>
+        /// Controls when the funds will be captured from the customer's account.
+        /// One of: <c>automatic</c>, or <c>manual</c>.
+        /// </summary>
+        [JsonProperty("capture_method")]
+        public string CaptureMethod { get; set; }
+
+        /// <summary>
+        /// Indicates that you intend to <a
+        /// href="https://stripe.com/docs/payments/payment-intents#future-usage">make future
+        /// payments</a> with the payment method collected by this Checkout Session.
+        ///
+        /// When setting this to <c>on_session</c>, Checkout will show a notice to the customer that
+        /// their payment details will be saved.
+        ///
+        /// When setting this to <c>off_session</c>, Checkout will show a notice to the customer
+        /// that their payment details will be saved and used for future payments.
+        ///
+        /// If a Customer has been provided or Checkout creates a new Customer,Checkout will attach
+        /// the payment method to the Customer.
+        ///
+        /// If Checkout does not create a Customer, the payment method is not attached to a
+        /// Customer. To reuse the payment method, you can retrieve it from the Checkout Session's
+        /// PaymentIntent.
+        ///
+        /// When processing card payments, Checkout also uses <c>setup_future_usage</c> to
+        /// dynamically optimize your payment flow and comply with regional legislation and network
+        /// rules, such as SCA.
+        /// One of: <c>off_session</c>, or <c>on_session</c>.
+        /// </summary>
+        [JsonProperty("setup_future_usage")]
+        public string SetupFutureUsage { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkShippingOptionOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkShippingOptionOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkShippingOptionOptions : INestedOptions
+    {
+        /// <summary>
+        /// The ID of the Shipping Rate to use for this shipping option.
+        /// </summary>
+        [JsonProperty("shipping_rate")]
+        public string ShippingRate { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkTaxIdCollectionOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkTaxIdCollectionOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+
+    public class PaymentLinkTaxIdCollectionOptions : INestedOptions
+    {
+        /// <summary>
+        /// Set to <c>true</c> to enable tax ID collection.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkUpdateOptions.cs
@@ -39,6 +39,15 @@ namespace Stripe
         public string BillingAddressCollection { get; set; }
 
         /// <summary>
+        /// Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+        /// sessions</a> created by this payment link create a <a
+        /// href="https://stripe.com/docs/api/customers">Customer</a>.
+        /// One of: <c>always</c>, or <c>if_required</c>.
+        /// </summary>
+        [JsonProperty("customer_creation")]
+        public string CustomerCreation { get; set; }
+
+        /// <summary>
         /// The line items representing what is being sold. Each line item represents an item being
         /// sold. Up to 20 line items are supported.
         /// </summary>

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionSchedulePhaseOptions.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
 
-    public class SubscriptionSchedulePhaseOptions : INestedOptions
+    public class SubscriptionSchedulePhaseOptions : INestedOptions, IHasMetadata
     {
         /// <summary>
         /// A list of prices and quantities that will generate invoice items appended to the next
@@ -115,6 +115,19 @@ namespace Stripe
         /// </summary>
         [JsonProperty("iterations")]
         public long? Iterations { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to a phase. Metadata on a schedule's phase will update the underlying
+        /// subscription's <c>metadata</c> when the phase is entered, adding new keys and replacing
+        /// existing keys in the subscription's <c>metadata</c>. Individual keys in the
+        /// subscription's <c>metadata</c> can be unset by posting an empty value to them in the
+        /// phase's <c>metadata</c>. To unset all keys in the subscription's <c>metadata</c>, update
+        /// the subscription directly or unset every key individually from the phase's
+        /// <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// If a subscription schedule will create prorations when transitioning to this phase.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -137,6 +137,13 @@ namespace Stripe
         public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
+        /// The subscription's description, meant to be displayable to the customer. Use this field
+        /// to optionally store an explanation of the subscription for rendering in Stripe surfaces.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// A list of up to 20 subscription items, each with an attached price.
         /// </summary>
         [JsonProperty("items")]

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -123,6 +123,13 @@ namespace Stripe
         public List<string> DefaultTaxRates { get; set; }
 
         /// <summary>
+        /// The subscription's description, meant to be displayable to the customer. Use this field
+        /// to optionally store an explanation of the subscription for rendering in Stripe surfaces.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
         /// A list of up to 20 subscription items, each with an attached price.
         /// </summary>
         [JsonProperty("items")]


### PR DESCRIPTION
Codegen for openapi 7789931.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `Description` on `CheckoutSessionSubscriptionDataOptions`, `SubscriptionCreateOptions`, `SubscriptionUpdateOptions`, and `Subscription`
* Add support for `ConsentCollection`, `PaymentIntentData`, `ShippingOptions`, `SubmitType`, and `TaxIdCollection` on `PaymentLinkCreateOptions` and `PaymentLink`
* Add support for `CustomerCreation` on `PaymentLinkCreateOptions`, `PaymentLinkUpdateOptions`, and `PaymentLink`
* Add support for `Metadata` on `SubscriptionSchedulePhasesOptions` and `SubscriptionSchedulePhases`

