### PR TITLE
Remove deprecated items, and update outdated types

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -1,8 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    using System;
-
     public static class Events
     {
         /// <summary>
@@ -498,14 +496,6 @@ namespace Stripe
         public const string InvoiceDeleted = "invoice.deleted";
 
         /// <summary>
-        /// The "invoice.finalization_error" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-invoice.finalization_error for
-        /// details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string InvoiceFinalizationError = "invoice.finalization_error";
-
-        /// <summary>
         /// The "invoice.finalization_failed" event type. See
         /// https://stripe.com/docs/api/events/types#event_types-invoice.finalization_failed for
         /// details.
@@ -701,13 +691,6 @@ namespace Stripe
         public const string OrderCreated = "order.created";
 
         /// <summary>
-        /// The "order.payment_failed" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-order.payment_failed for details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string OrderPaymentFailed = "order.payment_failed";
-
-        /// <summary>
         /// The "payment_intent.amount_capturable_updated" event type. See
         /// https://stripe.com/docs/api/events/types#event_types-payment_intent.amount_capturable_updated
         /// for details.
@@ -789,14 +772,6 @@ namespace Stripe
         public const string PaymentMethodAutomaticallyUpdated = "payment_method.automatically_updated";
 
         /// <summary>
-        /// The "payment_method.card_automatically_updated" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-payment_method.card_automatically_updated
-        /// for details.
-        /// </summary>
-        [Obsolete("Use PaymentMethodAutomaticallyUpdated instead.")]
-        public const string PaymentMethodCardAutomaticallyUpdated = "payment_method.card_automatically_updated";
-
-        /// <summary>
         /// The "payment_method.detached" event type. See
         /// https://stripe.com/docs/api/events/types#event_types-payment_method.detached for
         /// details.
@@ -808,12 +783,6 @@ namespace Stripe
         /// https://stripe.com/docs/api/events/types#event_types-payment_method.updated for details.
         /// </summary>
         public const string PaymentMethodUpdated = "payment_method.updated";
-
-        /// <summary>
-        /// The "payment.created" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-payment.created for details.
-        /// </summary>
-        public const string PaymentCreated = "payment.created";
 
         /// <summary>
         /// The "payout.canceled" event type. See
@@ -1080,8 +1049,7 @@ namespace Stripe
         /// https://stripe.com/docs/api/events/types#event_types-sigma.scheduled_query_run.created
         /// for details.
         /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string SigmaScheduleQueryRunCreated = "sigma.scheduled_query_run.created";
+        public const string SigmaScheduledQueryRunCreated = "sigma.scheduled_query_run.created";
 
         /// <summary>
         /// The "sku.created" event type. See
@@ -1312,62 +1280,6 @@ namespace Stripe
         public const string TransferUpdated = "transfer.updated";
 
         /// <summary>
-        /// The "treasury.check_deposit.canceled" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.canceled for
-        /// details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositCanceled = "treasury.check_deposit.canceled";
-
-        /// <summary>
-        /// The "treasury.check_deposit.created" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.created for
-        /// details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositCreated = "treasury.check_deposit.created";
-
-        /// <summary>
-        /// The "treasury.check_deposit.processing" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.processing
-        /// for details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositProcessing = "treasury.check_deposit.processing";
-
-        /// <summary>
-        /// The "treasury.check_deposit.received" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.received for
-        /// details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositReceived = "treasury.check_deposit.received";
-
-        /// <summary>
-        /// The "treasury.check_deposit.requires_action" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.requires_action
-        /// for details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositRequiresAction = "treasury.check_deposit.requires_action";
-
-        /// <summary>
-        /// The "treasury.check_deposit.requires_confirmation" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.requires_confirmation
-        /// for details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositRequiresConfirmation = "treasury.check_deposit.requires_confirmation";
-
-        /// <summary>
-        /// The "treasury.check_deposit.reversed" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.check_deposit.reversed for
-        /// details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryCheckDepositReversed = "treasury.check_deposit.reversed";
-
-        /// <summary>
         /// The "treasury.credit_reversal.created" event type. See
         /// https://stripe.com/docs/api/events/types#event_types-treasury.credit_reversal.created
         /// for details.
@@ -1548,14 +1460,6 @@ namespace Stripe
         /// details.
         /// </summary>
         public const string TreasuryReceivedCreditFailed = "treasury.received_credit.failed";
-
-        /// <summary>
-        /// The "treasury.received_credit.reversed" event type. See
-        /// https://stripe.com/docs/api/events/types#event_types-treasury.received_credit.reversed
-        /// for details.
-        /// </summary>
-        [Obsolete("This event is part of a beta or deprecated API and will be removed.")]
-        public const string TreasuryReceivedCreditReversed = "treasury.received_credit.reversed";
 
         /// <summary>
         /// The "treasury.received_credit.succeeded" event type. See

--- a/src/Stripe.net/Entities/Discounts/Discount.cs
+++ b/src/Stripe.net/Entities/Discounts/Discount.cs
@@ -147,39 +147,13 @@ namespace Stripe
         /// </summary>
         [JsonProperty("start")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
-        public DateTime? Start { get; set; }
-
-        #region Expandable Subscription
+        public DateTime Start { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
-        /// (ID of the Subscription)
         /// The subscription that this coupon is applied to, if it is applied to a particular
         /// subscription.
         /// </summary>
-        [JsonIgnore]
-        public string SubscriptionId
-        {
-            get => this.InternalSubscription?.Id;
-            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
-        }
-
-        /// <summary>
-        /// (Expanded)
-        /// The subscription that this coupon is applied to, if it is applied to a particular
-        /// subscription.
-        ///
-        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
-        /// </summary>
-        [JsonIgnore]
-        public Subscription Subscription
-        {
-            get => this.InternalSubscription?.ExpandedObject;
-            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
-        }
-
         [JsonProperty("subscription")]
-        [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]
-        internal ExpandableField<Subscription> InternalSubscription { get; set; }
-        #endregion
+        public string Subscription { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItem.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItem.cs
@@ -91,12 +91,38 @@ namespace Stripe
         internal List<ExpandableField<Discount>> InternalDiscounts { get; set; }
         #endregion
 
+        #region Expandable InvoiceItem
+
         /// <summary>
+        /// (ID of the InvoiceItem)
         /// The ID of the <a href="https://stripe.com/docs/api/invoiceitems">invoice item</a>
         /// associated with this line item if any.
         /// </summary>
+        [JsonIgnore]
+        public string InvoiceItemId
+        {
+            get => this.InternalInvoiceItem?.Id;
+            set => this.InternalInvoiceItem = SetExpandableFieldId(value, this.InternalInvoiceItem);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The ID of the <a href="https://stripe.com/docs/api/invoiceitems">invoice item</a>
+        /// associated with this line item if any.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public InvoiceItem InvoiceItem
+        {
+            get => this.InternalInvoiceItem?.ExpandedObject;
+            set => this.InternalInvoiceItem = SetExpandableFieldObject(value, this.InternalInvoiceItem);
+        }
+
         [JsonProperty("invoice_item")]
-        public string InvoiceItem { get; set; }
+        [JsonConverter(typeof(ExpandableFieldConverter<InvoiceItem>))]
+        internal ExpandableField<InvoiceItem> InternalInvoiceItem { get; set; }
+        #endregion
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
@@ -148,18 +174,69 @@ namespace Stripe
         [JsonProperty("quantity")]
         public long? Quantity { get; set; }
 
-        /// <summary>
-        /// The subscription that the invoice item pertains to, if any.
-        /// </summary>
-        [JsonProperty("subscription")]
-        public string Subscription { get; set; }
+        #region Expandable Subscription
 
         /// <summary>
+        /// (ID of the Subscription)
+        /// The subscription that the invoice item pertains to, if any.
+        /// </summary>
+        [JsonIgnore]
+        public string SubscriptionId
+        {
+            get => this.InternalSubscription?.Id;
+            set => this.InternalSubscription = SetExpandableFieldId(value, this.InternalSubscription);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The subscription that the invoice item pertains to, if any.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public Subscription Subscription
+        {
+            get => this.InternalSubscription?.ExpandedObject;
+            set => this.InternalSubscription = SetExpandableFieldObject(value, this.InternalSubscription);
+        }
+
+        [JsonProperty("subscription")]
+        [JsonConverter(typeof(ExpandableFieldConverter<Subscription>))]
+        internal ExpandableField<Subscription> InternalSubscription { get; set; }
+        #endregion
+
+        #region Expandable SubscriptionItem
+
+        /// <summary>
+        /// (ID of the SubscriptionItem)
         /// The subscription item that generated this line item. Left empty if the line item is not
         /// an explicit result of a subscription.
         /// </summary>
+        [JsonIgnore]
+        public string SubscriptionItemId
+        {
+            get => this.InternalSubscriptionItem?.Id;
+            set => this.InternalSubscriptionItem = SetExpandableFieldId(value, this.InternalSubscriptionItem);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// The subscription item that generated this line item. Left empty if the line item is not
+        /// an explicit result of a subscription.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        public SubscriptionItem SubscriptionItem
+        {
+            get => this.InternalSubscriptionItem?.ExpandedObject;
+            set => this.InternalSubscriptionItem = SetExpandableFieldObject(value, this.InternalSubscriptionItem);
+        }
+
         [JsonProperty("subscription_item")]
-        public string SubscriptionItem { get; set; }
+        [JsonConverter(typeof(ExpandableFieldConverter<SubscriptionItem>))]
+        internal ExpandableField<SubscriptionItem> InternalSubscriptionItem { get; set; }
+        #endregion
 
         /// <summary>
         /// The amount of tax calculated per tax rate for this line item.


### PR DESCRIPTION
## Summary
The changes in this PR reflect ways that the Stripe API has already changed that would have caused breaking changes in stripe-dotnet and that we postponed in order to avoid shipping breaking changes outside a major release.
## Changelog
* Remove deprecated event constants
* Make `Discount.Start` non-nullable 
* Reflect that `Discount.Subscription` is not expandable
* Reflect that several fields on `InvoiceLineItem` *are* expandable.
