### PR TITLE
Fix CI issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             3.1.x
             5.0.x
             6.0.x
-            7.0.x
+            7.0.307
 
       - name: Install tools
         run: |


### PR DESCRIPTION
CI has started [failing](https://github.com/stripe/stripe-dotnet/actions/runs/5823610861/job/15790876478#step:8:63) with
>  FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: The type initializer for 'Microsoft.VisualStudio.TestPlatform.ObjectModel.EqtTrace' threw an exception. ---> System.TypeLoadException: Could not load type of field 'Microsoft.VisualStudio.TestPlatform.ObjectModel.PlatformEqtTrace:TraceSourceLevelsMap' (1) due to: Could not resolve type with token 01000019 from typeref (expected class 'System.Diagnostics.TraceLevel' in assembly 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089') assembly:System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 type:System.Diagnostics.TraceLevel member:(null)


Apparently the issue is [known](https://github.com/microsoft/vstest/issues/4549) and the fix is forthcoming.
Found [another library encountering this issue](https://github.com/G-Research/consuldotnet/pull/232) and I applied their workaround. 