### PR TITLE
Use the generated API version

### DIFF
--- a/src/Stripe.net/Constants/ApiVersion.cs
+++ b/src/Stripe.net/Constants/ApiVersion.cs
@@ -1,0 +1,8 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    internal class ApiVersion
+    {
+        public const string Current = "2020-08-27";
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -30,7 +30,7 @@ namespace Stripe
         }
 
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => "2020-08-27";
+        public static string ApiVersion => Stripe.ApiVersion.Current;
 
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>


### PR DESCRIPTION
To support generating beta header values, use the generated ApiVersion value instead of the hardcoded one.

r? @dcr-stripe  