### PR TITLE
Add missing parameters to the Upcoming Invoice API

### DIFF
--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -16,6 +16,9 @@ namespace Stripe
         [JsonProperty("coupon")]
         public string Coupon { get; set; }
 
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
         [JsonProperty("customer")]
         public string Customer { get; set; }
 
@@ -34,6 +37,9 @@ namespace Stripe
         [JsonProperty("schedule")]
         public string Schedule { get; set; }
 
+        [JsonProperty("subscription")]
+        public string Subscription { get; set; }
+
         [JsonProperty("subscription_billing_cycle_anchor")]
         [JsonConverter(typeof(AnyOfConverter))]
         public AnyOf<DateTime?, SubscriptionBillingCycleAnchor> SubscriptionBillingCycleAnchor { get; set; }
@@ -51,9 +57,6 @@ namespace Stripe
         [JsonProperty("subscription_default_tax_rates")]
         public List<string> SubscriptionDefaultTaxRates { get; set; }
 
-        [JsonProperty("subscription")]
-        public string Subscription { get; set; }
-
         [JsonProperty("subscription_items")]
         public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
 
@@ -67,6 +70,10 @@ namespace Stripe
         [JsonProperty("subscription_proration_date")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
         public DateTime? SubscriptionProrationDate { get; set; }
+
+        [JsonProperty("subscription_resume_at")]
+        [JsonConverter(typeof(AnyOfConverter))]
+        public AnyOf<DateTime?, UpcomingInvoiceSubscriptionResumeAt> SubscriptionResumeAt { get; set; }
 
         [JsonProperty("subscription_start_date")]
         [JsonConverter(typeof(UnixDateTimeConverter))]

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceSubscriptionResumeAt.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceSubscriptionResumeAt.cs
@@ -1,0 +1,14 @@
+namespace Stripe
+{
+    public class UpcomingInvoiceSubscriptionResumeAt : StringEnum
+    {
+        /// <summary>When viewing an upcoming invoice for a subscription, simulates it resuming to the current time.</summary>
+        public static readonly UpcomingInvoiceSubscriptionResumeAt Now
+            = new UpcomingInvoiceSubscriptionResumeAt("now");
+
+        private UpcomingInvoiceSubscriptionResumeAt(string value)
+            : base(value)
+        {
+        }
+    }
+}

--- a/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
+++ b/src/StripeTests/Services/Invoices/UpcomingInvoiceOptionsTest.cs
@@ -52,6 +52,22 @@ namespace StripeTests
                     },
                     want = "subscription_trial_end=now",
                 },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionResumeAt = DateTime.Parse("Fri, 13 Feb 2009 23:31:30Z"),
+                    },
+                    want = "subscription_resume_at=1234567890",
+                },
+                new
+                {
+                    options = new UpcomingInvoiceOptions
+                    {
+                        SubscriptionResumeAt = UpcomingInvoiceSubscriptionResumeAt.Now,
+                    },
+                    want = "subscription_resume_at=now",
+                },
             };
 
             foreach (var testCase in testCases)


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-dotnet/issues/2645

* Add `currency` and `subscription_resume_at` to the Upcoming Invoice API.