### PR TITLE
Fix AccountSettingsPayoutsScheduleOptions.MonthlyAnchor type

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountSettingsPayoutsScheduleOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountSettingsPayoutsScheduleOptions.cs
@@ -33,7 +33,7 @@ namespace Stripe
         /// is <c>monthly</c>.
         /// </summary>
         [JsonProperty("monthly_anchor")]
-        public string MonthlyAnchor { get; set; }
+        public long? MonthlyAnchor { get; set; }
 
         /// <summary>
         /// The day of the week when available funds are paid out, specified as <c>monday</c>,

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationLoginPageOptions.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationLoginPageOptions.cs
@@ -9,6 +9,8 @@ namespace Stripe.BillingPortal
         /// Set to <c>true</c> to generate a shareable URL <a
         /// href="https://stripe.com/docs/api/customer_portal/configuration#portal_configuration_object-login_page-url"><c>login_page.url</c></a>
         /// that will take your customers to a hosted login page for the customer portal.
+        ///
+        /// Set to <c>false</c> to deactivate the <c>login_page.url</c>.
         /// </summary>
         [JsonProperty("enabled")]
         public bool? Enabled { get; set; }

--- a/src/Stripe.net/Services/Persons/PersonRelationshipOptions.cs
+++ b/src/Stripe.net/Services/Persons/PersonRelationshipOptions.cs
@@ -14,14 +14,15 @@ namespace Stripe
         public bool? Director { get; set; }
 
         /// <summary>
-        /// Whether the person has significant responsibility to control, manage, or direct the
-        /// organization.
+        /// A filter on the list of people returned based on whether these people are executives of
+        /// the account's company.
         /// </summary>
         [JsonProperty("executive")]
         public bool? Executive { get; set; }
 
         /// <summary>
-        /// Whether the person is an owner of the account’s legal entity.
+        /// A filter on the list of people returned based on whether these people are owners of the
+        /// account's company.
         /// </summary>
         [JsonProperty("owner")]
         public bool? Owner { get; set; }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionItemOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionItemOptions.cs
@@ -49,7 +49,8 @@ namespace Stripe
         public string Plan { get; set; }
 
         /// <summary>
-        /// The ID of the price object.
+        /// The ID of the price object. When changing a subscription item's price, <c>quantity</c>
+        /// is set to 1 unless a <c>quantity</c> parameter is provided.
         /// </summary>
         [JsonProperty("price")]
         public string Price { get; set; }

--- a/src/StripeTests/Services/Accounts/AccountServiceTest.cs
+++ b/src/StripeTests/Services/Accounts/AccountServiceTest.cs
@@ -92,7 +92,7 @@ namespace StripeTests
                         Schedule = new AccountSettingsPayoutsScheduleOptions
                         {
                             Interval = "monthly",
-                            MonthlyAnchor = "10",
+                            MonthlyAnchor = 10,
                         },
                     },
                 },


### PR DESCRIPTION
`MonthlyAnchor` is a number between 1 and 31. It should not be a string.

Also some code-generation-related switching around of docstrings.