### PR TITLE
Do not run Coveralls if secret token is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         run: echo "commitBranch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
       - name: Send code coverage report to coveralls.io
+        if: env.COVERALLS_REPO_TOKEN
         run: |
           export ARGS="--opencover \
             -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml \


### PR DESCRIPTION
## Summary
Do not run Coveralls step if the secret token does not exist (for pushes triggered by outside collaborators).

## Motivation
https://github.com/stripe/stripe-php/pull/1379 - make this change consistent across all languages