### PR TITLE
Rename BalanceDetails to BalanceIssuing.

### DIFF
--- a/src/Stripe.net/Entities/Balance/Balance.cs
+++ b/src/Stripe.net/Entities/Balance/Balance.cs
@@ -50,7 +50,7 @@ namespace Stripe
         public List<BalanceInstantAvailable> InstantAvailable { get; set; }
 
         [JsonProperty("issuing")]
-        public BalanceDetails Issuing { get; set; }
+        public BalanceIssuing Issuing { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if

--- a/src/Stripe.net/Entities/Balance/BalanceIssuing.cs
+++ b/src/Stripe.net/Entities/Balance/BalanceIssuing.cs
@@ -1,10 +1,14 @@
+// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class BalanceDetails : StripeEntity<BalanceDetails>
+    public class BalanceIssuing : StripeEntity<BalanceIssuing>
     {
+        /// <summary>
+        /// Funds that are available for use.
+        /// </summary>
         [JsonProperty("available")]
         public List<BalanceAmount> Available { get; set; }
     }


### PR DESCRIPTION
r? @kamil-stripe @yejia-stripe 

## Changelog
* ⚠️ Rename `BalanceDetails` to `BalanceIssuing` entity to be consistent with field name and other SDK languages.