### PR TITLE
Add test coverage using Coveralls

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "coveralls.net": {
+      "version": "4.0.1",
+      "commands": [
+        "csmacnz.Coveralls"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,27 @@ jobs:
       - name: Run test suite (Debug)
         run: dotnet test --no-build src/StripeTests/StripeTests.csproj -c Debug
 
+      - name: Collect coverage
+        run: dotnet test --no-build -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
+
+      - name: Send code coverage report to coveralls.io
+        run: |
+          dotnet tool run csmacnz.Coveralls \
+            --opencover \
+            -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml \
+            --repoToken $COVERALLS_REPO_TOKEN \
+            --useRelativePaths \
+            --commitId $commitId \
+            --commitBranch $commitBranch \
+            --commitAuthor $commitAuthor \
+            --jobId $jobId
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          commitId: ${{ github.sha }}
+          commitBranch: ${{ github.event.pull_request.head.ref }}
+          commitAuthor: ${{ github.event.pull_request.user.login }}
+          jobId: ${{ github.run_id }}
+
       - name: Pack
         run: dotnet pack src -c Release --no-build --output nuget
       - name: 'Upload Artifact'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
 [![Build Status](https://github.com/stripe/stripe-dotnet/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-dotnet/actions?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
 The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.6.1+.
 


### PR DESCRIPTION
### Summary
r? @kamil-stripe 
r? @pakrym-stripe 

Add steps to collect test coverage and upload to coveralls in CI. Test coverage data will be published to https://coveralls.io/github/stripe/stripe-dotnet and displayed as a badge in the README.