### PR TITLE
Stop using RedirectUrl in test

### DIFF
--- a/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
+++ b/src/StripeTests/Services/LoginLinks/LoginLinkServiceTest.cs
@@ -21,10 +21,7 @@ namespace StripeTests
         {
             this.service = new LoginLinkService(this.StripeClient);
 
-            this.createOptions = new LoginLinkCreateOptions
-            {
-                RedirectUrl = "https://stripe.com/redirect?param=value",
-            };
+            this.createOptions = new LoginLinkCreateOptions();
         }
 
         [Fact]


### PR DESCRIPTION
The stripe-mock will soon stop supporting this property.