### PR TITLE
Stop `FileService` from mutating its `RequestOptions` argument

### DIFF
--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -72,6 +72,7 @@ namespace Stripe
 
             if (requestOptions.BaseUrl == null)
             {
+                requestOptions = (RequestOptions)requestOptions.Clone();
                 requestOptions.BaseUrl = this.Client.FilesBase;
             }
 

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -72,7 +72,7 @@ namespace Stripe
 
             if (requestOptions.BaseUrl == null)
             {
-                requestOptions = (RequestOptions)requestOptions.Clone();
+                requestOptions = requestOptions.Clone();
                 requestOptions.BaseUrl = this.Client.FilesBase;
             }
 

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using System;
 
-    public class RequestOptions
+    public class RequestOptions : ICloneable
     {
         /// <summary>
         /// Gets or sets the <a href="https://stripe.com/docs/api/authentication?lang=dotnet">API
@@ -38,5 +38,10 @@ namespace Stripe
         /// is only used for creating ephemeral keys, which require a specific API version.
         /// </remarks>
         internal string StripeVersion { get; set; }
+
+        public object Clone()
+            {
+                return this.MemberwiseClone();
+            }
     }
 }

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using System;
 
-    public class RequestOptions : ICloneable
+    public class RequestOptions
     {
         /// <summary>
         /// Gets or sets the <a href="https://stripe.com/docs/api/authentication?lang=dotnet">API
@@ -39,9 +39,9 @@ namespace Stripe
         /// </remarks>
         internal string StripeVersion { get; set; }
 
-        public object Clone()
+        internal RequestOptions Clone()
             {
-                return this.MemberwiseClone();
+                return (RequestOptions)this.MemberwiseClone();
             }
     }
 }

--- a/src/StripeTests/Services/Files/FileServiceTest.cs
+++ b/src/StripeTests/Services/Files/FileServiceTest.cs
@@ -57,8 +57,11 @@ namespace StripeTests
         [Fact]
         public void Create()
         {
-            var file = this.service.Create(this.createOptions);
+            var requestOptions = new RequestOptions();
+
+            var file = this.service.Create(this.createOptions, requestOptions);
             this.AssertRequest(HttpMethod.Post, "/v1/files");
+            Assert.Null(requestOptions.BaseUrl);
             Assert.NotNull(file);
             Assert.Equal("file", file.Object);
         }


### PR DESCRIPTION
## Notify
r? @anniel-stripe 

## Summary
A user reported getting an error like `Unrecognized request URL (GET: /v1/terminal/configurations)` after reusing RequestOptions in FileService and then the ConfigurationService, because FileService mutates RequestOptions and sets the base to files.stripe.com and `files.stripe.com/v1/terminal/configurations` doesn't exist.

This is unintuitive. Fixing it shouldn't be considered breaking. I can't imagine that any user is dependent on this behavior.