### PR TITLE
Move ShippingOptions

### DIFF
--- a/src/Stripe.net/Services/_common/ShippingOptions.cs
+++ b/src/Stripe.net/Services/_common/ShippingOptions.cs
@@ -1,4 +1,3 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using Newtonsoft.Json;


### PR DESCRIPTION
This is a shared class, it makes no sense for it to live in the `Invoices` folder. Moving folders should be non-breaking.