### PR TITLE
Handle developer_message in preview error responses

### DIFF
--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -43,6 +43,13 @@ namespace Stripe
         public string Message { get; set; }
 
         /// <summary>
+        /// A human-readable message providing more details about the error. For card errors, these
+        /// messages can be shown to your users.
+        /// </summary>
+        [JsonProperty("developer_message")]
+        public string DeveloperMessage { get; set; }
+
+        /// <summary>
         /// If the error is parameter-specific, the parameter related to the error. For example,
         /// you can use this to display a message near the correct form field.
         /// </summary>

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -187,8 +187,15 @@ namespace Stripe
 
             var request = StripeRequest.CreateWithStringContent(this, method, path, content, requestOptions);
 
-            return await this.HttpClient.MakeRequestAsync(request, cancellationToken)
+            var response = await this.HttpClient.MakeRequestAsync(request, cancellationToken)
                     .ConfigureAwait(false);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw BuildStripeException(response);
+            }
+
+            return response;
         }
 
         /// <summary>Deserializes a JSON string into a Stripe object.</summary>
@@ -261,7 +268,7 @@ namespace Stripe
             return new StripeException(
                 response.StatusCode,
                 stripeError,
-                stripeError.Message ?? stripeError.ErrorDescription)
+                stripeError.Message ?? stripeError.ErrorDescription ?? stripeError.DeveloperMessage)
             {
                 StripeResponse = response,
             };

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -320,6 +320,18 @@ namespace StripeTests
         }
 
         [Fact]
+        public void PreviewGet_ThrowsExceptionWithDeveloperMessageAsMessage()
+        {
+            var content = "{\"error\": {\"developer_message\": \"Unacceptable!\"}}";
+            var response = new StripeResponse(HttpStatusCode.BadRequest, null, content);
+            this.httpClient.Response = response;
+
+            var exception = Assert.Throws<StripeException>(() => this.stripeClient.Preview.Get("/v1/charges/ch_123"));
+
+            Assert.Equal("Unacceptable!", exception.Message);
+        }
+
+        [Fact]
         public async Task PreviewPostAsync_Json()
         {
             var content = "{\"id\": \"ch_123\", \"object\": \"charge\"}";


### PR DESCRIPTION
The error message can be returned in a `developer_message` field, handle this case and throw a useful exception.