### PR TITLE
Update Coveralls command line arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Collect coverage
         run: dotnet test --no-build -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
 
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        run: echo "commitBranch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        run: echo "commitBranch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
       - name: Send code coverage report to coveralls.io
         run: |
           dotnet tool run csmacnz.Coveralls \
@@ -68,11 +76,10 @@ jobs:
             --commitBranch $commitBranch \
             --commitAuthor $commitAuthor \
             --jobId $jobId \
-            --pullRequestId $pullRequestId
+            --pullRequest $pullRequestId
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           commitId: ${{ github.sha }}
-          commitBranch: ${{ github.ref }}
           commitAuthor: ${{ github.actor }}
           jobId: ${{ github.run_id }}
           pullRequestId: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
             --commitBranch $commitBranch \
             --commitAuthor $commitAuthor \
             --jobId $jobId
+            --pullRequestId $pullRequestId
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           commitId: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             --commitId $commitId \
             --commitBranch $commitBranch \
             --commitAuthor $commitAuthor \
-            --jobId $jobId
+            --jobId $jobId \
             --pullRequestId $pullRequestId
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,20 @@ jobs:
 
       - name: Send code coverage report to coveralls.io
         run: |
-          dotnet tool run csmacnz.Coveralls \
-            --opencover \
+          export ARGS="--opencover \
             -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml \
             --repoToken $COVERALLS_REPO_TOKEN \
             --useRelativePaths \
             --commitId $commitId \
             --commitBranch $commitBranch \
             --commitAuthor $commitAuthor \
-            --jobId $jobId \
-            --pullRequest $pullRequestId
+            --jobId $jobId"
+          if [ ! -z "${pullRequestId}" ];
+          then
+            export ARGS="$ARGS \
+              --pullRequest $pullRequestId"
+          fi
+          dotnet tool run csmacnz.Coveralls $ARGS
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           commitId: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,10 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           commitId: ${{ github.sha }}
-          commitBranch: ${{ github.event.pull_request.head.ref }}
-          commitAuthor: ${{ github.event.pull_request.user.login }}
+          commitBranch: ${{ github.ref }}
+          commitAuthor: ${{ github.actor }}
           jobId: ${{ github.run_id }}
+          pullRequestId: ${{ github.event.pull_request.number }}
 
       - name: Pack
         run: dotnet pack src -c Release --no-build --output nuget


### PR DESCRIPTION
### Summary
r? @pakrym-stripe 

Update Coveralls command line arguments to account for both push and pull request events.

Example build for pull request: https://coveralls.io/builds/52036808
Example build for push: https://coveralls.io/builds/52036814