### PR TITLE
Drop builds for out of support frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/stripe/stripe-dotnet/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-dotnet/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
-The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.6.1+.
+The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET 6.0+, and .NET Framework 4.6.2+.
 
 ## Installation
 

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -25,12 +25,12 @@ namespace Stripe
         public const int DefaultMaxNumberRetries = 2;
 
         private const string StripeNetTargetFramework =
-#if NET5_0
-            "net5.0"
+#if NET6_0
+            "net6.0"
 #elif NETSTANDARD2_0
             "netstandard2.0"
-#elif NET461
-            "net461"
+#elif NET462
+            "net462"
 #else
             "unknown"
 #endif

--- a/src/Stripe.net/Infrastructure/RuntimeInformation.cs
+++ b/src/Stripe.net/Infrastructure/RuntimeInformation.cs
@@ -112,10 +112,10 @@ namespace Stripe.Infrastructure
 
         internal static string MapToReleaseVersion(string servicingVersion)
         {
-            // the following code assumes that .NET 4.6.1 is the oldest supported version
+            // the following code assumes that .NET 4.6.2 is the oldest supported version
             if (string.Compare(servicingVersion, "4.6.2") < 0)
             {
-                return "4.6.1";
+                return "4.6.2";
             }
 
             if (string.Compare(servicingVersion, "4.7") < 0)

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -292,7 +292,7 @@ namespace Stripe
             RequestOptions requestOptions)
             where T : IStripeEntity
         {
-#if NET461
+#if NETFRAMEWORK
             return
                 this.ListRequestAutoPagingSync<T>(url, options, requestOptions);
 #else
@@ -301,7 +301,7 @@ namespace Stripe
 #endif
         }
 
-#if NET461
+#if NETFRAMEWORK
         protected IEnumerable<T> ListRequestAutoPagingSync<T>(
             string url,
             ListOptions options,
@@ -450,7 +450,7 @@ namespace Stripe
             RequestOptions requestOptions)
             where T : IStripeEntity
         {
-#if NET461
+#if NETFRAMEWORK
             return
                 this.SearchRequestAutoPagingSync<T>(url, options, requestOptions);
 #else
@@ -459,7 +459,7 @@ namespace Stripe
 #endif
         }
 
-#if NET461
+#if NETFRAMEWORK
         private IEnumerable<T> SearchRequestAutoPagingSync<T>(
             string url,
             SearchOptions options,

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Stripe.net is a sync/async .NET 4.6.1+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
+    <Description>Stripe.net is a sync/async .NET 4.6.2+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
     <Version>41.5.0</Version>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/stripe/stripe-dotnet</PackageProjectUrl>
@@ -36,19 +36,9 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -57,7 +47,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/StripeTests/Services/PromotionCodes/PromotionCodeServiceTest.cs
+++ b/src/StripeTests/Services/PromotionCodes/PromotionCodeServiceTest.cs
@@ -110,7 +110,6 @@ namespace StripeTests
             Assert.Equal("promotion_code", promotionCode.Object);
         }
 
-#if !NET45
         [Fact]
         public async Task ListAutoPagingAsync()
         {
@@ -118,7 +117,6 @@ namespace StripeTests
             Assert.NotNull(promotionCode);
             Assert.Equal("promotion_code", promotionCode.Object);
         }
-#endif
 
         [Fact]
         public void Update()

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1;netcoreapp2.1;net462</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
@@ -24,7 +24,7 @@
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
.NET Framework 4.5.1, .NETCORE 3.1 & .NET 5.0 have gone out of support and are no longer updated by Microsoft.

This PR drops these targets from the main library build, and raises the minimum .NET Framework target to 4.6.2.

Note that the library can still be utilized by .NETCORE 3.1 & .NET 5.0 via the NETSTANDARD2.0 target. These targets also continued by tested by the test configuration.