### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @stripe/server-api-libraries-admins


### PR DESCRIPTION
@server-api-libraries-admins group is the only one that has permissions to merge PRs anyway. Having codeowners and explicit assignment at the same time leads to double-assignments (as illustrated by this PR).
