### PR TITLE
API Updates

### DIFF
--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptions.cs
@@ -8,17 +8,47 @@ namespace Stripe.Checkout
         [JsonProperty("acss_debit")]
         public SessionPaymentMethodOptionsAcssDebit AcssDebit { get; set; }
 
+        [JsonProperty("afterpay_clearpay")]
+        public SessionPaymentMethodOptionsAfterpayClearpay AfterpayClearpay { get; set; }
+
         [JsonProperty("alipay")]
         public SessionPaymentMethodOptionsAlipay Alipay { get; set; }
 
+        [JsonProperty("au_becs_debit")]
+        public SessionPaymentMethodOptionsAuBecsDebit AuBecsDebit { get; set; }
+
+        [JsonProperty("bacs_debit")]
+        public SessionPaymentMethodOptionsBacsDebit BacsDebit { get; set; }
+
         [JsonProperty("boleto")]
         public SessionPaymentMethodOptionsBoleto Boleto { get; set; }
+
+        [JsonProperty("eps")]
+        public SessionPaymentMethodOptionsEps Eps { get; set; }
+
+        [JsonProperty("fpx")]
+        public SessionPaymentMethodOptionsFpx Fpx { get; set; }
+
+        [JsonProperty("giropay")]
+        public SessionPaymentMethodOptionsGiropay Giropay { get; set; }
+
+        [JsonProperty("grabpay")]
+        public SessionPaymentMethodOptionsGrabpay Grabpay { get; set; }
+
+        [JsonProperty("klarna")]
+        public SessionPaymentMethodOptionsKlarna Klarna { get; set; }
 
         [JsonProperty("konbini")]
         public SessionPaymentMethodOptionsKonbini Konbini { get; set; }
 
         [JsonProperty("oxxo")]
         public SessionPaymentMethodOptionsOxxo Oxxo { get; set; }
+
+        [JsonProperty("paynow")]
+        public SessionPaymentMethodOptionsPaynow Paynow { get; set; }
+
+        [JsonProperty("sepa_debit")]
+        public SessionPaymentMethodOptionsSepaDebit SepaDebit { get; set; }
 
         [JsonProperty("us_bank_account")]
         public SessionPaymentMethodOptionsUsBankAccount UsBankAccount { get; set; }

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAfterpayClearpay.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAfterpayClearpay.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsAfterpayClearpay : StripeEntity<SessionPaymentMethodOptionsAfterpayClearpay>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAuBecsDebit.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsAuBecsDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsAuBecsDebit : StripeEntity<SessionPaymentMethodOptionsAuBecsDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsBacsDebit.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsBacsDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsBacsDebit : StripeEntity<SessionPaymentMethodOptionsBacsDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsEps.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsEps.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsEps : StripeEntity<SessionPaymentMethodOptionsEps>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsFpx.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsFpx.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsFpx : StripeEntity<SessionPaymentMethodOptionsFpx>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsGiropay.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsGiropay.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsGiropay : StripeEntity<SessionPaymentMethodOptionsGiropay>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsGrabpay.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsGrabpay.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsGrabpay : StripeEntity<SessionPaymentMethodOptionsGrabpay>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsKlarna.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsKlarna.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsKlarna : StripeEntity<SessionPaymentMethodOptionsKlarna>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsPaynow.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsPaynow.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsPaynow : StripeEntity<SessionPaymentMethodOptionsPaynow>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsSepaDebit.cs
+++ b/src/Stripe.net/Entities/Checkout/Sessions/SessionPaymentMethodOptionsSepaDebit.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Checkout
+{
+    public class SessionPaymentMethodOptionsSepaDebit : StripeEntity<SessionPaymentMethodOptionsSepaDebit>
+    {
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/Authorization.cs
@@ -185,6 +185,14 @@ namespace Stripe.Issuing
         [JsonProperty("transactions")]
         public List<Transaction> Transactions { get; set; }
 
+        /// <summary>
+        /// <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this
+        /// authorization if it was created on a <a
+        /// href="https://stripe.com/docs/api/treasury/financial_accounts">FinancialAccount</a>.
+        /// </summary>
+        [JsonProperty("treasury")]
+        public AuthorizationTreasury Treasury { get; set; }
+
         [JsonProperty("verification_data")]
         public AuthorizationVerificationData VerificationData { get; set; }
 

--- a/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationTreasury.cs
+++ b/src/Stripe.net/Entities/Issuing/Authorizations/AuthorizationTreasury.cs
@@ -1,0 +1,32 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Issuing
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class AuthorizationTreasury : StripeEntity<AuthorizationTreasury>
+    {
+        /// <summary>
+        /// The array of <a
+        /// href="https://stripe.com/docs/api/treasury/received_credits">ReceivedCredits</a>
+        /// associated with this authorization.
+        /// </summary>
+        [JsonProperty("received_credits")]
+        public List<string> ReceivedCredits { get; set; }
+
+        /// <summary>
+        /// The array of <a
+        /// href="https://stripe.com/docs/api/treasury/received_debits">ReceivedDebits</a>
+        /// associated with this authorization.
+        /// </summary>
+        [JsonProperty("received_debits")]
+        public List<string> ReceivedDebits { get; set; }
+
+        /// <summary>
+        /// The Treasury <a href="https://stripe.com/docs/api/treasury/transactions">Transaction</a>
+        /// associated with this authorization.
+        /// </summary>
+        [JsonProperty("transaction")]
+        public string Transaction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Cards/Card.cs
+++ b/src/Stripe.net/Entities/Issuing/Cards/Card.cs
@@ -86,6 +86,12 @@ namespace Stripe.Issuing
         public long ExpYear { get; set; }
 
         /// <summary>
+        /// The financial account this card is attached to.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
         /// The last 4 digits of the card number.
         /// </summary>
         [JsonProperty("last4")]

--- a/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/Dispute.cs
@@ -110,5 +110,12 @@ namespace Stripe.Issuing
         [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
         internal ExpandableField<Transaction> InternalTransaction { get; set; }
         #endregion
+
+        /// <summary>
+        /// <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this
+        /// dispute if it was created on a [FinancialAccount](/docs/api/treasury/financial_accounts.
+        /// </summary>
+        [JsonProperty("treasury")]
+        public DisputeTreasury Treasury { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Issuing/Disputes/DisputeTreasury.cs
+++ b/src/Stripe.net/Entities/Issuing/Disputes/DisputeTreasury.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeTreasury : StripeEntity<DisputeTreasury>
+    {
+        /// <summary>
+        /// The Treasury <a
+        /// href="https://stripe.com/docs/api/treasury/debit_reversals">DebitReversal</a>
+        /// representing this Issuing dispute.
+        /// </summary>
+        [JsonProperty("debit_reversal")]
+        public string DebitReversal { get; set; }
+
+        /// <summary>
+        /// The Treasury <a
+        /// href="https://stripe.com/docs/api/treasury/received_debits">ReceivedDebit</a> that is
+        /// being disputed.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/Transaction.cs
@@ -256,6 +256,14 @@ namespace Stripe.Issuing
         public TransactionPurchaseDetails PurchaseDetails { get; set; }
 
         /// <summary>
+        /// <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this
+        /// transaction if it was created on a
+        /// [FinancialAccount](/docs/api/treasury/financial_accounts.
+        /// </summary>
+        [JsonProperty("treasury")]
+        public TransactionTreasury Treasury { get; set; }
+
+        /// <summary>
         /// The nature of the transaction.
         /// One of: <c>capture</c>, or <c>refund</c>.
         /// </summary>

--- a/src/Stripe.net/Entities/Issuing/Transactions/TransactionTreasury.cs
+++ b/src/Stripe.net/Entities/Issuing/Transactions/TransactionTreasury.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class TransactionTreasury : StripeEntity<TransactionTreasury>
+    {
+        /// <summary>
+        /// The Treasury <a
+        /// href="https://stripe.com/docs/api/treasury/received_debits">ReceivedCredit</a>
+        /// representing this Issuing transaction if it is a refund.
+        /// </summary>
+        [JsonProperty("received_credit")]
+        public string ReceivedCredit { get; set; }
+
+        /// <summary>
+        /// The Treasury <a
+        /// href="https://stripe.com/docs/api/treasury/received_credits">ReceivedDebit</a>
+        /// representing this Issuing transaction if it is a capture.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccount.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccount.cs
@@ -45,6 +45,12 @@ namespace Stripe
         public string Last4 { get; set; }
 
         /// <summary>
+        /// Contains information about US bank account networks that can be used.
+        /// </summary>
+        [JsonProperty("networks")]
+        public PaymentMethodUsBankAccountNetworks Networks { get; set; }
+
+        /// <summary>
         /// Routing number of the bank account.
         /// </summary>
         [JsonProperty("routing_number")]

--- a/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccountNetworks.cs
+++ b/src/Stripe.net/Entities/PaymentMethods/PaymentMethodUsBankAccountNetworks.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class PaymentMethodUsBankAccountNetworks : StripeEntity<PaymentMethodUsBankAccountNetworks>
+    {
+        /// <summary>
+        /// The preferred network.
+        /// </summary>
+        [JsonProperty("preferred")]
+        public string Preferred { get; set; }
+
+        /// <summary>
+        /// All supported networks.
+        /// </summary>
+        [JsonProperty("supported")]
+        public List<string> Supported { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
+++ b/src/Stripe.net/Entities/SetupIntents/SetupIntent.cs
@@ -86,6 +86,18 @@ namespace Stripe
         #endregion
 
         /// <summary>
+        /// If present, the SetupIntent's payment method will be attached to the in-context Stripe
+        /// Account.
+        ///
+        /// It can only be used for this Stripe Account’s own money movement flows like
+        /// InboundTransfer and OutboundTransfers. It cannot be set to true when setting up a
+        /// PaymentMethod for a Customer, and defaults to false when attaching a PaymentMethod to a
+        /// Customer.
+        /// </summary>
+        [JsonProperty("attach_to_self")]
+        public bool AttachToSelf { get; set; }
+
+        /// <summary>
         /// Reason for cancellation of this SetupIntent, one of <c>abandoned</c>,
         /// <c>requested_by_customer</c>, or <c>duplicate</c>.
         /// One of: <c>abandoned</c>, <c>duplicate</c>, or <c>requested_by_customer</c>.
@@ -155,6 +167,18 @@ namespace Stripe
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
+
+        /// <summary>
+        /// Indicates the directions of money movement for which this payment method is intended to
+        /// be used.
+        ///
+        /// Include <c>inbound</c> if you intend to use the payment method as the origin to pull
+        /// funds from. Include <c>outbound</c> if you intend to use the payment method as the
+        /// destination to send funds to. You can include both if you intend to use the payment
+        /// method for both purposes.
+        /// </summary>
+        [JsonProperty("flow_directions")]
+        public List<string> FlowDirections { get; set; }
 
         /// <summary>
         /// The error encountered in the previous SetupIntent confirmation.

--- a/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettings.cs
+++ b/src/Stripe.net/Entities/Subscriptions/SubscriptionPaymentSettings.cs
@@ -23,5 +23,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
+
+        /// <summary>
+        /// Either <c>off</c>, or <c>on_subscription</c>. With <c>on_subscription</c> Stripe updates
+        /// <c>subscription.default_payment_method</c> when a subscription payment succeeds.
+        /// One of: <c>off</c>, or <c>on_subscription</c>.
+        /// </summary>
+        [JsonProperty("save_default_payment_method")]
+        public string SaveDefaultPaymentMethod { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Terminal/Configurations/ConfigurationTipping.cs
+++ b/src/Stripe.net/Entities/Terminal/Configurations/ConfigurationTipping.cs
@@ -14,6 +14,9 @@ namespace Stripe.Terminal
         [JsonProperty("chf")]
         public ConfigurationTippingChf Chf { get; set; }
 
+        [JsonProperty("czk")]
+        public ConfigurationTippingCzk Czk { get; set; }
+
         [JsonProperty("dkk")]
         public ConfigurationTippingDkk Dkk { get; set; }
 

--- a/src/Stripe.net/Entities/Terminal/Configurations/ConfigurationTippingCzk.cs
+++ b/src/Stripe.net/Entities/Terminal/Configurations/ConfigurationTippingCzk.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationTippingCzk : StripeEntity<ConfigurationTippingCzk>
+    {
+        /// <summary>
+        /// Fixed amounts displayed when collecting a tip.
+        /// </summary>
+        [JsonProperty("fixed_amounts")]
+        public List<long> FixedAmounts { get; set; }
+
+        /// <summary>
+        /// Percentages displayed when collecting a tip.
+        /// </summary>
+        [JsonProperty("percentages")]
+        public List<long> Percentages { get; set; }
+
+        /// <summary>
+        /// Below this amount, fixed amounts will be displayed; above it, percentages will be
+        /// displayed.
+        /// </summary>
+        [JsonProperty("smart_tip_threshold")]
+        public long SmartTipThreshold { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/CreditReversals/CreditReversal.cs
+++ b/src/Stripe.net/Entities/Treasury/CreditReversals/CreditReversal.cs
@@ -1,0 +1,124 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// You can reverse some <a
+    /// href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on
+    /// their network and source flow. Reversing a ReceivedCredit leads to the creation of a new
+    /// object known as a CreditReversal.
+    /// </summary>
+    public class CreditReversal : StripeEntity<CreditReversal>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to reverse funds from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// A hosted transaction receipt URL that is provided when money movement is considered
+        /// regulated under Stripe's money transmission licenses.
+        /// </summary>
+        [JsonProperty("hosted_regulatory_receipt_url")]
+        public string HostedRegulatoryReceiptUrl { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The rails used to reverse the funds.
+        /// One of: <c>ach</c>, or <c>stripe</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// The ReceivedCredit being reversed.
+        /// </summary>
+        [JsonProperty("received_credit")]
+        public string ReceivedCredit { get; set; }
+
+        /// <summary>
+        /// Status of the CreditReversal.
+        /// One of: <c>canceled</c>, <c>posted</c>, or <c>processing</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public CreditReversalStatusTransitions StatusTransitions { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/CreditReversals/CreditReversalStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/CreditReversals/CreditReversalStatusTransitions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class CreditReversalStatusTransitions : StripeEntity<CreditReversalStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when the CreditReversal changed status to <c>posted</c>.
+        /// </summary>
+        [JsonProperty("posted_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? PostedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversal.cs
+++ b/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversal.cs
@@ -1,0 +1,130 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// You can reverse some <a
+    /// href="https://stripe.com/docs/api#received_debits">ReceivedDebits</a> depending on their
+    /// network and source flow. Reversing a ReceivedDebit leads to the creation of a new object
+    /// known as a DebitReversal.
+    /// </summary>
+    public class DebitReversal : StripeEntity<DebitReversal>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to reverse funds from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// A hosted transaction receipt URL that is provided when money movement is considered
+        /// regulated under Stripe's money transmission licenses.
+        /// </summary>
+        [JsonProperty("hosted_regulatory_receipt_url")]
+        public string HostedRegulatoryReceiptUrl { get; set; }
+
+        /// <summary>
+        /// Other flows linked to a DebitReversal.
+        /// </summary>
+        [JsonProperty("linked_flows")]
+        public DebitReversalLinkedFlows LinkedFlows { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The rails used to reverse the funds.
+        /// One of: <c>ach</c>, or <c>card</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// The ReceivedDebit being reversed.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+
+        /// <summary>
+        /// Status of the DebitReversal.
+        /// One of: <c>failed</c>, <c>processing</c>, or <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public DebitReversalStatusTransitions StatusTransitions { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversalLinkedFlows.cs
+++ b/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversalLinkedFlows.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class DebitReversalLinkedFlows : StripeEntity<DebitReversalLinkedFlows>
+    {
+        /// <summary>
+        /// Set if there is an Issuing dispute associated with the DebitReversal.
+        /// </summary>
+        [JsonProperty("issuing_dispute")]
+        public string IssuingDispute { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversalStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/DebitReversals/DebitReversalStatusTransitions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class DebitReversalStatusTransitions : StripeEntity<DebitReversalStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when the DebitReversal changed status to <c>completed</c>.
+        /// </summary>
+        [JsonProperty("completed_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CompletedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeatures.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeatures.cs
@@ -1,0 +1,61 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Encodes whether a FinancialAccount has access to a particular Feature, with a
+    /// <c>status</c> enum and associated <c>status_details</c>. Stripe or the platform can
+    /// control Features via the requested field.
+    /// </summary>
+    public class FinancialAccountFeatures : StripeEntity<FinancialAccountFeatures>, IHasObject
+    {
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("card_issuing")]
+        public FinancialAccountFeaturesCardIssuing CardIssuing { get; set; }
+
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("deposit_insurance")]
+        public FinancialAccountFeaturesDepositInsurance DepositInsurance { get; set; }
+
+        /// <summary>
+        /// Settings related to Financial Addresses features on a Financial Account.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+        public FinancialAccountFeaturesFinancialAddresses FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// InboundTransfers contains inbound transfers features for a FinancialAccount.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+        public FinancialAccountFeaturesInboundTransfers InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("intra_stripe_flows")]
+        public FinancialAccountFeaturesIntraStripeFlows IntraStripeFlows { get; set; }
+
+        /// <summary>
+        /// Settings related to Outbound Payments features on a Financial Account.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+        public FinancialAccountFeaturesOutboundPayments OutboundPayments { get; set; }
+
+        /// <summary>
+        /// OutboundTransfers contains outbound transfers features for a FinancialAccount.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+        public FinancialAccountFeaturesOutboundTransfers OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesCardIssuing.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesCardIssuing.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesCardIssuing : StripeEntity<FinancialAccountFeaturesCardIssuing>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesCardIssuingStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesCardIssuingStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesCardIssuingStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesCardIssuingStatusDetail : StripeEntity<FinancialAccountFeaturesCardIssuingStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesDepositInsurance.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesDepositInsurance.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesDepositInsurance : StripeEntity<FinancialAccountFeaturesDepositInsurance>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesDepositInsuranceStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesDepositInsuranceStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesDepositInsuranceStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesDepositInsuranceStatusDetail : StripeEntity<FinancialAccountFeaturesDepositInsuranceStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddresses.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddresses.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesFinancialAddresses : StripeEntity<FinancialAccountFeaturesFinancialAddresses>
+    {
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("aba")]
+        public FinancialAccountFeaturesFinancialAddressesAba Aba { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddressesAba.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddressesAba.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesFinancialAddressesAba : StripeEntity<FinancialAccountFeaturesFinancialAddressesAba>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesFinancialAddressesAbaStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddressesAbaStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesFinancialAddressesAbaStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesFinancialAddressesAbaStatusDetail : StripeEntity<FinancialAccountFeaturesFinancialAddressesAbaStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfers.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfers.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesInboundTransfers : StripeEntity<FinancialAccountFeaturesInboundTransfers>
+    {
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesInboundTransfersAch Ach { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfersAch.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfersAch.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesInboundTransfersAch : StripeEntity<FinancialAccountFeaturesInboundTransfersAch>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesInboundTransfersAchStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfersAchStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesInboundTransfersAchStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesInboundTransfersAchStatusDetail : StripeEntity<FinancialAccountFeaturesInboundTransfersAchStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesIntraStripeFlows.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesIntraStripeFlows.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesIntraStripeFlows : StripeEntity<FinancialAccountFeaturesIntraStripeFlows>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesIntraStripeFlowsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesIntraStripeFlowsStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesIntraStripeFlowsStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesIntraStripeFlowsStatusDetail : StripeEntity<FinancialAccountFeaturesIntraStripeFlowsStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPayments.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPayments.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPayments : StripeEntity<FinancialAccountFeaturesOutboundPayments>
+    {
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesOutboundPaymentsAch Ach { get; set; }
+
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountFeaturesOutboundPaymentsUsDomesticWire UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsAch.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsAch.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsAch : StripeEntity<FinancialAccountFeaturesOutboundPaymentsAch>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesOutboundPaymentsAchStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsAchStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsAchStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsAchStatusDetail : StripeEntity<FinancialAccountFeaturesOutboundPaymentsAchStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsUsDomesticWire.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsUsDomesticWire.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsUsDomesticWire : StripeEntity<FinancialAccountFeaturesOutboundPaymentsUsDomesticWire>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesOutboundPaymentsUsDomesticWireStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsUsDomesticWireStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundPaymentsUsDomesticWireStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsUsDomesticWireStatusDetail : StripeEntity<FinancialAccountFeaturesOutboundPaymentsUsDomesticWireStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfers.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfers.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfers : StripeEntity<FinancialAccountFeaturesOutboundTransfers>
+    {
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesOutboundTransfersAch Ach { get; set; }
+
+        /// <summary>
+        /// Toggle settings for enabling/disabling a feature.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountFeaturesOutboundTransfersUsDomesticWire UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersAch.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersAch.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersAch : StripeEntity<FinancialAccountFeaturesOutboundTransfersAch>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesOutboundTransfersAchStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersAchStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersAchStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersAchStatusDetail : StripeEntity<FinancialAccountFeaturesOutboundTransfersAchStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersUsDomesticWire.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersUsDomesticWire.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersUsDomesticWire : StripeEntity<FinancialAccountFeaturesOutboundTransfersUsDomesticWire>
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// Whether the Feature is operational.
+        /// One of: <c>active</c>, <c>pending</c>, or <c>restricted</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details; includes at least one entry when the status is not <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+        public List<FinancialAccountFeaturesOutboundTransfersUsDomesticWireStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersUsDomesticWireStatusDetail.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesOutboundTransfersUsDomesticWireStatusDetail.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersUsDomesticWireStatusDetail : StripeEntity<FinancialAccountFeaturesOutboundTransfersUsDomesticWireStatusDetail>
+    {
+        /// <summary>
+        /// Represents the reason why the status is <c>pending</c> or <c>restricted</c>.
+        /// One of: <c>activating</c>, <c>capability_not_requested</c>,
+        /// <c>financial_account_closed</c>, <c>rejected_other</c>,
+        /// <c>rejected_unsupported_business</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_by_platform</c>, or
+        /// <c>restricted_other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Represents what the user should do, if anything, to activate the Feature.
+        /// One of: <c>contact_stripe</c>, <c>provide_information</c>, or <c>remove_restriction</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        /// <summary>
+        /// The <c>platform_restrictions</c> that are restricting this Feature.
+        /// One of: <c>inbound_flows</c>, or <c>outbound_flows</c>.
+        /// </summary>
+        [JsonProperty("restriction")]
+        public string Restriction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccount.cs
@@ -1,0 +1,119 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// Stripe Treasury provides users with a container for money called a FinancialAccount that
+    /// is separate from their Payments balance. FinancialAccounts serve as the source and
+    /// destination of Treasury’s money movement APIs.
+    /// </summary>
+    public class FinancialAccount : StripeEntity<FinancialAccount>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// The array of paths to active Features in the Features hash.
+        /// </summary>
+        [JsonProperty("active_features")]
+        public List<string> ActiveFeatures { get; set; }
+
+        /// <summary>
+        /// Balance information for the FinancialAccount.
+        /// </summary>
+        [JsonProperty("balance")]
+        public FinancialAccountBalance Balance { get; set; }
+
+        /// <summary>
+        /// Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+        /// 3166-1 alpha-2</a>).
+        /// </summary>
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Encodes whether a FinancialAccount has access to a particular Feature, with a
+        /// <c>status</c> enum and associated <c>status_details</c>. Stripe or the platform can
+        /// control Features via the requested field.
+        /// </summary>
+        [JsonProperty("features")]
+        public FinancialAccountFeatures Features { get; set; }
+
+        /// <summary>
+        /// The set of credentials that resolve to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+        public List<FinancialAccountFinancialAddress> FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The array of paths to pending Features in the Features hash.
+        /// </summary>
+        [JsonProperty("pending_features")]
+        public List<string> PendingFeatures { get; set; }
+
+        /// <summary>
+        /// The set of functionalities that the platform can restrict on the FinancialAccount.
+        /// </summary>
+        [JsonProperty("platform_restrictions")]
+        public FinancialAccountPlatformRestrictions PlatformRestrictions { get; set; }
+
+        /// <summary>
+        /// The array of paths to restricted Features in the Features hash.
+        /// </summary>
+        [JsonProperty("restricted_features")]
+        public List<string> RestrictedFeatures { get; set; }
+
+        /// <summary>
+        /// The enum specifying what state the account is in.
+        /// One of: <c>closed</c>, or <c>open</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_details")]
+        public FinancialAccountStatusDetails StatusDetails { get; set; }
+
+        /// <summary>
+        /// The currencies the FinancialAccount can hold a balance in. Three-letter <a
+        /// href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in
+        /// lowercase.
+        /// </summary>
+        [JsonProperty("supported_currencies")]
+        public List<string> SupportedCurrencies { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountBalance.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountBalance.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountBalance : StripeEntity<FinancialAccountBalance>
+    {
+        /// <summary>
+        /// Funds the user can spend right now.
+        /// </summary>
+        [JsonProperty("cash")]
+        public Dictionary<string, long> Cash { get; set; }
+
+        /// <summary>
+        /// Funds not spendable yet, but will become available at a later time.
+        /// </summary>
+        [JsonProperty("inbound_pending")]
+        public Dictionary<string, long> InboundPending { get; set; }
+
+        /// <summary>
+        /// Funds in the account, but not spendable because they are being held for pending outbound
+        /// flows.
+        /// </summary>
+        [JsonProperty("outbound_pending")]
+        public Dictionary<string, long> OutboundPending { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountFinancialAddress.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountFinancialAddress.cs
@@ -1,0 +1,27 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFinancialAddress : StripeEntity<FinancialAccountFinancialAddress>
+    {
+        /// <summary>
+        /// ABA Records contain U.S. bank account details per the ABA format.
+        /// </summary>
+        [JsonProperty("aba")]
+        public FinancialAccountFinancialAddressAba Aba { get; set; }
+
+        /// <summary>
+        /// The list of networks that the address supports.
+        /// </summary>
+        [JsonProperty("supported_networks")]
+        public List<string> SupportedNetworks { get; set; }
+
+        /// <summary>
+        /// The type of financial address.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountFinancialAddressAba.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountFinancialAddressAba.cs
@@ -1,0 +1,38 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFinancialAddressAba : StripeEntity<FinancialAccountFinancialAddressAba>
+    {
+        /// <summary>
+        /// The name of the person or business that owns the bank account.
+        /// </summary>
+        [JsonProperty("account_holder_name")]
+        public string AccountHolderName { get; set; }
+
+        /// <summary>
+        /// The account number.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// The last four characters of the account number.
+        /// </summary>
+        [JsonProperty("account_number_last4")]
+        public string AccountNumberLast4 { get; set; }
+
+        /// <summary>
+        /// Name of the bank.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Routing number for the account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountPlatformRestrictions.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountPlatformRestrictions.cs
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountPlatformRestrictions : StripeEntity<FinancialAccountPlatformRestrictions>
+    {
+        /// <summary>
+        /// Restricts all inbound money movement.
+        /// One of: <c>restricted</c>, or <c>unrestricted</c>.
+        /// </summary>
+        [JsonProperty("inbound_flows")]
+        public string InboundFlows { get; set; }
+
+        /// <summary>
+        /// Restricts all outbound money movement.
+        /// One of: <c>restricted</c>, or <c>unrestricted</c>.
+        /// </summary>
+        [JsonProperty("outbound_flows")]
+        public string OutboundFlows { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountStatusDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountStatusDetails.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountStatusDetails : StripeEntity<FinancialAccountStatusDetails>
+    {
+        /// <summary>
+        /// Details related to the closure of this FinancialAccount.
+        /// </summary>
+        [JsonProperty("closed")]
+        public FinancialAccountStatusDetailsClosed Closed { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountStatusDetailsClosed.cs
+++ b/src/Stripe.net/Entities/Treasury/FinancialAccounts/FinancialAccountStatusDetailsClosed.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountStatusDetailsClosed : StripeEntity<FinancialAccountStatusDetailsClosed>
+    {
+        /// <summary>
+        /// The array that contains reasons for a FinancialAccount closure.
+        /// </summary>
+        [JsonProperty("reasons")]
+        public List<string> Reasons { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransfer.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransfer.cs
@@ -1,0 +1,169 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// Use InboundTransfers to add funds to your <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> via a
+    /// PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
+    /// </summary>
+    public class InboundTransfer : StripeEntity<InboundTransfer>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the InboundTransfer is able to be canceled.
+        /// </summary>
+        [JsonProperty("cancelable")]
+        public bool Cancelable { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Details about this InboundTransfer's failure. Only set when status is <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failure_details")]
+        public InboundTransferFailureDetails FailureDetails { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount that received the funds.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// A hosted transaction receipt URL that is provided when money movement is considered
+        /// regulated under Stripe's money transmission licenses.
+        /// </summary>
+        [JsonProperty("hosted_regulatory_receipt_url")]
+        public string HostedRegulatoryReceiptUrl { get; set; }
+
+        [JsonProperty("linked_flows")]
+        public InboundTransferLinkedFlows LinkedFlows { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The origin payment method to be debited for an InboundTransfer.
+        /// </summary>
+        [JsonProperty("origin_payment_method")]
+        public string OriginPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Details about the PaymentMethod for an InboundTransfer.
+        /// </summary>
+        [JsonProperty("origin_payment_method_details")]
+        public InboundTransferOriginPaymentMethodDetails OriginPaymentMethodDetails { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the funds for an InboundTransfer were returned after the
+        /// InboundTransfer went to the <c>succeeded</c> state.
+        /// </summary>
+        [JsonProperty("returned")]
+        public bool? Returned { get; set; }
+
+        /// <summary>
+        /// Statement descriptor shown when funds are debited from the source. Not all payment
+        /// networks support <c>statement_descriptor</c>.
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+
+        /// <summary>
+        /// Status of the InboundTransfer: <c>processing</c>, <c>succeeded</c>, <c>failed</c>, and
+        /// <c>canceled</c>. An InboundTransfer is <c>processing</c> if it is created and pending.
+        /// The status changes to <c>succeeded</c> once the funds have been "confirmed" and a
+        /// <c>transaction</c> is created and posted. The status changes to <c>failed</c> if the
+        /// transfer fails.
+        /// One of: <c>canceled</c>, <c>failed</c>, <c>processing</c>, or <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public InboundTransferStatusTransitions StatusTransitions { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferFailureDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferFailureDetails.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferFailureDetails : StripeEntity<InboundTransferFailureDetails>
+    {
+        /// <summary>
+        /// Reason for the failure.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>debit_not_authorized</c>,
+        /// <c>incorrect_account_holder_address</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>incorrect_account_holder_tax_id</c>, <c>insufficient_funds</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferLinkedFlows.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferLinkedFlows.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferLinkedFlows : StripeEntity<InboundTransferLinkedFlows>
+    {
+        /// <summary>
+        /// If funds for this flow were returned after the flow went to the <c>succeeded</c> state,
+        /// this field contains a reference to the ReceivedDebit return.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetails.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferOriginPaymentMethodDetails : StripeEntity<InboundTransferOriginPaymentMethodDetails>
+    {
+        [JsonProperty("billing_details")]
+        public InboundTransferOriginPaymentMethodDetailsBillingDetails BillingDetails { get; set; }
+
+        /// <summary>
+        /// The type of the payment method used in the InboundTransfer.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public InboundTransferOriginPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetailsBillingDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetailsBillingDetails.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferOriginPaymentMethodDetailsBillingDetails : StripeEntity<InboundTransferOriginPaymentMethodDetailsBillingDetails>
+    {
+        [JsonProperty("address")]
+        public Address Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferOriginPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,53 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferOriginPaymentMethodDetailsUsBankAccount : StripeEntity<InboundTransferOriginPaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// The US bank account network used to debit funds.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/InboundTransfers/InboundTransferStatusTransitions.cs
@@ -1,0 +1,31 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class InboundTransferStatusTransitions : StripeEntity<InboundTransferStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when an InboundTransfer changed status to <c>canceled</c>.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an InboundTransfer changed status to <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failed_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? FailedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an InboundTransfer changed status to <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("succeeded_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? SucceededAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPayment.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPayment.cs
@@ -1,0 +1,186 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// Use OutboundPayments to send funds to another party's external bank account or <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send
+    /// money to an account belonging to the same user, use an <a
+    /// href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+    ///
+    /// Simulate OutboundPayment state changes with the
+    /// <c>/v1/test_helpers/treasury/outbound_payments</c> endpoints. These methods can only be
+    /// called on test mode objects.
+    /// </summary>
+    public class OutboundPayment : StripeEntity<OutboundPayment>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the object can be canceled, and <c>false</c> otherwise.
+        /// </summary>
+        [JsonProperty("cancelable")]
+        public bool Cancelable { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// ID of the customer to whom an OutboundPayment is sent.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The PaymentMethod via which an OutboundPayment is sent. This field can be empty if the
+        /// OutboundPayment was created using <c>destination_payment_method_data</c>.
+        /// </summary>
+        [JsonProperty("destination_payment_method")]
+        public string DestinationPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Details about the PaymentMethod for an OutboundPayment.
+        /// </summary>
+        [JsonProperty("destination_payment_method_details")]
+        public OutboundPaymentDestinationPaymentMethodDetails DestinationPaymentMethodDetails { get; set; }
+
+        /// <summary>
+        /// Details about the end user.
+        /// </summary>
+        [JsonProperty("end_user_details")]
+        public OutboundPaymentEndUserDetails EndUserDetails { get; set; }
+
+        /// <summary>
+        /// The date when funds are expected to arrive in the destination account.
+        /// </summary>
+        [JsonProperty("expected_arrival_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ExpectedArrivalDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The FinancialAccount that funds were pulled from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// A hosted transaction receipt URL that is provided when money movement is considered
+        /// regulated under Stripe's money transmission licenses.
+        /// </summary>
+        [JsonProperty("hosted_regulatory_receipt_url")]
+        public string HostedRegulatoryReceiptUrl { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Details about a returned OutboundPayment. Only set when the status is <c>returned</c>.
+        /// </summary>
+        [JsonProperty("returned_details")]
+        public OutboundPaymentReturnedDetails ReturnedDetails { get; set; }
+
+        /// <summary>
+        /// The description that appears on the receiving end for an OutboundPayment (for example,
+        /// bank statement for external bank transfer).
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+
+        /// <summary>
+        /// Current status of the OutboundPayment: <c>processing</c>, <c>failed</c>, <c>posted</c>,
+        /// <c>returned</c>, <c>canceled</c>. An OutboundPayment is <c>processing</c> if it has been
+        /// created and is pending. The status changes to <c>posted</c> once the OutboundPayment has
+        /// been "confirmed" and funds have left the account, or to <c>failed</c> or
+        /// <c>canceled</c>. If an OutboundPayment fails to arrive at its destination, its status
+        /// will change to <c>returned</c>.
+        /// One of: <c>canceled</c>, <c>failed</c>, <c>posted</c>, <c>processing</c>, or
+        /// <c>returned</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public OutboundPaymentStatusTransitions StatusTransitions { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetails.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDetails : StripeEntity<OutboundPaymentDestinationPaymentMethodDetails>
+    {
+        [JsonProperty("billing_details")]
+        public OutboundPaymentDestinationPaymentMethodDetailsBillingDetails BillingDetails { get; set; }
+
+        [JsonProperty("financial_account")]
+        public OutboundPaymentDestinationPaymentMethodDetailsFinancialAccount FinancialAccount { get; set; }
+
+        /// <summary>
+        /// The type of the payment method used in the OutboundPayment.
+        /// One of: <c>financial_account</c>, or <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public OutboundPaymentDestinationPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsBillingDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsBillingDetails.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDetailsBillingDetails : StripeEntity<OutboundPaymentDestinationPaymentMethodDetailsBillingDetails>
+    {
+        [JsonProperty("address")]
+        public Address Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsFinancialAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsFinancialAccount.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDetailsFinancialAccount : StripeEntity<OutboundPaymentDestinationPaymentMethodDetailsFinancialAccount>, IHasId
+    {
+        /// <summary>
+        /// Token of the FinancialAccount.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The rails used to send funds.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDetailsUsBankAccount : StripeEntity<OutboundPaymentDestinationPaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// The US bank account network used to send funds.
+        /// One of: <c>ach</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentEndUserDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentEndUserDetails.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentEndUserDetails : StripeEntity<OutboundPaymentEndUserDetails>
+    {
+        /// <summary>
+        /// IP address of the user initiating the OutboundPayment. Set if <c>present</c> is set to
+        /// <c>true</c>. IP address collection is required for risk and compliance reasons. This
+        /// will be used to help determine if the OutboundPayment is authorized or should be
+        /// blocked.
+        /// </summary>
+        [JsonProperty("ip_address")]
+        public string IpAddress { get; set; }
+
+        /// <summary>
+        /// <c>true`` if the OutboundPayment creation request is being made on behalf of an end user
+        /// by a platform. Otherwise, </c>false`.
+        /// </summary>
+        [JsonProperty("present")]
+        public bool Present { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentReturnedDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentReturnedDetails.cs
@@ -1,0 +1,50 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class OutboundPaymentReturnedDetails : StripeEntity<OutboundPaymentReturnedDetails>
+    {
+        /// <summary>
+        /// Reason for the return.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>declined</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundPayments/OutboundPaymentStatusTransitions.cs
@@ -1,0 +1,38 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class OutboundPaymentStatusTransitions : StripeEntity<OutboundPaymentStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when an OutboundPayment changed status to <c>canceled</c>.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundPayment changed status to <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failed_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? FailedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundPayment changed status to <c>posted</c>.
+        /// </summary>
+        [JsonProperty("posted_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? PostedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundPayment changed status to <c>returned</c>.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransfer.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransfer.cs
@@ -1,0 +1,171 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// Use OutboundTransfers to transfer funds from a <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> to a
+    /// PaymentMethod belonging to the same entity. To send funds to a different party, use <a
+    /// href="https://stripe.com/docs/api#outbound_payments">OutboundPayments</a> instead. You
+    /// can send funds over ACH rails or through a domestic wire transfer to a user's own
+    /// external bank account.
+    ///
+    /// Simulate OutboundTransfer state changes with the
+    /// <c>/v1/test_helpers/treasury/outbound_transfers</c> endpoints. These methods can only be
+    /// called on test mode objects.
+    /// </summary>
+    public class OutboundTransfer : StripeEntity<OutboundTransfer>, IHasId, IHasMetadata, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the object can be canceled, and <c>false</c> otherwise.
+        /// </summary>
+        [JsonProperty("cancelable")]
+        public bool Cancelable { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The PaymentMethod used as the payment instrument for an OutboundTransfer.
+        /// </summary>
+        [JsonProperty("destination_payment_method")]
+        public string DestinationPaymentMethod { get; set; }
+
+        [JsonProperty("destination_payment_method_details")]
+        public OutboundTransferDestinationPaymentMethodDetails DestinationPaymentMethodDetails { get; set; }
+
+        /// <summary>
+        /// The date when funds are expected to arrive in the destination account.
+        /// </summary>
+        [JsonProperty("expected_arrival_date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ExpectedArrivalDate { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The FinancialAccount that funds were pulled from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// A hosted transaction receipt URL that is provided when money movement is considered
+        /// regulated under Stripe's money transmission licenses.
+        /// </summary>
+        [JsonProperty("hosted_regulatory_receipt_url")]
+        public string HostedRegulatoryReceiptUrl { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Details about a returned OutboundTransfer. Only set when the status is <c>returned</c>.
+        /// </summary>
+        [JsonProperty("returned_details")]
+        public OutboundTransferReturnedDetails ReturnedDetails { get; set; }
+
+        /// <summary>
+        /// Information about the OutboundTransfer to be sent to the recipient account.
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+
+        /// <summary>
+        /// Current status of the OutboundTransfer: <c>processing</c>, <c>failed</c>,
+        /// <c>canceled</c>, <c>posted</c>, <c>returned</c>. An OutboundTransfer is
+        /// <c>processing</c> if it has been created and is pending. The status changes to
+        /// <c>posted</c> once the OutboundTransfer has been "confirmed" and funds have left the
+        /// account, or to <c>failed</c> or <c>canceled</c>. If an OutboundTransfer fails to arrive
+        /// at its destination, its status will change to <c>returned</c>.
+        /// One of: <c>canceled</c>, <c>failed</c>, <c>posted</c>, <c>processing</c>, or
+        /// <c>returned</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public OutboundTransferStatusTransitions StatusTransitions { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetails.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferDestinationPaymentMethodDetails : StripeEntity<OutboundTransferDestinationPaymentMethodDetails>
+    {
+        [JsonProperty("billing_details")]
+        public OutboundTransferDestinationPaymentMethodDetailsBillingDetails BillingDetails { get; set; }
+
+        /// <summary>
+        /// The type of the payment method used in the OutboundTransfer.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public OutboundTransferDestinationPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetailsBillingDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetailsBillingDetails.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferDestinationPaymentMethodDetailsBillingDetails : StripeEntity<OutboundTransferDestinationPaymentMethodDetailsBillingDetails>
+    {
+        [JsonProperty("address")]
+        public Address Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferDestinationPaymentMethodDetailsUsBankAccount : StripeEntity<OutboundTransferDestinationPaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// Name of the bank associated with the bank account.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// Uniquely identifies this particular bank account. You can use this attribute to check
+        /// whether two bank accounts are the same.
+        /// </summary>
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+
+        /// <summary>
+        /// Last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// The US bank account network used to send funds.
+        /// One of: <c>ach</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferReturnedDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferReturnedDetails.cs
@@ -1,0 +1,50 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class OutboundTransferReturnedDetails : StripeEntity<OutboundTransferReturnedDetails>
+    {
+        /// <summary>
+        /// Reason for the return.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>declined</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/OutboundTransfers/OutboundTransferStatusTransitions.cs
@@ -1,0 +1,38 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class OutboundTransferStatusTransitions : StripeEntity<OutboundTransferStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when an OutboundTransfer changed status to <c>canceled</c>.
+        /// </summary>
+        [JsonProperty("canceled_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? CanceledAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundTransfer changed status to <c>failed</c>.
+        /// </summary>
+        [JsonProperty("failed_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? FailedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundTransfer changed status to <c>posted</c>.
+        /// </summary>
+        [JsonProperty("posted_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? PostedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when an OutboundTransfer changed status to <c>returned</c>.
+        /// </summary>
+        [JsonProperty("returned_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ReturnedAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCredit.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCredit.cs
@@ -1,0 +1,128 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// ReceivedCredits represent funds sent to a <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> (for example,
+    /// via ACH or wire). These money movements are not initiated from the FinancialAccount.
+    /// </summary>
+    public class ReceivedCredit : StripeEntity<ReceivedCredit>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Reason for the failure. A ReceivedCredit might fail because the receiving
+        /// FinancialAccount is closed or frozen.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, or <c>other</c>.
+        /// </summary>
+        [JsonProperty("failure_code")]
+        public string FailureCode { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount that received the funds.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("initiating_payment_method_details")]
+        public ReceivedCreditInitiatingPaymentMethodDetails InitiatingPaymentMethodDetails { get; set; }
+
+        [JsonProperty("linked_flows")]
+        public ReceivedCreditLinkedFlows LinkedFlows { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// The rails used to send the funds.
+        /// One of: <c>ach</c>, <c>card</c>, <c>stripe</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// Status of the ReceivedCredit. ReceivedCredits are created either <c>succeeded</c>
+        /// (approved) or <c>failed</c> (declined). If a ReceivedCredit is declined, the failure
+        /// reason can be found in the <c>failure_code</c> field.
+        /// One of: <c>failed</c>, or <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetails.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetails : StripeEntity<ReceivedCreditInitiatingPaymentMethodDetails>
+    {
+        /// <summary>
+        /// Set when <c>type</c> is <c>balance</c>.
+        /// </summary>
+        [JsonProperty("balance")]
+        public string Balance { get; set; }
+
+        [JsonProperty("billing_details")]
+        public ReceivedCreditInitiatingPaymentMethodDetailsBillingDetails BillingDetails { get; set; }
+
+        [JsonProperty("financial_account")]
+        public ReceivedCreditInitiatingPaymentMethodDetailsFinancialAccount FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set when <c>type</c> is <c>issuing_card</c>. This is an <a
+        /// href="https://stripe.com/docs/api#issuing_cards">Issuing Card</a> ID.
+        /// </summary>
+        [JsonProperty("issuing_card")]
+        public string IssuingCard { get; set; }
+
+        /// <summary>
+        /// Polymorphic type matching the originating money movement's source. This can be an
+        /// external account, a Stripe balance, or a FinancialAccount.
+        /// One of: <c>balance</c>, <c>financial_account</c>, <c>issuing_card</c>, <c>stripe</c>, or
+        /// <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsBillingDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsBillingDetails.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetailsBillingDetails : StripeEntity<ReceivedCreditInitiatingPaymentMethodDetailsBillingDetails>
+    {
+        [JsonProperty("address")]
+        public Address Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsFinancialAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsFinancialAccount.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetailsFinancialAccount : StripeEntity<ReceivedCreditInitiatingPaymentMethodDetailsFinancialAccount>, IHasId
+    {
+        /// <summary>
+        /// The FinancialAccount ID.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over
+        /// <c>stripe</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount : StripeEntity<ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank name.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// The last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// The routing number for the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditLinkedFlows.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditLinkedFlows.cs
@@ -1,0 +1,50 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditLinkedFlows : StripeEntity<ReceivedCreditLinkedFlows>
+    {
+        /// <summary>
+        /// The CreditReversal created as a result of this ReceivedCredit being reversed.
+        /// </summary>
+        [JsonProperty("credit_reversal")]
+        public string CreditReversal { get; set; }
+
+        /// <summary>
+        /// Set if the ReceivedCredit was created due to an <a
+        /// href="https://stripe.com/docs/api#issuing_authorizations">Issuing Authorization</a>
+        /// object.
+        /// </summary>
+        [JsonProperty("issuing_authorization")]
+        public string IssuingAuthorization { get; set; }
+
+        /// <summary>
+        /// Set if the ReceivedCredit is also viewable as an <a
+        /// href="https://stripe.com/docs/api#issuing_transactions">Issuing transaction</a> object.
+        /// </summary>
+        [JsonProperty("issuing_transaction")]
+        public string IssuingTransaction { get; set; }
+
+        /// <summary>
+        /// ID of the source flow. Set if <c>network</c> is <c>stripe</c> and the source flow is
+        /// visible to the merchant. Examples of source flows include OutboundPayments, payouts, or
+        /// CreditReversals.
+        /// </summary>
+        [JsonProperty("source_flow")]
+        public string SourceFlow { get; set; }
+
+        /// <summary>
+        /// The expandable object of the source flow.
+        /// </summary>
+        [JsonProperty("source_flow_details")]
+        public ReceivedCreditLinkedFlowsSourceFlowDetails SourceFlowDetails { get; set; }
+
+        /// <summary>
+        /// The type of flow that originated the ReceivedCredit (for example,
+        /// <c>outbound_payment</c>).
+        /// </summary>
+        [JsonProperty("source_flow_type")]
+        public string SourceFlowType { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditLinkedFlowsSourceFlowDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedCredits/ReceivedCreditLinkedFlowsSourceFlowDetails.cs
@@ -1,0 +1,50 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditLinkedFlowsSourceFlowDetails : StripeEntity<ReceivedCreditLinkedFlowsSourceFlowDetails>
+    {
+        /// <summary>
+        /// You can reverse some <a
+        /// href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on
+        /// their network and source flow. Reversing a ReceivedCredit leads to the creation of a new
+        /// object known as a CreditReversal.
+        /// </summary>
+        [JsonProperty("credit_reversal")]
+        public CreditReversal CreditReversal { get; set; }
+
+        /// <summary>
+        /// Use OutboundPayments to send funds to another party's external bank account or <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send
+        /// money to an account belonging to the same user, use an <a
+        /// href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+        ///
+        /// Simulate OutboundPayment state changes with the
+        /// <c>/v1/test_helpers/treasury/outbound_payments</c> endpoints. These methods can only be
+        /// called on test mode objects.
+        /// </summary>
+        [JsonProperty("outbound_payment")]
+        public OutboundPayment OutboundPayment { get; set; }
+
+        /// <summary>
+        /// A <c>Payout</c> object is created when you receive funds from Stripe, or when you
+        /// initiate a payout to either a bank account or debit card of a <a
+        /// href="https://stripe.com/docs/connect/bank-debit-card-payouts">connected Stripe
+        /// account</a>. You can retrieve individual payouts, as well as list all payouts. Payouts
+        /// are made on <a href="https://stripe.com/docs/connect/manage-payout-schedule">varying
+        /// schedules</a>, depending on your country and industry.
+        ///
+        /// Related guide: <a href="https://stripe.com/docs/payouts">Receiving Payouts</a>.
+        /// </summary>
+        [JsonProperty("payout")]
+        public Payout Payout { get; set; }
+
+        /// <summary>
+        /// The type of the source flow that originated the ReceivedCredit.
+        /// One of: <c>credit_reversal</c>, <c>other</c>, <c>outbound_payment</c>, or <c>payout</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebit.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebit.cs
@@ -1,0 +1,129 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// ReceivedDebits represent funds pulled from a <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. These are
+    /// not initiated from the FinancialAccount.
+    /// </summary>
+    public class ReceivedDebit : StripeEntity<ReceivedDebit>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Reason for the failure. A ReceivedDebit might fail because the FinancialAccount doesn't
+        /// have sufficient funds, is closed, or is frozen.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>insufficient_funds</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("failure_code")]
+        public string FailureCode { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount that funds were pulled from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("initiating_payment_method_details")]
+        public ReceivedDebitInitiatingPaymentMethodDetails InitiatingPaymentMethodDetails { get; set; }
+
+        [JsonProperty("linked_flows")]
+        public ReceivedDebitLinkedFlows LinkedFlows { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// The network used for the ReceivedDebit.
+        /// One of: <c>ach</c>, <c>card</c>, or <c>stripe</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+
+        /// <summary>
+        /// Status of the ReceivedDebit. ReceivedDebits are created with a status of either
+        /// <c>succeeded</c> (approved) or <c>failed</c> (declined). The failure reason can be found
+        /// under the <c>failure_code</c>.
+        /// One of: <c>failed</c>, or <c>succeeded</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetails.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetails : StripeEntity<ReceivedDebitInitiatingPaymentMethodDetails>
+    {
+        /// <summary>
+        /// Set when <c>type</c> is <c>balance</c>.
+        /// </summary>
+        [JsonProperty("balance")]
+        public string Balance { get; set; }
+
+        [JsonProperty("billing_details")]
+        public ReceivedDebitInitiatingPaymentMethodDetailsBillingDetails BillingDetails { get; set; }
+
+        [JsonProperty("financial_account")]
+        public ReceivedDebitInitiatingPaymentMethodDetailsFinancialAccount FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set when <c>type</c> is <c>issuing_card</c>. This is an <a
+        /// href="https://stripe.com/docs/api#issuing_cards">Issuing Card</a> ID.
+        /// </summary>
+        [JsonProperty("issuing_card")]
+        public string IssuingCard { get; set; }
+
+        /// <summary>
+        /// Polymorphic type matching the originating money movement's source. This can be an
+        /// external account, a Stripe balance, or a FinancialAccount.
+        /// One of: <c>balance</c>, <c>financial_account</c>, <c>issuing_card</c>, <c>stripe</c>, or
+        /// <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("us_bank_account")]
+        public ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsBillingDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsBillingDetails.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetailsBillingDetails : StripeEntity<ReceivedDebitInitiatingPaymentMethodDetailsBillingDetails>
+    {
+        [JsonProperty("address")]
+        public Address Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsFinancialAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsFinancialAccount.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetailsFinancialAccount : StripeEntity<ReceivedDebitInitiatingPaymentMethodDetailsFinancialAccount>, IHasId
+    {
+        /// <summary>
+        /// The FinancialAccount ID.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over
+        /// <c>stripe</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount : StripeEntity<ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount>
+    {
+        /// <summary>
+        /// Bank name.
+        /// </summary>
+        [JsonProperty("bank_name")]
+        public string BankName { get; set; }
+
+        /// <summary>
+        /// The last four digits of the bank account number.
+        /// </summary>
+        [JsonProperty("last4")]
+        public string Last4 { get; set; }
+
+        /// <summary>
+        /// The routing number for the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitLinkedFlows.cs
+++ b/src/Stripe.net/Entities/Treasury/ReceivedDebits/ReceivedDebitLinkedFlows.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitLinkedFlows : StripeEntity<ReceivedDebitLinkedFlows>
+    {
+        /// <summary>
+        /// Set if the ReceivedDebit is associated with an InboundTransfer's return of funds.
+        /// </summary>
+        [JsonProperty("inbound_transfer")]
+        public string InboundTransfer { get; set; }
+
+        /// <summary>
+        /// Set if the ReceivedCredit was created due to an <a
+        /// href="https://stripe.com/docs/api#issuing_authorizations">Issuing Authorization</a>
+        /// object.
+        /// </summary>
+        [JsonProperty("issuing_authorization")]
+        public string IssuingAuthorization { get; set; }
+
+        /// <summary>
+        /// Set if the ReceivedDebit is also viewable as an <a
+        /// href="https://stripe.com/docs/api#issuing_disputes">Issuing Dispute</a> object.
+        /// </summary>
+        [JsonProperty("issuing_transaction")]
+        public string IssuingTransaction { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntry.cs
+++ b/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntry.cs
@@ -1,0 +1,134 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// TransactionEntries represent individual units of money movements within a single <a
+    /// href="https://stripe.com/docs/api#transactions">Transaction</a>.
+    /// </summary>
+    public class TransactionEntry : StripeEntity<TransactionEntry>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Change to a FinancialAccount's balance.
+        /// </summary>
+        [JsonProperty("balance_impact")]
+        public TransactionEntryBalanceImpact BalanceImpact { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// When the TransactionEntry will impact the FinancialAccount's balance.
+        /// </summary>
+        [JsonProperty("effective_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime EffectiveAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// The FinancialAccount associated with this object.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Token of the flow associated with the TransactionEntry.
+        /// </summary>
+        [JsonProperty("flow")]
+        public string Flow { get; set; }
+
+        /// <summary>
+        /// Details of the flow associated with the TransactionEntry.
+        /// </summary>
+        [JsonProperty("flow_details")]
+        public TransactionEntryFlowDetails FlowDetails { get; set; }
+
+        /// <summary>
+        /// Type of the flow associated with the TransactionEntry.
+        /// One of: <c>credit_reversal</c>, <c>debit_reversal</c>, <c>inbound_transfer</c>,
+        /// <c>issuing_authorization</c>, <c>other</c>, <c>outbound_payment</c>,
+        /// <c>outbound_transfer</c>, <c>received_credit</c>, or <c>received_debit</c>.
+        /// </summary>
+        [JsonProperty("flow_type")]
+        public string FlowType { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        #region Expandable Transaction
+
+        /// <summary>
+        /// (ID of the Transaction)
+        /// The Transaction associated with this object.
+        /// </summary>
+        [JsonIgnore]
+        public string TransactionId
+        {
+            get => this.InternalTransaction?.Id;
+            set => this.InternalTransaction = SetExpandableFieldId(value, this.InternalTransaction);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The Transaction associated with this object.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Transaction Transaction
+        {
+            get => this.InternalTransaction?.ExpandedObject;
+            set => this.InternalTransaction = SetExpandableFieldObject(value, this.InternalTransaction);
+        }
+
+        [JsonProperty("transaction")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Transaction>))]
+        internal ExpandableField<Transaction> InternalTransaction { get; set; }
+        #endregion
+
+        /// <summary>
+        /// The specific money movement that generated the TransactionEntry.
+        /// One of: <c>credit_reversal</c>, <c>credit_reversal_posting</c>, <c>debit_reversal</c>,
+        /// <c>inbound_transfer</c>, <c>inbound_transfer_return</c>,
+        /// <c>issuing_authorization_hold</c>, <c>issuing_authorization_release</c>, <c>other</c>,
+        /// <c>outbound_payment</c>, <c>outbound_payment_cancellation</c>,
+        /// <c>outbound_payment_failure</c>, <c>outbound_payment_posting</c>,
+        /// <c>outbound_payment_return</c>, <c>outbound_transfer</c>,
+        /// <c>outbound_transfer_cancellation</c>, <c>outbound_transfer_failure</c>,
+        /// <c>outbound_transfer_posting</c>, <c>outbound_transfer_return</c>,
+        /// <c>received_credit</c>, or <c>received_debit</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntryBalanceImpact.cs
+++ b/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntryBalanceImpact.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class TransactionEntryBalanceImpact : StripeEntity<TransactionEntryBalanceImpact>
+    {
+        /// <summary>
+        /// The change made to funds the user can spend right now.
+        /// </summary>
+        [JsonProperty("cash")]
+        public long Cash { get; set; }
+
+        /// <summary>
+        /// The change made to funds that are not spendable yet, but will become available at a
+        /// later time.
+        /// </summary>
+        [JsonProperty("inbound_pending")]
+        public long InboundPending { get; set; }
+
+        /// <summary>
+        /// The change made to funds in the account, but not spendable because they are being held
+        /// for pending outbound flows.
+        /// </summary>
+        [JsonProperty("outbound_pending")]
+        public long OutboundPending { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntryFlowDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/TransactionEntries/TransactionEntryFlowDetails.cs
@@ -1,0 +1,100 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class TransactionEntryFlowDetails : StripeEntity<TransactionEntryFlowDetails>
+    {
+        /// <summary>
+        /// You can reverse some <a
+        /// href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on
+        /// their network and source flow. Reversing a ReceivedCredit leads to the creation of a new
+        /// object known as a CreditReversal.
+        /// </summary>
+        [JsonProperty("credit_reversal")]
+        public CreditReversal CreditReversal { get; set; }
+
+        /// <summary>
+        /// You can reverse some <a
+        /// href="https://stripe.com/docs/api#received_debits">ReceivedDebits</a> depending on their
+        /// network and source flow. Reversing a ReceivedDebit leads to the creation of a new object
+        /// known as a DebitReversal.
+        /// </summary>
+        [JsonProperty("debit_reversal")]
+        public DebitReversal DebitReversal { get; set; }
+
+        /// <summary>
+        /// Use InboundTransfers to add funds to your <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> via a
+        /// PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
+        /// </summary>
+        [JsonProperty("inbound_transfer")]
+        public InboundTransfer InboundTransfer { get; set; }
+
+        /// <summary>
+        /// When an <a href="https://stripe.com/docs/issuing">issued card</a> is used to make a
+        /// purchase, an Issuing <c>Authorization</c> object is created. <a
+        /// href="https://stripe.com/docs/issuing/purchases/authorizations">Authorizations</a> must
+        /// be approved for the purchase to be completed successfully.
+        ///
+        /// Related guide: <a href="https://stripe.com/docs/issuing/purchases/authorizations">Issued
+        /// Card Authorizations</a>.
+        /// </summary>
+        [JsonProperty("issuing_authorization")]
+        public Issuing.Authorization IssuingAuthorization { get; set; }
+
+        /// <summary>
+        /// Use OutboundPayments to send funds to another party's external bank account or <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send
+        /// money to an account belonging to the same user, use an <a
+        /// href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+        ///
+        /// Simulate OutboundPayment state changes with the
+        /// <c>/v1/test_helpers/treasury/outbound_payments</c> endpoints. These methods can only be
+        /// called on test mode objects.
+        /// </summary>
+        [JsonProperty("outbound_payment")]
+        public OutboundPayment OutboundPayment { get; set; }
+
+        /// <summary>
+        /// Use OutboundTransfers to transfer funds from a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> to a
+        /// PaymentMethod belonging to the same entity. To send funds to a different party, use <a
+        /// href="https://stripe.com/docs/api#outbound_payments">OutboundPayments</a> instead. You
+        /// can send funds over ACH rails or through a domestic wire transfer to a user's own
+        /// external bank account.
+        ///
+        /// Simulate OutboundTransfer state changes with the
+        /// <c>/v1/test_helpers/treasury/outbound_transfers</c> endpoints. These methods can only be
+        /// called on test mode objects.
+        /// </summary>
+        [JsonProperty("outbound_transfer")]
+        public OutboundTransfer OutboundTransfer { get; set; }
+
+        /// <summary>
+        /// ReceivedCredits represent funds sent to a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> (for example,
+        /// via ACH or wire). These money movements are not initiated from the FinancialAccount.
+        /// </summary>
+        [JsonProperty("received_credit")]
+        public ReceivedCredit ReceivedCredit { get; set; }
+
+        /// <summary>
+        /// ReceivedDebits represent funds pulled from a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. These are
+        /// not initiated from the FinancialAccount.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public ReceivedDebit ReceivedDebit { get; set; }
+
+        /// <summary>
+        /// Type of the flow that created the Transaction. Set to the same value as
+        /// <c>flow_type</c>.
+        /// One of: <c>credit_reversal</c>, <c>debit_reversal</c>, <c>inbound_transfer</c>,
+        /// <c>issuing_authorization</c>, <c>other</c>, <c>outbound_payment</c>,
+        /// <c>outbound_transfer</c>, <c>received_credit</c>, or <c>received_debit</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/Transactions/Transaction.cs
+++ b/src/Stripe.net/Entities/Treasury/Transactions/Transaction.cs
@@ -1,0 +1,110 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    /// <summary>
+    /// Transactions represent changes to a <a
+    /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount's</a> balance.
+    /// </summary>
+    public class Transaction : StripeEntity<Transaction>, IHasId, IHasObject
+    {
+        /// <summary>
+        /// Unique identifier for the object.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <summary>
+        /// Amount (in cents) transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long Amount { get; set; }
+
+        /// <summary>
+        /// Change to a FinancialAccount's balance.
+        /// </summary>
+        [JsonProperty("balance_impact")]
+        public TransactionBalanceImpact BalanceImpact { get; set; }
+
+        /// <summary>
+        /// Time at which the object was created. Measured in seconds since the Unix epoch.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// A list of TransactionEntries that are part of this Transaction. This cannot be expanded
+        /// in any list endpoints.
+        /// </summary>
+        [JsonProperty("entries")]
+        public StripeList<TransactionEntry> Entries { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount associated with this object.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// ID of the flow that created the Transaction.
+        /// </summary>
+        [JsonProperty("flow")]
+        public string Flow { get; set; }
+
+        /// <summary>
+        /// Details of the flow that created the Transaction.
+        /// </summary>
+        [JsonProperty("flow_details")]
+        public TransactionFlowDetails FlowDetails { get; set; }
+
+        /// <summary>
+        /// Type of the flow that created the Transaction.
+        /// One of: <c>credit_reversal</c>, <c>debit_reversal</c>, <c>inbound_transfer</c>,
+        /// <c>issuing_authorization</c>, <c>other</c>, <c>outbound_payment</c>,
+        /// <c>outbound_transfer</c>, <c>received_credit</c>, or <c>received_debit</c>.
+        /// </summary>
+        [JsonProperty("flow_type")]
+        public string FlowType { get; set; }
+
+        /// <summary>
+        /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
+        /// the object exists in test mode.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; set; }
+
+        /// <summary>
+        /// Status of the Transaction.
+        /// One of: <c>open</c>, <c>posted</c>, or <c>void</c>.
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public TransactionStatusTransitions StatusTransitions { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/Transactions/TransactionBalanceImpact.cs
+++ b/src/Stripe.net/Entities/Treasury/Transactions/TransactionBalanceImpact.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class TransactionBalanceImpact : StripeEntity<TransactionBalanceImpact>
+    {
+        /// <summary>
+        /// The change made to funds the user can spend right now.
+        /// </summary>
+        [JsonProperty("cash")]
+        public long Cash { get; set; }
+
+        /// <summary>
+        /// The change made to funds that are not spendable yet, but will become available at a
+        /// later time.
+        /// </summary>
+        [JsonProperty("inbound_pending")]
+        public long InboundPending { get; set; }
+
+        /// <summary>
+        /// The change made to funds in the account, but not spendable because they are being held
+        /// for pending outbound flows.
+        /// </summary>
+        [JsonProperty("outbound_pending")]
+        public long OutboundPending { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/Transactions/TransactionFlowDetails.cs
+++ b/src/Stripe.net/Entities/Treasury/Transactions/TransactionFlowDetails.cs
@@ -1,0 +1,100 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class TransactionFlowDetails : StripeEntity<TransactionFlowDetails>
+    {
+        /// <summary>
+        /// You can reverse some <a
+        /// href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on
+        /// their network and source flow. Reversing a ReceivedCredit leads to the creation of a new
+        /// object known as a CreditReversal.
+        /// </summary>
+        [JsonProperty("credit_reversal")]
+        public CreditReversal CreditReversal { get; set; }
+
+        /// <summary>
+        /// You can reverse some <a
+        /// href="https://stripe.com/docs/api#received_debits">ReceivedDebits</a> depending on their
+        /// network and source flow. Reversing a ReceivedDebit leads to the creation of a new object
+        /// known as a DebitReversal.
+        /// </summary>
+        [JsonProperty("debit_reversal")]
+        public DebitReversal DebitReversal { get; set; }
+
+        /// <summary>
+        /// Use InboundTransfers to add funds to your <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> via a
+        /// PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
+        /// </summary>
+        [JsonProperty("inbound_transfer")]
+        public InboundTransfer InboundTransfer { get; set; }
+
+        /// <summary>
+        /// When an <a href="https://stripe.com/docs/issuing">issued card</a> is used to make a
+        /// purchase, an Issuing <c>Authorization</c> object is created. <a
+        /// href="https://stripe.com/docs/issuing/purchases/authorizations">Authorizations</a> must
+        /// be approved for the purchase to be completed successfully.
+        ///
+        /// Related guide: <a href="https://stripe.com/docs/issuing/purchases/authorizations">Issued
+        /// Card Authorizations</a>.
+        /// </summary>
+        [JsonProperty("issuing_authorization")]
+        public Issuing.Authorization IssuingAuthorization { get; set; }
+
+        /// <summary>
+        /// Use OutboundPayments to send funds to another party's external bank account or <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send
+        /// money to an account belonging to the same user, use an <a
+        /// href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+        ///
+        /// Simulate OutboundPayment state changes with the
+        /// <c>/v1/test_helpers/treasury/outbound_payments</c> endpoints. These methods can only be
+        /// called on test mode objects.
+        /// </summary>
+        [JsonProperty("outbound_payment")]
+        public OutboundPayment OutboundPayment { get; set; }
+
+        /// <summary>
+        /// Use OutboundTransfers to transfer funds from a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> to a
+        /// PaymentMethod belonging to the same entity. To send funds to a different party, use <a
+        /// href="https://stripe.com/docs/api#outbound_payments">OutboundPayments</a> instead. You
+        /// can send funds over ACH rails or through a domestic wire transfer to a user's own
+        /// external bank account.
+        ///
+        /// Simulate OutboundTransfer state changes with the
+        /// <c>/v1/test_helpers/treasury/outbound_transfers</c> endpoints. These methods can only be
+        /// called on test mode objects.
+        /// </summary>
+        [JsonProperty("outbound_transfer")]
+        public OutboundTransfer OutboundTransfer { get; set; }
+
+        /// <summary>
+        /// ReceivedCredits represent funds sent to a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> (for example,
+        /// via ACH or wire). These money movements are not initiated from the FinancialAccount.
+        /// </summary>
+        [JsonProperty("received_credit")]
+        public ReceivedCredit ReceivedCredit { get; set; }
+
+        /// <summary>
+        /// ReceivedDebits represent funds pulled from a <a
+        /// href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. These are
+        /// not initiated from the FinancialAccount.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public ReceivedDebit ReceivedDebit { get; set; }
+
+        /// <summary>
+        /// Type of the flow that created the Transaction. Set to the same value as
+        /// <c>flow_type</c>.
+        /// One of: <c>credit_reversal</c>, <c>debit_reversal</c>, <c>inbound_transfer</c>,
+        /// <c>issuing_authorization</c>, <c>other</c>, <c>outbound_payment</c>,
+        /// <c>outbound_transfer</c>, <c>received_credit</c>, or <c>received_debit</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/Treasury/Transactions/TransactionStatusTransitions.cs
+++ b/src/Stripe.net/Entities/Treasury/Transactions/TransactionStatusTransitions.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionStatusTransitions : StripeEntity<TransactionStatusTransitions>
+    {
+        /// <summary>
+        /// Timestamp describing when the Transaction changed status to <c>posted</c>.
+        /// </summary>
+        [JsonProperty("posted_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? PostedAt { get; set; }
+
+        /// <summary>
+        /// Timestamp describing when the Transaction changed status to <c>void</c>.
+        /// </summary>
+        [JsonProperty("void_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? VoidAt { get; set; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -136,6 +136,35 @@ namespace Stripe
                 { "topup", typeof(Topup) },
                 { "transfer", typeof(Transfer) },
                 { "transfer_reversal", typeof(TransferReversal) },
+                { "treasury.credit_reversal", typeof(Treasury.CreditReversal) },
+                { "treasury.debit_reversal", typeof(Treasury.DebitReversal) },
+                {
+                    "treasury.financial_account", typeof(
+                        Treasury.FinancialAccount)
+                },
+                {
+                    "treasury.financial_account_features", typeof(
+                        Treasury.FinancialAccountFeatures)
+                },
+                {
+                    "treasury.inbound_transfer", typeof(
+                        Treasury.InboundTransfer)
+                },
+                {
+                    "treasury.outbound_payment", typeof(
+                        Treasury.OutboundPayment)
+                },
+                {
+                    "treasury.outbound_transfer", typeof(
+                        Treasury.OutboundTransfer)
+                },
+                { "treasury.received_credit", typeof(Treasury.ReceivedCredit) },
+                { "treasury.received_debit", typeof(Treasury.ReceivedDebit) },
+                { "treasury.transaction", typeof(Treasury.Transaction) },
+                {
+                    "treasury.transaction_entry", typeof(
+                        Treasury.TransactionEntry)
+                },
                 { "usage_record", typeof(UsageRecord) },
                 { "usage_record_summary", typeof(UsageRecordSummary) },
                 { "webhook_endpoint", typeof(WebhookEndpoint) },

--- a/src/Stripe.net/Services/Accounts/AccountCreateOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountCreateOptions.cs
@@ -49,7 +49,10 @@ namespace Stripe
         /// established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are
         /// in the United States and the business for which you're creating an account is legally
         /// represented in Canada, you would use <c>CA</c> as the country for the account being
-        /// created.
+        /// created. Available countries include <a href="https://stripe.com/global">Stripe's global
+        /// markets</a> as well as countries where <a
+        /// href="https://stripe.com/docs/connect/cross-border-payouts">cross-border payouts</a> are
+        /// supported.
         /// </summary>
         [JsonProperty("country")]
         public string Country { get; set; }

--- a/src/Stripe.net/Services/Accounts/AccountIndividualOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountIndividualOptions.cs
@@ -83,13 +83,13 @@ namespace Stripe
         public string LastName { get; set; }
 
         /// <summary>
-        /// The Kana varation of the individual's last name (Japan only).
+        /// The Kana variation of the individual's last name (Japan only).
         /// </summary>
         [JsonProperty("last_name_kana")]
         public string LastNameKana { get; set; }
 
         /// <summary>
-        /// The Kanji varation of the individual's last name (Japan only).
+        /// The Kanji variation of the individual's last name (Japan only).
         /// </summary>
         [JsonProperty("last_name_kanji")]
         public string LastNameKanji { get; set; }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionCreateOptions.cs
@@ -192,6 +192,9 @@ namespace Stripe.Checkout
         /// A list of the types of payment methods (e.g., <c>card</c>) this Checkout Session can
         /// accept.
         ///
+        /// Do not include this attribute if you prefer to manage your payment methods from the <a
+        /// href="https://dashboard.stripe.com/settings/payment_methods">Stripe Dashboard</a>.
+        ///
         /// Read more about the supported payment methods and their requirements in our <a
         /// href="https://stripe.com/docs/payments/checkout/payment-methods">payment method details
         /// guide</a>.

--- a/src/Stripe.net/Services/Customers/CustomerRetrievePaymentMethodOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerRetrievePaymentMethodOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    public class CustomerRetrievePaymentMethodOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -106,6 +106,16 @@ namespace Stripe
             return this.ListRequestAutoPagingAsync<PaymentMethod>($"{this.InstanceUrl(id)}/payment_methods", options, requestOptions, cancellationToken);
         }
 
+        public virtual PaymentMethod RetrievePaymentMethod(string id, string payment_method, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<PaymentMethod>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods/{payment_method}", options, requestOptions);
+        }
+
+        public virtual Task<PaymentMethod> RetrievePaymentMethodAsync(string id, string payment_method, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods/{payment_method}", options, requestOptions, cancellationToken);
+        }
+
         public virtual StripeSearchResult<Customer> Search(CustomerSearchOptions options = null, RequestOptions requestOptions = null)
         {
             return this.Request<StripeSearchResult<Customer>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountAccountHolderOptions.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountAccountHolderOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.FinancialConnections
+{
+    using Newtonsoft.Json;
+
+    public class AccountAccountHolderOptions : INestedOptions
+    {
+        /// <summary>
+        /// The ID of the Stripe account whose accounts will be retrieved.
+        /// </summary>
+        [JsonProperty("account")]
+        public string Account { get; set; }
+
+        /// <summary>
+        /// The ID of the Stripe customer whose accounts will be retrieved.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountListOptions.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountListOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.FinancialConnections
+{
+    using Newtonsoft.Json;
+
+    public class AccountListOptions : ListOptions
+    {
+        [JsonProperty("account_holder")]
+        public AccountAccountHolderOptions AccountHolder { get; set; }
+
+        [JsonProperty("session")]
+        public string Session { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountListOwnersOptions.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountListOwnersOptions.cs
@@ -1,0 +1,11 @@
+// File generated from our OpenAPI spec
+namespace Stripe.FinancialConnections
+{
+    using Newtonsoft.Json;
+
+    public class AccountListOwnersOptions : ListOptions
+    {
+        [JsonProperty("ownership")]
+        public string Ownership { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
@@ -1,11 +1,13 @@
 // File generated from our OpenAPI spec
 namespace Stripe.FinancialConnections
 {
+    using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
     public class AccountService : Service<Account>,
+        IListable<Account, AccountListOptions>,
         IRetrievable<Account, AccountGetOptions>
     {
         public AccountService()
@@ -38,6 +40,46 @@ namespace Stripe.FinancialConnections
         public virtual Task<Account> GetAsync(string id, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<Account>> ListAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Account> ListAutoPaging(AccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<Account> ListAutoPagingAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<AccountOwner> ListOwners(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<StripeList<AccountOwner>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/owners", options, requestOptions);
+        }
+
+        public virtual Task<StripeList<AccountOwner>> ListOwnersAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<StripeList<AccountOwner>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/owners", options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<AccountOwner> ListOwnersAutoPaging(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<AccountOwner>($"{this.InstanceUrl(id)}/owners", options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<AccountOwner> ListOwnersAutoPagingAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<AccountOwner>($"{this.InstanceUrl(id)}/owners", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Refresh(string id, AccountRefreshOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/Issuing/Cards/CardCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardCreateOptions.cs
@@ -19,6 +19,9 @@ namespace Stripe.Issuing
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
         /// <summary>
         /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
         /// attach to an object. This can be useful for storing additional information about the

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeCreateOptions.cs
@@ -27,5 +27,11 @@ namespace Stripe.Issuing
         /// </summary>
         [JsonProperty("transaction")]
         public string Transaction { get; set; }
+
+        /// <summary>
+        /// Params for disputes related to Treasury FinancialAccounts.
+        /// </summary>
+        [JsonProperty("treasury")]
+        public DisputeTreasuryOptions Treasury { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeTreasuryOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeTreasuryOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Issuing
+{
+    using Newtonsoft.Json;
+
+    public class DisputeTreasuryOptions : INestedOptions
+    {
+        /// <summary>
+        /// The ID of the ReceivedDebit to initiate an Issuings dispute for.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentCreateOptions.cs
@@ -162,7 +162,9 @@ namespace Stripe
 
         /// <summary>
         /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
-        /// If this is not provided, defaults to ["card"].
+        /// If this is not provided, defaults to ["card"]. Use automatic_payment_methods to manage
+        /// payment methods from the <a
+        /// href="https://dashboard.stripe.com/settings/payment_methods">Stripe Dashboard</a>.
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountNetworksOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountNetworksOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class PaymentIntentPaymentMethodOptionsUsBankAccountNetworksOptions : INestedOptions
+    {
+        /// <summary>
+        /// Triggers validations to run across the selected networks.
+        /// </summary>
+        [JsonProperty("requested")]
+        public List<string> Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentPaymentMethodOptionsUsBankAccountOptions.cs
@@ -12,6 +12,12 @@ namespace Stripe
         public PaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsOptions FinancialConnections { get; set; }
 
         /// <summary>
+        /// Additional fields for network related functions.
+        /// </summary>
+        [JsonProperty("networks")]
+        public PaymentIntentPaymentMethodOptionsUsBankAccountNetworksOptions Networks { get; set; }
+
+        /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment
         /// method.
         ///

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentUpdateOptions.cs
@@ -91,6 +91,8 @@ namespace Stripe
 
         /// <summary>
         /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
+        /// Use automatic_payment_methods to manage payment methods from the <a
+        /// href="https://dashboard.stripe.com/settings/payment_methods">Stripe Dashboard</a>.
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountNetworksOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountNetworksOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class SetupIntentPaymentMethodOptionsUsBankAccountNetworksOptions : INestedOptions
+    {
+        /// <summary>
+        /// Triggers validations to run across the selected networks.
+        /// </summary>
+        [JsonProperty("requested")]
+        public List<string> Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentPaymentMethodOptionsUsBankAccountOptions.cs
@@ -12,6 +12,12 @@ namespace Stripe
         public SetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsOptions FinancialConnections { get; set; }
 
         /// <summary>
+        /// Additional fields for network related functions.
+        /// </summary>
+        [JsonProperty("networks")]
+        public SetupIntentPaymentMethodOptionsUsBankAccountNetworksOptions Networks { get; set; }
+
+        /// <summary>
         /// Verification method for the intent.
         /// One of: <c>automatic</c>, <c>instant</c>, or <c>microdeposits</c>.
         /// </summary>

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionCreateOptions.cs
@@ -27,7 +27,8 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
-        /// Automatic tax settings for this subscription.
+        /// Automatic tax settings for this subscription. We recommend you only include this
+        /// parameter when the existing value is being changed.
         /// </summary>
         [JsonProperty("automatic_tax")]
         public SubscriptionAutomaticTaxOptions AutomaticTax { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionPaymentSettingsOptions.cs
@@ -23,5 +23,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("payment_method_types")]
         public List<string> PaymentMethodTypes { get; set; }
+
+        /// <summary>
+        /// Either <c>off</c>, or <c>on_subscription</c>. With <c>on_subscription</c> Stripe updates
+        /// <c>subscription.default_payment_method</c> when a subscription payment succeeds.
+        /// One of: <c>off</c>, or <c>on_subscription</c>.
+        /// </summary>
+        [JsonProperty("save_default_payment_method")]
+        public string SaveDefaultPaymentMethod { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionUpdateOptions.cs
@@ -27,7 +27,8 @@ namespace Stripe
         public decimal? ApplicationFeePercent { get; set; }
 
         /// <summary>
-        /// Automatic tax settings for this subscription.
+        /// Automatic tax settings for this subscription. We recommend you only include this
+        /// parameter when the existing value is being changed.
         /// </summary>
         [JsonProperty("automatic_tax")]
         public SubscriptionAutomaticTaxOptions AutomaticTax { get; set; }

--- a/src/Stripe.net/Services/Terminal/Configurations/ConfigurationTippingCzkOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Configurations/ConfigurationTippingCzkOptions.cs
@@ -1,0 +1,28 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Terminal
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class ConfigurationTippingCzkOptions : INestedOptions
+    {
+        /// <summary>
+        /// Fixed amounts displayed when collecting a tip.
+        /// </summary>
+        [JsonProperty("fixed_amounts")]
+        public List<long?> FixedAmounts { get; set; }
+
+        /// <summary>
+        /// Percentages displayed when collecting a tip.
+        /// </summary>
+        [JsonProperty("percentages")]
+        public List<long?> Percentages { get; set; }
+
+        /// <summary>
+        /// Below this amount, fixed amounts will be displayed; above it, percentages will be
+        /// displayed.
+        /// </summary>
+        [JsonProperty("smart_tip_threshold")]
+        public long? SmartTipThreshold { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Terminal/Configurations/ConfigurationTippingOptions.cs
+++ b/src/Stripe.net/Services/Terminal/Configurations/ConfigurationTippingOptions.cs
@@ -24,6 +24,12 @@ namespace Stripe.Terminal
         public ConfigurationTippingChfOptions Chf { get; set; }
 
         /// <summary>
+        /// Tipping configuration for CZK.
+        /// </summary>
+        [JsonProperty("czk")]
+        public ConfigurationTippingCzkOptions Czk { get; set; }
+
+        /// <summary>
         /// Tipping configuration for DKK.
         /// </summary>
         [JsonProperty("dkk")]

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferFailOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferFailOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferFailOptions : BaseOptions
+    {
+        /// <summary>
+        /// Details about a failed InboundTransfer.
+        /// </summary>
+        [JsonProperty("failure_details")]
+        public InboundTransferFailureDetailsOptions FailureDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferFailureDetailsOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferFailureDetailsOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferFailureDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Reason for the failure.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>debit_not_authorized</c>,
+        /// <c>incorrect_account_holder_address</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>incorrect_account_holder_tax_id</c>, <c>insufficient_funds</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferReturnInboundTransferOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferReturnInboundTransferOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class InboundTransferReturnInboundTransferOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
@@ -1,0 +1,53 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Treasury;
+
+    public class InboundTransferService : Service<InboundTransfer>
+    {
+        public InboundTransferService()
+            : base(null)
+        {
+        }
+
+        public InboundTransferService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/treasury/inbound_transfers";
+
+        public virtual InboundTransfer Fail(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> FailAsync(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+        }
+
+        public virtual InboundTransfer ReturnInboundTransfer(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> ReturnInboundTransferAsync(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+        }
+
+        public virtual InboundTransfer Succeed(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/succeed", options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> SucceedAsync(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/succeed", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferSucceedOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferSucceedOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class InboundTransferSucceedOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentFailOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentFailOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class OutboundPaymentFailOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentPostOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentPostOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class OutboundPaymentPostOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentReturnOutboundPaymentOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentReturnOutboundPaymentOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentReturnOutboundPaymentOptions : BaseOptions
+    {
+        /// <summary>
+        /// Optional hash to set the the return code.
+        /// </summary>
+        [JsonProperty("returned_details")]
+        public OutboundPaymentReturnedDetailsOptions ReturnedDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentReturnedDetailsOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentReturnedDetailsOptions.cs
@@ -1,0 +1,18 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentReturnedDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// The return code to be set on the OutboundPayment object.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>declined</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -1,0 +1,53 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Treasury;
+
+    public class OutboundPaymentService : Service<OutboundPayment>
+    {
+        public OutboundPaymentService()
+            : base(null)
+        {
+        }
+
+        public OutboundPaymentService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/treasury/outbound_payments";
+
+        public virtual OutboundPayment Fail(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> FailAsync(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundPayment Post(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> PostAsync(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundPayment ReturnOutboundPayment(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> ReturnOutboundPaymentAsync(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferFailOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferFailOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class OutboundTransferFailOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferPostOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferPostOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    public class OutboundTransferPostOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferReturnOutboundTransferOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferReturnOutboundTransferOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferReturnOutboundTransferOptions : BaseOptions
+    {
+        /// <summary>
+        /// Details about a returned OutboundTransfer.
+        /// </summary>
+        [JsonProperty("returned_details")]
+        public OutboundTransferReturnedDetailsOptions ReturnedDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferReturnedDetailsOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferReturnedDetailsOptions.cs
@@ -1,0 +1,18 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferReturnedDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Reason for the return.
+        /// One of: <c>account_closed</c>, <c>account_frozen</c>, <c>bank_account_restricted</c>,
+        /// <c>bank_ownership_changed</c>, <c>declined</c>, <c>incorrect_account_holder_name</c>,
+        /// <c>invalid_account_number</c>, <c>invalid_currency</c>, <c>no_account</c>, or
+        /// <c>other</c>.
+        /// </summary>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -1,0 +1,53 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Treasury;
+
+    public class OutboundTransferService : Service<OutboundTransfer>
+    {
+        public OutboundTransferService()
+            : base(null)
+        {
+        }
+
+        public OutboundTransferService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/treasury/outbound_transfers";
+
+        public virtual OutboundTransfer Fail(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> FailAsync(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundTransfer Post(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> PostAsync(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundTransfer ReturnOutboundTransfer(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> ReturnOutboundTransferAsync(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditCreateOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditCreateOptions.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditCreateOptions : BaseOptions
+    {
+        /// <summary>
+        /// Amount (in cents) to be transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to send funds to.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Initiating payment method details for the object.
+        /// </summary>
+        [JsonProperty("initiating_payment_method_details")]
+        public ReceivedCreditInitiatingPaymentMethodDetailsOptions InitiatingPaymentMethodDetails { get; set; }
+
+        /// <summary>
+        /// The rails used for the object.
+        /// One of: <c>ach</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// The source type.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Optional fields for <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccountOptions UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccountOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditInitiatingPaymentMethodDetailsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// The bank account holder's name.
+        /// </summary>
+        [JsonProperty("account_holder_name")]
+        public string AccountHolderName { get; set; }
+
+        /// <summary>
+        /// The bank account number.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// The bank account's routing number.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Treasury;
+
+    public class ReceivedCreditService : Service<ReceivedCredit>
+    {
+        public ReceivedCreditService()
+            : base(null)
+        {
+        }
+
+        public ReceivedCreditService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/treasury/received_credits";
+
+        public virtual ReceivedCredit Create(ReceivedCreditCreateOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions);
+        }
+
+        public virtual Task<ReceivedCredit> CreateAsync(ReceivedCreditCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -1,7 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe.TestHelpers.Treasury
 {
-    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Treasury;
@@ -20,14 +19,14 @@ namespace Stripe.TestHelpers.Treasury
 
         public override string BasePath => "/v1/test_helpers/treasury/received_credits";
 
-        public virtual ReceivedCredit Create(ReceivedCreditCreateOptions options = null, RequestOptions requestOptions = null)
+        public virtual ReceivedCredit Create(ReceivedCreditCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions);
+            return this.CreateEntity(options, requestOptions);
         }
 
-        public virtual Task<ReceivedCredit> CreateAsync(ReceivedCreditCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<ReceivedCredit> CreateAsync(ReceivedCreditCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions, cancellationToken);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitCreateOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitCreateOptions.cs
@@ -1,0 +1,46 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitCreateOptions : BaseOptions
+    {
+        /// <summary>
+        /// Amount (in cents) to be transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to pull funds from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Initiating payment method details for the object.
+        /// </summary>
+        [JsonProperty("initiating_payment_method_details")]
+        public ReceivedDebitInitiatingPaymentMethodDetailsOptions InitiatingPaymentMethodDetails { get; set; }
+
+        /// <summary>
+        /// The rails used for the object.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// The source type.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Optional fields for <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccountOptions UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccountOptions.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitInitiatingPaymentMethodDetailsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// The bank account holder's name.
+        /// </summary>
+        [JsonProperty("account_holder_name")]
+        public string AccountHolderName { get; set; }
+
+        /// <summary>
+        /// The bank account number.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// The bank account's routing number.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -1,0 +1,33 @@
+// File generated from our OpenAPI spec
+namespace Stripe.TestHelpers.Treasury
+{
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe.Treasury;
+
+    public class ReceivedDebitService : Service<ReceivedDebit>
+    {
+        public ReceivedDebitService()
+            : base(null)
+        {
+        }
+
+        public ReceivedDebitService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/test_helpers/treasury/received_debits";
+
+        public virtual ReceivedDebit Create(ReceivedDebitCreateOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions);
+        }
+
+        public virtual Task<ReceivedDebit> CreateAsync(ReceivedDebitCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -1,7 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe.TestHelpers.Treasury
 {
-    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Treasury;
@@ -20,14 +19,14 @@ namespace Stripe.TestHelpers.Treasury
 
         public override string BasePath => "/v1/test_helpers/treasury/received_debits";
 
-        public virtual ReceivedDebit Create(ReceivedDebitCreateOptions options = null, RequestOptions requestOptions = null)
+        public virtual ReceivedDebit Create(ReceivedDebitCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions);
+            return this.CreateEntity(options, requestOptions);
         }
 
-        public virtual Task<ReceivedDebit> CreateAsync(ReceivedDebitCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<ReceivedDebit> CreateAsync(ReceivedDebitCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("undefined")}", options, requestOptions, cancellationToken);
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenAccountIndividualOptions.cs
+++ b/src/Stripe.net/Services/Tokens/TokenAccountIndividualOptions.cs
@@ -83,13 +83,13 @@ namespace Stripe
         public string LastName { get; set; }
 
         /// <summary>
-        /// The Kana varation of the individual's last name (Japan only).
+        /// The Kana variation of the individual's last name (Japan only).
         /// </summary>
         [JsonProperty("last_name_kana")]
         public string LastNameKana { get; set; }
 
         /// <summary>
-        /// The Kanji varation of the individual's last name (Japan only).
+        /// The Kanji variation of the individual's last name (Japan only).
         /// </summary>
         [JsonProperty("last_name_kanji")]
         public string LastNameKanji { get; set; }

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalCreateOptions.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class CreditReversalCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The ReceivedCredit to reverse.
+        /// </summary>
+        [JsonProperty("received_credit")]
+        public string ReceivedCredit { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class CreditReversalGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalListOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class CreditReversalListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("received_credit")]
+        public string ReceivedCredit { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
@@ -1,0 +1,65 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class CreditReversalService : Service<CreditReversal>,
+        ICreatable<CreditReversal, CreditReversalCreateOptions>,
+        IListable<CreditReversal, CreditReversalListOptions>,
+        IRetrievable<CreditReversal, CreditReversalGetOptions>
+    {
+        public CreditReversalService()
+            : base(null)
+        {
+        }
+
+        public CreditReversalService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/credit_reversals";
+
+        public virtual CreditReversal Create(CreditReversalCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<CreditReversal> CreateAsync(CreditReversalCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual CreditReversal Get(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<CreditReversal> GetAsync(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<CreditReversal> List(CreditReversalListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<CreditReversal>> ListAsync(CreditReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<CreditReversal> ListAutoPaging(CreditReversalListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<CreditReversal> ListAutoPagingAsync(CreditReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalCreateOptions.cs
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class DebitReversalCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The ReceivedDebit to reverse.
+        /// </summary>
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class DebitReversalGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalListOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class DebitReversalListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("received_debit")]
+        public string ReceivedDebit { get; set; }
+
+        [JsonProperty("resolution")]
+        public string Resolution { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
@@ -1,0 +1,65 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class DebitReversalService : Service<DebitReversal>,
+        ICreatable<DebitReversal, DebitReversalCreateOptions>,
+        IListable<DebitReversal, DebitReversalListOptions>,
+        IRetrievable<DebitReversal, DebitReversalGetOptions>
+    {
+        public DebitReversalService()
+            : base(null)
+        {
+        }
+
+        public DebitReversalService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/debit_reversals";
+
+        public virtual DebitReversal Create(DebitReversalCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<DebitReversal> CreateAsync(DebitReversalCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual DebitReversal Get(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<DebitReversal> GetAsync(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<DebitReversal> List(DebitReversalListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<DebitReversal>> ListAsync(DebitReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<DebitReversal> ListAutoPaging(DebitReversalListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<DebitReversal> ListAutoPagingAsync(DebitReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountCreateOptions.cs
@@ -1,0 +1,37 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Encodes whether a FinancialAccount has access to a particular feature. Stripe or the
+        /// platform can control features via the requested field.
+        /// </summary>
+        [JsonProperty("features")]
+        public FinancialAccountFeaturesOptions Features { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The set of functionalities that the platform can restrict on the FinancialAccount.
+        /// </summary>
+        [JsonProperty("platform_restrictions")]
+        public FinancialAccountPlatformRestrictionsOptions PlatformRestrictions { get; set; }
+
+        /// <summary>
+        /// The currencies the FinancialAccount can hold a balance in.
+        /// </summary>
+        [JsonProperty("supported_currencies")]
+        public List<string> SupportedCurrencies { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountDepositInsuranceOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountDepositInsuranceOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountDepositInsuranceOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesDepositInsuranceOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesDepositInsuranceOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesDepositInsuranceOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesFinancialAddressesAbaOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesFinancialAddressesAbaOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesFinancialAddressesAbaOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesFinancialAddressesOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesFinancialAddressesOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesFinancialAddressesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Adds an ABA FinancialAddress to the FinancialAccount.
+        /// </summary>
+        [JsonProperty("aba")]
+        public FinancialAccountFeaturesFinancialAddressesAbaOptions Aba { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesInboundTransfersAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesInboundTransfersAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesInboundTransfersAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesInboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesInboundTransfersOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesInboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH Debits via the InboundTransfers API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesInboundTransfersAchOptions Ach { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesIntraStripeFlowsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesIntraStripeFlowsOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesIntraStripeFlowsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOptions.cs
@@ -1,0 +1,49 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Represents whether this FinancialAccount is eligible for deposit insurance. Various
+        /// factors determine the insurance amount.
+        /// </summary>
+        [JsonProperty("deposit_insurance")]
+        public FinancialAccountFeaturesDepositInsuranceOptions DepositInsurance { get; set; }
+
+        /// <summary>
+        /// Contains Features that add FinancialAddresses to the FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+        public FinancialAccountFeaturesFinancialAddressesOptions FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Contains settings related to adding funds to a FinancialAccount from another Account
+        /// with the same owner.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+        public FinancialAccountFeaturesInboundTransfersOptions InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Represents the ability for the FinancialAccount to send money to, or receive money from
+        /// other FinancialAccounts (for example, via OutboundPayment).
+        /// </summary>
+        [JsonProperty("intra_stripe_flows")]
+        public FinancialAccountFeaturesIntraStripeFlowsOptions IntraStripeFlows { get; set; }
+
+        /// <summary>
+        /// Includes Features related to initiating money movement out of the FinancialAccount to
+        /// someone else's bucket of money.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+        public FinancialAccountFeaturesOutboundPaymentsOptions OutboundPayments { get; set; }
+
+        /// <summary>
+        /// Contains a Feature and settings related to moving money out of the FinancialAccount into
+        /// another Account with the same owner.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+        public FinancialAccountFeaturesOutboundTransfersOptions OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH transfers via the OutboundPayments API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesOutboundPaymentsAchOptions Ach { get; set; }
+
+        /// <summary>
+        /// Enables US domestic wire tranfers via the OutboundPayments API.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountFeaturesOutboundPaymentsUsDomesticWireOptions UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsUsDomesticWireOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundPaymentsUsDomesticWireOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundPaymentsUsDomesticWireOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH transfers via the OutboundTransfers API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountFeaturesOutboundTransfersAchOptions Ach { get; set; }
+
+        /// <summary>
+        /// Enables US domestic wire tranfers via the OutboundTransfers API.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountFeaturesOutboundTransfersUsDomesticWireOptions UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersUsDomesticWireOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFeaturesOutboundTransfersUsDomesticWireOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFeaturesOutboundTransfersUsDomesticWireOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFinancialAddressesAbaOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFinancialAddressesAbaOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFinancialAddressesAbaOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFinancialAddressesOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountFinancialAddressesOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountFinancialAddressesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Adds an ABA FinancialAddress to the FinancialAccount.
+        /// </summary>
+        [JsonProperty("aba")]
+        public FinancialAccountFinancialAddressesAbaOptions Aba { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class FinancialAccountGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountInboundTransfersAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountInboundTransfersAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountInboundTransfersAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountInboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountInboundTransfersOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountInboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH Debits via the InboundTransfers API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountInboundTransfersAchOptions Ach { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountIntraStripeFlowsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountIntraStripeFlowsOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountIntraStripeFlowsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountListOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class FinancialAccountListOptions : ListOptionsWithCreated
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundPaymentsAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH transfers via the OutboundPayments API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountOutboundPaymentsAchOptions Ach { get; set; }
+
+        /// <summary>
+        /// Enables US domestic wire tranfers via the OutboundPayments API.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountOutboundPaymentsUsDomesticWireOptions UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsUsDomesticWireOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundPaymentsUsDomesticWireOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundPaymentsUsDomesticWireOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersAchOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersAchOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundTransfersAchOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Enables ACH transfers via the OutboundTransfers API.
+        /// </summary>
+        [JsonProperty("ach")]
+        public FinancialAccountOutboundTransfersAchOptions Ach { get; set; }
+
+        /// <summary>
+        /// Enables US domestic wire tranfers via the OutboundTransfers API.
+        /// </summary>
+        [JsonProperty("us_domestic_wire")]
+        public FinancialAccountOutboundTransfersUsDomesticWireOptions UsDomesticWire { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersUsDomesticWireOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountOutboundTransfersUsDomesticWireOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountOutboundTransfersUsDomesticWireOptions : INestedOptions
+    {
+        /// <summary>
+        /// Whether the FinancialAccount should have the Feature.
+        /// </summary>
+        [JsonProperty("requested")]
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountPlatformRestrictionsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountPlatformRestrictionsOptions.cs
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountPlatformRestrictionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Restricts all inbound money movement.
+        /// One of: <c>restricted</c>, or <c>unrestricted</c>.
+        /// </summary>
+        [JsonProperty("inbound_flows")]
+        public string InboundFlows { get; set; }
+
+        /// <summary>
+        /// Restricts all outbound money movement.
+        /// One of: <c>restricted</c>, or <c>unrestricted</c>.
+        /// </summary>
+        [JsonProperty("outbound_flows")]
+        public string OutboundFlows { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountRetrieveFeaturesOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountRetrieveFeaturesOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class FinancialAccountRetrieveFeaturesOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
@@ -1,0 +1,97 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class FinancialAccountService : Service<FinancialAccount>,
+        ICreatable<FinancialAccount, FinancialAccountCreateOptions>,
+        IListable<FinancialAccount, FinancialAccountListOptions>,
+        IRetrievable<FinancialAccount, FinancialAccountGetOptions>,
+        IUpdatable<FinancialAccount, FinancialAccountUpdateOptions>
+    {
+        public FinancialAccountService()
+            : base(null)
+        {
+        }
+
+        public FinancialAccountService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/financial_accounts";
+
+        public virtual FinancialAccount Create(FinancialAccountCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<FinancialAccount> CreateAsync(FinancialAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual FinancialAccount Get(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<FinancialAccount> GetAsync(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<FinancialAccount> List(FinancialAccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<FinancialAccount>> ListAsync(FinancialAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<FinancialAccount> ListAutoPaging(FinancialAccountListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<FinancialAccount> ListAutoPagingAsync(FinancialAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual FinancialAccountFeatures RetrieveFeatures(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Get, $"{this.InstanceUrl(id)}/features", options, requestOptions);
+        }
+
+        public virtual Task<FinancialAccountFeatures> RetrieveFeaturesAsync(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Get, $"{this.InstanceUrl(id)}/features", options, requestOptions, cancellationToken);
+        }
+
+        public virtual FinancialAccount Update(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.UpdateEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<FinancialAccount> UpdateAsync(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual FinancialAccountFeatures UpdateFeatures(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Post, $"{this.InstanceUrl(id)}/features", options, requestOptions);
+        }
+
+        public virtual Task<FinancialAccountFeatures> UpdateFeaturesAsync(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Post, $"{this.InstanceUrl(id)}/features", options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountUpdateFeaturesOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountUpdateFeaturesOptions.cs
@@ -1,0 +1,49 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class FinancialAccountUpdateFeaturesOptions : BaseOptions
+    {
+        /// <summary>
+        /// Represents whether this FinancialAccount is eligible for deposit insurance. Various
+        /// factors determine the insurance amount.
+        /// </summary>
+        [JsonProperty("deposit_insurance")]
+        public FinancialAccountDepositInsuranceOptions DepositInsurance { get; set; }
+
+        /// <summary>
+        /// Contains Features that add FinancialAddresses to the FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+        public FinancialAccountFinancialAddressesOptions FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Contains settings related to adding funds to a FinancialAccount from another Account
+        /// with the same owner.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+        public FinancialAccountInboundTransfersOptions InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Represents the ability for the FinancialAccount to send money to, or receive money from
+        /// other FinancialAccounts (for example, via OutboundPayment).
+        /// </summary>
+        [JsonProperty("intra_stripe_flows")]
+        public FinancialAccountIntraStripeFlowsOptions IntraStripeFlows { get; set; }
+
+        /// <summary>
+        /// Includes Features related to initiating money movement out of the FinancialAccount to
+        /// someone else's bucket of money.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+        public FinancialAccountOutboundPaymentsOptions OutboundPayments { get; set; }
+
+        /// <summary>
+        /// Contains a Feature and settings related to moving money out of the FinancialAccount into
+        /// another Account with the same owner.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+        public FinancialAccountOutboundTransfersOptions OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountUpdateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountUpdateOptions.cs
@@ -1,0 +1,32 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class FinancialAccountUpdateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Encodes whether a FinancialAccount has access to a particular feature, with a status
+        /// enum and associated <c>status_details</c>. Stripe or the platform may control features
+        /// via the requested field.
+        /// </summary>
+        [JsonProperty("features")]
+        public FinancialAccountFeaturesOptions Features { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The set of functionalities that the platform can restrict on the FinancialAccount.
+        /// </summary>
+        [JsonProperty("platform_restrictions")]
+        public FinancialAccountPlatformRestrictionsOptions PlatformRestrictions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCancelOptions.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCancelOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class InboundTransferCancelOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCreateOptions.cs
@@ -1,0 +1,57 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class InboundTransferCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Amount (in cents) to be transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to send funds to.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The origin payment method to be debited for the InboundTransfer.
+        /// </summary>
+        [JsonProperty("origin_payment_method")]
+        public string OriginPaymentMethod { get; set; }
+
+        /// <summary>
+        /// The complete description that appears on your customers' statements. Must contain at
+        /// least one letter, maximum 10 characters.
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferCreateOptions.cs
@@ -48,8 +48,8 @@ namespace Stripe.Treasury
         public string OriginPaymentMethod { get; set; }
 
         /// <summary>
-        /// The complete description that appears on your customers' statements. Must contain at
-        /// least one letter, maximum 10 characters.
+        /// The complete description that appears on your customers' statements. Maximum 10
+        /// characters.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class InboundTransferGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferListOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class InboundTransferListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
@@ -1,0 +1,76 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class InboundTransferService : Service<InboundTransfer>,
+        ICreatable<InboundTransfer, InboundTransferCreateOptions>,
+        IListable<InboundTransfer, InboundTransferListOptions>,
+        IRetrievable<InboundTransfer, InboundTransferGetOptions>
+    {
+        public InboundTransferService()
+            : base(null)
+        {
+        }
+
+        public InboundTransferService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/inbound_transfers";
+
+        public virtual InboundTransfer Cancel(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> CancelAsync(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+        }
+
+        public virtual InboundTransfer Create(InboundTransferCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> CreateAsync(InboundTransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual InboundTransfer Get(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<InboundTransfer> GetAsync(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<InboundTransfer> List(InboundTransferListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<InboundTransfer>> ListAsync(InboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<InboundTransfer> ListAutoPaging(InboundTransferListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<InboundTransfer> ListAutoPagingAsync(InboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCancelOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCancelOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class OutboundPaymentCancelOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCreateOptions.cs
@@ -76,7 +76,9 @@ namespace Stripe.Treasury
 
         /// <summary>
         /// The description that appears on the receiving end for this OutboundPayment (for example,
-        /// bank statement for external bank transfer).
+        /// bank statement for external bank transfer). Maximum 10 characters for <c>ach</c>
+        /// payments, 140 characters for <c>wire</c> payments, or 500 characters for <c>stripe</c>
+        /// network transfers. The default value is <c>payment</c>.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentCreateOptions.cs
@@ -1,0 +1,84 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Amount (in cents) to be transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// ID of the customer to whom the OutboundPayment is sent. Must match the Customer attached
+        /// to the <c>destination_payment_method</c> passed in.
+        /// </summary>
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The PaymentMethod to use as the payment instrument for the OutboundPayment. Exclusive
+        /// with <c>destination_payment_method_data</c>.
+        /// </summary>
+        [JsonProperty("destination_payment_method")]
+        public string DestinationPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Hash used to generate the PaymentMethod to be used for this OutboundPayment. Exclusive
+        /// with <c>destination_payment_method</c>.
+        /// </summary>
+        [JsonProperty("destination_payment_method_data")]
+        public OutboundPaymentDestinationPaymentMethodDataOptions DestinationPaymentMethodData { get; set; }
+
+        /// <summary>
+        /// Payment method-specific configuration for this OutboundPayment.
+        /// </summary>
+        [JsonProperty("destination_payment_method_options")]
+        public OutboundPaymentDestinationPaymentMethodOptionsOptions DestinationPaymentMethodOptions { get; set; }
+
+        /// <summary>
+        /// End user details.
+        /// </summary>
+        [JsonProperty("end_user_details")]
+        public OutboundPaymentEndUserDetailsOptions EndUserDetails { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to pull funds from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The description that appears on the receiving end for this OutboundPayment (for example,
+        /// bank statement for external bank transfer).
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataBillingDetailsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataBillingDetailsOptions.cs
@@ -1,0 +1,32 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDataBillingDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Billing address.
+        /// </summary>
+        [JsonProperty("address")]
+        public AddressOptions Address { get; set; }
+
+        /// <summary>
+        /// Email address.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Full name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Billing phone number (including extension).
+        /// </summary>
+        [JsonProperty("phone")]
+        public string Phone { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataOptions.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDataOptions : INestedOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Billing information associated with the PaymentMethod that may be used or required by
+        /// particular types of payment methods.
+        /// </summary>
+        [JsonProperty("billing_details")]
+        public OutboundPaymentDestinationPaymentMethodDataBillingDetailsOptions BillingDetails { get; set; }
+
+        /// <summary>
+        /// Required if type is set to <c>financial_account</c>. The FinancialAccount ID to send
+        /// funds to.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// The type of the PaymentMethod. An additional hash is included on the PaymentMethod with
+        /// a name matching this value. It contains additional information specific to the
+        /// PaymentMethod type.
+        /// One of: <c>financial_account</c>, or <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Required hash if type is set to <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public OutboundPaymentDestinationPaymentMethodDataUsBankAccountOptions UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodDataUsBankAccountOptions.cs
@@ -1,0 +1,40 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodDataUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Account holder type: individual or company.
+        /// One of: <c>company</c>, or <c>individual</c>.
+        /// </summary>
+        [JsonProperty("account_holder_type")]
+        public string AccountHolderType { get; set; }
+
+        /// <summary>
+        /// Account number of the bank account.
+        /// </summary>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>
+        /// Account type: checkings or savings. Defaults to checking if omitted.
+        /// One of: <c>checking</c>, or <c>savings</c>.
+        /// </summary>
+        [JsonProperty("account_type")]
+        public string AccountType { get; set; }
+
+        /// <summary>
+        /// The ID of a Financial Connections Account to use as a payment method.
+        /// </summary>
+        [JsonProperty("financial_connections_account")]
+        public string FinancialConnectionsAccount { get; set; }
+
+        /// <summary>
+        /// Routing number of the bank account.
+        /// </summary>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodOptionsOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Optional fields for <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public OutboundPaymentDestinationPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentDestinationPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,16 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentDestinationPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// The US bank account network that must be used for this OutboundPayment. If not set, we
+        /// will default to the PaymentMethod's preferred network.
+        /// One of: <c>ach</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentEndUserDetailsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentEndUserDetailsOptions.cs
@@ -1,0 +1,22 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentEndUserDetailsOptions : INestedOptions
+    {
+        /// <summary>
+        /// IP address of the user initiating the OutboundPayment. Must be supplied if
+        /// <c>present</c> is set to <c>true</c>.
+        /// </summary>
+        [JsonProperty("ip_address")]
+        public string IpAddress { get; set; }
+
+        /// <summary>
+        /// <c>True</c> if the OutboundPayment creation request is being made on behalf of an end
+        /// user by a platform. Otherwise, <c>false</c>.
+        /// </summary>
+        [JsonProperty("present")]
+        public bool? Present { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class OutboundPaymentGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentListOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundPaymentListOptions : ListOptions
+    {
+        [JsonProperty("customer")]
+        public string Customer { get; set; }
+
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -1,0 +1,76 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class OutboundPaymentService : Service<OutboundPayment>,
+        ICreatable<OutboundPayment, OutboundPaymentCreateOptions>,
+        IListable<OutboundPayment, OutboundPaymentListOptions>,
+        IRetrievable<OutboundPayment, OutboundPaymentGetOptions>
+    {
+        public OutboundPaymentService()
+            : base(null)
+        {
+        }
+
+        public OutboundPaymentService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/outbound_payments";
+
+        public virtual OutboundPayment Cancel(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> CancelAsync(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundPayment Create(OutboundPaymentCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> CreateAsync(OutboundPaymentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundPayment Get(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<OutboundPayment> GetAsync(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<OutboundPayment> List(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<OutboundPayment>> ListAsync(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<OutboundPayment> ListAutoPaging(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<OutboundPayment> ListAutoPagingAsync(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCancelOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCancelOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class OutboundTransferCancelOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCreateOptions.cs
@@ -54,7 +54,9 @@ namespace Stripe.Treasury
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
-        /// Statement descriptor to be shown on the receiving end of an OutboundTransfer.
+        /// Statement descriptor to be shown on the receiving end of an OutboundTransfer. Maximum 10
+        /// characters for <c>ach</c> transfers or 140 characters for <c>wire</c> transfers. The
+        /// default value is <c>transfer</c>.
         /// </summary>
         [JsonProperty("statement_descriptor")]
         public string StatementDescriptor { get; set; }

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCreateOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferCreateOptions.cs
@@ -1,0 +1,62 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class OutboundTransferCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Amount (in cents) to be transferred.
+        /// </summary>
+        [JsonProperty("amount")]
+        public long? Amount { get; set; }
+
+        /// <summary>
+        /// Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+        /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+        /// currency</a>.
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// An arbitrary string attached to the object. Often useful for displaying to users.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The PaymentMethod to use as the payment instrument for the OutboundTransfer.
+        /// </summary>
+        [JsonProperty("destination_payment_method")]
+        public string DestinationPaymentMethod { get; set; }
+
+        /// <summary>
+        /// Hash describing payment method configuration details.
+        /// </summary>
+        [JsonProperty("destination_payment_method_options")]
+        public OutboundTransferDestinationPaymentMethodOptionsOptions DestinationPaymentMethodOptions { get; set; }
+
+        /// <summary>
+        /// The FinancialAccount to pull funds from.
+        /// </summary>
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format. Individual keys can be unset by posting an empty value to
+        /// them. All keys can be unset by posting an empty value to <c>metadata</c>.
+        /// </summary>
+        [JsonProperty("metadata")]
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Statement descriptor to be shown on the receiving end of an OutboundTransfer.
+        /// </summary>
+        [JsonProperty("statement_descriptor")]
+        public string StatementDescriptor { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodOptionsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodOptionsOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferDestinationPaymentMethodOptionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Optional fields for <c>us_bank_account</c>.
+        /// </summary>
+        [JsonProperty("us_bank_account")]
+        public OutboundTransferDestinationPaymentMethodOptionsUsBankAccountOptions UsBankAccount { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodOptionsUsBankAccountOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferDestinationPaymentMethodOptionsUsBankAccountOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferDestinationPaymentMethodOptionsUsBankAccountOptions : INestedOptions
+    {
+        /// <summary>
+        /// Designate the OutboundTransfer as using a US bank account network configuration.
+        /// One of: <c>ach</c>, or <c>us_domestic_wire</c>.
+        /// </summary>
+        [JsonProperty("network")]
+        public string Network { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class OutboundTransferGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferListOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class OutboundTransferListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -1,0 +1,76 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class OutboundTransferService : Service<OutboundTransfer>,
+        ICreatable<OutboundTransfer, OutboundTransferCreateOptions>,
+        IListable<OutboundTransfer, OutboundTransferListOptions>,
+        IRetrievable<OutboundTransfer, OutboundTransferGetOptions>
+    {
+        public OutboundTransferService()
+            : base(null)
+        {
+        }
+
+        public OutboundTransferService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/outbound_transfers";
+
+        public virtual OutboundTransfer Cancel(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> CancelAsync(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundTransfer Create(OutboundTransferCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.CreateEntity(options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> CreateAsync(OutboundTransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual OutboundTransfer Get(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<OutboundTransfer> GetAsync(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<OutboundTransfer> List(OutboundTransferListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<OutboundTransfer>> ListAsync(OutboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<OutboundTransfer> ListAutoPaging(OutboundTransferListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<OutboundTransfer> ListAutoPagingAsync(OutboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class ReceivedCreditGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditLinkedFlowsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditLinkedFlowsOptions.cs
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditLinkedFlowsOptions : INestedOptions
+    {
+        /// <summary>
+        /// The source flow type.
+        /// One of: <c>credit_reversal</c>, <c>other</c>, <c>outbound_payment</c>, or <c>payout</c>.
+        /// </summary>
+        [JsonProperty("source_flow_type")]
+        public string SourceFlowType { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditListOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedCreditListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("linked_flows")]
+        public ReceivedCreditLinkedFlowsOptions LinkedFlows { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class ReceivedCreditService : Service<ReceivedCredit>,
+        IListable<ReceivedCredit, ReceivedCreditListOptions>,
+        IRetrievable<ReceivedCredit, ReceivedCreditGetOptions>
+    {
+        public ReceivedCreditService()
+            : base(null)
+        {
+        }
+
+        public ReceivedCreditService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/received_credits";
+
+        public virtual ReceivedCredit Get(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<ReceivedCredit> GetAsync(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<ReceivedCredit> List(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<ReceivedCredit>> ListAsync(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ReceivedCredit> ListAutoPaging(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<ReceivedCredit> ListAutoPagingAsync(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class ReceivedDebitGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitListOptions.cs
@@ -1,0 +1,14 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class ReceivedDebitListOptions : ListOptions
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class ReceivedDebitService : Service<ReceivedDebit>,
+        IListable<ReceivedDebit, ReceivedDebitListOptions>,
+        IRetrievable<ReceivedDebit, ReceivedDebitGetOptions>
+    {
+        public ReceivedDebitService()
+            : base(null)
+        {
+        }
+
+        public ReceivedDebitService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/received_debits";
+
+        public virtual ReceivedDebit Get(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<ReceivedDebit> GetAsync(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<ReceivedDebit> List(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<ReceivedDebit>> ListAsync(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<ReceivedDebit> ListAutoPaging(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<ReceivedDebit> ListAutoPagingAsync(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class TransactionEntryGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryListOptions.cs
@@ -1,0 +1,23 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionEntryListOptions : ListOptionsWithCreated
+    {
+        [JsonProperty("effective_at")]
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> EffectiveAt { get; set; }
+
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("order_by")]
+        public string OrderBy { get; set; }
+
+        [JsonProperty("transaction")]
+        public string Transaction { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class TransactionEntryService : Service<TransactionEntry>,
+        IListable<TransactionEntry, TransactionEntryListOptions>,
+        IRetrievable<TransactionEntry, TransactionEntryGetOptions>
+    {
+        public TransactionEntryService()
+            : base(null)
+        {
+        }
+
+        public TransactionEntryService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/transaction_entries";
+
+        public virtual TransactionEntry Get(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<TransactionEntry> GetAsync(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<TransactionEntry> List(TransactionEntryListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<TransactionEntry>> ListAsync(TransactionEntryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<TransactionEntry> ListAutoPaging(TransactionEntryListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<TransactionEntry> ListAutoPagingAsync(TransactionEntryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionGetOptions.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionGetOptions.cs
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    public class TransactionGetOptions : BaseOptions
+    {
+    }
+}

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionListOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using Newtonsoft.Json;
+
+    public class TransactionListOptions : ListOptionsWithCreated
+    {
+        [JsonProperty("financial_account")]
+        public string FinancialAccount { get; set; }
+
+        [JsonProperty("order_by")]
+        public string OrderBy { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("status_transitions")]
+        public TransactionStatusTransitionsOptions StatusTransitions { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
@@ -1,0 +1,54 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class TransactionService : Service<Transaction>,
+        IListable<Transaction, TransactionListOptions>,
+        IRetrievable<Transaction, TransactionGetOptions>
+    {
+        public TransactionService()
+            : base(null)
+        {
+        }
+
+        public TransactionService(IStripeClient client)
+            : base(client)
+        {
+        }
+
+        public override string BasePath => "/v1/treasury/transactions";
+
+        public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.GetEntity(id, options, requestOptions);
+        }
+
+        public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+        }
+
+        public virtual StripeList<Transaction> List(TransactionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntities(options, requestOptions);
+        }
+
+        public virtual Task<StripeList<Transaction>> ListAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+        }
+
+        public virtual IEnumerable<Transaction> ListAutoPaging(TransactionListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListEntitiesAutoPaging(options, requestOptions);
+        }
+
+        public virtual IAsyncEnumerable<Transaction> ListAutoPagingAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+        }
+    }
+}

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionStatusTransitionsOptions.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionStatusTransitionsOptions.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Treasury
+{
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+
+    public class TransactionStatusTransitionsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Returns Transactions with <c>posted_at</c> within the specified range.
+        /// </summary>
+        [JsonProperty("posted_at")]
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, DateRangeOptions> PostedAt { get; set; }
+    }
+}

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -153,22 +153,6 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestBalanceTransactionServiceList()
-        {
-            var options = new BalanceTransactionListOptions { Limit = 3 };
-            var service = new BalanceTransactionService(this.StripeClient);
-            StripeList<BalanceTransaction> balancetransactions = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestBalanceTransactionServiceRetrieve()
-        {
-            var service = new BalanceTransactionService(this.StripeClient);
-            service.Get("txn_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
         public void TestBillingPortalConfigurationServiceCreate()
         {
             var options = new Stripe.BillingPortal.ConfigurationCreateOptions
@@ -306,6 +290,17 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestChargeServiceSearch()
+        {
+            var options = new ChargeSearchOptions
+            {
+                Query = "amount>999 AND metadata['order_id']:'6735'",
+            };
+            var service = new ChargeService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
         public void TestChargeServiceUpdate()
         {
             var options = new ChargeUpdateOptions
@@ -321,28 +316,6 @@ namespace StripeTests
 
         [Fact]
         public void TestCheckoutSessionServiceCreate()
-        {
-            var options = new Stripe.Checkout.SessionCreateOptions
-            {
-                SuccessUrl = "https://example.com/success",
-                CancelUrl = "https://example.com/cancel",
-                PaymentMethodTypes = new List<string> { "card" },
-                LineItems = new List<Stripe.Checkout.SessionLineItemOptions>
-                {
-                    new Stripe.Checkout.SessionLineItemOptions
-                    {
-                        Price = "price_xxxxxxxxxxxxx",
-                        Quantity = 2,
-                    },
-                },
-                Mode = "payment",
-            };
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestCheckoutSessionServiceCreate2()
         {
             var options = new Stripe.Checkout.SessionCreateOptions
             {
@@ -382,10 +355,38 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestCheckoutSessionServiceCreate2()
+        {
+            var options = new Stripe.Checkout.SessionCreateOptions
+            {
+                SuccessUrl = "https://example.com/success",
+                CancelUrl = "https://example.com/cancel",
+                LineItems = new List<Stripe.Checkout.SessionLineItemOptions>
+                {
+                    new Stripe.Checkout.SessionLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 2,
+                    },
+                },
+                Mode = "payment",
+            };
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
         public void TestCheckoutSessionServiceExpire()
         {
             var service = new Stripe.Checkout.SessionService(this.StripeClient);
             service.Expire("sess_xyz");
+        }
+
+        [Fact]
+        public void TestCheckoutSessionServiceExpire2()
+        {
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            service.Expire("cs_test_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -424,7 +425,7 @@ namespace StripeTests
         {
             var options = new CouponCreateOptions
             {
-                PercentOff = 25m,
+                PercentOff = 25.5m,
                 Duration = "repeating",
                 DurationInMonths = 3,
             };
@@ -436,7 +437,7 @@ namespace StripeTests
         public void TestCouponServiceDelete()
         {
             var service = new CouponService(this.StripeClient);
-            service.Delete("co_xxxxxxxxxxxxx");
+            service.Delete("Z4OV52SU");
         }
 
         [Fact]
@@ -451,7 +452,7 @@ namespace StripeTests
         public void TestCouponServiceRetrieve()
         {
             var service = new CouponService(this.StripeClient);
-            service.Get("25_5OFF");
+            service.Get("Z4OV52SU");
         }
 
         [Fact]
@@ -465,7 +466,7 @@ namespace StripeTests
                 },
             };
             var service = new CouponService(this.StripeClient);
-            service.Update("co_xxxxxxxxxxxxx", options);
+            service.Update("Z4OV52SU", options);
         }
 
         [Fact]
@@ -494,46 +495,6 @@ namespace StripeTests
             var options = new CreditNoteListOptions { Limit = 3 };
             var service = new CreditNoteService(this.StripeClient);
             StripeList<CreditNote> creditnotes = service.List(options);
-        }
-
-        [Fact]
-        public void TestCreditNoteServicePreview()
-        {
-            var options = new CreditNotePreviewOptions
-            {
-                Invoice = "in_xxxxxxxxxxxxx",
-                Lines = new List<CreditNoteLineOptions>
-                {
-                    new CreditNoteLineOptions
-                    {
-                        Type = "invoice_line_item",
-                        InvoiceLineItem = "il_xxxxxxxxxxxxx",
-                        Quantity = 1,
-                    },
-                },
-            };
-            var service = new CreditNoteService(this.StripeClient);
-            service.Preview(options);
-        }
-
-        [Fact]
-        public void TestCreditNoteServicePreview2()
-        {
-            var options = new CreditNotePreviewOptions
-            {
-                Invoice = "in_xxxxxxxxxxxxx",
-                Lines = new List<CreditNoteLineOptions>
-                {
-                    new CreditNoteLineOptions
-                    {
-                        Type = "invoice_line_item",
-                        InvoiceLineItem = "il_xxxxxxxxxxxxx",
-                        Quantity = 1,
-                    },
-                },
-            };
-            var service = new CreditNoteService(this.StripeClient);
-            service.Preview(options);
         }
 
         [Fact]
@@ -677,10 +638,43 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestCustomerServiceListPaymentMethods2()
+        {
+            var options = new CustomerListPaymentMethodsOptions
+            {
+                Type = "card",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.ListPaymentMethods("cus_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
         public void TestCustomerServiceRetrieve()
         {
             var service = new CustomerService(this.StripeClient);
             service.Get("cus_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCustomerServiceSearch()
+        {
+            var options = new CustomerSearchOptions
+            {
+                Query = "name:'fakename' AND metadata['foo']:'bar'",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestCustomerServiceSearch2()
+        {
+            var options = new CustomerSearchOptions
+            {
+                Query = "name:'fakename' AND metadata['foo']:'bar'",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.Search(options);
         }
 
         [Fact]
@@ -812,6 +806,55 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestFinancialConnectionsAccountServiceList()
+        {
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            StripeList<Stripe.FinancialConnections.Account> accounts = service.List();
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountServiceList2()
+        {
+            var options = new Stripe.FinancialConnections.AccountListOptions
+            {
+                AccountHolder = new Stripe.FinancialConnections.AccountAccountHolderOptions
+                {
+                    Customer = "cus_xxxxxxxxxxxxx",
+                },
+            };
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            StripeList<Stripe.FinancialConnections.Account> accounts = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountServiceListOwners()
+        {
+            var options = new Stripe.FinancialConnections.AccountListOwnersOptions
+            {
+                Ownership = "fcaowns_xyz",
+            };
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            service.ListOwners("fca_xyz", options);
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountServiceListOwners2()
+        {
+            var options = new Stripe.FinancialConnections.AccountListOwnersOptions
+            {
+                Limit = 3,
+                Ownership = "fcaowns_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            service.ListOwners("fca_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
         public void TestFinancialConnectionsAccountServiceRefresh()
         {
             var options = new Stripe.FinancialConnections.AccountRefreshOptions
@@ -832,6 +875,14 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestFinancialConnectionsAccountServiceRetrieve2()
+        {
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            service.Get("fca_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
         public void TestFinancialConnectionsSessionServiceCreate()
         {
             var options = new Stripe.FinancialConnections.SessionCreateOptions
@@ -849,11 +900,122 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestFinancialConnectionsSessionServiceCreate2()
+        {
+            var options = new Stripe.FinancialConnections.SessionCreateOptions
+            {
+                AccountHolder = new Stripe.FinancialConnections.SessionAccountHolderOptions
+                {
+                    Type = "customer",
+                    Customer = "cus_xxxxxxxxxxxxx",
+                },
+                Permissions = new List<string> { "payment_method", "balances" },
+                Filters = new Stripe.FinancialConnections.SessionFiltersOptions
+                {
+                    Countries = new List<string> { "US" },
+                },
+            };
+            var service = new Stripe.FinancialConnections.SessionService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
         public void TestFinancialConnectionsSessionServiceRetrieve()
         {
             var service = new Stripe.FinancialConnections.SessionService(
                 this.StripeClient);
             service.Get("fcsess_xyz");
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsSessionServiceRetrieve2()
+        {
+            var service = new Stripe.FinancialConnections.SessionService(
+                this.StripeClient);
+            service.Get("fcsess_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationReportServiceList()
+        {
+            var options = new Stripe.Identity.VerificationReportListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Identity.VerificationReportService(
+                this.StripeClient);
+            StripeList<Stripe.Identity.VerificationReport> verificationreports = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestIdentityVerificationReportServiceRetrieve()
+        {
+            var service = new Stripe.Identity.VerificationReportService(
+                this.StripeClient);
+            service.Get("vr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceCancel()
+        {
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Cancel("vs_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceCreate()
+        {
+            var options = new Stripe.Identity.VerificationSessionCreateOptions
+            {
+                Type = "document",
+            };
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceList()
+        {
+            var options = new Stripe.Identity.VerificationSessionListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            StripeList<Stripe.Identity.VerificationSession> verificationsessions = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceRedact()
+        {
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Redact("vs_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceRetrieve()
+        {
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Get("vs_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionServiceUpdate()
+        {
+            var options = new Stripe.Identity.VerificationSessionUpdateOptions
+            {
+                Type = "id_number",
+            };
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Update("vs_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -956,6 +1118,17 @@ namespace StripeTests
         {
             var service = new InvoiceService(this.StripeClient);
             service.Get("in_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoiceServiceSearch()
+        {
+            var options = new InvoiceSearchOptions
+            {
+                Query = "total>999 AND metadata['order_id']:'6735'",
+            };
+            var service = new InvoiceService(this.StripeClient);
+            service.Search(options);
         }
 
         [Fact]
@@ -1258,6 +1431,13 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestPaymentIntentServiceApplyCustomerBalance()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.ApplyCustomerBalance("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
         public void TestPaymentIntentServiceCancel()
         {
             var service = new PaymentIntentService(this.StripeClient);
@@ -1287,9 +1467,12 @@ namespace StripeTests
         {
             var options = new PaymentIntentCreateOptions
             {
-                Amount = 2000,
-                Currency = "usd",
-                PaymentMethodTypes = new List<string> { "card" },
+                Amount = 1099,
+                Currency = "eur",
+                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
+                {
+                    Enabled = true,
+                },
             };
             var service = new PaymentIntentService(this.StripeClient);
             service.Create(options);
@@ -1300,15 +1483,23 @@ namespace StripeTests
         {
             var options = new PaymentIntentCreateOptions
             {
-                Amount = 1099,
-                Currency = "eur",
-                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
-                {
-                    Enabled = true,
-                },
+                Amount = 2000,
+                Currency = "usd",
+                PaymentMethodTypes = new List<string> { "card" },
             };
             var service = new PaymentIntentService(this.StripeClient);
             service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentServiceIncrementAuthorization()
+        {
+            var options = new PaymentIntentIncrementAuthorizationOptions
+            {
+                Amount = 2099,
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.IncrementAuthorization("pi_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -1324,6 +1515,17 @@ namespace StripeTests
         {
             var service = new PaymentIntentService(this.StripeClient);
             service.Get("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentServiceSearch()
+        {
+            var options = new PaymentIntentSearchOptions
+            {
+                Query = "status:'succeeded' AND metadata['order_id']:'6735'",
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Search(options);
         }
 
         [Fact]
@@ -1366,6 +1568,32 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestPaymentLinkServiceCreate2()
+        {
+            var options = new PaymentLinkCreateOptions
+            {
+                LineItems = new List<PaymentLinkLineItemOptions>
+                {
+                    new PaymentLinkLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 1,
+                    },
+                },
+            };
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentLinkServiceList()
+        {
+            var options = new PaymentLinkListOptions { Limit = 3 };
+            var service = new PaymentLinkService(this.StripeClient);
+            StripeList<PaymentLink> paymentlinks = service.List(options);
+        }
+
+        [Fact]
         public void TestPaymentLinkServiceListLineItems()
         {
             var service = new PaymentLinkService(this.StripeClient);
@@ -1377,6 +1605,21 @@ namespace StripeTests
         {
             var service = new PaymentLinkService(this.StripeClient);
             service.Get("pl_xyz");
+        }
+
+        [Fact]
+        public void TestPaymentLinkServiceRetrieve2()
+        {
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Get("plink_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentLinkServiceUpdate()
+        {
+            var options = new PaymentLinkUpdateOptions { Active = false };
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Update("plink_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -1400,7 +1643,7 @@ namespace StripeTests
                 {
                     Number = "4242424242424242",
                     ExpMonth = 5,
-                    ExpYear = 2022,
+                    ExpYear = 2023,
                     Cvc = "314",
                 },
             };
@@ -1636,6 +1879,17 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestPriceServiceSearch()
+        {
+            var options = new PriceSearchOptions
+            {
+                Query = "active:'true' AND metadata['order_id']:'6735'",
+            };
+            var service = new PriceService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
         public void TestPriceServiceUpdate()
         {
             var options = new PriceUpdateOptions
@@ -1680,6 +1934,17 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestProductServiceSearch()
+        {
+            var options = new ProductSearchOptions
+            {
+                Query = "active:'true' AND metadata['order_id']:'6735'",
+            };
+            var service = new ProductService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
         public void TestProductServiceUpdate()
         {
             var options = new ProductUpdateOptions
@@ -1696,7 +1961,10 @@ namespace StripeTests
         [Fact]
         public void TestPromotionCodeServiceCreate()
         {
-            var options = new PromotionCodeCreateOptions { Coupon = "25_5OFF" };
+            var options = new PromotionCodeCreateOptions
+            {
+                Coupon = "Z4OV52SU",
+            };
             var service = new PromotionCodeService(this.StripeClient);
             service.Create(options);
         }
@@ -1728,6 +1996,75 @@ namespace StripeTests
             };
             var service = new PromotionCodeService(this.StripeClient);
             service.Update("promo_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestQuoteServiceAccept()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Accept("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuoteServiceCancel()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Cancel("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuoteServiceCreate()
+        {
+            var options = new QuoteCreateOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+                LineItems = new List<QuoteLineItemOptions>
+                {
+                    new QuoteLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 2,
+                    },
+                },
+            };
+            var service = new QuoteService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestQuoteServiceFinalizeQuote()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.FinalizeQuote("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuoteServiceList()
+        {
+            var options = new QuoteListOptions { Limit = 3 };
+            var service = new QuoteService(this.StripeClient);
+            StripeList<Quote> quotes = service.List(options);
+        }
+
+        [Fact]
+        public void TestQuoteServiceRetrieve()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Get("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuoteServiceUpdate()
+        {
+            var options = new QuoteUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new QuoteService(this.StripeClient);
+            service.Update("qt_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -1839,6 +2176,13 @@ namespace StripeTests
             };
             var service = new Stripe.Radar.ValueListService(this.StripeClient);
             service.Update("rsl_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestRefundServiceCancel()
+        {
+            var service = new RefundService(this.StripeClient);
+            service.Cancel("re_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -1973,8 +2317,8 @@ namespace StripeTests
         {
             var options = new SetupAttemptListOptions
             {
-                SetupIntent = "seti_xxxxxxxxxxxxx",
                 Limit = 3,
+                SetupIntent = "si_xyz",
             };
             var service = new SetupAttemptService(this.StripeClient);
             StripeList<SetupAttempt> setupattempts = service.List(options);
@@ -2063,10 +2407,56 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestShippingRateServiceCreate2()
+        {
+            var options = new ShippingRateCreateOptions
+            {
+                DisplayName = "Ground shipping",
+                Type = "fixed_amount",
+                FixedAmount = new ShippingRateFixedAmountOptions
+                {
+                    Amount = 500,
+                    Currency = "usd",
+                },
+            };
+            var service = new ShippingRateService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
         public void TestShippingRateServiceList()
         {
             var service = new ShippingRateService(this.StripeClient);
             StripeList<ShippingRate> shippingrates = service.List();
+        }
+
+        [Fact]
+        public void TestShippingRateServiceList2()
+        {
+            var options = new ShippingRateListOptions { Limit = 3 };
+            var service = new ShippingRateService(this.StripeClient);
+            StripeList<ShippingRate> shippingrates = service.List(options);
+        }
+
+        [Fact]
+        public void TestShippingRateServiceRetrieve()
+        {
+            var service = new ShippingRateService(this.StripeClient);
+            service.Get("shr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestShippingRateServiceUpdate()
+        {
+            var options = new ShippingRateUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new ShippingRateService(this.StripeClient);
+            service.Update("shr_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -2151,6 +2541,13 @@ namespace StripeTests
 
         [Fact]
         public void TestSourceServiceRetrieve()
+        {
+            var service = new SourceService(this.StripeClient);
+            service.Get("src_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSourceServiceRetrieve2()
         {
             var service = new SourceService(this.StripeClient);
             service.Get("src_xxxxxxxxxxxxx");
@@ -2305,6 +2702,17 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestSubscriptionServiceSearch()
+        {
+            var options = new SubscriptionSearchOptions
+            {
+                Query = "status:'active' AND metadata['order_id']:'6735'",
+            };
+            var service = new SubscriptionService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
         public void TestSubscriptionServiceUpdate()
         {
             var options = new SubscriptionUpdateOptions
@@ -2316,6 +2724,21 @@ namespace StripeTests
             };
             var service = new SubscriptionService(this.StripeClient);
             service.Update("sub_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTaxCodeServiceList()
+        {
+            var options = new TaxCodeListOptions { Limit = 3 };
+            var service = new TaxCodeService(this.StripeClient);
+            StripeList<TaxCode> taxcodes = service.List(options);
+        }
+
+        [Fact]
+        public void TestTaxCodeServiceRetrieve()
+        {
+            var service = new TaxCodeService(this.StripeClient);
+            service.Get("txcd_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2402,11 +2825,34 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTerminalConfigurationServiceCreate2()
+        {
+            var options = new Stripe.Terminal.ConfigurationCreateOptions
+            {
+                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
+                {
+                    Splashscreen = "file_xxxxxxxxxxxxx",
+                },
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
         public void TestTerminalConfigurationServiceDelete()
         {
             var service = new Stripe.Terminal.ConfigurationService(
                 this.StripeClient);
             service.Delete("uc_123");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationServiceDelete2()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Delete("tmc_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2418,11 +2864,32 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTerminalConfigurationServiceList2()
+        {
+            var options = new Stripe.Terminal.ConfigurationListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            StripeList<Stripe.Terminal.Configuration> configurations = service.List(
+                options);
+        }
+
+        [Fact]
         public void TestTerminalConfigurationServiceRetrieve()
         {
             var service = new Stripe.Terminal.ConfigurationService(
                 this.StripeClient);
             service.Get("uc_123");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationServiceRetrieve2()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Get("tmc_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2441,6 +2908,21 @@ namespace StripeTests
             var service = new Stripe.Terminal.ConfigurationService(
                 this.StripeClient);
             service.Update("uc_123", options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationServiceUpdate2()
+        {
+            var options = new Stripe.Terminal.ConfigurationUpdateOptions
+            {
+                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
+                {
+                    Splashscreen = "file_xxxxxxxxxxxxx",
+                },
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Update("tmc_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -2501,6 +2983,13 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTerminalReaderServiceCancelAction()
+        {
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.CancelAction("tmr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
         public void TestTerminalReaderServiceCreate()
         {
             var options = new Stripe.Terminal.ReaderCreateOptions
@@ -2517,7 +3006,7 @@ namespace StripeTests
         public void TestTerminalReaderServiceDelete()
         {
             var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Delete("tmr_P400-123-456-789");
+            service.Delete("tmr_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2529,10 +3018,33 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTerminalReaderServiceProcessPaymentIntent()
+        {
+            var options = new Stripe.Terminal.ReaderProcessPaymentIntentOptions
+            {
+                PaymentIntent = "pi_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.ProcessPaymentIntent("tmr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTerminalReaderServiceProcessSetupIntent()
+        {
+            var options = new Stripe.Terminal.ReaderProcessSetupIntentOptions
+            {
+                SetupIntent = "seti_xxxxxxxxxxxxx",
+                CustomerConsentCollected = true,
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.ProcessSetupIntent("tmr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
         public void TestTerminalReaderServiceRetrieve()
         {
             var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Get("tmr_P400-123-456-789");
+            service.Get("tmr_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2543,7 +3055,7 @@ namespace StripeTests
                 Label = "Blue Rabbit",
             };
             var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Update("tmr_P400-123-456-789", options);
+            service.Update("tmr_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -2557,6 +3069,19 @@ namespace StripeTests
             var service = new Stripe.TestHelpers.TestClockService(
                 this.StripeClient);
             service.Advance("clock_xyz", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceAdvance2()
+        {
+            var options = new Stripe.TestHelpers.TestClockAdvanceOptions
+            {
+                FrozenTime = DateTimeOffset.FromUnixTimeSeconds(1652390605)
+                    .UtcDateTime,
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Advance("clock_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
@@ -2574,11 +3099,32 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTestHelpersTestClockServiceCreate2()
+        {
+            var options = new Stripe.TestHelpers.TestClockCreateOptions
+            {
+                FrozenTime = DateTimeOffset.FromUnixTimeSeconds(1577836800)
+                    .UtcDateTime,
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
         public void TestTestHelpersTestClockServiceDelete()
         {
             var service = new Stripe.TestHelpers.TestClockService(
                 this.StripeClient);
             service.Delete("clock_xyz");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceDelete2()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Delete("clock_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2590,11 +3136,32 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTestHelpersTestClockServiceList2()
+        {
+            var options = new Stripe.TestHelpers.TestClockListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            StripeList<Stripe.TestHelpers.TestClock> testclocks = service.List(
+                options);
+        }
+
+        [Fact]
         public void TestTestHelpersTestClockServiceRetrieve()
         {
             var service = new Stripe.TestHelpers.TestClockService(
                 this.StripeClient);
             service.Get("clock_xyz");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClockServiceRetrieve2()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Get("clock_xxxxxxxxxxxxx");
         }
 
         [Fact]
@@ -2734,6 +3301,366 @@ namespace StripeTests
             };
             var service = new TransferService(this.StripeClient);
             service.Update("tr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalServiceCreate()
+        {
+            var options = new Stripe.Treasury.CreditReversalCreateOptions
+            {
+                ReceivedCredit = "rc_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.Treasury.CreditReversalService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalServiceList()
+        {
+            var options = new Stripe.Treasury.CreditReversalListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.CreditReversalService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.CreditReversal> creditreversals = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.CreditReversalService(
+                this.StripeClient);
+            service.Get("credrev_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryDebitReversalServiceCreate()
+        {
+            var options = new Stripe.Treasury.DebitReversalCreateOptions
+            {
+                ReceivedDebit = "rd_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.Treasury.DebitReversalService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryDebitReversalServiceList()
+        {
+            var options = new Stripe.Treasury.DebitReversalListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.DebitReversalService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.DebitReversal> debitreversals = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryDebitReversalServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.DebitReversalService(
+                this.StripeClient);
+            service.Get("debrev_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceCreate()
+        {
+            var options = new Stripe.Treasury.FinancialAccountCreateOptions
+            {
+                SupportedCurrencies = new List<string> { "usd" },
+                Features = new Stripe.Treasury.FinancialAccountFeaturesOptions(),
+            };
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceList()
+        {
+            var options = new Stripe.Treasury.FinancialAccountListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.FinancialAccount> financialaccounts = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.Get("fa_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceRetrieveFeatures()
+        {
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.RetrieveFeatures("fa_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceUpdate()
+        {
+            var options = new Stripe.Treasury.FinancialAccountUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.Update("fa_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountServiceUpdateFeatures()
+        {
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.UpdateFeatures("fa_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceCancel()
+        {
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Cancel("ibt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceCreate()
+        {
+            var options = new Stripe.Treasury.InboundTransferCreateOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Amount = 10000,
+                Currency = "usd",
+                OriginPaymentMethod = "pm_xxxxxxxxxxxxx",
+                Description = "InboundTransfer from my bank account",
+            };
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceList()
+        {
+            var options = new Stripe.Treasury.InboundTransferListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.InboundTransfer> inboundtransfers = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Get("ibt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentServiceCancel()
+        {
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            service.Cancel("obp_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentServiceCreate()
+        {
+            var options = new Stripe.Treasury.OutboundPaymentCreateOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Amount = 10000,
+                Currency = "usd",
+                Customer = "cu_xxxxxxxxxxxxx",
+                DestinationPaymentMethod = "pm_xxxxxxxxxxxxx",
+                Description = "OutboundPayment to a 3rd party",
+            };
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentServiceList()
+        {
+            var options = new Stripe.Treasury.OutboundPaymentListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.OutboundPayment> outboundpayments = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            service.Get("obp_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransferServiceCancel()
+        {
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Cancel("obt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransferServiceCreate()
+        {
+            var options = new Stripe.Treasury.OutboundTransferCreateOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                DestinationPaymentMethod = "pm_xxxxxxxxxxxxx",
+                Amount = 500,
+                Currency = "usd",
+                Description = "OutboundTransfer to my external bank account",
+            };
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransferServiceList()
+        {
+            var options = new Stripe.Treasury.OutboundTransferListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.OutboundTransfer> outboundtransfers = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransferServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Get("obt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedCreditServiceList()
+        {
+            var options = new Stripe.Treasury.ReceivedCreditListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.ReceivedCreditService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.ReceivedCredit> receivedcredits = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedCreditServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.ReceivedCreditService(
+                this.StripeClient);
+            service.Get("rc_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedDebitServiceList()
+        {
+            var options = new Stripe.Treasury.ReceivedDebitListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.ReceivedDebitService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.ReceivedDebit> receiveddebits = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedDebitServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.ReceivedDebitService(
+                this.StripeClient);
+            service.Get("rd_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryTransactionEntryServiceList()
+        {
+            var options = new Stripe.Treasury.TransactionEntryListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.TransactionEntryService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.TransactionEntry> transactionentries = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryTransactionEntryServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.TransactionEntryService(
+                this.StripeClient);
+            service.Get("trxne_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryTransactionServiceList()
+        {
+            var options = new Stripe.Treasury.TransactionListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.TransactionService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.Transaction> transactions = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTreasuryTransactionServiceRetrieve()
+        {
+            var service = new Stripe.Treasury.TransactionService(
+                this.StripeClient);
+            service.Get("trxn_xxxxxxxxxxxxx");
         }
 
         [Fact]

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -3461,6 +3461,21 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTreasuryInboundTransferServiceFail()
+        {
+            var options = new Stripe.TestHelpers.Treasury.InboundTransferFailOptions
+            {
+                FailureDetails = new Stripe.TestHelpers.Treasury.InboundTransferFailureDetailsOptions
+                {
+                    Code = "account_closed",
+                },
+            };
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Fail("ibt_123", options);
+        }
+
+        [Fact]
         public void TestTreasuryInboundTransferServiceList()
         {
             var options = new Stripe.Treasury.InboundTransferListOptions
@@ -3480,6 +3495,22 @@ namespace StripeTests
             var service = new Stripe.Treasury.InboundTransferService(
                 this.StripeClient);
             service.Get("ibt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceReturnInboundTransfer()
+        {
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.ReturnInboundTransfer("ibt_123");
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransferServiceSucceed()
+        {
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Succeed("ibt_123");
         }
 
         [Fact]
@@ -3554,6 +3585,14 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTreasuryOutboundTransferServiceFail()
+        {
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Fail("obt_123");
+        }
+
+        [Fact]
         public void TestTreasuryOutboundTransferServiceList()
         {
             var options = new Stripe.Treasury.OutboundTransferListOptions
@@ -3568,11 +3607,49 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestTreasuryOutboundTransferServicePost()
+        {
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Post("obt_123");
+        }
+
+        [Fact]
         public void TestTreasuryOutboundTransferServiceRetrieve()
         {
             var service = new Stripe.Treasury.OutboundTransferService(
                 this.StripeClient);
             service.Get("obt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransferServiceReturnOutboundTransfer()
+        {
+            var options = new Stripe.TestHelpers.Treasury.OutboundTransferReturnOutboundTransferOptions
+            {
+                ReturnedDetails = new Stripe.TestHelpers.Treasury.OutboundTransferReturnedDetailsOptions
+                {
+                    Code = "account_closed",
+                },
+            };
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.ReturnOutboundTransfer("obt_123", options);
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedCreditServiceCreate()
+        {
+            var options = new Stripe.TestHelpers.Treasury.ReceivedCreditCreateOptions
+            {
+                FinancialAccount = "fa_123",
+                Network = "ach",
+                Amount = 1234,
+                Currency = "usd",
+            };
+            var service = new Stripe.TestHelpers.Treasury.ReceivedCreditService(
+                this.StripeClient);
+            service.Create(options);
         }
 
         [Fact]
@@ -3595,6 +3672,21 @@ namespace StripeTests
             var service = new Stripe.Treasury.ReceivedCreditService(
                 this.StripeClient);
             service.Get("rc_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryReceivedDebitServiceCreate()
+        {
+            var options = new Stripe.TestHelpers.Treasury.ReceivedDebitCreateOptions
+            {
+                FinancialAccount = "fa_123",
+                Network = "ach",
+                Amount = 1234,
+                Currency = "usd",
+            };
+            var service = new Stripe.TestHelpers.Treasury.ReceivedDebitService(
+                this.StripeClient);
+            service.Create(options);
         }
 
         [Fact]

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -9,7 +9,7 @@ namespace StripeTests
     public class StripeMockFixture : IDisposable
     {
         /// <value>Minimum required version of stripe-mock.</value>
-        private const string MockMinimumVersion = "0.119.0";
+        private const string MockMinimumVersion = "0.128.0";
 
         private readonly string port;
 


### PR DESCRIPTION
Codegen for openapi 056745c.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resources `Treasury.CreditReversal`, `Treasury.DebitReversal`, `Treasury.FinancialAccountFeatures`, `Treasury.FinancialAccount`, `Treasury.FlowDetails`, `Treasury.InboundTransfer`, `Treasury.OutboundPayment`, `Treasury.OutboundTransfer`, `Treasury.ReceivedCredit`, `Treasury.ReceivedDebit`, `Treasury.TransactionEntry`, and `Treasury.Transaction`
* Add support for `RetrievePaymentMethod` method on resource `Customer`
* Add support for `ListOwners` and `List` methods on resource `FinancialConnections.Account`
* Change type of `BillingPortalSessionReturnUrl` from `string` to `nullable(string)`
* Add support for `AfterpayClearpay`, `AuBecsDebit`, `BacsDebit`, `Eps`, `Fpx`, `Giropay`, `Grabpay`, `Klarna`, `Paynow`, and `SepaDebit` on `CheckoutSessionPaymentMethodOptions`
* Add support for `Treasury` on `IssuingAuthorization`, `IssuingDisputeCreateOptions`, `IssuingDispute`, and `IssuingTransaction`
* Add support for `FinancialAccount` on `IssuingCardCreateOptions` and `IssuingCard`
* Add support for `ClientSecret` on `Order`
* Add support for `Networks` on `PaymentIntentPaymentMethodOptionsUsBankAccountOptions`, `PaymentMethodUsBankAccount`, and `SetupIntentPaymentMethodOptionsUsBankAccountOptions`
* Add support for `AttachToSelf` and `FlowDirections` on `SetupIntent`
* Add support for `SaveDefaultPaymentMethod` on `SubscriptionPaymentSettingsOptions` and `SubscriptionPaymentSettings`
* Add support for `Czk` on `TerminalConfigurationTippingOptions` and `TerminalConfigurationTipping`
