### PR TITLE
Make APIVersion configuration settable

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -23,14 +23,26 @@ namespace Stripe
         private static int maxNetworkRetries = SystemNetHttpClient.DefaultMaxNumberRetries;
 
         private static IStripeClient stripeClient;
+        private static string apiVersion;
 
         static StripeConfiguration()
         {
             StripeNetVersion = new AssemblyName(typeof(StripeConfiguration).GetTypeInfo().Assembly.FullName).Version.ToString(3);
+            ApiVersion = Stripe.ApiVersion.Current;
         }
 
+        internal static string TrimmedApiVersion { get; private set; }
+
         /// <summary>API version used by Stripe.net.</summary>
-        public static string ApiVersion => Stripe.ApiVersion.Current;
+        public static string ApiVersion
+        {
+            get => apiVersion;
+            set
+            {
+                apiVersion = value;
+                TrimmedApiVersion = StringUtils.TrimApiVersion(value);
+            }
+        }
 
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>

--- a/src/Stripe.net/Infrastructure/StringUtils.cs
+++ b/src/Stripe.net/Infrastructure/StringUtils.cs
@@ -73,10 +73,10 @@ namespace Stripe.Infrastructure
 
         /// <summary>
         /// Trims the beta header part of an API Version string.
-        /// For example, "22-12-2022; orders_beta=v3" is converted to "22-12-2022".
+        /// For example, "12-22-2022; orders_beta=v3" is converted to "12-22-2022".
         /// </summary>
-        /// <param name="apiVersion">The API Version to trim. For example, "22-12-2022; orders_beta=v3".</param>
-        /// <returns>The trimmed API Version string. For example, "22-12-2022".</returns>
+        /// <param name="apiVersion">The API Version to trim. For example, "12-22-2022; orders_beta=v3".</param>
+        /// <returns>The trimmed API Version string. For example, "12-22-2022".</returns>
         public static string TrimApiVersion(string apiVersion)
         {
             var indexOfSemicolon = apiVersion?.IndexOf(';');

--- a/src/Stripe.net/Infrastructure/StringUtils.cs
+++ b/src/Stripe.net/Infrastructure/StringUtils.cs
@@ -70,5 +70,22 @@ namespace Stripe.Infrastructure
 
             return whitespaceRegex.IsMatch(str);
         }
+
+        /// <summary>
+        /// Trims the beta header part of an API Version string.
+        /// For example, "22-12-2022; orders_beta=v3" is converted to "22-12-2022".
+        /// </summary>
+        /// <param name="apiVersion">The API Version to trim. For example, "22-12-2022; orders_beta=v3".</param>
+        /// <returns>The trimmed API Version string. For example, "22-12-2022".</returns>
+        public static string TrimApiVersion(string apiVersion)
+        {
+            var indexOfSemicolon = apiVersion?.IndexOf(';');
+            if (indexOfSemicolon > -1)
+            {
+                return apiVersion.Substring(0, indexOfSemicolon.Value);
+            }
+
+            return apiVersion;
+        }
     }
 }

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -42,12 +42,12 @@ namespace Stripe
                 StripeConfiguration.SerializerSettings);
 
             if (throwOnApiVersionMismatch &&
-                stripeEvent.ApiVersion != StripeConfiguration.ApiVersion)
+                stripeEvent.ApiVersion != StripeConfiguration.TrimmedApiVersion)
             {
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "
                     + $"{StripeConfiguration.StripeNetVersion} expects API version "
-                    + $"{StripeConfiguration.ApiVersion}. We recommend that you create a "
+                    + $"{StripeConfiguration.TrimmedApiVersion}. We recommend that you create a "
                     + "WebhookEndpoint with this API version. Otherwise, you can disable this "
                     + "exception by passing `throwOnApiVersionMismatch: false` to "
                     + "`Stripe.EventUtility.ParseEvent` or `Stripe.EventUtility.ConstructEvent`, "

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -6,6 +6,7 @@ namespace StripeTests
     using StripeTests.Infrastructure.TestData;
     using Xunit;
 
+    [Collection(nameof(TestsThatModifyApiVersion))]
     public class StripeRequestTest : BaseStripeTest
     {
         private readonly IStripeClient stripeClient;
@@ -128,6 +129,29 @@ namespace StripeTests
                 new StripeRequest(client, HttpMethod.Get, "/get", null, requestOptions));
 
             Assert.Contains("No API key provided.", exception.Message);
+        }
+
+        [Fact]
+        public void CanModifyApiVersion()
+        {
+            string oldVersion = StripeConfiguration.ApiVersion;
+            try
+            {
+                StripeConfiguration.ApiVersion = "2022-08-01; feature_in_beta=v3";
+                var request = new StripeRequest(
+                    this.stripeClient,
+                    HttpMethod.Get,
+                    "/get",
+                    new TestOptions { String = "string!" },
+                    new RequestOptions());
+
+                Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
+                Assert.Equal("2022-08-01; feature_in_beta=v3", request.StripeHeaders["Stripe-Version"]);
+            }
+            finally
+            {
+                StripeConfiguration.ApiVersion = oldVersion;
+            }
         }
     }
 }

--- a/src/StripeTests/Infrastructure/TestsThatModifyApiVersion.cs
+++ b/src/StripeTests/Infrastructure/TestsThatModifyApiVersion.cs
@@ -1,0 +1,9 @@
+namespace StripeTests
+{
+    using Xunit;
+
+    [CollectionDefinition(nameof(TestsThatModifyApiVersion), DisableParallelization = true)]
+    public class TestsThatModifyApiVersion
+    {
+    }
+}

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -3,6 +3,7 @@ namespace StripeTests
     using Stripe;
     using Xunit;
 
+    [Collection(nameof(TestsThatModifyApiVersion))]
     public class EventUtilityTest : BaseStripeTest
     {
         private readonly long eventTimestamp;
@@ -84,6 +85,27 @@ namespace StripeTests
 
             evt = EventUtility.ParseEvent(serialized);
             Assert.Equal(StripeConfiguration.ApiVersion, evt.ApiVersion);
+        }
+
+        [Fact]
+        public void AcceptsExpectedApiVersionWhenConfiguredWithBeta()
+        {
+            string oldVersion = StripeConfiguration.ApiVersion;
+            try
+            {
+                StripeConfiguration.ApiVersion = "2022-08-02; feature_in_beta=v3";
+
+                var evt = Event.FromJson(this.json);
+                evt.ApiVersion = "2022-08-02";
+                var serialized = evt.ToJson();
+
+                evt = EventUtility.ParseEvent(serialized);
+                Assert.Equal("2022-08-02", evt.ApiVersion);
+            }
+            finally
+            {
+                StripeConfiguration.ApiVersion = oldVersion;
+            }
         }
 
         [Fact]

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -80,11 +80,11 @@ namespace StripeTests
         public void AcceptsExpectedApiVersion()
         {
             var evt = Event.FromJson(this.json);
-            evt.ApiVersion = StripeConfiguration.ApiVersion;
+            evt.ApiVersion = StripeConfiguration.TrimmedApiVersion;
             var serialized = evt.ToJson();
 
             evt = EventUtility.ParseEvent(serialized);
-            Assert.Equal(StripeConfiguration.ApiVersion, evt.ApiVersion);
+            Assert.Equal(StripeConfiguration.TrimmedApiVersion, evt.ApiVersion);
         }
 
         [Fact]


### PR DESCRIPTION
Allows StripeConfiguration.ApiVersion value to be modified. Trims beta headers before using them in WebHook event version check.

r? @dcr-stripe 
