### PR TITLE
Use RequestAsync directly

### DIFF
--- a/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe
 
         public virtual AccountLink Create(AccountLinkCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<AccountLink>(HttpMethod.Post, $"/v1/account_links", options, requestOptions);
         }
 
         public virtual Task<AccountLink> CreateAsync(AccountLinkCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<AccountLink>(HttpMethod.Post, $"/v1/account_links", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/AccountSessions/AccountSessionService.cs
+++ b/src/Stripe.net/Services/AccountSessions/AccountSessionService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe
 
         public virtual AccountSession Create(AccountSessionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<AccountSession>(HttpMethod.Post, $"/v1/account_sessions", options, requestOptions);
         }
 
         public virtual Task<AccountSession> CreateAsync(AccountSessionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<AccountSession>(HttpMethod.Post, $"/v1/account_sessions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -27,72 +27,72 @@ namespace Stripe
 
         public virtual Account Create(AccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts", options, requestOptions);
         }
 
         public virtual Task<Account> CreateAsync(AccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Delete(string id, AccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Account>(HttpMethod.Delete, $"/v1/accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<Account> DeleteAsync(string id, AccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Delete, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Get(string id, AccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Account>(HttpMethod.Get, $"/v1/accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<Account> GetAsync(string id, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Account>>(HttpMethod.Get, $"/v1/accounts", options, requestOptions);
         }
 
         public virtual Task<StripeList<Account>> ListAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Account>>(HttpMethod.Get, $"/v1/accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Account> ListAutoPaging(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Account>($"/v1/accounts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Account> ListAutoPagingAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Account>($"/v1/accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Reject(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/reject", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{id}/reject", options, requestOptions);
         }
 
         public virtual Task<Account> RejectAsync(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/reject", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{id}/reject", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Update(string id, AccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<Account> UpdateAsync(string id, AccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual ApplePayDomain Create(ApplePayDomainCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ApplePayDomain>(HttpMethod.Post, $"/v1/apple_pay/domains", options, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> CreateAsync(ApplePayDomainCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplePayDomain>(HttpMethod.Post, $"/v1/apple_pay/domains", options, requestOptions, cancellationToken);
         }
 
         public virtual ApplePayDomain Delete(string id, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{id}", options, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> DeleteAsync(string id, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual ApplePayDomain Get(string id, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{id}", options, requestOptions);
         }
 
         public virtual Task<ApplePayDomain> GetAsync(string id, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplePayDomain> List(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ApplePayDomain>>(HttpMethod.Get, $"/v1/apple_pay/domains", options, requestOptions);
         }
 
         public virtual Task<StripeList<ApplePayDomain>> ListAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ApplePayDomain>>(HttpMethod.Get, $"/v1/apple_pay/domains", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ApplePayDomain> ListAutoPaging(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ApplePayDomain>($"/v1/apple_pay/domains", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ApplePayDomain> ListAutoPagingAsync(ApplePayDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ApplePayDomain>($"/v1/apple_pay/domains", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual ApplicationFeeRefund Create(string parentId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds", options, requestOptions);
         }
 
         public virtual Task<ApplicationFeeRefund> CreateAsync(string parentId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual ApplicationFeeRefund Get(string parentId, string id, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions);
         }
 
         public virtual Task<ApplicationFeeRefund> GetAsync(string parentId, string id, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplicationFeeRefund> List(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds", options, requestOptions);
         }
 
         public virtual Task<StripeList<ApplicationFeeRefund>> ListAsync(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ApplicationFeeRefund> ListAutoPaging(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<ApplicationFeeRefund>($"/v1/application_fees/{parentId}/refunds", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ApplicationFeeRefund> ListAutoPagingAsync(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ApplicationFeeRefund>($"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual ApplicationFeeRefund Update(string parentId, string id, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions);
         }
 
         public virtual Task<ApplicationFeeRefund> UpdateAsync(string parentId, string id, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual ApplicationFee Get(string id, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{id}", options, requestOptions);
         }
 
         public virtual Task<ApplicationFee> GetAsync(string id, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ApplicationFee> List(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ApplicationFee>>(HttpMethod.Get, $"/v1/application_fees", options, requestOptions);
         }
 
         public virtual Task<StripeList<ApplicationFee>> ListAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ApplicationFee>>(HttpMethod.Get, $"/v1/application_fees", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ApplicationFee> ListAutoPaging(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ApplicationFee>($"/v1/application_fees", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ApplicationFee> ListAutoPagingAsync(ApplicationFeeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ApplicationFee>($"/v1/application_fees", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Apps/Secrets/SecretService.cs
+++ b/src/Stripe.net/Services/Apps/Secrets/SecretService.cs
@@ -24,52 +24,52 @@ namespace Stripe.Apps
 
         public virtual Secret Create(SecretCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Secret>(HttpMethod.Post, $"/v1/apps/secrets", options, requestOptions);
         }
 
         public virtual Task<Secret> CreateAsync(SecretCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Secret>(HttpMethod.Post, $"/v1/apps/secrets", options, requestOptions, cancellationToken);
         }
 
         public virtual Secret DeleteWhere(SecretDeleteWhereOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("delete")}", options, requestOptions);
+            return this.Request<Secret>(HttpMethod.Post, $"/v1/apps/secrets/delete", options, requestOptions);
         }
 
         public virtual Task<Secret> DeleteWhereAsync(SecretDeleteWhereOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("delete")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Secret>(HttpMethod.Post, $"/v1/apps/secrets/delete", options, requestOptions, cancellationToken);
         }
 
         public virtual Secret Find(SecretFindOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Get, $"{this.InstanceUrl("find")}", options, requestOptions);
+            return this.Request<Secret>(HttpMethod.Get, $"/v1/apps/secrets/find", options, requestOptions);
         }
 
         public virtual Task<Secret> FindAsync(SecretFindOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Get, $"{this.InstanceUrl("find")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Secret>(HttpMethod.Get, $"/v1/apps/secrets/find", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Secret> List(SecretListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Secret>>(HttpMethod.Get, $"/v1/apps/secrets", options, requestOptions);
         }
 
         public virtual Task<StripeList<Secret>> ListAsync(SecretListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Secret>>(HttpMethod.Get, $"/v1/apps/secrets", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Secret> ListAutoPaging(SecretListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Secret>($"/v1/apps/secrets", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Secret> ListAutoPagingAsync(SecretListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Secret>($"/v1/apps/secrets", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual BalanceTransaction Get(string id, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<BalanceTransaction> GetAsync(string id, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<BalanceTransaction> List(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<BalanceTransaction>>(HttpMethod.Get, $"/v1/balance_transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<BalanceTransaction>> ListAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<BalanceTransaction>>(HttpMethod.Get, $"/v1/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<BalanceTransaction> ListAutoPaging(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<BalanceTransaction>($"/v1/balance_transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<BalanceTransaction> ListAutoPagingAsync(BalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<BalanceTransaction>($"/v1/balance_transactions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Balances/BalanceService.cs
+++ b/src/Stripe.net/Services/Balances/BalanceService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,12 +27,12 @@ namespace Stripe
 
         public virtual Balance Get(RequestOptions requestOptions = null)
         {
-            return this.GetEntity(null, null, requestOptions);
+            return this.Request<Balance>(HttpMethod.Get, $"/v1/balance", null, requestOptions);
         }
 
         public virtual Task<Balance> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(null, null, requestOptions, cancellationToken);
+            return this.RequestAsync<Balance>(HttpMethod.Get, $"/v1/balance", null, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -13,6 +13,7 @@ namespace Stripe
         INestedRetrievable<BankAccount, BankAccountGetOptions>,
         INestedUpdatable<BankAccount, BankAccountUpdateOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public BankAccountService()
             : base(null)
         {
@@ -94,5 +95,6 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(parentId, id)}/verify", options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.BillingPortal
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe.BillingPortal
 
         public virtual Configuration Create(ConfigurationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations", options, requestOptions);
         }
 
         public virtual Task<Configuration> CreateAsync(ConfigurationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual Configuration Get(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<Configuration> GetAsync(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Configuration> List(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Configuration>>(HttpMethod.Get, $"/v1/billing_portal/configurations", options, requestOptions);
         }
 
         public virtual Task<StripeList<Configuration>> ListAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Configuration>>(HttpMethod.Get, $"/v1/billing_portal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Configuration> ListAutoPaging(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Configuration>($"/v1/billing_portal/configurations", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Configuration> ListAutoPagingAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Configuration>($"/v1/billing_portal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual Configuration Update(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<Configuration> UpdateAsync(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.BillingPortal
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe.BillingPortal
 
         public virtual Session Create(SessionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/billing_portal/sessions", options, requestOptions);
         }
 
         public virtual Task<Session> CreateAsync(SessionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/billing_portal/sessions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe
 
         public virtual Capability Get(string parentId, string id, CapabilityGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Capability>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions);
         }
 
         public virtual Task<Capability> GetAsync(string parentId, string id, CapabilityGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Capability>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Capability> List(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities", options, requestOptions);
         }
 
         public virtual Task<StripeList<Capability>> ListAsync(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Capability> ListAutoPaging(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<Capability>($"/v1/accounts/{parentId}/capabilities", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Capability> ListAutoPagingAsync(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Capability>($"/v1/accounts/{parentId}/capabilities", options, requestOptions, cancellationToken);
         }
 
         public virtual Capability Update(string parentId, string id, CapabilityUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Capability>(HttpMethod.Post, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions);
         }
 
         public virtual Task<Capability> UpdateAsync(string parentId, string id, CapabilityUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Capability>(HttpMethod.Post, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -12,6 +12,7 @@ namespace Stripe
         INestedRetrievable<Card, CardGetOptions>,
         INestedUpdatable<Card, CardUpdateOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public CardService()
             : base(null)
         {
@@ -83,5 +84,6 @@ namespace Stripe
         {
             return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/CashBalances/CashBalanceService.cs
+++ b/src/Stripe.net/Services/CashBalances/CashBalanceService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,22 +22,22 @@ namespace Stripe
 
         public virtual CashBalance Get(string parentId, CashBalanceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, null, options, requestOptions);
+            return this.Request<CashBalance>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance", options, requestOptions);
         }
 
         public virtual Task<CashBalance> GetAsync(string parentId, CashBalanceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, null, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CashBalance>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance", options, requestOptions, cancellationToken);
         }
 
         public virtual CashBalance Update(string parentId, CashBalanceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, null, options, requestOptions);
+            return this.Request<CashBalance>(HttpMethod.Post, $"/v1/customers/{parentId}/cash_balance", options, requestOptions);
         }
 
         public virtual Task<CashBalance> UpdateAsync(string parentId, CashBalanceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, null, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CashBalance>(HttpMethod.Post, $"/v1/customers/{parentId}/cash_balance", options, requestOptions, cancellationToken);
         }
 
         protected override string InstanceUrl(string parentId, string id)

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -27,82 +27,82 @@ namespace Stripe
 
         public virtual Charge Capture(string id, ChargeCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{id}/capture", options, requestOptions);
         }
 
         public virtual Task<Charge> CaptureAsync(string id, ChargeCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{id}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Create(ChargeCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges", options, requestOptions);
         }
 
         public virtual Task<Charge> CreateAsync(ChargeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges", options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Get(string id, ChargeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Get, $"/v1/charges/{id}", options, requestOptions);
         }
 
         public virtual Task<Charge> GetAsync(string id, ChargeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Get, $"/v1/charges/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Charge> List(ChargeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Charge>>(HttpMethod.Get, $"/v1/charges", options, requestOptions);
         }
 
         public virtual Task<StripeList<Charge>> ListAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Charge>>(HttpMethod.Get, $"/v1/charges", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Charge> ListAutoPaging(ChargeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Charge>($"/v1/charges", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Charge> ListAutoPagingAsync(ChargeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Charge>($"/v1/charges", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Charge> Search(ChargeSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Charge>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Charge>>(HttpMethod.Get, $"/v1/charges/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Charge>> SearchAsync(ChargeSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Charge>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Charge>>(HttpMethod.Get, $"/v1/charges/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Charge> SearchAutoPaging(ChargeSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Charge>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Charge>($"/v1/charges/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Charge> SearchAutoPagingAsync(ChargeSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Charge>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Charge>($"/v1/charges/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Charge Update(string id, ChargeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{id}", options, requestOptions);
         }
 
         public virtual Task<Charge> UpdateAsync(string id, ChargeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -25,72 +25,72 @@ namespace Stripe.Checkout
 
         public virtual Session Create(SessionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions", options, requestOptions);
         }
 
         public virtual Task<Session> CreateAsync(SessionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual Session Expire(string id, SessionExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}/expire", options, requestOptions);
         }
 
         public virtual Task<Session> ExpireAsync(string id, SessionExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}/expire", options, requestOptions, cancellationToken);
         }
 
         public virtual Session Get(string id, SessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{id}", options, requestOptions);
         }
 
         public virtual Task<Session> GetAsync(string id, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Session> List(SessionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Session>>(HttpMethod.Get, $"/v1/checkout/sessions", options, requestOptions);
         }
 
         public virtual Task<StripeList<Session>> ListAsync(SessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Session>>(HttpMethod.Get, $"/v1/checkout/sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Session> ListAutoPaging(SessionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Session>($"/v1/checkout/sessions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Session> ListAutoPagingAsync(SessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Session>($"/v1/checkout/sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<LineItem> ListLineItems(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{id}/line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/checkout/sessions/{id}/line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/checkout/sessions/{id}/line_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual CountrySpec Get(string id, CountrySpecGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{id}", options, requestOptions);
         }
 
         public virtual Task<CountrySpec> GetAsync(string id, CountrySpecGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CountrySpec> List(CountrySpecListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<CountrySpec>>(HttpMethod.Get, $"/v1/country_specs", options, requestOptions);
         }
 
         public virtual Task<StripeList<CountrySpec>> ListAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CountrySpec>>(HttpMethod.Get, $"/v1/country_specs", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CountrySpec> ListAutoPaging(CountrySpecListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<CountrySpec>($"/v1/country_specs", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CountrySpec> ListAutoPagingAsync(CountrySpecListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CountrySpec>($"/v1/country_specs", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual Coupon Create(CouponCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Post, $"/v1/coupons", options, requestOptions);
         }
 
         public virtual Task<Coupon> CreateAsync(CouponCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Post, $"/v1/coupons", options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Delete(string id, CouponDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Delete, $"/v1/coupons/{id}", options, requestOptions);
         }
 
         public virtual Task<Coupon> DeleteAsync(string id, CouponDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Delete, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Get(string id, CouponGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Get, $"/v1/coupons/{id}", options, requestOptions);
         }
 
         public virtual Task<Coupon> GetAsync(string id, CouponGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Get, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Coupon> List(CouponListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Coupon>>(HttpMethod.Get, $"/v1/coupons", options, requestOptions);
         }
 
         public virtual Task<StripeList<Coupon>> ListAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Coupon>>(HttpMethod.Get, $"/v1/coupons", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Coupon> ListAutoPaging(CouponListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Coupon>($"/v1/coupons", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Coupon> ListAutoPagingAsync(CouponListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Coupon>($"/v1/coupons", options, requestOptions, cancellationToken);
         }
 
         public virtual Coupon Update(string id, CouponUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Post, $"/v1/coupons/{id}", options, requestOptions);
         }
 
         public virtual Task<Coupon> UpdateAsync(string id, CouponUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Post, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -11,6 +11,7 @@ namespace Stripe
         IRetrievable<CreditNote, CreditNoteGetOptions>,
         IUpdatable<CreditNote, CreditNoteUpdateOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public CreditNoteService()
             : base(null)
         {
@@ -132,5 +133,6 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual CustomerBalanceTransaction Create(string parentId, CustomerBalanceTransactionCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
         }
 
         public virtual Task<CustomerBalanceTransaction> CreateAsync(string parentId, CustomerBalanceTransactionCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual CustomerBalanceTransaction Get(string parentId, string id, CustomerBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<CustomerBalanceTransaction> GetAsync(string parentId, string id, CustomerBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CustomerBalanceTransaction> List(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<CustomerBalanceTransaction>> ListAsync(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CustomerBalanceTransaction> ListAutoPaging(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<CustomerBalanceTransaction>($"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CustomerBalanceTransaction> ListAutoPagingAsync(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CustomerBalanceTransaction>($"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual CustomerBalanceTransaction Update(string parentId, string id, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<CustomerBalanceTransaction> UpdateAsync(string parentId, string id, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual CustomerCashBalanceTransaction Get(string parentId, string id, CustomerCashBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<CustomerCashBalanceTransaction> GetAsync(string parentId, string id, CustomerCashBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CustomerCashBalanceTransaction> List(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<CustomerCashBalanceTransaction>> ListAsync(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CustomerCashBalanceTransaction> ListAutoPaging(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<CustomerCashBalanceTransaction>($"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CustomerCashBalanceTransaction> ListAutoPagingAsync(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CustomerCashBalanceTransaction>($"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -28,122 +28,122 @@ namespace Stripe
 
         public virtual Customer Create(CustomerCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Post, $"/v1/customers", options, requestOptions);
         }
 
         public virtual Task<Customer> CreateAsync(CustomerCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Post, $"/v1/customers", options, requestOptions, cancellationToken);
         }
 
         public virtual FundingInstructions CreateFundingInstructions(string id, CustomerCreateFundingInstructionsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FundingInstructions>(HttpMethod.Post, $"{this.InstanceUrl(id)}/funding_instructions", options, requestOptions);
+            return this.Request<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{id}/funding_instructions", options, requestOptions);
         }
 
         public virtual Task<FundingInstructions> CreateFundingInstructionsAsync(string id, CustomerCreateFundingInstructionsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FundingInstructions>(HttpMethod.Post, $"{this.InstanceUrl(id)}/funding_instructions", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{id}/funding_instructions", options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Delete(string id, CustomerDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Delete, $"/v1/customers/{id}", options, requestOptions);
         }
 
         public virtual Task<Customer> DeleteAsync(string id, CustomerDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Delete, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Get(string id, CustomerGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Get, $"/v1/customers/{id}", options, requestOptions);
         }
 
         public virtual Task<Customer> GetAsync(string id, CustomerGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Get, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Customer> List(CustomerListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Customer>>(HttpMethod.Get, $"/v1/customers", options, requestOptions);
         }
 
         public virtual Task<StripeList<Customer>> ListAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Customer>>(HttpMethod.Get, $"/v1/customers", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Customer> ListAutoPaging(CustomerListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Customer>($"/v1/customers", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Customer> ListAutoPagingAsync(CustomerListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Customer>($"/v1/customers", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentMethod> ListPaymentMethods(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<PaymentMethod>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods", options, requestOptions);
+            return this.Request<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{id}/payment_methods", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentMethod>> ListPaymentMethodsAsync(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<PaymentMethod>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{id}/payment_methods", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentMethod> ListPaymentMethodsAutoPaging(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<PaymentMethod>($"{this.InstanceUrl(id)}/payment_methods", options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentMethod>($"/v1/customers/{id}/payment_methods", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentMethod> ListPaymentMethodsAutoPagingAsync(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<PaymentMethod>($"{this.InstanceUrl(id)}/payment_methods", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentMethod>($"/v1/customers/{id}/payment_methods", options, requestOptions, cancellationToken);
         }
 
-        public virtual PaymentMethod RetrievePaymentMethod(string id, string payment_method, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null)
+        public virtual PaymentMethod RetrievePaymentMethod(string parentId, string id, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods/{payment_method}", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{parentId}/payment_methods/{id}", options, requestOptions);
         }
 
-        public virtual Task<PaymentMethod> RetrievePaymentMethodAsync(string id, string payment_method, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<PaymentMethod> RetrievePaymentMethodAsync(string parentId, string id, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"{this.InstanceUrl(id)}/payment_methods/{payment_method}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{parentId}/payment_methods/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Customer> Search(CustomerSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Customer>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Customer>>(HttpMethod.Get, $"/v1/customers/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Customer>> SearchAsync(CustomerSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Customer>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Customer>>(HttpMethod.Get, $"/v1/customers/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Customer> SearchAutoPaging(CustomerSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Customer>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Customer>($"/v1/customers/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Customer> SearchAutoPagingAsync(CustomerSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Customer>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Customer>($"/v1/customers/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Customer Update(string id, CustomerUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Post, $"/v1/customers/{id}", options, requestOptions);
         }
 
         public virtual Task<Customer> UpdateAsync(string id, CustomerUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Post, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -25,52 +25,52 @@ namespace Stripe
 
         public virtual Dispute Close(string id, DisputeCloseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/close", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}/close", options, requestOptions);
         }
 
         public virtual Task<Dispute> CloseAsync(string id, DisputeCloseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/close", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}/close", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Get(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Get, $"/v1/disputes/{id}", options, requestOptions);
         }
 
         public virtual Task<Dispute> GetAsync(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/disputes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Dispute>>(HttpMethod.Get, $"/v1/disputes", options, requestOptions);
         }
 
         public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Dispute>>(HttpMethod.Get, $"/v1/disputes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Dispute> ListAutoPaging(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Dispute>($"/v1/disputes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Dispute>($"/v1/disputes", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}", options, requestOptions);
         }
 
         public virtual Task<Dispute> UpdateAsync(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -7,6 +7,7 @@ namespace Stripe
         ICreatable<EphemeralKey, EphemeralKeyCreateOptions>,
         IDeletable<EphemeralKey, EphemeralKeyDeleteOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public EphemeralKeyService()
             : base(null)
         {
@@ -53,5 +54,6 @@ namespace Stripe
         {
             return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual Event Get(string id, EventGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Event>(HttpMethod.Get, $"/v1/events/{id}", options, requestOptions);
         }
 
         public virtual Task<Event> GetAsync(string id, EventGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Event>(HttpMethod.Get, $"/v1/events/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Event> List(EventListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Event>>(HttpMethod.Get, $"/v1/events", options, requestOptions);
         }
 
         public virtual Task<StripeList<Event>> ListAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Event>>(HttpMethod.Get, $"/v1/events", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Event>($"/v1/events", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Event>($"/v1/events", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual IExternalAccount Create(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
         }
 
         public virtual Task<IExternalAccount> CreateAsync(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IExternalAccount Delete(string parentId, string id, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<IExternalAccount> DeleteAsync(string parentId, string id, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual IExternalAccount Get(string parentId, string id, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<IExternalAccount> GetAsync(string parentId, string id, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<IExternalAccount> List(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
         }
 
         public virtual Task<StripeList<IExternalAccount>> ListAsync(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<IExternalAccount> ListAutoPaging(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<IExternalAccount>($"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<IExternalAccount> ListAutoPagingAsync(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<IExternalAccount>($"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IExternalAccount Update(string parentId, string id, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<IExternalAccount> UpdateAsync(string parentId, string id, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual FileLink Create(FileLinkCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<FileLink>(HttpMethod.Post, $"/v1/file_links", options, requestOptions);
         }
 
         public virtual Task<FileLink> CreateAsync(FileLinkCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<FileLink>(HttpMethod.Post, $"/v1/file_links", options, requestOptions, cancellationToken);
         }
 
         public virtual FileLink Get(string id, FileLinkGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<FileLink>(HttpMethod.Get, $"/v1/file_links/{id}", options, requestOptions);
         }
 
         public virtual Task<FileLink> GetAsync(string id, FileLinkGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<FileLink>(HttpMethod.Get, $"/v1/file_links/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<FileLink> List(FileLinkListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<FileLink>>(HttpMethod.Get, $"/v1/file_links", options, requestOptions);
         }
 
         public virtual Task<StripeList<FileLink>> ListAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<FileLink>>(HttpMethod.Get, $"/v1/file_links", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<FileLink> ListAutoPaging(FileLinkListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<FileLink>($"/v1/file_links", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<FileLink> ListAutoPagingAsync(FileLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<FileLink>($"/v1/file_links", options, requestOptions, cancellationToken);
         }
 
         public virtual FileLink Update(string id, FileLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<FileLink>(HttpMethod.Post, $"/v1/file_links/{id}", options, requestOptions);
         }
 
         public virtual Task<FileLink> UpdateAsync(string id, FileLinkUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<FileLink>(HttpMethod.Post, $"/v1/file_links/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -9,6 +9,7 @@ namespace Stripe
         IListable<File, FileListOptions>,
         IRetrievable<File, FileGetOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public FileService()
             : base(null)
         {
@@ -78,5 +79,6 @@ namespace Stripe
 
             return requestOptions;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
@@ -24,72 +24,72 @@ namespace Stripe.FinancialConnections
 
         public virtual Account Disconnect(string id, AccountDisconnectOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/disconnect", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/disconnect", options, requestOptions);
         }
 
         public virtual Task<Account> DisconnectAsync(string id, AccountDisconnectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/disconnect", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/disconnect", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Get(string id, AccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<Account> GetAsync(string id, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Account> List(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Account>>(HttpMethod.Get, $"/v1/financial_connections/accounts", options, requestOptions);
         }
 
         public virtual Task<StripeList<Account>> ListAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Account>>(HttpMethod.Get, $"/v1/financial_connections/accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Account> ListAutoPaging(AccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Account>($"/v1/financial_connections/accounts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Account> ListAutoPagingAsync(AccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Account>($"/v1/financial_connections/accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<AccountOwner> ListOwners(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<AccountOwner>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/owners", options, requestOptions);
+            return this.Request<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}/owners", options, requestOptions);
         }
 
         public virtual Task<StripeList<AccountOwner>> ListOwnersAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<AccountOwner>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/owners", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}/owners", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<AccountOwner> ListOwnersAutoPaging(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<AccountOwner>($"{this.InstanceUrl(id)}/owners", options, requestOptions);
+            return this.ListRequestAutoPaging<AccountOwner>($"/v1/financial_connections/accounts/{id}/owners", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<AccountOwner> ListOwnersAutoPagingAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<AccountOwner>($"{this.InstanceUrl(id)}/owners", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<AccountOwner>($"/v1/financial_connections/accounts/{id}/owners", options, requestOptions, cancellationToken);
         }
 
         public virtual Account Refresh(string id, AccountRefreshOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/refresh", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/refresh", options, requestOptions);
         }
 
         public virtual Task<Account> RefreshAsync(string id, AccountRefreshOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/refresh", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/refresh", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.FinancialConnections
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -22,22 +23,22 @@ namespace Stripe.FinancialConnections
 
         public virtual Session Create(SessionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/financial_connections/sessions", options, requestOptions);
         }
 
         public virtual Task<Session> CreateAsync(SessionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/financial_connections/sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual Session Get(string id, SessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{id}", options, requestOptions);
         }
 
         public virtual Task<Session> GetAsync(string id, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Identity
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Identity
 
         public virtual VerificationReport Get(string id, VerificationReportGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{id}", options, requestOptions);
         }
 
         public virtual Task<VerificationReport> GetAsync(string id, VerificationReportGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<VerificationReport> List(VerificationReportListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<VerificationReport>>(HttpMethod.Get, $"/v1/identity/verification_reports", options, requestOptions);
         }
 
         public virtual Task<StripeList<VerificationReport>> ListAsync(VerificationReportListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<VerificationReport>>(HttpMethod.Get, $"/v1/identity/verification_reports", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<VerificationReport> ListAutoPaging(VerificationReportListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<VerificationReport>($"/v1/identity/verification_reports", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<VerificationReport> ListAutoPagingAsync(VerificationReportListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<VerificationReport>($"/v1/identity/verification_reports", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
@@ -26,72 +26,72 @@ namespace Stripe.Identity
 
         public virtual VerificationSession Cancel(string id, VerificationSessionCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<VerificationSession> CancelAsync(string id, VerificationSessionCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual VerificationSession Create(VerificationSessionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions", options, requestOptions);
         }
 
         public virtual Task<VerificationSession> CreateAsync(VerificationSessionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual VerificationSession Get(string id, VerificationSessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{id}", options, requestOptions);
         }
 
         public virtual Task<VerificationSession> GetAsync(string id, VerificationSessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<VerificationSession> List(VerificationSessionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<VerificationSession>>(HttpMethod.Get, $"/v1/identity/verification_sessions", options, requestOptions);
         }
 
         public virtual Task<StripeList<VerificationSession>> ListAsync(VerificationSessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<VerificationSession>>(HttpMethod.Get, $"/v1/identity/verification_sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<VerificationSession> ListAutoPaging(VerificationSessionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<VerificationSession>($"/v1/identity/verification_sessions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<VerificationSession> ListAutoPagingAsync(VerificationSessionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<VerificationSession>($"/v1/identity/verification_sessions", options, requestOptions, cancellationToken);
         }
 
         public virtual VerificationSession Redact(string id, VerificationSessionRedactOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/redact", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/redact", options, requestOptions);
         }
 
         public virtual Task<VerificationSession> RedactAsync(string id, VerificationSessionRedactOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/redact", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/redact", options, requestOptions, cancellationToken);
         }
 
         public virtual VerificationSession Update(string id, VerificationSessionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}", options, requestOptions);
         }
 
         public virtual Task<VerificationSession> UpdateAsync(string id, VerificationSessionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual InvoiceItem Create(InvoiceItemCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems", options, requestOptions);
         }
 
         public virtual Task<InvoiceItem> CreateAsync(InvoiceItemCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems", options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceItem Delete(string id, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{id}", options, requestOptions);
         }
 
         public virtual Task<InvoiceItem> DeleteAsync(string id, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceItem Get(string id, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{id}", options, requestOptions);
         }
 
         public virtual Task<InvoiceItem> GetAsync(string id, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InvoiceItem> List(InvoiceItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<InvoiceItem>>(HttpMethod.Get, $"/v1/invoiceitems", options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceItem>> ListAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceItem>>(HttpMethod.Get, $"/v1/invoiceitems", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InvoiceItem> ListAutoPaging(InvoiceItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<InvoiceItem>($"/v1/invoiceitems", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<InvoiceItem> ListAutoPagingAsync(InvoiceItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<InvoiceItem>($"/v1/invoiceitems", options, requestOptions, cancellationToken);
         }
 
         public virtual InvoiceItem Update(string id, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{id}", options, requestOptions);
         }
 
         public virtual Task<InvoiceItem> UpdateAsync(string id, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -12,6 +12,7 @@ namespace Stripe
         IRetrievable<Invoice, InvoiceGetOptions>,
         IUpdatable<Invoice, InvoiceUpdateOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public InvoiceService()
             : base(null)
         {
@@ -203,5 +204,6 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -25,62 +25,62 @@ namespace Stripe.Issuing
 
         public virtual Authorization Approve(string id, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/approve", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/approve", options, requestOptions);
         }
 
         public virtual Task<Authorization> ApproveAsync(string id, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/approve", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Decline(string id, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/decline", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/decline", options, requestOptions);
         }
 
         public virtual Task<Authorization> DeclineAsync(string id, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/decline", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/decline", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Get(string id, AuthorizationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{id}", options, requestOptions);
         }
 
         public virtual Task<Authorization> GetAsync(string id, AuthorizationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Authorization> List(AuthorizationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Authorization>>(HttpMethod.Get, $"/v1/issuing/authorizations", options, requestOptions);
         }
 
         public virtual Task<StripeList<Authorization>> ListAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Authorization>>(HttpMethod.Get, $"/v1/issuing/authorizations", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Authorization> ListAutoPaging(AuthorizationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Authorization>($"/v1/issuing/authorizations", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Authorization> ListAutoPagingAsync(AuthorizationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Authorization>($"/v1/issuing/authorizations", options, requestOptions, cancellationToken);
         }
 
         public virtual Authorization Update(string id, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}", options, requestOptions);
         }
 
         public virtual Task<Authorization> UpdateAsync(string id, AuthorizationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe.Issuing
 
         public virtual Cardholder Create(CardholderCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders", options, requestOptions);
         }
 
         public virtual Task<Cardholder> CreateAsync(CardholderCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders", options, requestOptions, cancellationToken);
         }
 
         public virtual Cardholder Get(string id, CardholderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{id}", options, requestOptions);
         }
 
         public virtual Task<Cardholder> GetAsync(string id, CardholderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Cardholder> List(CardholderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Cardholder>>(HttpMethod.Get, $"/v1/issuing/cardholders", options, requestOptions);
         }
 
         public virtual Task<StripeList<Cardholder>> ListAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Cardholder>>(HttpMethod.Get, $"/v1/issuing/cardholders", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Cardholder> ListAutoPaging(CardholderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Cardholder>($"/v1/issuing/cardholders", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Cardholder> ListAutoPagingAsync(CardholderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Cardholder>($"/v1/issuing/cardholders", options, requestOptions, cancellationToken);
         }
 
         public virtual Cardholder Update(string id, CardholderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{id}", options, requestOptions);
         }
 
         public virtual Task<Cardholder> UpdateAsync(string id, CardholderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe.Issuing
 
         public virtual Card Create(CardCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Card>(HttpMethod.Post, $"/v1/issuing/cards", options, requestOptions);
         }
 
         public virtual Task<Card> CreateAsync(CardCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/issuing/cards", options, requestOptions, cancellationToken);
         }
 
         public virtual Card Get(string id, CardGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Get, $"/v1/issuing/cards/{id}", options, requestOptions);
         }
 
         public virtual Task<Card> GetAsync(string id, CardGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Get, $"/v1/issuing/cards/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Card>>(HttpMethod.Get, $"/v1/issuing/cards", options, requestOptions);
         }
 
         public virtual Task<StripeList<Card>> ListAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Card>>(HttpMethod.Get, $"/v1/issuing/cards", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Card> ListAutoPaging(CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Card>($"/v1/issuing/cards", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Card>($"/v1/issuing/cards", options, requestOptions, cancellationToken);
         }
 
         public virtual Card Update(string id, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Post, $"/v1/issuing/cards/{id}", options, requestOptions);
         }
 
         public virtual Task<Card> UpdateAsync(string id, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/issuing/cards/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -26,62 +26,62 @@ namespace Stripe.Issuing
 
         public virtual Dispute Create(DisputeCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes", options, requestOptions);
         }
 
         public virtual Task<Dispute> CreateAsync(DisputeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Get(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{id}", options, requestOptions);
         }
 
         public virtual Task<Dispute> GetAsync(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Dispute> List(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Dispute>>(HttpMethod.Get, $"/v1/issuing/disputes", options, requestOptions);
         }
 
         public virtual Task<StripeList<Dispute>> ListAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Dispute>>(HttpMethod.Get, $"/v1/issuing/disputes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Dispute> ListAutoPaging(DisputeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Dispute>($"/v1/issuing/disputes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Dispute> ListAutoPagingAsync(DisputeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Dispute>($"/v1/issuing/disputes", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Submit(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/submit", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}/submit", options, requestOptions);
         }
 
         public virtual Task<Dispute> SubmitAsync(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/submit", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}/submit", options, requestOptions, cancellationToken);
         }
 
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}", options, requestOptions);
         }
 
         public virtual Task<Dispute> UpdateAsync(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe.Issuing
 
         public virtual Token Get(string id, TokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{id}", options, requestOptions);
         }
 
         public virtual Task<Token> GetAsync(string id, TokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Token> List(TokenListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Token>>(HttpMethod.Get, $"/v1/issuing/tokens", options, requestOptions);
         }
 
         public virtual Task<StripeList<Token>> ListAsync(TokenListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Token>>(HttpMethod.Get, $"/v1/issuing/tokens", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Token> ListAutoPaging(TokenListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Token>($"/v1/issuing/tokens", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Token> ListAutoPagingAsync(TokenListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Token>($"/v1/issuing/tokens", options, requestOptions, cancellationToken);
         }
 
         public virtual Token Update(string id, TokenUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{id}", options, requestOptions);
         }
 
         public virtual Task<Token> UpdateAsync(string id, TokenUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Issuing
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe.Issuing
 
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transaction> List(TransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Transaction>>(HttpMethod.Get, $"/v1/issuing/transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<Transaction>> ListAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Transaction>>(HttpMethod.Get, $"/v1/issuing/transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Transaction> ListAutoPaging(TransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Transaction>($"/v1/issuing/transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Transaction> ListAutoPagingAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Transaction>($"/v1/issuing/transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual Transaction Update(string id, TransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<Transaction> UpdateAsync(string id, TransactionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/LoginLinks/LoginLinkService.cs
+++ b/src/Stripe.net/Services/LoginLinks/LoginLinkService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe
 
         public virtual LoginLink Create(string parentId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<LoginLink>(HttpMethod.Post, $"/v1/accounts/{parentId}/login_links", options, requestOptions);
         }
 
         public virtual Task<LoginLink> CreateAsync(string parentId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<LoginLink>(HttpMethod.Post, $"/v1/accounts/{parentId}/login_links", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Mandates/MandateService.cs
+++ b/src/Stripe.net/Services/Mandates/MandateService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe
 
         public virtual Mandate Get(string id, MandateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Mandate>(HttpMethod.Get, $"/v1/mandates/{id}", options, requestOptions);
         }
 
         public virtual Task<Mandate> GetAsync(string id, MandateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Mandate>(HttpMethod.Get, $"/v1/mandates/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -9,6 +9,7 @@ namespace Stripe
     public class OAuthTokenService : Service<OAuthToken>,
         ICreatable<OAuthToken, OAuthTokenCreateOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public OAuthTokenService()
             : base(null)
         {
@@ -108,5 +109,6 @@ namespace Stripe
 
             return options;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -27,132 +27,132 @@ namespace Stripe
 
         public virtual PaymentIntent ApplyCustomerBalance(string id, PaymentIntentApplyCustomerBalanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/apply_customer_balance", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/apply_customer_balance", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> ApplyCustomerBalanceAsync(string id, PaymentIntentApplyCustomerBalanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/apply_customer_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/apply_customer_balance", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Cancel(string id, PaymentIntentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CancelAsync(string id, PaymentIntentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Capture(string id, PaymentIntentCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/capture", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CaptureAsync(string id, PaymentIntentCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Confirm(string id, PaymentIntentConfirmOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/confirm", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/confirm", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> ConfirmAsync(string id, PaymentIntentConfirmOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/confirm", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/confirm", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Create(PaymentIntentCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> CreateAsync(PaymentIntentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Get(string id, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> GetAsync(string id, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent IncrementAuthorization(string id, PaymentIntentIncrementAuthorizationOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/increment_authorization", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/increment_authorization", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> IncrementAuthorizationAsync(string id, PaymentIntentIncrementAuthorizationOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/increment_authorization", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/increment_authorization", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentIntent> List(PaymentIntentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PaymentIntent>>(HttpMethod.Get, $"/v1/payment_intents", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentIntent>> ListAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentIntent>>(HttpMethod.Get, $"/v1/payment_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentIntent> ListAutoPaging(PaymentIntentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentIntent>($"/v1/payment_intents", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentIntent> ListAutoPagingAsync(PaymentIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentIntent>($"/v1/payment_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<PaymentIntent> Search(PaymentIntentSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<PaymentIntent>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<PaymentIntent>>(HttpMethod.Get, $"/v1/payment_intents/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<PaymentIntent>> SearchAsync(PaymentIntentSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<PaymentIntent>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<PaymentIntent>>(HttpMethod.Get, $"/v1/payment_intents/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentIntent> SearchAutoPaging(PaymentIntentSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<PaymentIntent>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<PaymentIntent>($"/v1/payment_intents/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentIntent> SearchAutoPagingAsync(PaymentIntentSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<PaymentIntent>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<PaymentIntent>($"/v1/payment_intents/search", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent Update(string id, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> UpdateAsync(string id, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentIntent VerifyMicrodeposits(string id, PaymentIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify_microdeposits", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/verify_microdeposits", options, requestOptions);
         }
 
         public virtual Task<PaymentIntent> VerifyMicrodepositsAsync(string id, PaymentIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify_microdeposits", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/verify_microdeposits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
@@ -26,72 +26,72 @@ namespace Stripe
 
         public virtual PaymentLink Create(PaymentLinkCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PaymentLink>(HttpMethod.Post, $"/v1/payment_links", options, requestOptions);
         }
 
         public virtual Task<PaymentLink> CreateAsync(PaymentLinkCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentLink>(HttpMethod.Post, $"/v1/payment_links", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentLink Get(string id, PaymentLinkGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentLink> GetAsync(string id, PaymentLinkGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentLink> List(PaymentLinkListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PaymentLink>>(HttpMethod.Get, $"/v1/payment_links", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentLink>> ListAsync(PaymentLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentLink>>(HttpMethod.Get, $"/v1/payment_links", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentLink> ListAutoPaging(PaymentLinkListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentLink>($"/v1/payment_links", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentLink> ListAutoPagingAsync(PaymentLinkListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentLink>($"/v1/payment_links", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<LineItem> ListLineItems(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{id}/line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/payment_links/{id}/line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/payment_links/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentLink Update(string id, PaymentLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentLink> UpdateAsync(string id, PaymentLinkUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
+++ b/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual PaymentMethodConfiguration Create(PaymentMethodConfigurationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodConfiguration> CreateAsync(PaymentMethodConfigurationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethodConfiguration Get(string id, PaymentMethodConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodConfiguration> GetAsync(string id, PaymentMethodConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentMethodConfiguration> List(PaymentMethodConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PaymentMethodConfiguration>>(HttpMethod.Get, $"/v1/payment_method_configurations", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentMethodConfiguration>> ListAsync(PaymentMethodConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentMethodConfiguration>>(HttpMethod.Get, $"/v1/payment_method_configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentMethodConfiguration> ListAutoPaging(PaymentMethodConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentMethodConfiguration>($"/v1/payment_method_configurations", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentMethodConfiguration> ListAutoPagingAsync(PaymentMethodConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentMethodConfiguration>($"/v1/payment_method_configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethodConfiguration Update(string id, PaymentMethodConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodConfiguration> UpdateAsync(string id, PaymentMethodConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
+++ b/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
@@ -26,62 +26,62 @@ namespace Stripe
 
         public virtual PaymentMethodDomain Create(PaymentMethodDomainCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodDomain> CreateAsync(PaymentMethodDomainCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethodDomain Get(string id, PaymentMethodDomainGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodDomain> GetAsync(string id, PaymentMethodDomainGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentMethodDomain> List(PaymentMethodDomainListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PaymentMethodDomain>>(HttpMethod.Get, $"/v1/payment_method_domains", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentMethodDomain>> ListAsync(PaymentMethodDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentMethodDomain>>(HttpMethod.Get, $"/v1/payment_method_domains", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentMethodDomain> ListAutoPaging(PaymentMethodDomainListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentMethodDomain>($"/v1/payment_method_domains", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentMethodDomain> ListAutoPagingAsync(PaymentMethodDomainListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentMethodDomain>($"/v1/payment_method_domains", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethodDomain Update(string id, PaymentMethodDomainUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodDomain> UpdateAsync(string id, PaymentMethodDomainUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethodDomain Validate(string id, PaymentMethodDomainValidateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/validate", options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}/validate", options, requestOptions);
         }
 
         public virtual Task<PaymentMethodDomain> ValidateAsync(string id, PaymentMethodDomainValidateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/validate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}/validate", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -26,72 +26,72 @@ namespace Stripe
 
         public virtual PaymentMethod Attach(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/attach", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/attach", options, requestOptions);
         }
 
         public virtual Task<PaymentMethod> AttachAsync(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/attach", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/attach", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethod Create(PaymentMethodCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods", options, requestOptions);
         }
 
         public virtual Task<PaymentMethod> CreateAsync(PaymentMethodCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethod Detach(string id, PaymentMethodDetachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/detach", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/detach", options, requestOptions);
         }
 
         public virtual Task<PaymentMethod> DetachAsync(string id, PaymentMethodDetachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/detach", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/detach", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethod Get(string id, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethod> GetAsync(string id, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PaymentMethod> List(PaymentMethodListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/payment_methods", options, requestOptions);
         }
 
         public virtual Task<StripeList<PaymentMethod>> ListAsync(PaymentMethodListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/payment_methods", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PaymentMethod> ListAutoPaging(PaymentMethodListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentMethod>($"/v1/payment_methods", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PaymentMethod> ListAutoPagingAsync(PaymentMethodListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentMethod>($"/v1/payment_methods", options, requestOptions, cancellationToken);
         }
 
         public virtual PaymentMethod Update(string id, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}", options, requestOptions);
         }
 
         public virtual Task<PaymentMethod> UpdateAsync(string id, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -26,72 +26,72 @@ namespace Stripe
 
         public virtual Payout Cancel(string id, PayoutCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<Payout> CancelAsync(string id, PayoutCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Create(PayoutCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts", options, requestOptions);
         }
 
         public virtual Task<Payout> CreateAsync(PayoutCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts", options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Get(string id, PayoutGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Get, $"/v1/payouts/{id}", options, requestOptions);
         }
 
         public virtual Task<Payout> GetAsync(string id, PayoutGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Get, $"/v1/payouts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Payout> List(PayoutListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Payout>>(HttpMethod.Get, $"/v1/payouts", options, requestOptions);
         }
 
         public virtual Task<StripeList<Payout>> ListAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Payout>>(HttpMethod.Get, $"/v1/payouts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Payout> ListAutoPaging(PayoutListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Payout>($"/v1/payouts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Payout> ListAutoPagingAsync(PayoutListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Payout>($"/v1/payouts", options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Reverse(string id, PayoutReverseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/reverse", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/reverse", options, requestOptions);
         }
 
         public virtual Task<Payout> ReverseAsync(string id, PayoutReverseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/reverse", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/reverse", options, requestOptions, cancellationToken);
         }
 
         public virtual Payout Update(string id, PayoutUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}", options, requestOptions);
         }
 
         public virtual Task<Payout> UpdateAsync(string id, PayoutUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual Person Create(string parentId, PersonCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons", options, requestOptions);
         }
 
         public virtual Task<Person> CreateAsync(string parentId, PersonCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
         }
 
         public virtual Person Delete(string parentId, string id, PersonDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Person>(HttpMethod.Delete, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
         }
 
         public virtual Task<Person> DeleteAsync(string parentId, string id, PersonDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Delete, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Person Get(string parentId, string id, PersonGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Person>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
         }
 
         public virtual Task<Person> GetAsync(string parentId, string id, PersonGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Person> List(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons", options, requestOptions);
         }
 
         public virtual Task<StripeList<Person>> ListAsync(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Person> ListAutoPaging(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<Person>($"/v1/accounts/{parentId}/persons", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Person> ListAutoPagingAsync(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Person>($"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
         }
 
         public virtual Person Update(string parentId, string id, PersonUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
         }
 
         public virtual Task<Person> UpdateAsync(string parentId, string id, PersonUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual Plan Create(PlanCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Post, $"/v1/plans", options, requestOptions);
         }
 
         public virtual Task<Plan> CreateAsync(PlanCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Post, $"/v1/plans", options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Delete(string id, PlanDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Delete, $"/v1/plans/{id}", options, requestOptions);
         }
 
         public virtual Task<Plan> DeleteAsync(string id, PlanDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Delete, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Get(string id, PlanGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Get, $"/v1/plans/{id}", options, requestOptions);
         }
 
         public virtual Task<Plan> GetAsync(string id, PlanGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Get, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Plan> List(PlanListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Plan>>(HttpMethod.Get, $"/v1/plans", options, requestOptions);
         }
 
         public virtual Task<StripeList<Plan>> ListAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Plan>>(HttpMethod.Get, $"/v1/plans", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Plan> ListAutoPaging(PlanListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Plan>($"/v1/plans", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Plan> ListAutoPagingAsync(PlanListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Plan>($"/v1/plans", options, requestOptions, cancellationToken);
         }
 
         public virtual Plan Update(string id, PlanUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Post, $"/v1/plans/{id}", options, requestOptions);
         }
 
         public virtual Task<Plan> UpdateAsync(string id, PlanUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Post, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Prices/PriceService.cs
+++ b/src/Stripe.net/Services/Prices/PriceService.cs
@@ -27,72 +27,72 @@ namespace Stripe
 
         public virtual Price Create(PriceCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Price>(HttpMethod.Post, $"/v1/prices", options, requestOptions);
         }
 
         public virtual Task<Price> CreateAsync(PriceCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Price>(HttpMethod.Post, $"/v1/prices", options, requestOptions, cancellationToken);
         }
 
         public virtual Price Get(string id, PriceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Price>(HttpMethod.Get, $"/v1/prices/{id}", options, requestOptions);
         }
 
         public virtual Task<Price> GetAsync(string id, PriceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Price>(HttpMethod.Get, $"/v1/prices/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Price> List(PriceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Price>>(HttpMethod.Get, $"/v1/prices", options, requestOptions);
         }
 
         public virtual Task<StripeList<Price>> ListAsync(PriceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Price>>(HttpMethod.Get, $"/v1/prices", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Price> ListAutoPaging(PriceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Price>($"/v1/prices", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Price> ListAutoPagingAsync(PriceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Price>($"/v1/prices", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Price> Search(PriceSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Price>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Price>>(HttpMethod.Get, $"/v1/prices/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Price>> SearchAsync(PriceSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Price>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Price>>(HttpMethod.Get, $"/v1/prices/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Price> SearchAutoPaging(PriceSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Price>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Price>($"/v1/prices/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Price> SearchAutoPagingAsync(PriceSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Price>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Price>($"/v1/prices/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Price Update(string id, PriceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Price>(HttpMethod.Post, $"/v1/prices/{id}", options, requestOptions);
         }
 
         public virtual Task<Price> UpdateAsync(string id, PriceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Price>(HttpMethod.Post, $"/v1/prices/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -28,82 +28,82 @@ namespace Stripe
 
         public virtual Product Create(ProductCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Product>(HttpMethod.Post, $"/v1/products", options, requestOptions);
         }
 
         public virtual Task<Product> CreateAsync(ProductCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Post, $"/v1/products", options, requestOptions, cancellationToken);
         }
 
         public virtual Product Delete(string id, ProductDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Product>(HttpMethod.Delete, $"/v1/products/{id}", options, requestOptions);
         }
 
         public virtual Task<Product> DeleteAsync(string id, ProductDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Delete, $"/v1/products/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Product Get(string id, ProductGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Product>(HttpMethod.Get, $"/v1/products/{id}", options, requestOptions);
         }
 
         public virtual Task<Product> GetAsync(string id, ProductGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Get, $"/v1/products/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Product> List(ProductListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Product>>(HttpMethod.Get, $"/v1/products", options, requestOptions);
         }
 
         public virtual Task<StripeList<Product>> ListAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Product>>(HttpMethod.Get, $"/v1/products", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Product> ListAutoPaging(ProductListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Product>($"/v1/products", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Product> ListAutoPagingAsync(ProductListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Product>($"/v1/products", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Product> Search(ProductSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Product>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Product>>(HttpMethod.Get, $"/v1/products/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Product>> SearchAsync(ProductSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Product>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Product>>(HttpMethod.Get, $"/v1/products/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Product> SearchAutoPaging(ProductSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Product>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Product>($"/v1/products/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Product> SearchAutoPagingAsync(ProductSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Product>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Product>($"/v1/products/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Product Update(string id, ProductUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Product>(HttpMethod.Post, $"/v1/products/{id}", options, requestOptions);
         }
 
         public virtual Task<Product> UpdateAsync(string id, ProductUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Post, $"/v1/products/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual PromotionCode Create(PromotionCodeCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes", options, requestOptions);
         }
 
         public virtual Task<PromotionCode> CreateAsync(PromotionCodeCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes", options, requestOptions, cancellationToken);
         }
 
         public virtual PromotionCode Get(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{id}", options, requestOptions);
         }
 
         public virtual Task<PromotionCode> GetAsync(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<PromotionCode> List(PromotionCodeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<PromotionCode>>(HttpMethod.Get, $"/v1/promotion_codes", options, requestOptions);
         }
 
         public virtual Task<StripeList<PromotionCode>> ListAsync(PromotionCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PromotionCode>>(HttpMethod.Get, $"/v1/promotion_codes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<PromotionCode> ListAutoPaging(PromotionCodeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<PromotionCode>($"/v1/promotion_codes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<PromotionCode> ListAutoPagingAsync(PromotionCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PromotionCode>($"/v1/promotion_codes", options, requestOptions, cancellationToken);
         }
 
         public virtual PromotionCode Update(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{id}", options, requestOptions);
         }
 
         public virtual Task<PromotionCode> UpdateAsync(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Quotes/QuoteService.cs
+++ b/src/Stripe.net/Services/Quotes/QuoteService.cs
@@ -27,136 +27,136 @@ namespace Stripe
 
         public virtual Quote Accept(string id, QuoteAcceptOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/accept", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/accept", options, requestOptions);
         }
 
         public virtual Task<Quote> AcceptAsync(string id, QuoteAcceptOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/accept", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/accept", options, requestOptions, cancellationToken);
         }
 
         public virtual Quote Cancel(string id, QuoteCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<Quote> CancelAsync(string id, QuoteCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual Quote Create(QuoteCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes", options, requestOptions);
         }
 
         public virtual Task<Quote> CreateAsync(QuoteCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes", options, requestOptions, cancellationToken);
         }
 
         public virtual Quote FinalizeQuote(string id, QuoteFinalizeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/finalize", options, requestOptions);
         }
 
         public virtual Task<Quote> FinalizeQuoteAsync(string id, QuoteFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/finalize", options, requestOptions, cancellationToken);
         }
 
         public virtual Quote Get(string id, QuoteGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Get, $"/v1/quotes/{id}", options, requestOptions);
         }
 
         public virtual Task<Quote> GetAsync(string id, QuoteGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Get, $"/v1/quotes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Quote> List(QuoteListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Quote>>(HttpMethod.Get, $"/v1/quotes", options, requestOptions);
         }
 
         public virtual Task<StripeList<Quote>> ListAsync(QuoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Quote>>(HttpMethod.Get, $"/v1/quotes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Quote> ListAutoPaging(QuoteListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Quote>($"/v1/quotes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Quote> ListAutoPagingAsync(QuoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Quote>($"/v1/quotes", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<LineItem> ListComputedUpfrontLineItems(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/computed_upfront_line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<LineItem>> ListComputedUpfrontLineItemsAsync(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/computed_upfront_line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<LineItem> ListComputedUpfrontLineItemsAutoPaging(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"{this.InstanceUrl(id)}/computed_upfront_line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<LineItem> ListComputedUpfrontLineItemsAutoPagingAsync(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"{this.InstanceUrl(id)}/computed_upfront_line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<LineItem> ListLineItems(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{id}/line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual Stream Pdf(string id, QuotePdfOptions options = null, RequestOptions requestOptions = null)
         {
             requestOptions ??= new RequestOptions();
             requestOptions.BaseUrl ??= this.Client.FilesBase;
-            return this.RequestStreaming(HttpMethod.Get, $"{this.InstanceUrl(id)}/pdf", options, requestOptions);
+            return this.RequestStreaming(HttpMethod.Get, $"/v1/quotes/{id}/pdf", options, requestOptions);
         }
 
         public virtual Task<Stream> PdfAsync(string id, QuotePdfOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             requestOptions ??= new RequestOptions();
             requestOptions.BaseUrl ??= this.Client.FilesBase;
-            return this.RequestStreamingAsync(HttpMethod.Get, $"{this.InstanceUrl(id)}/pdf", options, requestOptions, cancellationToken);
+            return this.RequestStreamingAsync(HttpMethod.Get, $"/v1/quotes/{id}/pdf", options, requestOptions, cancellationToken);
         }
 
         public virtual Quote Update(string id, QuoteUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}", options, requestOptions);
         }
 
         public virtual Task<Quote> UpdateAsync(string id, QuoteUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Radar
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Radar
 
         public virtual EarlyFraudWarning Get(string id, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{id}", options, requestOptions);
         }
 
         public virtual Task<EarlyFraudWarning> GetAsync(string id, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<EarlyFraudWarning> List(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<EarlyFraudWarning>>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings", options, requestOptions);
         }
 
         public virtual Task<StripeList<EarlyFraudWarning>> ListAsync(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<EarlyFraudWarning>>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<EarlyFraudWarning> ListAutoPaging(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<EarlyFraudWarning>($"/v1/radar/early_fraud_warnings", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<EarlyFraudWarning> ListAutoPagingAsync(EarlyFraudWarningListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<EarlyFraudWarning>($"/v1/radar/early_fraud_warnings", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Radar
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe.Radar
 
         public virtual ValueListItem Create(ValueListItemCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ValueListItem>(HttpMethod.Post, $"/v1/radar/value_list_items", options, requestOptions);
         }
 
         public virtual Task<ValueListItem> CreateAsync(ValueListItemCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueListItem>(HttpMethod.Post, $"/v1/radar/value_list_items", options, requestOptions, cancellationToken);
         }
 
         public virtual ValueListItem Delete(string id, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{id}", options, requestOptions);
         }
 
         public virtual Task<ValueListItem> DeleteAsync(string id, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual ValueListItem Get(string id, ValueListItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{id}", options, requestOptions);
         }
 
         public virtual Task<ValueListItem> GetAsync(string id, ValueListItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ValueListItem> List(ValueListItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ValueListItem>>(HttpMethod.Get, $"/v1/radar/value_list_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<ValueListItem>> ListAsync(ValueListItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ValueListItem>>(HttpMethod.Get, $"/v1/radar/value_list_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ValueListItem> ListAutoPaging(ValueListItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ValueListItem>($"/v1/radar/value_list_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ValueListItem> ListAutoPagingAsync(ValueListItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ValueListItem>($"/v1/radar/value_list_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Radar
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe.Radar
 
         public virtual ValueList Create(ValueListCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists", options, requestOptions);
         }
 
         public virtual Task<ValueList> CreateAsync(ValueListCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists", options, requestOptions, cancellationToken);
         }
 
         public virtual ValueList Delete(string id, ValueListDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{id}", options, requestOptions);
         }
 
         public virtual Task<ValueList> DeleteAsync(string id, ValueListDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual ValueList Get(string id, ValueListGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{id}", options, requestOptions);
         }
 
         public virtual Task<ValueList> GetAsync(string id, ValueListGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ValueList> List(ValueListListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ValueList>>(HttpMethod.Get, $"/v1/radar/value_lists", options, requestOptions);
         }
 
         public virtual Task<StripeList<ValueList>> ListAsync(ValueListListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ValueList>>(HttpMethod.Get, $"/v1/radar/value_lists", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ValueList> ListAutoPaging(ValueListListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ValueList>($"/v1/radar/value_lists", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ValueList> ListAutoPagingAsync(ValueListListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ValueList>($"/v1/radar/value_lists", options, requestOptions, cancellationToken);
         }
 
         public virtual ValueList Update(string id, ValueListUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{id}", options, requestOptions);
         }
 
         public virtual Task<ValueList> UpdateAsync(string id, ValueListUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -26,62 +26,62 @@ namespace Stripe
 
         public virtual Refund Cancel(string id, RefundCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<Refund> CancelAsync(string id, RefundCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual Refund Create(RefundCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds", options, requestOptions);
         }
 
         public virtual Task<Refund> CreateAsync(RefundCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual Refund Get(string id, RefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Get, $"/v1/refunds/{id}", options, requestOptions);
         }
 
         public virtual Task<Refund> GetAsync(string id, RefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Get, $"/v1/refunds/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Refund> List(RefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Refund>>(HttpMethod.Get, $"/v1/refunds", options, requestOptions);
         }
 
         public virtual Task<StripeList<Refund>> ListAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Refund>>(HttpMethod.Get, $"/v1/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Refund> ListAutoPaging(RefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Refund>($"/v1/refunds", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Refund> ListAutoPagingAsync(RefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Refund>($"/v1/refunds", options, requestOptions, cancellationToken);
         }
 
         public virtual Refund Update(string id, RefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{id}", options, requestOptions);
         }
 
         public virtual Task<Refund> UpdateAsync(string id, RefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Reporting
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe.Reporting
 
         public virtual ReportRun Create(ReportRunCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ReportRun>(HttpMethod.Post, $"/v1/reporting/report_runs", options, requestOptions);
         }
 
         public virtual Task<ReportRun> CreateAsync(ReportRunCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReportRun>(HttpMethod.Post, $"/v1/reporting/report_runs", options, requestOptions, cancellationToken);
         }
 
         public virtual ReportRun Get(string id, ReportRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{id}", options, requestOptions);
         }
 
         public virtual Task<ReportRun> GetAsync(string id, ReportRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportRun> List(ReportRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ReportRun>>(HttpMethod.Get, $"/v1/reporting/report_runs", options, requestOptions);
         }
 
         public virtual Task<StripeList<ReportRun>> ListAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ReportRun>>(HttpMethod.Get, $"/v1/reporting/report_runs", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ReportRun> ListAutoPaging(ReportRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ReportRun>($"/v1/reporting/report_runs", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ReportRun> ListAutoPagingAsync(ReportRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ReportRun>($"/v1/reporting/report_runs", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Reporting
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Reporting
 
         public virtual ReportType Get(string id, ReportTypeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{id}", options, requestOptions);
         }
 
         public virtual Task<ReportType> GetAsync(string id, ReportTypeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReportType> List(ReportTypeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ReportType>>(HttpMethod.Get, $"/v1/reporting/report_types", options, requestOptions);
         }
 
         public virtual Task<StripeList<ReportType>> ListAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ReportType>>(HttpMethod.Get, $"/v1/reporting/report_types", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ReportType> ListAutoPaging(ReportTypeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ReportType>($"/v1/reporting/report_types", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ReportType> ListAutoPagingAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ReportType>($"/v1/reporting/report_types", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -24,42 +24,42 @@ namespace Stripe
 
         public virtual Review Approve(string id, ReviewApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/approve", options, requestOptions);
+            return this.Request<Review>(HttpMethod.Post, $"/v1/reviews/{id}/approve", options, requestOptions);
         }
 
         public virtual Task<Review> ApproveAsync(string id, ReviewApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Review>(HttpMethod.Post, $"/v1/reviews/{id}/approve", options, requestOptions, cancellationToken);
         }
 
         public virtual Review Get(string id, ReviewGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Review>(HttpMethod.Get, $"/v1/reviews/{id}", options, requestOptions);
         }
 
         public virtual Task<Review> GetAsync(string id, ReviewGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Review>(HttpMethod.Get, $"/v1/reviews/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Review> List(ReviewListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Review>>(HttpMethod.Get, $"/v1/reviews", options, requestOptions);
         }
 
         public virtual Task<StripeList<Review>> ListAsync(ReviewListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Review>>(HttpMethod.Get, $"/v1/reviews", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Review> ListAutoPaging(ReviewListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Review>($"/v1/reviews", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Review> ListAutoPagingAsync(ReviewListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Review>($"/v1/reviews", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SetupAttempts/SetupAttemptService.cs
+++ b/src/Stripe.net/Services/SetupAttempts/SetupAttemptService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -22,22 +23,22 @@ namespace Stripe
 
         public virtual StripeList<SetupAttempt> List(SetupAttemptListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<SetupAttempt>>(HttpMethod.Get, $"/v1/setup_attempts", options, requestOptions);
         }
 
         public virtual Task<StripeList<SetupAttempt>> ListAsync(SetupAttemptListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<SetupAttempt>>(HttpMethod.Get, $"/v1/setup_attempts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<SetupAttempt> ListAutoPaging(SetupAttemptListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<SetupAttempt>($"/v1/setup_attempts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<SetupAttempt> ListAutoPagingAsync(SetupAttemptListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<SetupAttempt>($"/v1/setup_attempts", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -26,82 +26,82 @@ namespace Stripe
 
         public virtual SetupIntent Cancel(string id, SetupIntentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> CancelAsync(string id, SetupIntentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual SetupIntent Confirm(string id, SetupIntentConfirmOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/confirm", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/confirm", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> ConfirmAsync(string id, SetupIntentConfirmOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/confirm", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/confirm", options, requestOptions, cancellationToken);
         }
 
         public virtual SetupIntent Create(SetupIntentCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> CreateAsync(SetupIntentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual SetupIntent Get(string id, SetupIntentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{id}", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> GetAsync(string id, SetupIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SetupIntent> List(SetupIntentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<SetupIntent>>(HttpMethod.Get, $"/v1/setup_intents", options, requestOptions);
         }
 
         public virtual Task<StripeList<SetupIntent>> ListAsync(SetupIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<SetupIntent>>(HttpMethod.Get, $"/v1/setup_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<SetupIntent> ListAutoPaging(SetupIntentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<SetupIntent>($"/v1/setup_intents", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<SetupIntent> ListAutoPagingAsync(SetupIntentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<SetupIntent>($"/v1/setup_intents", options, requestOptions, cancellationToken);
         }
 
         public virtual SetupIntent Update(string id, SetupIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> UpdateAsync(string id, SetupIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual SetupIntent VerifyMicrodeposits(string id, SetupIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify_microdeposits", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/verify_microdeposits", options, requestOptions);
         }
 
         public virtual Task<SetupIntent> VerifyMicrodepositsAsync(string id, SetupIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify_microdeposits", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/verify_microdeposits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
+++ b/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual ShippingRate Create(ShippingRateCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates", options, requestOptions);
         }
 
         public virtual Task<ShippingRate> CreateAsync(ShippingRateCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual ShippingRate Get(string id, ShippingRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{id}", options, requestOptions);
         }
 
         public virtual Task<ShippingRate> GetAsync(string id, ShippingRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ShippingRate> List(ShippingRateListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ShippingRate>>(HttpMethod.Get, $"/v1/shipping_rates", options, requestOptions);
         }
 
         public virtual Task<StripeList<ShippingRate>> ListAsync(ShippingRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ShippingRate>>(HttpMethod.Get, $"/v1/shipping_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ShippingRate> ListAutoPaging(ShippingRateListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ShippingRate>($"/v1/shipping_rates", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ShippingRate> ListAutoPagingAsync(ShippingRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ShippingRate>($"/v1/shipping_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual ShippingRate Update(string id, ShippingRateUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{id}", options, requestOptions);
         }
 
         public virtual Task<ShippingRate> UpdateAsync(string id, ShippingRateUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Sigma
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Sigma
 
         public virtual ScheduledQueryRun Get(string id, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{id}", options, requestOptions);
         }
 
         public virtual Task<ScheduledQueryRun> GetAsync(string id, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ScheduledQueryRun> List(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ScheduledQueryRun>>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs", options, requestOptions);
         }
 
         public virtual Task<StripeList<ScheduledQueryRun>> ListAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ScheduledQueryRun>>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ScheduledQueryRun> ListAutoPaging(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ScheduledQueryRun>($"/v1/sigma/scheduled_query_runs", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ScheduledQueryRun> ListAutoPagingAsync(ScheduledQueryRunListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ScheduledQueryRun>($"/v1/sigma/scheduled_query_runs", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -7,6 +7,7 @@ namespace Stripe
     public class SourceTransactionService : ServiceNested<SourceTransaction>,
         INestedListable<SourceTransaction, SourceTransactionsListOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public SourceTransactionService()
             : base(null)
         {
@@ -38,5 +39,6 @@ namespace Stripe
         {
             return this.ListNestedEntitiesAutoPagingAsync(sourceId, options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -11,6 +11,7 @@ namespace Stripe
         IUpdatable<Source, SourceUpdateOptions>,
         INestedListable<Source, SourceListOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         public SourceService()
             : base(null)
         {
@@ -102,5 +103,6 @@ namespace Stripe
         {
             return this.RequestAsync<Source>(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify", options, requestOptions, cancellationToken);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual SubscriptionItem Create(SubscriptionItemCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items", options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> CreateAsync(SubscriptionItemCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Delete(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{id}", options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> DeleteAsync(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Get(string id, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{id}", options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> GetAsync(string id, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionItem> List(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<SubscriptionItem>>(HttpMethod.Get, $"/v1/subscription_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<SubscriptionItem>> ListAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<SubscriptionItem>>(HttpMethod.Get, $"/v1/subscription_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<SubscriptionItem> ListAutoPaging(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<SubscriptionItem>($"/v1/subscription_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<SubscriptionItem> ListAutoPagingAsync(SubscriptionItemListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<SubscriptionItem>($"/v1/subscription_items", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionItem Update(string id, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{id}", options, requestOptions);
         }
 
         public virtual Task<SubscriptionItem> UpdateAsync(string id, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -26,72 +26,72 @@ namespace Stripe
 
         public virtual SubscriptionSchedule Cancel(string id, SubscriptionScheduleCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<SubscriptionSchedule> CancelAsync(string id, SubscriptionScheduleCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionSchedule Create(SubscriptionScheduleCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules", options, requestOptions);
         }
 
         public virtual Task<SubscriptionSchedule> CreateAsync(SubscriptionScheduleCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionSchedule Get(string id, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{id}", options, requestOptions);
         }
 
         public virtual Task<SubscriptionSchedule> GetAsync(string id, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<SubscriptionSchedule> List(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<SubscriptionSchedule>>(HttpMethod.Get, $"/v1/subscription_schedules", options, requestOptions);
         }
 
         public virtual Task<StripeList<SubscriptionSchedule>> ListAsync(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<SubscriptionSchedule>>(HttpMethod.Get, $"/v1/subscription_schedules", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<SubscriptionSchedule> ListAutoPaging(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<SubscriptionSchedule>($"/v1/subscription_schedules", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<SubscriptionSchedule> ListAutoPagingAsync(SubscriptionScheduleListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<SubscriptionSchedule>($"/v1/subscription_schedules", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionSchedule Release(string id, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/release", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/release", options, requestOptions);
         }
 
         public virtual Task<SubscriptionSchedule> ReleaseAsync(string id, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/release", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/release", options, requestOptions, cancellationToken);
         }
 
         public virtual SubscriptionSchedule Update(string id, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}", options, requestOptions);
         }
 
         public virtual Task<SubscriptionSchedule> UpdateAsync(string id, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -27,92 +27,92 @@ namespace Stripe
 
         public virtual Subscription Cancel(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Delete, $"{this.InstanceUrl(id)}", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{id}", options, requestOptions);
         }
 
         public virtual Task<Subscription> CancelAsync(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Delete, $"{this.InstanceUrl(id)}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Create(SubscriptionCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions", options, requestOptions);
         }
 
         public virtual Task<Subscription> CreateAsync(SubscriptionCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions", options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Get(string id, SubscriptionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{id}", options, requestOptions);
         }
 
         public virtual Task<Subscription> GetAsync(string id, SubscriptionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Subscription> List(SubscriptionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Subscription>>(HttpMethod.Get, $"/v1/subscriptions", options, requestOptions);
         }
 
         public virtual Task<StripeList<Subscription>> ListAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Subscription>>(HttpMethod.Get, $"/v1/subscriptions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Subscription> ListAutoPaging(SubscriptionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Subscription>($"/v1/subscriptions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Subscription> ListAutoPagingAsync(SubscriptionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Subscription>($"/v1/subscriptions", options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Resume(string id, SubscriptionResumeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/resume", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}/resume", options, requestOptions);
         }
 
         public virtual Task<Subscription> ResumeAsync(string id, SubscriptionResumeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/resume", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}/resume", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Subscription> Search(SubscriptionSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Subscription>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Subscription>>(HttpMethod.Get, $"/v1/subscriptions/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Subscription>> SearchAsync(SubscriptionSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Subscription>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Subscription>>(HttpMethod.Get, $"/v1/subscriptions/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Subscription> SearchAutoPaging(SubscriptionSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Subscription>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Subscription>($"/v1/subscriptions/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Subscription> SearchAutoPagingAsync(SubscriptionSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Subscription>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Subscription>($"/v1/subscriptions/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Subscription Update(string id, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}", options, requestOptions);
         }
 
         public virtual Task<Subscription> UpdateAsync(string id, SubscriptionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
+++ b/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
@@ -23,32 +23,32 @@ namespace Stripe.Tax
 
         public virtual Calculation Create(CalculationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Calculation>(HttpMethod.Post, $"/v1/tax/calculations", options, requestOptions);
         }
 
         public virtual Task<Calculation> CreateAsync(CalculationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Calculation>(HttpMethod.Post, $"/v1/tax/calculations", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CalculationLineItem> ListLineItems(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CalculationLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.Request<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{id}/line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<CalculationLineItem>> ListLineItemsAsync(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CalculationLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CalculationLineItem> ListLineItemsAutoPaging(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CalculationLineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<CalculationLineItem>($"/v1/tax/calculations/{id}/line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CalculationLineItem> ListLineItemsAutoPagingAsync(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CalculationLineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CalculationLineItem>($"/v1/tax/calculations/{id}/line_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Settings/SettingsService.cs
+++ b/src/Stripe.net/Services/Tax/Settings/SettingsService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Tax
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,22 +27,22 @@ namespace Stripe.Tax
 
         public virtual Settings Get(RequestOptions requestOptions = null)
         {
-            return this.GetEntity(null, null, requestOptions);
+            return this.Request<Settings>(HttpMethod.Get, $"/v1/tax/settings", null, requestOptions);
         }
 
         public virtual Task<Settings> GetAsync(RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(null, null, requestOptions, cancellationToken);
+            return this.RequestAsync<Settings>(HttpMethod.Get, $"/v1/tax/settings", null, requestOptions, cancellationToken);
         }
 
         public virtual Settings Update(SettingsUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(null, options, requestOptions);
+            return this.Request<Settings>(HttpMethod.Post, $"/v1/tax/settings", options, requestOptions);
         }
 
         public virtual Task<Settings> UpdateAsync(SettingsUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(null, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Settings>(HttpMethod.Post, $"/v1/tax/settings", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
@@ -23,52 +23,52 @@ namespace Stripe.Tax
 
         public virtual Transaction CreateFromCalculation(TransactionCreateFromCalculationOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("create_from_calculation")}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Post, $"/v1/tax/transactions/create_from_calculation", options, requestOptions);
         }
 
         public virtual Task<Transaction> CreateFromCalculationAsync(TransactionCreateFromCalculationOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("create_from_calculation")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Post, $"/v1/tax/transactions/create_from_calculation", options, requestOptions, cancellationToken);
         }
 
         public virtual Transaction CreateReversal(TransactionCreateReversalOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("create_reversal")}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Post, $"/v1/tax/transactions/create_reversal", options, requestOptions);
         }
 
         public virtual Task<Transaction> CreateReversalAsync(TransactionCreateReversalOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("create_reversal")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Post, $"/v1/tax/transactions/create_reversal", options, requestOptions, cancellationToken);
         }
 
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TransactionLineItem> ListLineItems(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<TransactionLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.Request<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{id}/line_items", options, requestOptions);
         }
 
         public virtual Task<StripeList<TransactionLineItem>> ListLineItemsAsync(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<TransactionLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{id}/line_items", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TransactionLineItem> ListLineItemsAutoPaging(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<TransactionLineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<TransactionLineItem>($"/v1/tax/transactions/{id}/line_items", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TransactionLineItem> ListLineItemsAutoPagingAsync(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<TransactionLineItem>($"{this.InstanceUrl(id)}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TransactionLineItem>($"/v1/tax/transactions/{id}/line_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
+++ b/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe
 
         public virtual TaxCode Get(string id, TaxCodeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{id}", options, requestOptions);
         }
 
         public virtual Task<TaxCode> GetAsync(string id, TaxCodeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TaxCode> List(TaxCodeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<TaxCode>>(HttpMethod.Get, $"/v1/tax_codes", options, requestOptions);
         }
 
         public virtual Task<StripeList<TaxCode>> ListAsync(TaxCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TaxCode>>(HttpMethod.Get, $"/v1/tax_codes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TaxCode> ListAutoPaging(TaxCodeListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<TaxCode>($"/v1/tax_codes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TaxCode> ListAutoPagingAsync(TaxCodeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TaxCode>($"/v1/tax_codes", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual TaxId Create(string parentId, TaxIdCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Post, $"/v1/customers/{parentId}/tax_ids", options, requestOptions);
         }
 
         public virtual Task<TaxId> CreateAsync(string parentId, TaxIdCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Post, $"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
         }
 
         public virtual TaxId Delete(string parentId, string id, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Delete, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions);
         }
 
         public virtual Task<TaxId> DeleteAsync(string parentId, string id, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Delete, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual TaxId Get(string parentId, string id, TaxIdGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions);
         }
 
         public virtual Task<TaxId> GetAsync(string parentId, string id, TaxIdGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TaxId> List(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids", options, requestOptions);
         }
 
         public virtual Task<StripeList<TaxId>> ListAsync(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TaxId> ListAutoPaging(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<TaxId>($"/v1/customers/{parentId}/tax_ids", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TaxId> ListAutoPagingAsync(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TaxId>($"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual TaxRate Create(TaxRateCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<TaxRate>(HttpMethod.Post, $"/v1/tax_rates", options, requestOptions);
         }
 
         public virtual Task<TaxRate> CreateAsync(TaxRateCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxRate>(HttpMethod.Post, $"/v1/tax_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual TaxRate Get(string id, TaxRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{id}", options, requestOptions);
         }
 
         public virtual Task<TaxRate> GetAsync(string id, TaxRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TaxRate> List(TaxRateListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<TaxRate>>(HttpMethod.Get, $"/v1/tax_rates", options, requestOptions);
         }
 
         public virtual Task<StripeList<TaxRate>> ListAsync(TaxRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TaxRate>>(HttpMethod.Get, $"/v1/tax_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TaxRate> ListAutoPaging(TaxRateListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<TaxRate>($"/v1/tax_rates", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TaxRate> ListAutoPagingAsync(TaxRateListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TaxRate>($"/v1/tax_rates", options, requestOptions, cancellationToken);
         }
 
         public virtual TaxRate Update(string id, TaxRateUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{id}", options, requestOptions);
         }
 
         public virtual Task<TaxRate> UpdateAsync(string id, TaxRateUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Terminal
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe.Terminal
 
         public virtual Configuration Create(ConfigurationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations", options, requestOptions);
         }
 
         public virtual Task<Configuration> CreateAsync(ConfigurationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual Configuration Delete(string id, ConfigurationDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<Configuration> DeleteAsync(string id, ConfigurationDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Configuration Get(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<Configuration> GetAsync(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Configuration> List(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Configuration>>(HttpMethod.Get, $"/v1/terminal/configurations", options, requestOptions);
         }
 
         public virtual Task<StripeList<Configuration>> ListAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Configuration>>(HttpMethod.Get, $"/v1/terminal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Configuration> ListAutoPaging(ConfigurationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Configuration>($"/v1/terminal/configurations", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Configuration> ListAutoPagingAsync(ConfigurationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Configuration>($"/v1/terminal/configurations", options, requestOptions, cancellationToken);
         }
 
         public virtual Configuration Update(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{id}", options, requestOptions);
         }
 
         public virtual Task<Configuration> UpdateAsync(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
+++ b/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Terminal
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe.Terminal
 
         public virtual ConnectionToken Create(ConnectionTokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<ConnectionToken>(HttpMethod.Post, $"/v1/terminal/connection_tokens", options, requestOptions);
         }
 
         public virtual Task<ConnectionToken> CreateAsync(ConnectionTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<ConnectionToken>(HttpMethod.Post, $"/v1/terminal/connection_tokens", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Terminal
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe.Terminal
 
         public virtual Location Create(LocationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Location>(HttpMethod.Post, $"/v1/terminal/locations", options, requestOptions);
         }
 
         public virtual Task<Location> CreateAsync(LocationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Post, $"/v1/terminal/locations", options, requestOptions, cancellationToken);
         }
 
         public virtual Location Delete(string id, LocationDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{id}", options, requestOptions);
         }
 
         public virtual Task<Location> DeleteAsync(string id, LocationDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Location Get(string id, LocationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Location>(HttpMethod.Get, $"/v1/terminal/locations/{id}", options, requestOptions);
         }
 
         public virtual Task<Location> GetAsync(string id, LocationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Get, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Location> List(LocationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Location>>(HttpMethod.Get, $"/v1/terminal/locations", options, requestOptions);
         }
 
         public virtual Task<StripeList<Location>> ListAsync(LocationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Location>>(HttpMethod.Get, $"/v1/terminal/locations", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Location> ListAutoPaging(LocationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Location>($"/v1/terminal/locations", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Location> ListAutoPagingAsync(LocationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Location>($"/v1/terminal/locations", options, requestOptions, cancellationToken);
         }
 
         public virtual Location Update(string id, LocationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Location>(HttpMethod.Post, $"/v1/terminal/locations/{id}", options, requestOptions);
         }
 
         public virtual Task<Location> UpdateAsync(string id, LocationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Post, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -27,112 +27,112 @@ namespace Stripe.Terminal
 
         public virtual Reader CancelAction(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel_action", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/cancel_action", options, requestOptions);
         }
 
         public virtual Task<Reader> CancelActionAsync(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel_action", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/cancel_action", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Create(ReaderCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers", options, requestOptions);
         }
 
         public virtual Task<Reader> CreateAsync(ReaderCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Delete(string id, ReaderDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{id}", options, requestOptions);
         }
 
         public virtual Task<Reader> DeleteAsync(string id, ReaderDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Get(string id, ReaderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{id}", options, requestOptions);
         }
 
         public virtual Task<Reader> GetAsync(string id, ReaderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Reader> List(ReaderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Reader>>(HttpMethod.Get, $"/v1/terminal/readers", options, requestOptions);
         }
 
         public virtual Task<StripeList<Reader>> ListAsync(ReaderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Reader>>(HttpMethod.Get, $"/v1/terminal/readers", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Reader> ListAutoPaging(ReaderListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Reader>($"/v1/terminal/readers", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Reader> ListAutoPagingAsync(ReaderListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Reader>($"/v1/terminal/readers", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader ProcessPaymentIntent(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_payment_intent", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_payment_intent", options, requestOptions);
         }
 
         public virtual Task<Reader> ProcessPaymentIntentAsync(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_payment_intent", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_payment_intent", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader ProcessSetupIntent(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_setup_intent", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_setup_intent", options, requestOptions);
         }
 
         public virtual Task<Reader> ProcessSetupIntentAsync(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/process_setup_intent", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_setup_intent", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader RefundPayment(string id, ReaderRefundPaymentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/refund_payment", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/refund_payment", options, requestOptions);
         }
 
         public virtual Task<Reader> RefundPaymentAsync(string id, ReaderRefundPaymentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/refund_payment", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/refund_payment", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader SetReaderDisplay(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/set_reader_display", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/set_reader_display", options, requestOptions);
         }
 
         public virtual Task<Reader> SetReaderDisplayAsync(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/set_reader_display", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/set_reader_display", options, requestOptions, cancellationToken);
         }
 
         public virtual Reader Update(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}", options, requestOptions);
         }
 
         public virtual Task<Reader> UpdateAsync(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
@@ -21,12 +21,12 @@ namespace Stripe.TestHelpers
 
         public virtual CustomerCashBalanceTransaction FundCashBalance(string id, CustomerFundCashBalanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Post, $"{this.InstanceUrl(id)}/fund_cash_balance", options, requestOptions);
+            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{id}/fund_cash_balance", options, requestOptions);
         }
 
         public virtual Task<CustomerCashBalanceTransaction> FundCashBalanceAsync(string id, CustomerFundCashBalanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Post, $"{this.InstanceUrl(id)}/fund_cash_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{id}/fund_cash_balance", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
@@ -22,52 +22,52 @@ namespace Stripe.TestHelpers.Issuing
 
         public virtual Stripe.Issuing.Authorization Capture(string id, AuthorizationCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/capture", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Authorization> CaptureAsync(string id, AuthorizationCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/capture", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Authorization Create(AuthorizationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Authorization> CreateAsync(AuthorizationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Authorization Expire(string id, AuthorizationExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/expire", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Authorization> ExpireAsync(string id, AuthorizationExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/expire", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Authorization Increment(string id, AuthorizationIncrementOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/increment", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/increment", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Authorization> IncrementAsync(string id, AuthorizationIncrementOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/increment", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/increment", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Authorization Reverse(string id, AuthorizationReverseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/reverse", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/reverse", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Authorization> ReverseAsync(string id, AuthorizationReverseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/reverse", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/reverse", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
@@ -22,42 +22,42 @@ namespace Stripe.TestHelpers.Issuing
 
         public virtual Stripe.Issuing.Card DeliverCard(string id, CardDeliverCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/deliver", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/deliver", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Card> DeliverCardAsync(string id, CardDeliverCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/deliver", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/deliver", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Card FailCard(string id, CardFailCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/fail", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/fail", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Card> FailCardAsync(string id, CardFailCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/fail", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Card ReturnCard(string id, CardReturnCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/return", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/return", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Card> ReturnCardAsync(string id, CardReturnCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/return", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Card ShipCard(string id, CardShipCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/ship", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/ship", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Card> ShipCardAsync(string id, CardShipCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/shipping/ship", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/ship", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
@@ -22,32 +22,32 @@ namespace Stripe.TestHelpers.Issuing
 
         public virtual Stripe.Issuing.Transaction CreateForceCapture(TransactionCreateForceCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("create_force_capture")}", options, requestOptions);
+            return this.Request<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/create_force_capture", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Transaction> CreateForceCaptureAsync(TransactionCreateForceCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("create_force_capture")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/create_force_capture", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Transaction CreateUnlinkedRefund(TransactionCreateUnlinkedRefundOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl("create_unlinked_refund")}", options, requestOptions);
+            return this.Request<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/create_unlinked_refund", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Transaction> CreateUnlinkedRefundAsync(TransactionCreateUnlinkedRefundOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl("create_unlinked_refund")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/create_unlinked_refund", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Issuing.Transaction Refund(string id, TransactionRefundOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/refund", options, requestOptions);
+            return this.Request<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{id}/refund", options, requestOptions);
         }
 
         public virtual Task<Stripe.Issuing.Transaction> RefundAsync(string id, TransactionRefundOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/refund", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{id}/refund", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
@@ -21,12 +21,12 @@ namespace Stripe.TestHelpers
 
         public virtual Refund Expire(string id, RefundExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{id}/expire", options, requestOptions);
         }
 
         public virtual Task<Refund> ExpireAsync(string id, RefundExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{id}/expire", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
@@ -22,12 +22,12 @@ namespace Stripe.TestHelpers.Terminal
 
         public virtual Stripe.Terminal.Reader PresentPaymentMethod(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/present_payment_method", options, requestOptions);
+            return this.Request<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{id}/present_payment_method", options, requestOptions);
         }
 
         public virtual Task<Stripe.Terminal.Reader> PresentPaymentMethodAsync(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/present_payment_method", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{id}/present_payment_method", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
@@ -26,62 +26,62 @@ namespace Stripe.TestHelpers
 
         public virtual TestClock Advance(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TestClock>(HttpMethod.Post, $"{this.InstanceUrl(id)}/advance", options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{id}/advance", options, requestOptions);
         }
 
         public virtual Task<TestClock> AdvanceAsync(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TestClock>(HttpMethod.Post, $"{this.InstanceUrl(id)}/advance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{id}/advance", options, requestOptions, cancellationToken);
         }
 
         public virtual TestClock Create(TestClockCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks", options, requestOptions);
         }
 
         public virtual Task<TestClock> CreateAsync(TestClockCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks", options, requestOptions, cancellationToken);
         }
 
         public virtual TestClock Delete(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions);
         }
 
         public virtual Task<TestClock> DeleteAsync(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual TestClock Get(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions);
         }
 
         public virtual Task<TestClock> GetAsync(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TestClock> List(TestClockListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<TestClock>>(HttpMethod.Get, $"/v1/test_helpers/test_clocks", options, requestOptions);
         }
 
         public virtual Task<StripeList<TestClock>> ListAsync(TestClockListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TestClock>>(HttpMethod.Get, $"/v1/test_helpers/test_clocks", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TestClock> ListAutoPaging(TestClockListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<TestClock>($"/v1/test_helpers/test_clocks", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TestClock> ListAutoPagingAsync(TestClockListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TestClock>($"/v1/test_helpers/test_clocks", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
@@ -22,32 +22,32 @@ namespace Stripe.TestHelpers.Treasury
 
         public virtual Stripe.Treasury.InboundTransfer Fail(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/fail", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.InboundTransfer> FailAsync(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/fail", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.InboundTransfer ReturnInboundTransfer(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/return", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.InboundTransfer> ReturnInboundTransferAsync(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/return", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.InboundTransfer Succeed(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/succeed", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/succeed", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.InboundTransfer> SucceedAsync(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/succeed", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/succeed", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -22,32 +22,32 @@ namespace Stripe.TestHelpers.Treasury
 
         public virtual Stripe.Treasury.OutboundPayment Fail(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/fail", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundPayment> FailAsync(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/fail", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.OutboundPayment Post(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/post", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundPayment> PostAsync(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/post", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.OutboundPayment ReturnOutboundPayment(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/return", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundPayment> ReturnOutboundPaymentAsync(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/return", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -22,32 +22,32 @@ namespace Stripe.TestHelpers.Treasury
 
         public virtual Stripe.Treasury.OutboundTransfer Fail(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/fail", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundTransfer> FailAsync(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/fail", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.OutboundTransfer Post(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/post", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundTransfer> PostAsync(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/post", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/post", options, requestOptions, cancellationToken);
         }
 
         public virtual Stripe.Treasury.OutboundTransfer ReturnOutboundTransfer(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/return", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.OutboundTransfer> ReturnOutboundTransferAsync(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/return", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.TestHelpers.Treasury
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Treasury;
@@ -21,12 +22,12 @@ namespace Stripe.TestHelpers.Treasury
 
         public virtual Stripe.Treasury.ReceivedCredit Create(ReceivedCreditCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Stripe.Treasury.ReceivedCredit>(HttpMethod.Post, $"/v1/test_helpers/treasury/received_credits", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.ReceivedCredit> CreateAsync(ReceivedCreditCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.ReceivedCredit>(HttpMethod.Post, $"/v1/test_helpers/treasury/received_credits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.TestHelpers.Treasury
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Stripe.Treasury;
@@ -21,12 +22,12 @@ namespace Stripe.TestHelpers.Treasury
 
         public virtual Stripe.Treasury.ReceivedDebit Create(ReceivedDebitCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Stripe.Treasury.ReceivedDebit>(HttpMethod.Post, $"/v1/test_helpers/treasury/received_debits", options, requestOptions);
         }
 
         public virtual Task<Stripe.Treasury.ReceivedDebit> CreateAsync(ReceivedDebitCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.ReceivedDebit>(HttpMethod.Post, $"/v1/test_helpers/treasury/received_debits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -22,22 +23,22 @@ namespace Stripe
 
         public virtual Token Create(TokenCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Token>(HttpMethod.Post, $"/v1/tokens", options, requestOptions);
         }
 
         public virtual Task<Token> CreateAsync(TokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Post, $"/v1/tokens", options, requestOptions, cancellationToken);
         }
 
         public virtual Token Get(string id, TokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Token>(HttpMethod.Get, $"/v1/tokens/{id}", options, requestOptions);
         }
 
         public virtual Task<Token> GetAsync(string id, TokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/tokens/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -26,62 +26,62 @@ namespace Stripe
 
         public virtual Topup Cancel(string id, TopupCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<Topup> CancelAsync(string id, TopupCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual Topup Create(TopupCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups", options, requestOptions);
         }
 
         public virtual Task<Topup> CreateAsync(TopupCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups", options, requestOptions, cancellationToken);
         }
 
         public virtual Topup Get(string id, TopupGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Get, $"/v1/topups/{id}", options, requestOptions);
         }
 
         public virtual Task<Topup> GetAsync(string id, TopupGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Get, $"/v1/topups/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Topup> List(TopupListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Topup>>(HttpMethod.Get, $"/v1/topups", options, requestOptions);
         }
 
         public virtual Task<StripeList<Topup>> ListAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Topup>>(HttpMethod.Get, $"/v1/topups", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Topup> ListAutoPaging(TopupListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Topup>($"/v1/topups", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Topup> ListAutoPagingAsync(TopupListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Topup>($"/v1/topups", options, requestOptions, cancellationToken);
         }
 
         public virtual Topup Update(string id, TopupUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{id}", options, requestOptions);
         }
 
         public virtual Task<Topup> UpdateAsync(string id, TopupUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual TransferReversal Create(string parentId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals", options, requestOptions);
         }
 
         public virtual Task<TransferReversal> CreateAsync(string parentId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual TransferReversal Get(string parentId, string id, TransferReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions);
         }
 
         public virtual Task<TransferReversal> GetAsync(string parentId, string id, TransferReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TransferReversal> List(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals", options, requestOptions);
         }
 
         public virtual Task<StripeList<TransferReversal>> ListAsync(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TransferReversal> ListAutoPaging(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<TransferReversal>($"/v1/transfers/{parentId}/reversals", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TransferReversal> ListAutoPagingAsync(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TransferReversal>($"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual TransferReversal Update(string parentId, string id, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions);
         }
 
         public virtual Task<TransferReversal> UpdateAsync(string parentId, string id, TransferReversalUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,52 +26,52 @@ namespace Stripe
 
         public virtual Transfer Create(TransferCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Transfer>(HttpMethod.Post, $"/v1/transfers", options, requestOptions);
         }
 
         public virtual Task<Transfer> CreateAsync(TransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transfer>(HttpMethod.Post, $"/v1/transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual Transfer Get(string id, TransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Transfer>(HttpMethod.Get, $"/v1/transfers/{id}", options, requestOptions);
         }
 
         public virtual Task<Transfer> GetAsync(string id, TransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transfer>(HttpMethod.Get, $"/v1/transfers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transfer> List(TransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Transfer>>(HttpMethod.Get, $"/v1/transfers", options, requestOptions);
         }
 
         public virtual Task<StripeList<Transfer>> ListAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Transfer>>(HttpMethod.Get, $"/v1/transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Transfer> ListAutoPaging(TransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Transfer>($"/v1/transfers", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Transfer> ListAutoPagingAsync(TransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Transfer>($"/v1/transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual Transfer Update(string id, TransferUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Transfer>(HttpMethod.Post, $"/v1/transfers/{id}", options, requestOptions);
         }
 
         public virtual Task<Transfer> UpdateAsync(string id, TransferUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transfer>(HttpMethod.Post, $"/v1/transfers/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe.Treasury
 
         public virtual CreditReversal Create(CreditReversalCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<CreditReversal>(HttpMethod.Post, $"/v1/treasury/credit_reversals", options, requestOptions);
         }
 
         public virtual Task<CreditReversal> CreateAsync(CreditReversalCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditReversal>(HttpMethod.Post, $"/v1/treasury/credit_reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual CreditReversal Get(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{id}", options, requestOptions);
         }
 
         public virtual Task<CreditReversal> GetAsync(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditReversal> List(CreditReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<CreditReversal>>(HttpMethod.Get, $"/v1/treasury/credit_reversals", options, requestOptions);
         }
 
         public virtual Task<StripeList<CreditReversal>> ListAsync(CreditReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CreditReversal>>(HttpMethod.Get, $"/v1/treasury/credit_reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CreditReversal> ListAutoPaging(CreditReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<CreditReversal>($"/v1/treasury/credit_reversals", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CreditReversal> ListAutoPagingAsync(CreditReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CreditReversal>($"/v1/treasury/credit_reversals", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,42 +25,42 @@ namespace Stripe.Treasury
 
         public virtual DebitReversal Create(DebitReversalCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<DebitReversal>(HttpMethod.Post, $"/v1/treasury/debit_reversals", options, requestOptions);
         }
 
         public virtual Task<DebitReversal> CreateAsync(DebitReversalCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<DebitReversal>(HttpMethod.Post, $"/v1/treasury/debit_reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual DebitReversal Get(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{id}", options, requestOptions);
         }
 
         public virtual Task<DebitReversal> GetAsync(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<DebitReversal> List(DebitReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<DebitReversal>>(HttpMethod.Get, $"/v1/treasury/debit_reversals", options, requestOptions);
         }
 
         public virtual Task<StripeList<DebitReversal>> ListAsync(DebitReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<DebitReversal>>(HttpMethod.Get, $"/v1/treasury/debit_reversals", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<DebitReversal> ListAutoPaging(DebitReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<DebitReversal>($"/v1/treasury/debit_reversals", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<DebitReversal> ListAutoPagingAsync(DebitReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<DebitReversal>($"/v1/treasury/debit_reversals", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
@@ -26,72 +26,72 @@ namespace Stripe.Treasury
 
         public virtual FinancialAccount Create(FinancialAccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts", options, requestOptions);
         }
 
         public virtual Task<FinancialAccount> CreateAsync(FinancialAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual FinancialAccount Get(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<FinancialAccount> GetAsync(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<FinancialAccount> List(FinancialAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<FinancialAccount>>(HttpMethod.Get, $"/v1/treasury/financial_accounts", options, requestOptions);
         }
 
         public virtual Task<StripeList<FinancialAccount>> ListAsync(FinancialAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<FinancialAccount>>(HttpMethod.Get, $"/v1/treasury/financial_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<FinancialAccount> ListAutoPaging(FinancialAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<FinancialAccount>($"/v1/treasury/financial_accounts", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<FinancialAccount> ListAutoPagingAsync(FinancialAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<FinancialAccount>($"/v1/treasury/financial_accounts", options, requestOptions, cancellationToken);
         }
 
         public virtual FinancialAccountFeatures RetrieveFeatures(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccountFeatures>(HttpMethod.Get, $"{this.InstanceUrl(id)}/features", options, requestOptions);
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions);
         }
 
         public virtual Task<FinancialAccountFeatures> RetrieveFeaturesAsync(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Get, $"{this.InstanceUrl(id)}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions, cancellationToken);
         }
 
         public virtual FinancialAccount Update(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}", options, requestOptions);
         }
 
         public virtual Task<FinancialAccount> UpdateAsync(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual FinancialAccountFeatures UpdateFeatures(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccountFeatures>(HttpMethod.Post, $"{this.InstanceUrl(id)}/features", options, requestOptions);
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions);
         }
 
         public virtual Task<FinancialAccountFeatures> UpdateFeaturesAsync(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Post, $"{this.InstanceUrl(id)}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
@@ -25,52 +25,52 @@ namespace Stripe.Treasury
 
         public virtual InboundTransfer Cancel(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<InboundTransfer> CancelAsync(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual InboundTransfer Create(InboundTransferCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers", options, requestOptions);
         }
 
         public virtual Task<InboundTransfer> CreateAsync(InboundTransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual InboundTransfer Get(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{id}", options, requestOptions);
         }
 
         public virtual Task<InboundTransfer> GetAsync(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InboundTransfer> List(InboundTransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<InboundTransfer>>(HttpMethod.Get, $"/v1/treasury/inbound_transfers", options, requestOptions);
         }
 
         public virtual Task<StripeList<InboundTransfer>> ListAsync(InboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<InboundTransfer>>(HttpMethod.Get, $"/v1/treasury/inbound_transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InboundTransfer> ListAutoPaging(InboundTransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<InboundTransfer>($"/v1/treasury/inbound_transfers", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<InboundTransfer> ListAutoPagingAsync(InboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<InboundTransfer>($"/v1/treasury/inbound_transfers", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -25,52 +25,52 @@ namespace Stripe.Treasury
 
         public virtual OutboundPayment Cancel(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<OutboundPayment> CancelAsync(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual OutboundPayment Create(OutboundPaymentCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments", options, requestOptions);
         }
 
         public virtual Task<OutboundPayment> CreateAsync(OutboundPaymentCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments", options, requestOptions, cancellationToken);
         }
 
         public virtual OutboundPayment Get(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{id}", options, requestOptions);
         }
 
         public virtual Task<OutboundPayment> GetAsync(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<OutboundPayment> List(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<OutboundPayment>>(HttpMethod.Get, $"/v1/treasury/outbound_payments", options, requestOptions);
         }
 
         public virtual Task<StripeList<OutboundPayment>> ListAsync(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<OutboundPayment>>(HttpMethod.Get, $"/v1/treasury/outbound_payments", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<OutboundPayment> ListAutoPaging(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<OutboundPayment>($"/v1/treasury/outbound_payments", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<OutboundPayment> ListAutoPagingAsync(OutboundPaymentListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<OutboundPayment>($"/v1/treasury/outbound_payments", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -25,52 +25,52 @@ namespace Stripe.Treasury
 
         public virtual OutboundTransfer Cancel(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions);
+            return this.Request<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{id}/cancel", options, requestOptions);
         }
 
         public virtual Task<OutboundTransfer> CancelAsync(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{id}/cancel", options, requestOptions, cancellationToken);
         }
 
         public virtual OutboundTransfer Create(OutboundTransferCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers", options, requestOptions);
         }
 
         public virtual Task<OutboundTransfer> CreateAsync(OutboundTransferCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual OutboundTransfer Get(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{id}", options, requestOptions);
         }
 
         public virtual Task<OutboundTransfer> GetAsync(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<OutboundTransfer> List(OutboundTransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<OutboundTransfer>>(HttpMethod.Get, $"/v1/treasury/outbound_transfers", options, requestOptions);
         }
 
         public virtual Task<StripeList<OutboundTransfer>> ListAsync(OutboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<OutboundTransfer>>(HttpMethod.Get, $"/v1/treasury/outbound_transfers", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<OutboundTransfer> ListAutoPaging(OutboundTransferListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<OutboundTransfer>($"/v1/treasury/outbound_transfers", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<OutboundTransfer> ListAutoPagingAsync(OutboundTransferListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<OutboundTransfer>($"/v1/treasury/outbound_transfers", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Treasury
 
         public virtual ReceivedCredit Get(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{id}", options, requestOptions);
         }
 
         public virtual Task<ReceivedCredit> GetAsync(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReceivedCredit> List(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ReceivedCredit>>(HttpMethod.Get, $"/v1/treasury/received_credits", options, requestOptions);
         }
 
         public virtual Task<StripeList<ReceivedCredit>> ListAsync(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ReceivedCredit>>(HttpMethod.Get, $"/v1/treasury/received_credits", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ReceivedCredit> ListAutoPaging(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ReceivedCredit>($"/v1/treasury/received_credits", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ReceivedCredit> ListAutoPagingAsync(ReceivedCreditListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ReceivedCredit>($"/v1/treasury/received_credits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Treasury
 
         public virtual ReceivedDebit Get(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{id}", options, requestOptions);
         }
 
         public virtual Task<ReceivedDebit> GetAsync(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<ReceivedDebit> List(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<ReceivedDebit>>(HttpMethod.Get, $"/v1/treasury/received_debits", options, requestOptions);
         }
 
         public virtual Task<StripeList<ReceivedDebit>> ListAsync(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ReceivedDebit>>(HttpMethod.Get, $"/v1/treasury/received_debits", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<ReceivedDebit> ListAutoPaging(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<ReceivedDebit>($"/v1/treasury/received_debits", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<ReceivedDebit> ListAutoPagingAsync(ReceivedDebitListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ReceivedDebit>($"/v1/treasury/received_debits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Treasury
 
         public virtual TransactionEntry Get(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{id}", options, requestOptions);
         }
 
         public virtual Task<TransactionEntry> GetAsync(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<TransactionEntry> List(TransactionEntryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<TransactionEntry>>(HttpMethod.Get, $"/v1/treasury/transaction_entries", options, requestOptions);
         }
 
         public virtual Task<StripeList<TransactionEntry>> ListAsync(TransactionEntryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TransactionEntry>>(HttpMethod.Get, $"/v1/treasury/transaction_entries", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<TransactionEntry> ListAutoPaging(TransactionEntryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<TransactionEntry>($"/v1/treasury/transaction_entries", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<TransactionEntry> ListAutoPagingAsync(TransactionEntryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TransactionEntry>($"/v1/treasury/transaction_entries", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.Treasury
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,32 +24,32 @@ namespace Stripe.Treasury
 
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{id}", options, requestOptions);
         }
 
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Transaction> List(TransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Transaction>>(HttpMethod.Get, $"/v1/treasury/transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<Transaction>> ListAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Transaction>>(HttpMethod.Get, $"/v1/treasury/transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Transaction> ListAutoPaging(TransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Transaction>($"/v1/treasury/transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Transaction> ListAutoPagingAsync(TransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Transaction>($"/v1/treasury/transactions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -22,22 +23,22 @@ namespace Stripe
 
         public virtual StripeList<UsageRecordSummary> List(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options, requestOptions);
+            return this.Request<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions);
         }
 
         public virtual Task<StripeList<UsageRecordSummary>> ListAsync(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<UsageRecordSummary> ListAutoPaging(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options, requestOptions);
+            return this.ListRequestAutoPaging<UsageRecordSummary>($"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<UsageRecordSummary> ListAutoPagingAsync(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<UsageRecordSummary>($"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -21,12 +22,12 @@ namespace Stripe
 
         public virtual UsageRecord Create(string parentId, UsageRecordCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{parentId}/usage_records", options, requestOptions);
         }
 
         public virtual Task<UsageRecord> CreateAsync(string parentId, UsageRecordCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{parentId}/usage_records", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -26,62 +27,62 @@ namespace Stripe
 
         public virtual WebhookEndpoint Create(WebhookEndpointCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints", options, requestOptions);
         }
 
         public virtual Task<WebhookEndpoint> CreateAsync(WebhookEndpointCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints", options, requestOptions, cancellationToken);
         }
 
         public virtual WebhookEndpoint Delete(string id, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{id}", options, requestOptions);
         }
 
         public virtual Task<WebhookEndpoint> DeleteAsync(string id, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual WebhookEndpoint Get(string id, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{id}", options, requestOptions);
         }
 
         public virtual Task<WebhookEndpoint> GetAsync(string id, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<WebhookEndpoint> List(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<WebhookEndpoint>>(HttpMethod.Get, $"/v1/webhook_endpoints", options, requestOptions);
         }
 
         public virtual Task<StripeList<WebhookEndpoint>> ListAsync(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<WebhookEndpoint>>(HttpMethod.Get, $"/v1/webhook_endpoints", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<WebhookEndpoint> ListAutoPaging(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<WebhookEndpoint>($"/v1/webhook_endpoints", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<WebhookEndpoint> ListAutoPagingAsync(WebhookEndpointListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<WebhookEndpoint>($"/v1/webhook_endpoints", options, requestOptions, cancellationToken);
         }
 
         public virtual WebhookEndpoint Update(string id, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{id}", options, requestOptions);
         }
 
         public virtual Task<WebhookEndpoint> UpdateAsync(string id, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -56,6 +56,7 @@ namespace Stripe
             set => this.client = value;
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned CreateEntity(BaseOptions options, RequestOptions requestOptions)
         {
             return this.Request(
@@ -65,6 +66,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> CreateEntityAsync(
             BaseOptions options,
             RequestOptions requestOptions,
@@ -78,6 +80,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned DeleteEntity(
             string id,
             BaseOptions options,
@@ -90,6 +93,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> DeleteEntityAsync(
             string id,
             BaseOptions options,
@@ -104,6 +108,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned GetEntity(
             string id,
             BaseOptions options,
@@ -116,6 +121,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> GetEntityAsync(
             string id,
             BaseOptions options,
@@ -130,6 +136,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected StripeList<TEntityReturned> ListEntities(
             ListOptions options,
             RequestOptions requestOptions)
@@ -141,6 +148,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<StripeList<TEntityReturned>> ListEntitiesAsync(
             ListOptions options,
             RequestOptions requestOptions,
@@ -154,6 +162,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `ListRequestAutoPaging` method instead.")]
         protected IEnumerable<TEntityReturned> ListEntitiesAutoPaging(
             ListOptions options,
             RequestOptions requestOptions)
@@ -164,6 +173,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `ListRequestAutoPagingAsync` method instead.")]
         protected IAsyncEnumerable<TEntityReturned> ListEntitiesAutoPagingAsync(
             ListOptions options,
             RequestOptions requestOptions,
@@ -176,6 +186,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned UpdateEntity(
             string id,
             BaseOptions options,
@@ -188,6 +199,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> UpdateEntityAsync(
             string id,
             BaseOptions options,
@@ -582,13 +594,6 @@ namespace Stripe
             }
 
             return $"{this.ClassUrl()}/{WebUtility.UrlEncode(id)}";
-        }
-
-        private static bool IsStripeList<T>()
-        {
-            var typeInfo = typeof(T).GetTypeInfo();
-            return typeInfo.IsGenericType
-                && typeInfo.GetGenericTypeDefinition() == typeof(StripeList<>);
         }
     }
 }

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -20,6 +20,7 @@ namespace Stripe
         {
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned CreateNestedEntity(
             string parentId,
             BaseOptions options,
@@ -32,6 +33,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> CreateNestedEntityAsync(
             string parentId,
             BaseOptions options,
@@ -46,6 +48,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned DeleteNestedEntity(
             string parentId,
             string id,
@@ -59,6 +62,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> DeleteNestedEntityAsync(
             string parentId,
             string id,
@@ -74,6 +78,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned GetNestedEntity(
             string parentId,
             string id,
@@ -87,6 +92,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> GetNestedEntityAsync(
             string parentId,
             string id,
@@ -102,6 +108,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected StripeList<TEntityReturned> ListNestedEntities(
             string parentId,
             ListOptions options,
@@ -114,6 +121,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<StripeList<TEntityReturned>> ListNestedEntitiesAsync(
             string parentId,
             ListOptions options,
@@ -128,6 +136,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `ListRequestAutoPaging` method instead.")]
         protected IEnumerable<TEntityReturned> ListNestedEntitiesAutoPaging(
             string parentId,
             ListOptions options,
@@ -139,6 +148,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `ListRequestAutoPagingAsync` method instead.")]
         protected IAsyncEnumerable<TEntityReturned> ListNestedEntitiesAutoPagingAsync(
             string parentId,
             ListOptions options,
@@ -152,6 +162,7 @@ namespace Stripe
                 cancellationToken);
         }
 
+        [Obsolete("Use the `Request` method instead.")]
         protected TEntityReturned UpdateNestedEntity(
             string parentId,
             string id,
@@ -165,6 +176,7 @@ namespace Stripe
                 requestOptions);
         }
 
+        [Obsolete("Use the `RequestAsync` method instead.")]
         protected Task<TEntityReturned> UpdateNestedEntityAsync(
             string parentId,
             string id,

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -17,7 +17,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestAccountLinkServiceCreate()
+        public void TestAccountLinksPost()
         {
             var options = new AccountLinkCreateOptions
             {
@@ -31,7 +31,112 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestAccountServiceCreate()
+        public void TestAccountsCapabilitiesGet()
+        {
+            var service = new CapabilityService(this.StripeClient);
+            StripeList<Capability> capabilities = service.List(
+                "acct_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsCapabilitiesGet2()
+        {
+            var service = new CapabilityService(this.StripeClient);
+            service.Get("acct_xxxxxxxxxxxxx", "card_payments");
+        }
+
+        [Fact]
+        public void TestAccountsCapabilitiesPost()
+        {
+            var options = new CapabilityUpdateOptions { Requested = true };
+            var service = new CapabilityService(this.StripeClient);
+            service.Update("acct_xxxxxxxxxxxxx", "card_payments", options);
+        }
+
+        [Fact]
+        public void TestAccountsDelete()
+        {
+            var service = new AccountService(this.StripeClient);
+            service.Delete("acct_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsGet()
+        {
+            var options = new AccountListOptions { Limit = 3 };
+            var service = new AccountService(this.StripeClient);
+            StripeList<Account> accounts = service.List(options);
+        }
+
+        [Fact]
+        public void TestAccountsGet2()
+        {
+            var service = new AccountService(this.StripeClient);
+            service.Get("acct_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsLoginLinksPost()
+        {
+            var service = new LoginLinkService(this.StripeClient);
+            service.Create("acct_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsPersonsDelete()
+        {
+            var service = new PersonService(this.StripeClient);
+            service.Delete("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsPersonsGet()
+        {
+            var options = new PersonListOptions { Limit = 3 };
+            var service = new PersonService(this.StripeClient);
+            StripeList<Person> persons = service.List(
+                "acct_xxxxxxxxxxxxx",
+                options);
+        }
+
+        [Fact]
+        public void TestAccountsPersonsGet2()
+        {
+            var service = new PersonService(this.StripeClient);
+            service.Get("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestAccountsPersonsPost()
+        {
+            var options = new PersonCreateOptions
+            {
+                FirstName = "Jane",
+                LastName = "Diaz",
+            };
+            var service = new PersonService(this.StripeClient);
+            service.Create("acct_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestAccountsPersonsPost2()
+        {
+            var options = new PersonUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PersonService(this.StripeClient);
+            service.Update(
+                "acct_xxxxxxxxxxxxx",
+                "person_xxxxxxxxxxxxx",
+                options);
+        }
+
+        [Fact]
+        public void TestAccountsPost()
         {
             var options = new AccountCreateOptions
             {
@@ -55,37 +160,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestAccountServiceDelete()
-        {
-            var service = new AccountService(this.StripeClient);
-            service.Delete("acct_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestAccountServiceList()
-        {
-            var options = new AccountListOptions { Limit = 3 };
-            var service = new AccountService(this.StripeClient);
-            StripeList<Account> accounts = service.List(options);
-        }
-
-        [Fact]
-        public void TestAccountServiceReject()
-        {
-            var options = new AccountRejectOptions { Reason = "fraud" };
-            var service = new AccountService(this.StripeClient);
-            service.Reject("acct_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestAccountServiceRetrieve()
-        {
-            var service = new AccountService(this.StripeClient);
-            service.Get("acct_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestAccountServiceUpdate()
+        public void TestAccountsPost2()
         {
             var options = new AccountUpdateOptions
             {
@@ -99,31 +174,53 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestApplicationFeeRefundServiceCreate()
+        public void TestAccountsRejectPost()
         {
-            var service = new ApplicationFeeRefundService(this.StripeClient);
-            service.Create("fee_xxxxxxxxxxxxx");
+            var options = new AccountRejectOptions { Reason = "fraud" };
+            var service = new AccountService(this.StripeClient);
+            service.Reject("acct_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
-        public void TestApplicationFeeRefundServiceList()
+        public void TestApplicationFeesGet()
+        {
+            var options = new ApplicationFeeListOptions { Limit = 3 };
+            var service = new ApplicationFeeService(this.StripeClient);
+            StripeList<ApplicationFee> applicationFees = service.List(options);
+        }
+
+        [Fact]
+        public void TestApplicationFeesGet2()
+        {
+            var service = new ApplicationFeeService(this.StripeClient);
+            service.Get("fee_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestApplicationFeesRefundsGet()
         {
             var options = new ApplicationFeeRefundListOptions { Limit = 3 };
             var service = new ApplicationFeeRefundService(this.StripeClient);
-            StripeList<ApplicationFeeRefund> applicationfeerefunds = service.List(
-                "fee_xxxxxxxxxxxxx",
-                options);
+            StripeList<ApplicationFeeRefund> applicationFeeRefunds = service
+                .List("fee_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
-        public void TestApplicationFeeRefundServiceRetrieve()
+        public void TestApplicationFeesRefundsGet2()
         {
             var service = new ApplicationFeeRefundService(this.StripeClient);
             service.Get("fee_xxxxxxxxxxxxx", "fr_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestApplicationFeeRefundServiceUpdate()
+        public void TestApplicationFeesRefundsPost()
+        {
+            var service = new ApplicationFeeRefundService(this.StripeClient);
+            service.Create("fee_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestApplicationFeesRefundsPost2()
         {
             var options = new ApplicationFeeRefundUpdateOptions
             {
@@ -137,22 +234,55 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestApplicationFeeServiceList()
+        public void TestAppsSecretsDeletePost()
         {
-            var options = new ApplicationFeeListOptions { Limit = 3 };
-            var service = new ApplicationFeeService(this.StripeClient);
-            StripeList<ApplicationFee> applicationfees = service.List(options);
+            var options = new Stripe.Apps.SecretDeleteWhereOptions
+            {
+                Name = "my-api-key",
+                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
+            };
+            var service = new Stripe.Apps.SecretService(this.StripeClient);
+            service.DeleteWhere(options);
         }
 
         [Fact]
-        public void TestApplicationFeeServiceRetrieve()
+        public void TestAppsSecretsFindGet()
         {
-            var service = new ApplicationFeeService(this.StripeClient);
-            service.Get("fee_xxxxxxxxxxxxx");
+            var options = new Stripe.Apps.SecretFindOptions
+            {
+                Name = "sec_123",
+                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
+            };
+            var service = new Stripe.Apps.SecretService(this.StripeClient);
+            service.Find(options);
         }
 
         [Fact]
-        public void TestAppsSecretServiceCreate()
+        public void TestAppsSecretsGet()
+        {
+            var options = new Stripe.Apps.SecretListOptions
+            {
+                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
+                Limit = 2,
+            };
+            var service = new Stripe.Apps.SecretService(this.StripeClient);
+            StripeList<Stripe.Apps.Secret> secrets = service.List(options);
+        }
+
+        [Fact]
+        public void TestAppsSecretsGet2()
+        {
+            var options = new Stripe.Apps.SecretListOptions
+            {
+                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
+                Limit = 2,
+            };
+            var service = new Stripe.Apps.SecretService(this.StripeClient);
+            StripeList<Stripe.Apps.Secret> secrets = service.List(options);
+        }
+
+        [Fact]
+        public void TestAppsSecretsPost()
         {
             var options = new Stripe.Apps.SecretCreateOptions
             {
@@ -165,7 +295,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestAppsSecretServiceCreate2()
+        public void TestAppsSecretsPost2()
         {
             var options = new Stripe.Apps.SecretCreateOptions
             {
@@ -178,71 +308,44 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestAppsSecretServiceDeleteWhere()
-        {
-            var options = new Stripe.Apps.SecretDeleteWhereOptions
-            {
-                Name = "my-api-key",
-                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
-            };
-            var service = new Stripe.Apps.SecretService(this.StripeClient);
-            service.DeleteWhere(options);
-        }
-
-        [Fact]
-        public void TestAppsSecretServiceFind()
-        {
-            var options = new Stripe.Apps.SecretFindOptions
-            {
-                Name = "sec_123",
-                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
-            };
-            var service = new Stripe.Apps.SecretService(this.StripeClient);
-            service.Find(options);
-        }
-
-        [Fact]
-        public void TestAppsSecretServiceList()
-        {
-            var options = new Stripe.Apps.SecretListOptions
-            {
-                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
-                Limit = 2,
-            };
-            var service = new Stripe.Apps.SecretService(this.StripeClient);
-            StripeList<Stripe.Apps.Secret> secrets = service.List(options);
-        }
-
-        [Fact]
-        public void TestAppsSecretServiceList2()
-        {
-            var options = new Stripe.Apps.SecretListOptions
-            {
-                Scope = new Stripe.Apps.SecretScopeOptions { Type = "account" },
-                Limit = 2,
-            };
-            var service = new Stripe.Apps.SecretService(this.StripeClient);
-            StripeList<Stripe.Apps.Secret> secrets = service.List(options);
-        }
-
-        [Fact]
-        public void TestBalanceTransactionServiceList()
+        public void TestBalanceTransactionsGet()
         {
             var options = new BalanceTransactionListOptions { Limit = 3 };
             var service = new BalanceTransactionService(this.StripeClient);
-            StripeList<BalanceTransaction> balancetransactions = service.List(
+            StripeList<BalanceTransaction> balanceTransactions = service.List(
                 options);
         }
 
         [Fact]
-        public void TestBalanceTransactionServiceRetrieve()
+        public void TestBalanceTransactionsGet2()
         {
             var service = new BalanceTransactionService(this.StripeClient);
             service.Get("txn_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestBillingPortalConfigurationServiceCreate()
+        public void TestBillingPortalConfigurationsGet()
+        {
+            var options = new Stripe.BillingPortal.ConfigurationListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.BillingPortal.ConfigurationService(
+                this.StripeClient);
+            StripeList<Stripe.BillingPortal.Configuration> configurations = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestBillingPortalConfigurationsGet2()
+        {
+            var service = new Stripe.BillingPortal.ConfigurationService(
+                this.StripeClient);
+            service.Get("bpc_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestBillingPortalConfigurationsPost()
         {
             var options = new Stripe.BillingPortal.ConfigurationCreateOptions
             {
@@ -270,28 +373,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestBillingPortalConfigurationServiceList()
-        {
-            var options = new Stripe.BillingPortal.ConfigurationListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.BillingPortal.ConfigurationService(
-                this.StripeClient);
-            StripeList<Stripe.BillingPortal.Configuration> configurations = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestBillingPortalConfigurationServiceRetrieve()
-        {
-            var service = new Stripe.BillingPortal.ConfigurationService(
-                this.StripeClient);
-            service.Get("bpc_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestBillingPortalConfigurationServiceUpdate()
+        public void TestBillingPortalConfigurationsPost2()
         {
             var options = new Stripe.BillingPortal.ConfigurationUpdateOptions
             {
@@ -307,7 +389,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestBillingPortalSessionServiceCreate()
+        public void TestBillingPortalSessionsPost()
         {
             var options = new Stripe.BillingPortal.SessionCreateOptions
             {
@@ -320,58 +402,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCapabilityServiceList()
-        {
-            var service = new CapabilityService(this.StripeClient);
-            StripeList<Capability> capabilities = service.List(
-                "acct_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestCapabilityServiceRetrieve()
-        {
-            var service = new CapabilityService(this.StripeClient);
-            service.Get("acct_xxxxxxxxxxxxx", "card_payments");
-        }
-
-        [Fact]
-        public void TestCapabilityServiceUpdate()
-        {
-            var options = new CapabilityUpdateOptions { Requested = true };
-            var service = new CapabilityService(this.StripeClient);
-            service.Update("acct_xxxxxxxxxxxxx", "card_payments", options);
-        }
-
-        [Fact]
-        public void TestCashBalanceServiceRetrieve()
-        {
-            var service = new CashBalanceService(this.StripeClient);
-            service.Get("cus_123");
-        }
-
-        [Fact]
-        public void TestCashBalanceServiceUpdate()
-        {
-            var options = new CashBalanceUpdateOptions
-            {
-                Settings = new CashBalanceSettingsOptions
-                {
-                    ReconciliationMode = "manual",
-                },
-            };
-            var service = new CashBalanceService(this.StripeClient);
-            service.Update("cus_123", options);
-        }
-
-        [Fact]
-        public void TestChargeServiceCapture()
+        public void TestChargesCapturePost()
         {
             var service = new ChargeService(this.StripeClient);
             service.Capture("ch_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestChargeServiceCreate()
+        public void TestChargesGet()
+        {
+            var options = new ChargeListOptions { Limit = 3 };
+            var service = new ChargeService(this.StripeClient);
+            StripeList<Charge> charges = service.List(options);
+        }
+
+        [Fact]
+        public void TestChargesGet2()
+        {
+            var service = new ChargeService(this.StripeClient);
+            service.Get("ch_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestChargesPost()
         {
             var options = new ChargeCreateOptions
             {
@@ -385,33 +438,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestChargeServiceList()
-        {
-            var options = new ChargeListOptions { Limit = 3 };
-            var service = new ChargeService(this.StripeClient);
-            StripeList<Charge> charges = service.List(options);
-        }
-
-        [Fact]
-        public void TestChargeServiceRetrieve()
-        {
-            var service = new ChargeService(this.StripeClient);
-            service.Get("ch_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestChargeServiceSearch()
-        {
-            var options = new ChargeSearchOptions
-            {
-                Query = "amount>999 AND metadata['order_id']:'6735'",
-            };
-            var service = new ChargeService(this.StripeClient);
-            service.Search(options);
-        }
-
-        [Fact]
-        public void TestChargeServiceUpdate()
+        public void TestChargesPost2()
         {
             var options = new ChargeUpdateOptions
             {
@@ -425,7 +452,55 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCheckoutSessionServiceCreate()
+        public void TestChargesSearchGet()
+        {
+            var options = new ChargeSearchOptions
+            {
+                Query = "amount>999 AND metadata['order_id']:'6735'",
+            };
+            var service = new ChargeService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsExpirePost()
+        {
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            service.Expire("sess_xyz");
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsExpirePost2()
+        {
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            service.Expire("cs_test_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsGet()
+        {
+            var options = new Stripe.Checkout.SessionListOptions { Limit = 3 };
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            StripeList<Stripe.Checkout.Session> sessions = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsGet2()
+        {
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            service.Get("cs_test_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsLineItemsGet()
+        {
+            var service = new Stripe.Checkout.SessionService(this.StripeClient);
+            StripeList<LineItem> lineItems = service.ListLineItems("sess_xyz");
+        }
+
+        [Fact]
+        public void TestCheckoutSessionsPost()
         {
             var options = new Stripe.Checkout.SessionCreateOptions
             {
@@ -465,7 +540,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCheckoutSessionServiceCreate2()
+        public void TestCheckoutSessionsPost2()
         {
             var options = new Stripe.Checkout.SessionCreateOptions
             {
@@ -485,63 +560,48 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCheckoutSessionServiceExpire()
-        {
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            service.Expire("sess_xyz");
-        }
-
-        [Fact]
-        public void TestCheckoutSessionServiceExpire2()
-        {
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            service.Expire("cs_test_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestCheckoutSessionServiceList()
-        {
-            var options = new Stripe.Checkout.SessionListOptions { Limit = 3 };
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            StripeList<Stripe.Checkout.Session> sessions = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestCheckoutSessionServiceListLineItems()
-        {
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            service.ListLineItems("sess_xyz");
-        }
-
-        [Fact]
-        public void TestCheckoutSessionServiceRetrieve()
-        {
-            var service = new Stripe.Checkout.SessionService(this.StripeClient);
-            service.Get("cs_test_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestCountrySpecServiceList()
+        public void TestCountrySpecsGet()
         {
             var options = new CountrySpecListOptions { Limit = 3 };
             var service = new CountrySpecService(this.StripeClient);
-            StripeList<CountrySpec> countryspecs = service.List(options);
+            StripeList<CountrySpec> countrySpecs = service.List(options);
         }
 
         [Fact]
-        public void TestCountrySpecServiceRetrieve()
+        public void TestCountrySpecsGet2()
         {
             var service = new CountrySpecService(this.StripeClient);
             service.Get("US");
         }
 
         [Fact]
-        public void TestCouponServiceCreate()
+        public void TestCouponsDelete()
+        {
+            var service = new CouponService(this.StripeClient);
+            service.Delete("Z4OV52SU");
+        }
+
+        [Fact]
+        public void TestCouponsGet()
+        {
+            var options = new CouponListOptions { Limit = 3 };
+            var service = new CouponService(this.StripeClient);
+            StripeList<Coupon> coupons = service.List(options);
+        }
+
+        [Fact]
+        public void TestCouponsGet2()
+        {
+            var service = new CouponService(this.StripeClient);
+            service.Get("Z4OV52SU");
+        }
+
+        [Fact]
+        public void TestCouponsPost()
         {
             var options = new CouponCreateOptions
             {
-                PercentOff = 25.5m,
+                PercentOff = 25.5M,
                 Duration = "repeating",
                 DurationInMonths = 3,
             };
@@ -550,29 +610,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCouponServiceDelete()
-        {
-            var service = new CouponService(this.StripeClient);
-            service.Delete("Z4OV52SU");
-        }
-
-        [Fact]
-        public void TestCouponServiceList()
-        {
-            var options = new CouponListOptions { Limit = 3 };
-            var service = new CouponService(this.StripeClient);
-            StripeList<Coupon> coupons = service.List(options);
-        }
-
-        [Fact]
-        public void TestCouponServiceRetrieve()
-        {
-            var service = new CouponService(this.StripeClient);
-            service.Get("Z4OV52SU");
-        }
-
-        [Fact]
-        public void TestCouponServiceUpdate()
+        public void TestCouponsPost2()
         {
             var options = new CouponUpdateOptions
             {
@@ -586,7 +624,15 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCreditNoteServiceCreate()
+        public void TestCreditNotesGet()
+        {
+            var options = new CreditNoteListOptions { Limit = 3 };
+            var service = new CreditNoteService(this.StripeClient);
+            StripeList<CreditNote> creditNotes = service.List(options);
+        }
+
+        [Fact]
+        public void TestCreditNotesPost()
         {
             var options = new CreditNoteCreateOptions
             {
@@ -606,15 +652,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCreditNoteServiceList()
-        {
-            var options = new CreditNoteListOptions { Limit = 3 };
-            var service = new CreditNoteService(this.StripeClient);
-            StripeList<CreditNote> creditnotes = service.List(options);
-        }
-
-        [Fact]
-        public void TestCreditNoteServicePreview()
+        public void TestCreditNotesPreviewGet()
         {
             var options = new CreditNotePreviewOptions
             {
@@ -634,14 +672,35 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCreditNoteServiceVoidCreditNote()
+        public void TestCreditNotesVoidPost()
         {
             var service = new CreditNoteService(this.StripeClient);
             service.VoidCreditNote("cn_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestCustomerBalanceTransactionServiceCreate()
+        public void TestCustomersBalanceTransactionsGet()
+        {
+            var options = new CustomerBalanceTransactionListOptions
+            {
+                Limit = 3,
+            };
+            var service = new CustomerBalanceTransactionService(
+                this.StripeClient);
+            StripeList<CustomerBalanceTransaction> customerBalanceTransactions = service
+                .List("cus_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestCustomersBalanceTransactionsGet2()
+        {
+            var service = new CustomerBalanceTransactionService(
+                this.StripeClient);
+            service.Get("cus_xxxxxxxxxxxxx", "cbtxn_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCustomersBalanceTransactionsPost()
         {
             var options = new CustomerBalanceTransactionCreateOptions
             {
@@ -654,29 +713,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCustomerBalanceTransactionServiceList()
-        {
-            var options = new CustomerBalanceTransactionListOptions
-            {
-                Limit = 3,
-            };
-            var service = new CustomerBalanceTransactionService(
-                this.StripeClient);
-            StripeList<CustomerBalanceTransaction> customerbalancetransactions = service.List(
-                "cus_xxxxxxxxxxxxx",
-                options);
-        }
-
-        [Fact]
-        public void TestCustomerBalanceTransactionServiceRetrieve()
-        {
-            var service = new CustomerBalanceTransactionService(
-                this.StripeClient);
-            service.Get("cus_xxxxxxxxxxxxx", "cbtxn_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestCustomerBalanceTransactionServiceUpdate()
+        public void TestCustomersBalanceTransactionsPost2()
         {
             var options = new CustomerBalanceTransactionUpdateOptions
             {
@@ -691,18 +728,35 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCustomerServiceCreate()
+        public void TestCustomersCashBalanceGet()
         {
-            var options = new CustomerCreateOptions
-            {
-                Description = "My First Test Customer (created for API docs at https://www.stripe.com/docs/api)",
-            };
-            var service = new CustomerService(this.StripeClient);
-            service.Create(options);
+            var service = new CashBalanceService(this.StripeClient);
+            service.Get("cus_123");
         }
 
         [Fact]
-        public void TestCustomerServiceCreateFundingInstructions()
+        public void TestCustomersCashBalancePost()
+        {
+            var options = new CashBalanceUpdateOptions
+            {
+                Settings = new CashBalanceSettingsOptions
+                {
+                    ReconciliationMode = "manual",
+                },
+            };
+            var service = new CashBalanceService(this.StripeClient);
+            service.Update("cus_123", options);
+        }
+
+        [Fact]
+        public void TestCustomersDelete()
+        {
+            var service = new CustomerService(this.StripeClient);
+            service.Delete("cus_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCustomersFundingInstructionsPost()
         {
             var options = new CustomerCreateFundingInstructionsOptions
             {
@@ -719,27 +773,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCustomerServiceDelete()
-        {
-            var service = new CustomerService(this.StripeClient);
-            service.Delete("cus_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestCustomerServiceFundCashBalance()
-        {
-            var options = new Stripe.TestHelpers.CustomerFundCashBalanceOptions
-            {
-                Amount = 30,
-                Currency = "eur",
-            };
-            var service = new Stripe.TestHelpers.CustomerService(
-                this.StripeClient);
-            service.FundCashBalance("cus_123", options);
-        }
-
-        [Fact]
-        public void TestCustomerServiceList()
+        public void TestCustomersGet()
         {
             var options = new CustomerListOptions { Limit = 3 };
             var service = new CustomerService(this.StripeClient);
@@ -747,7 +781,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCustomerServiceList2()
+        public void TestCustomersGet2()
         {
             var options = new CustomerListOptions { Limit = 3 };
             var service = new CustomerService(this.StripeClient);
@@ -755,58 +789,49 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestCustomerServiceListPaymentMethods()
-        {
-            var options = new CustomerListPaymentMethodsOptions
-            {
-                Type = "card",
-            };
-            var service = new CustomerService(this.StripeClient);
-            service.ListPaymentMethods("cus_xyz", options);
-        }
-
-        [Fact]
-        public void TestCustomerServiceListPaymentMethods2()
-        {
-            var options = new CustomerListPaymentMethodsOptions
-            {
-                Type = "card",
-            };
-            var service = new CustomerService(this.StripeClient);
-            service.ListPaymentMethods("cus_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestCustomerServiceRetrieve()
+        public void TestCustomersGet3()
         {
             var service = new CustomerService(this.StripeClient);
             service.Get("cus_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestCustomerServiceSearch()
+        public void TestCustomersPaymentMethodsGet()
         {
-            var options = new CustomerSearchOptions
+            var options = new CustomerListPaymentMethodsOptions
             {
-                Query = "name:'fakename' AND metadata['foo']:'bar'",
+                Type = "card",
             };
             var service = new CustomerService(this.StripeClient);
-            service.Search(options);
+            StripeList<PaymentMethod> paymentMethods = service
+                .ListPaymentMethods("cus_xyz", options);
         }
 
         [Fact]
-        public void TestCustomerServiceSearch2()
+        public void TestCustomersPaymentMethodsGet2()
         {
-            var options = new CustomerSearchOptions
+            var options = new CustomerListPaymentMethodsOptions
             {
-                Query = "name:'fakename' AND metadata['foo']:'bar'",
+                Type = "card",
             };
             var service = new CustomerService(this.StripeClient);
-            service.Search(options);
+            StripeList<PaymentMethod> paymentMethods = service
+                .ListPaymentMethods("cus_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
-        public void TestCustomerServiceUpdate()
+        public void TestCustomersPost()
+        {
+            var options = new CustomerCreateOptions
+            {
+                Description = "My First Test Customer (created for API docs at https://www.stripe.com/docs/api)",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestCustomersPost2()
         {
             var options = new CustomerUpdateOptions
             {
@@ -820,21 +845,72 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestDiscountServiceDeleteSubscriptionDiscount()
+        public void TestCustomersSearchGet()
         {
-            var service = new DiscountService(this.StripeClient);
-            service.DeleteSubscriptionDiscount("sub_xyz");
+            var options = new CustomerSearchOptions
+            {
+                Query = "name:'fakename' AND metadata['foo']:'bar'",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.Search(options);
         }
 
         [Fact]
-        public void TestDisputeServiceClose()
+        public void TestCustomersSearchGet2()
+        {
+            var options = new CustomerSearchOptions
+            {
+                Query = "name:'fakename' AND metadata['foo']:'bar'",
+            };
+            var service = new CustomerService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestCustomersTaxIdsDelete()
+        {
+            var service = new TaxIdService(this.StripeClient);
+            service.Delete("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCustomersTaxIdsGet()
+        {
+            var options = new TaxIdListOptions { Limit = 3 };
+            var service = new TaxIdService(this.StripeClient);
+            StripeList<TaxId> taxIds = service.List(
+                "cus_xxxxxxxxxxxxx",
+                options);
+        }
+
+        [Fact]
+        public void TestCustomersTaxIdsGet2()
+        {
+            var service = new TaxIdService(this.StripeClient);
+            service.Get("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestCustomersTaxIdsPost()
+        {
+            var options = new TaxIdCreateOptions
+            {
+                Type = "eu_vat",
+                Value = "DE123456789",
+            };
+            var service = new TaxIdService(this.StripeClient);
+            service.Create("cus_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestDisputesClosePost()
         {
             var service = new DisputeService(this.StripeClient);
             service.Close("dp_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestDisputeServiceList()
+        public void TestDisputesGet()
         {
             var options = new DisputeListOptions { Limit = 3 };
             var service = new DisputeService(this.StripeClient);
@@ -842,14 +918,14 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestDisputeServiceRetrieve()
+        public void TestDisputesGet2()
         {
             var service = new DisputeService(this.StripeClient);
             service.Get("dp_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestDisputeServiceUpdate()
+        public void TestDisputesPost()
         {
             var options = new DisputeUpdateOptions
             {
@@ -863,7 +939,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestEventServiceList()
+        public void TestEventsGet()
         {
             var options = new EventListOptions { Limit = 3 };
             var service = new EventService(this.StripeClient);
@@ -871,14 +947,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestEventServiceRetrieve()
+        public void TestEventsGet2()
         {
             var service = new EventService(this.StripeClient);
             service.Get("evt_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestFileLinkServiceCreate()
+        public void TestFileLinksGet()
+        {
+            var options = new FileLinkListOptions { Limit = 3 };
+            var service = new FileLinkService(this.StripeClient);
+            StripeList<FileLink> fileLinks = service.List(options);
+        }
+
+        [Fact]
+        public void TestFileLinksGet2()
+        {
+            var service = new FileLinkService(this.StripeClient);
+            service.Get("link_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestFileLinksPost()
         {
             var options = new FileLinkCreateOptions
             {
@@ -889,22 +980,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFileLinkServiceList()
-        {
-            var options = new FileLinkListOptions { Limit = 3 };
-            var service = new FileLinkService(this.StripeClient);
-            StripeList<FileLink> filelinks = service.List(options);
-        }
-
-        [Fact]
-        public void TestFileLinkServiceRetrieve()
-        {
-            var service = new FileLinkService(this.StripeClient);
-            service.Get("link_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestFileLinkServiceUpdate()
+        public void TestFileLinksPost2()
         {
             var options = new FileLinkUpdateOptions
             {
@@ -918,7 +994,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFileServiceList()
+        public void TestFilesGet()
         {
             var options = new FileListOptions { Limit = 3 };
             var service = new FileService(this.StripeClient);
@@ -926,14 +1002,27 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFileServiceRetrieve()
+        public void TestFilesGet2()
         {
             var service = new FileService(this.StripeClient);
             service.Get("file_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceDisconnect()
+        public void TestFilesPost()
+        {
+            var options = new FileCreateOptions
+            {
+                Purpose = "account_requirement",
+                File = new System.IO.MemoryStream(
+                    System.Text.Encoding.UTF8.GetBytes("File contents")),
+            };
+            var service = new FileService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountsDisconnectPost()
         {
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
@@ -941,7 +1030,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceDisconnect2()
+        public void TestFinancialConnectionsAccountsDisconnectPost2()
         {
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
@@ -949,15 +1038,24 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceList()
+        public void TestFinancialConnectionsAccountsGet()
         {
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
-            StripeList<Stripe.FinancialConnections.Account> accounts = service.List();
+            StripeList<Stripe.FinancialConnections.Account> accounts = service
+                .List();
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceList2()
+        public void TestFinancialConnectionsAccountsGet2()
+        {
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            service.Get("fca_xyz");
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountsGet3()
         {
             var options = new Stripe.FinancialConnections.AccountListOptions
             {
@@ -968,12 +1066,20 @@ namespace StripeTests
             };
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
-            StripeList<Stripe.FinancialConnections.Account> accounts = service.List(
-                options);
+            StripeList<Stripe.FinancialConnections.Account> accounts = service
+                .List(options);
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceListOwners()
+        public void TestFinancialConnectionsAccountsGet4()
+        {
+            var service = new Stripe.FinancialConnections.AccountService(
+                this.StripeClient);
+            service.Get("fca_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestFinancialConnectionsAccountsOwnersGet()
         {
             var options = new Stripe.FinancialConnections.AccountListOwnersOptions
             {
@@ -981,11 +1087,12 @@ namespace StripeTests
             };
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
-            service.ListOwners("fca_xyz", options);
+            StripeList<Stripe.FinancialConnections.AccountOwner> accountOwners = service
+                .ListOwners("fca_xyz", options);
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceListOwners2()
+        public void TestFinancialConnectionsAccountsOwnersGet2()
         {
             var options = new Stripe.FinancialConnections.AccountListOwnersOptions
             {
@@ -994,11 +1101,12 @@ namespace StripeTests
             };
             var service = new Stripe.FinancialConnections.AccountService(
                 this.StripeClient);
-            service.ListOwners("fca_xxxxxxxxxxxxx", options);
+            StripeList<Stripe.FinancialConnections.AccountOwner> accountOwners = service
+                .ListOwners("fca_xxxxxxxxxxxxx", options);
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceRefresh()
+        public void TestFinancialConnectionsAccountsRefreshPost()
         {
             var options = new Stripe.FinancialConnections.AccountRefreshOptions
             {
@@ -1010,23 +1118,23 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceRetrieve()
+        public void TestFinancialConnectionsSessionsGet()
         {
-            var service = new Stripe.FinancialConnections.AccountService(
+            var service = new Stripe.FinancialConnections.SessionService(
                 this.StripeClient);
-            service.Get("fca_xyz");
+            service.Get("fcsess_xyz");
         }
 
         [Fact]
-        public void TestFinancialConnectionsAccountServiceRetrieve2()
+        public void TestFinancialConnectionsSessionsGet2()
         {
-            var service = new Stripe.FinancialConnections.AccountService(
+            var service = new Stripe.FinancialConnections.SessionService(
                 this.StripeClient);
-            service.Get("fca_xxxxxxxxxxxxx");
+            service.Get("fcsess_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestFinancialConnectionsSessionServiceCreate()
+        public void TestFinancialConnectionsSessionsPost()
         {
             var options = new Stripe.FinancialConnections.SessionCreateOptions
             {
@@ -1043,7 +1151,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFinancialConnectionsSessionServiceCreate2()
+        public void TestFinancialConnectionsSessionsPost2()
         {
             var options = new Stripe.FinancialConnections.SessionCreateOptions
             {
@@ -1064,23 +1172,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestFinancialConnectionsSessionServiceRetrieve()
-        {
-            var service = new Stripe.FinancialConnections.SessionService(
-                this.StripeClient);
-            service.Get("fcsess_xyz");
-        }
-
-        [Fact]
-        public void TestFinancialConnectionsSessionServiceRetrieve2()
-        {
-            var service = new Stripe.FinancialConnections.SessionService(
-                this.StripeClient);
-            service.Get("fcsess_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIdentityVerificationReportServiceList()
+        public void TestIdentityVerificationReportsGet()
         {
             var options = new Stripe.Identity.VerificationReportListOptions
             {
@@ -1088,12 +1180,12 @@ namespace StripeTests
             };
             var service = new Stripe.Identity.VerificationReportService(
                 this.StripeClient);
-            StripeList<Stripe.Identity.VerificationReport> verificationreports = service.List(
-                options);
+            StripeList<Stripe.Identity.VerificationReport> verificationReports = service
+                .List(options);
         }
 
         [Fact]
-        public void TestIdentityVerificationReportServiceRetrieve()
+        public void TestIdentityVerificationReportsGet2()
         {
             var service = new Stripe.Identity.VerificationReportService(
                 this.StripeClient);
@@ -1101,7 +1193,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIdentityVerificationSessionServiceCancel()
+        public void TestIdentityVerificationSessionsCancelPost()
         {
             var service = new Stripe.Identity.VerificationSessionService(
                 this.StripeClient);
@@ -1109,7 +1201,28 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIdentityVerificationSessionServiceCreate()
+        public void TestIdentityVerificationSessionsGet()
+        {
+            var options = new Stripe.Identity.VerificationSessionListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            StripeList<Stripe.Identity.VerificationSession> verificationSessions = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionsGet2()
+        {
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Get("vs_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIdentityVerificationSessionsPost()
         {
             var options = new Stripe.Identity.VerificationSessionCreateOptions
             {
@@ -1121,36 +1234,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIdentityVerificationSessionServiceList()
-        {
-            var options = new Stripe.Identity.VerificationSessionListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Identity.VerificationSessionService(
-                this.StripeClient);
-            StripeList<Stripe.Identity.VerificationSession> verificationsessions = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestIdentityVerificationSessionServiceRedact()
-        {
-            var service = new Stripe.Identity.VerificationSessionService(
-                this.StripeClient);
-            service.Redact("vs_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIdentityVerificationSessionServiceRetrieve()
-        {
-            var service = new Stripe.Identity.VerificationSessionService(
-                this.StripeClient);
-            service.Get("vs_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIdentityVerificationSessionServiceUpdate()
+        public void TestIdentityVerificationSessionsPost2()
         {
             var options = new Stripe.Identity.VerificationSessionUpdateOptions
             {
@@ -1162,7 +1246,37 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceItemServiceCreate()
+        public void TestIdentityVerificationSessionsRedactPost()
+        {
+            var service = new Stripe.Identity.VerificationSessionService(
+                this.StripeClient);
+            service.Redact("vs_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoiceitemsDelete()
+        {
+            var service = new InvoiceItemService(this.StripeClient);
+            service.Delete("ii_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoiceitemsGet()
+        {
+            var options = new InvoiceItemListOptions { Limit = 3 };
+            var service = new InvoiceItemService(this.StripeClient);
+            StripeList<InvoiceItem> invoiceItems = service.List(options);
+        }
+
+        [Fact]
+        public void TestInvoiceitemsGet2()
+        {
+            var service = new InvoiceItemService(this.StripeClient);
+            service.Get("ii_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoiceitemsPost()
         {
             var options = new InvoiceItemCreateOptions
             {
@@ -1174,29 +1288,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceItemServiceDelete()
-        {
-            var service = new InvoiceItemService(this.StripeClient);
-            service.Delete("ii_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestInvoiceItemServiceList()
-        {
-            var options = new InvoiceItemListOptions { Limit = 3 };
-            var service = new InvoiceItemService(this.StripeClient);
-            StripeList<InvoiceItem> invoiceitems = service.List(options);
-        }
-
-        [Fact]
-        public void TestInvoiceItemServiceRetrieve()
-        {
-            var service = new InvoiceItemService(this.StripeClient);
-            service.Get("ii_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestInvoiceItemServiceUpdate()
+        public void TestInvoiceitemsPost2()
         {
             var options = new InvoiceItemUpdateOptions
             {
@@ -1210,32 +1302,21 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceServiceCreate()
-        {
-            var options = new InvoiceCreateOptions
-            {
-                Customer = "cus_xxxxxxxxxxxxx",
-            };
-            var service = new InvoiceService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestInvoiceServiceDelete()
+        public void TestInvoicesDelete()
         {
             var service = new InvoiceService(this.StripeClient);
             service.Delete("in_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestInvoiceServiceFinalizeInvoice()
+        public void TestInvoicesFinalizePost()
         {
             var service = new InvoiceService(this.StripeClient);
             service.FinalizeInvoice("in_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestInvoiceServiceList()
+        public void TestInvoicesGet()
         {
             var options = new InvoiceListOptions { Limit = 3 };
             var service = new InvoiceService(this.StripeClient);
@@ -1243,28 +1324,14 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceServiceMarkUncollectible()
-        {
-            var service = new InvoiceService(this.StripeClient);
-            service.MarkUncollectible("in_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestInvoiceServicePay()
-        {
-            var service = new InvoiceService(this.StripeClient);
-            service.Pay("in_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestInvoiceServiceRetrieve()
+        public void TestInvoicesGet2()
         {
             var service = new InvoiceService(this.StripeClient);
             service.Get("in_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestInvoiceServiceRetrieve2()
+        public void TestInvoicesGet3()
         {
             var options = new InvoiceGetOptions
             {
@@ -1275,36 +1342,32 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceServiceSearch()
+        public void TestInvoicesMarkUncollectiblePost()
         {
-            var options = new InvoiceSearchOptions
+            var service = new InvoiceService(this.StripeClient);
+            service.MarkUncollectible("in_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoicesPayPost()
+        {
+            var service = new InvoiceService(this.StripeClient);
+            service.Pay("in_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoicesPost()
+        {
+            var options = new InvoiceCreateOptions
             {
-                Query = "total>999 AND metadata['order_id']:'6735'",
+                Customer = "cus_xxxxxxxxxxxxx",
             };
             var service = new InvoiceService(this.StripeClient);
-            service.Search(options);
+            service.Create(options);
         }
 
         [Fact]
-        public void TestInvoiceServiceSendInvoice()
-        {
-            var service = new InvoiceService(this.StripeClient);
-            service.SendInvoice("in_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestInvoiceServiceUpcoming()
-        {
-            var options = new UpcomingInvoiceOptions
-            {
-                Customer = "cus_9utnxg47pWjV1e",
-            };
-            var service = new InvoiceService(this.StripeClient);
-            service.Upcoming(options);
-        }
-
-        [Fact]
-        public void TestInvoiceServiceUpdate()
+        public void TestInvoicesPost2()
         {
             var options = new InvoiceUpdateOptions
             {
@@ -1318,14 +1381,43 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestInvoiceServiceVoidInvoice()
+        public void TestInvoicesSearchGet()
+        {
+            var options = new InvoiceSearchOptions
+            {
+                Query = "total>999 AND metadata['order_id']:'6735'",
+            };
+            var service = new InvoiceService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestInvoicesSendPost()
+        {
+            var service = new InvoiceService(this.StripeClient);
+            service.SendInvoice("in_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestInvoicesUpcomingGet()
+        {
+            var options = new UpcomingInvoiceOptions
+            {
+                Customer = "cus_9utnxg47pWjV1e",
+            };
+            var service = new InvoiceService(this.StripeClient);
+            service.Upcoming(options);
+        }
+
+        [Fact]
+        public void TestInvoicesVoidPost()
         {
             var service = new InvoiceService(this.StripeClient);
             service.VoidInvoice("in_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestIssuingAuthorizationServiceApprove()
+        public void TestIssuingAuthorizationsApprovePost()
         {
             var service = new Stripe.Issuing.AuthorizationService(
                 this.StripeClient);
@@ -1333,7 +1425,2013 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingAuthorizationServiceCapture()
+        public void TestIssuingAuthorizationsDeclinePost()
+        {
+            var service = new Stripe.Issuing.AuthorizationService(
+                this.StripeClient);
+            service.Decline("iauth_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingAuthorizationsGet()
+        {
+            var options = new Stripe.Issuing.AuthorizationListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Issuing.AuthorizationService(
+                this.StripeClient);
+            StripeList<Stripe.Issuing.Authorization> authorizations = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestIssuingAuthorizationsGet2()
+        {
+            var service = new Stripe.Issuing.AuthorizationService(
+                this.StripeClient);
+            service.Get("iauth_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingAuthorizationsPost()
+        {
+            var options = new Stripe.Issuing.AuthorizationUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new Stripe.Issuing.AuthorizationService(
+                this.StripeClient);
+            service.Update("iauth_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestIssuingCardholdersGet()
+        {
+            var options = new Stripe.Issuing.CardholderListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Issuing.CardholderService(
+                this.StripeClient);
+            StripeList<Stripe.Issuing.Cardholder> cardholders = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestIssuingCardholdersGet2()
+        {
+            var service = new Stripe.Issuing.CardholderService(
+                this.StripeClient);
+            service.Get("ich_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingCardholdersPost()
+        {
+            var options = new Stripe.Issuing.CardholderCreateOptions
+            {
+                Type = "individual",
+                Name = "Jenny Rosen",
+                Email = "jenny.rosen@example.com",
+                PhoneNumber = "+18888675309",
+                Billing = new Stripe.Issuing.CardholderBillingOptions
+                {
+                    Address = new AddressOptions
+                    {
+                        Line1 = "1234 Main Street",
+                        City = "San Francisco",
+                        State = "CA",
+                        Country = "US",
+                        PostalCode = "94111",
+                    },
+                },
+            };
+            var service = new Stripe.Issuing.CardholderService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestIssuingCardholdersPost2()
+        {
+            var options = new Stripe.Issuing.CardholderUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new Stripe.Issuing.CardholderService(
+                this.StripeClient);
+            service.Update("ich_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestIssuingCardsGet()
+        {
+            var options = new Stripe.Issuing.CardListOptions { Limit = 3 };
+            var service = new Stripe.Issuing.CardService(this.StripeClient);
+            StripeList<Stripe.Issuing.Card> cards = service.List(options);
+        }
+
+        [Fact]
+        public void TestIssuingCardsGet2()
+        {
+            var service = new Stripe.Issuing.CardService(this.StripeClient);
+            service.Get("ic_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingCardsPost()
+        {
+            var options = new Stripe.Issuing.CardCreateOptions
+            {
+                Cardholder = "ich_xxxxxxxxxxxxx",
+                Currency = "usd",
+                Type = "virtual",
+            };
+            var service = new Stripe.Issuing.CardService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestIssuingCardsPost2()
+        {
+            var options = new Stripe.Issuing.CardUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new Stripe.Issuing.CardService(this.StripeClient);
+            service.Update("ic_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestIssuingDisputesGet()
+        {
+            var options = new Stripe.Issuing.DisputeListOptions { Limit = 3 };
+            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
+            StripeList<Stripe.Issuing.Dispute> disputes = service.List(options);
+        }
+
+        [Fact]
+        public void TestIssuingDisputesGet2()
+        {
+            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
+            service.Get("idp_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingDisputesPost()
+        {
+            var options = new Stripe.Issuing.DisputeCreateOptions
+            {
+                Transaction = "ipi_xxxxxxxxxxxxx",
+                Evidence = new Stripe.Issuing.DisputeEvidenceOptions
+                {
+                    Reason = "fraudulent",
+                    Fraudulent = new Stripe.Issuing.DisputeEvidenceFraudulentOptions
+                    {
+                        Explanation = "Purchase was unrecognized.",
+                    },
+                },
+            };
+            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestIssuingDisputesSubmitPost()
+        {
+            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
+            service.Submit("idp_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingTransactionsGet()
+        {
+            var options = new Stripe.Issuing.TransactionListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Issuing.TransactionService(
+                this.StripeClient);
+            StripeList<Stripe.Issuing.Transaction> transactions = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestIssuingTransactionsGet2()
+        {
+            var service = new Stripe.Issuing.TransactionService(
+                this.StripeClient);
+            service.Get("ipi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestIssuingTransactionsPost()
+        {
+            var options = new Stripe.Issuing.TransactionUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new Stripe.Issuing.TransactionService(
+                this.StripeClient);
+            service.Update("ipi_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestMandatesGet()
+        {
+            var service = new MandateService(this.StripeClient);
+            service.Get("mandate_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsApplyCustomerBalancePost()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.ApplyCustomerBalance("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsCancelPost()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Cancel("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsCapturePost()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Capture("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsConfirmPost()
+        {
+            var options = new PaymentIntentConfirmOptions
+            {
+                PaymentMethod = "pm_card_visa",
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Confirm("pi_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsGet()
+        {
+            var options = new PaymentIntentListOptions { Limit = 3 };
+            var service = new PaymentIntentService(this.StripeClient);
+            StripeList<PaymentIntent> paymentIntents = service.List(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsGet2()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Get("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsIncrementAuthorizationPost()
+        {
+            var options = new PaymentIntentIncrementAuthorizationOptions
+            {
+                Amount = 2099,
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.IncrementAuthorization("pi_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsPost()
+        {
+            var options = new PaymentIntentCreateOptions
+            {
+                Amount = 1099,
+                Currency = "eur",
+                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
+                {
+                    Enabled = true,
+                },
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsPost2()
+        {
+            var options = new PaymentIntentCreateOptions
+            {
+                Amount = 2000,
+                Currency = "usd",
+                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
+                {
+                    Enabled = true,
+                },
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsPost3()
+        {
+            var options = new PaymentIntentUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Update("pi_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsPost4()
+        {
+            var options = new PaymentIntentCreateOptions
+            {
+                Amount = 200,
+                Currency = "usd",
+                PaymentMethodData = new PaymentIntentPaymentMethodDataOptions
+                {
+                    Type = "p24",
+                    P24 = new PaymentIntentPaymentMethodDataP24Options
+                    {
+                        Bank = "blik",
+                    },
+                },
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsSearchGet()
+        {
+            var options = new PaymentIntentSearchOptions
+            {
+                Query = "status:'succeeded' AND metadata['order_id']:'6735'",
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestPaymentIntentsVerifyMicrodepositsPost()
+        {
+            var service = new PaymentIntentService(this.StripeClient);
+            service.VerifyMicrodeposits("pi_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentIntentsVerifyMicrodepositsPost2()
+        {
+            var options = new PaymentIntentVerifyMicrodepositsOptions
+            {
+                Amounts = new List<long?> { 32, 45 },
+            };
+            var service = new PaymentIntentService(this.StripeClient);
+            service.VerifyMicrodeposits("pi_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentLinksGet()
+        {
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Get("pl_xyz");
+        }
+
+        [Fact]
+        public void TestPaymentLinksGet2()
+        {
+            var options = new PaymentLinkListOptions { Limit = 3 };
+            var service = new PaymentLinkService(this.StripeClient);
+            StripeList<PaymentLink> paymentLinks = service.List(options);
+        }
+
+        [Fact]
+        public void TestPaymentLinksGet3()
+        {
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Get("plink_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentLinksLineItemsGet()
+        {
+            var service = new PaymentLinkService(this.StripeClient);
+            StripeList<LineItem> lineItems = service.ListLineItems("pl_xyz");
+        }
+
+        [Fact]
+        public void TestPaymentLinksPost()
+        {
+            var options = new PaymentLinkCreateOptions
+            {
+                LineItems = new List<PaymentLinkLineItemOptions>
+                {
+                    new PaymentLinkLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 1,
+                    },
+                },
+            };
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentLinksPost2()
+        {
+            var options = new PaymentLinkCreateOptions
+            {
+                LineItems = new List<PaymentLinkLineItemOptions>
+                {
+                    new PaymentLinkLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 1,
+                    },
+                },
+            };
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentLinksPost3()
+        {
+            var options = new PaymentLinkUpdateOptions { Active = false };
+            var service = new PaymentLinkService(this.StripeClient);
+            service.Update("plink_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodConfigurationsGet()
+        {
+            var options = new PaymentMethodConfigurationListOptions
+            {
+                Application = "foo",
+            };
+            var service = new PaymentMethodConfigurationService(
+                this.StripeClient);
+            StripeList<PaymentMethodConfiguration> paymentMethodConfigurations = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodConfigurationsGet2()
+        {
+            var service = new PaymentMethodConfigurationService(
+                this.StripeClient);
+            service.Get("foo");
+        }
+
+        [Fact]
+        public void TestPaymentMethodConfigurationsPost()
+        {
+            var options = new PaymentMethodConfigurationCreateOptions
+            {
+                AcssDebit = new PaymentMethodConfigurationAcssDebitOptions
+                {
+                    DisplayPreference = new PaymentMethodConfigurationAcssDebitDisplayPreferenceOptions
+                    {
+                        Preference = "none",
+                    },
+                },
+                Affirm = new PaymentMethodConfigurationAffirmOptions
+                {
+                    DisplayPreference = new PaymentMethodConfigurationAffirmDisplayPreferenceOptions
+                    {
+                        Preference = "none",
+                    },
+                },
+            };
+            var service = new PaymentMethodConfigurationService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodConfigurationsPost2()
+        {
+            var options = new PaymentMethodConfigurationUpdateOptions
+            {
+                AcssDebit = new PaymentMethodConfigurationAcssDebitOptions
+                {
+                    DisplayPreference = new PaymentMethodConfigurationAcssDebitDisplayPreferenceOptions
+                    {
+                        Preference = "on",
+                    },
+                },
+            };
+            var service = new PaymentMethodConfigurationService(
+                this.StripeClient);
+            service.Update("foo", options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodsAttachPost()
+        {
+            var options = new PaymentMethodAttachOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+            };
+            var service = new PaymentMethodService(this.StripeClient);
+            service.Attach("pm_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodsDetachPost()
+        {
+            var service = new PaymentMethodService(this.StripeClient);
+            service.Detach("pm_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentMethodsGet()
+        {
+            var options = new PaymentMethodListOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+                Type = "card",
+            };
+            var service = new PaymentMethodService(this.StripeClient);
+            StripeList<PaymentMethod> paymentMethods = service.List(options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodsGet2()
+        {
+            var service = new PaymentMethodService(this.StripeClient);
+            service.Get("pm_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPaymentMethodsPost()
+        {
+            var options = new PaymentMethodCreateOptions
+            {
+                Type = "card",
+                Card = new PaymentMethodCardOptions
+                {
+                    Number = "4242424242424242",
+                    ExpMonth = 8,
+                    ExpYear = 2024,
+                    Cvc = "314",
+                },
+            };
+            var service = new PaymentMethodService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPaymentMethodsPost2()
+        {
+            var options = new PaymentMethodUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PaymentMethodService(this.StripeClient);
+            service.Update("pm_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPayoutsCancelPost()
+        {
+            var service = new PayoutService(this.StripeClient);
+            service.Cancel("po_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPayoutsGet()
+        {
+            var options = new PayoutListOptions { Limit = 3 };
+            var service = new PayoutService(this.StripeClient);
+            StripeList<Payout> payouts = service.List(options);
+        }
+
+        [Fact]
+        public void TestPayoutsGet2()
+        {
+            var service = new PayoutService(this.StripeClient);
+            service.Get("po_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPayoutsPost()
+        {
+            var options = new PayoutCreateOptions
+            {
+                Amount = 1100,
+                Currency = "usd",
+            };
+            var service = new PayoutService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPayoutsPost2()
+        {
+            var options = new PayoutUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PayoutService(this.StripeClient);
+            service.Update("po_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPayoutsReversePost()
+        {
+            var service = new PayoutService(this.StripeClient);
+            service.Reverse("po_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPlansDelete()
+        {
+            var service = new PlanService(this.StripeClient);
+            service.Delete("price_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPlansGet()
+        {
+            var options = new PlanListOptions { Limit = 3 };
+            var service = new PlanService(this.StripeClient);
+            StripeList<Plan> plans = service.List(options);
+        }
+
+        [Fact]
+        public void TestPlansGet2()
+        {
+            var service = new PlanService(this.StripeClient);
+            service.Get("price_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPlansPost()
+        {
+            var options = new PlanCreateOptions
+            {
+                Amount = 2000,
+                Currency = "usd",
+                Interval = "month",
+                Product = "prod_xxxxxxxxxxxxx",
+            };
+            var service = new PlanService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPlansPost2()
+        {
+            var options = new PlanCreateOptions
+            {
+                Amount = 2000,
+                Currency = "usd",
+                Interval = "month",
+                Product = new PlanProductOptions { Name = "My product" },
+            };
+            var service = new PlanService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPlansPost3()
+        {
+            var options = new PlanUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PlanService(this.StripeClient);
+            service.Update("price_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPricesGet()
+        {
+            var options = new PriceListOptions { Limit = 3 };
+            var service = new PriceService(this.StripeClient);
+            StripeList<Price> prices = service.List(options);
+        }
+
+        [Fact]
+        public void TestPricesGet2()
+        {
+            var service = new PriceService(this.StripeClient);
+            service.Get("price_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPricesPost()
+        {
+            var options = new PriceCreateOptions
+            {
+                UnitAmount = 2000,
+                Currency = "usd",
+                CurrencyOptions = new Dictionary<string, PriceCurrencyOptionsOptions>
+                {
+                    {
+                        "uah", new PriceCurrencyOptionsOptions
+                        {
+                            UnitAmount = 5000,
+                        }
+                    },
+                    {
+                        "eur", new PriceCurrencyOptionsOptions
+                        {
+                            UnitAmount = 1800,
+                        }
+                    },
+                },
+                Recurring = new PriceRecurringOptions { Interval = "month" },
+                Product = "prod_xxxxxxxxxxxxx",
+            };
+            var service = new PriceService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPricesPost2()
+        {
+            var options = new PriceCreateOptions
+            {
+                UnitAmount = 2000,
+                Currency = "usd",
+                Recurring = new PriceRecurringOptions { Interval = "month" },
+                Product = "prod_xxxxxxxxxxxxx",
+            };
+            var service = new PriceService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPricesPost3()
+        {
+            var options = new PriceUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PriceService(this.StripeClient);
+            service.Update("price_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestPricesSearchGet()
+        {
+            var options = new PriceSearchOptions
+            {
+                Query = "active:'true' AND metadata['order_id']:'6735'",
+            };
+            var service = new PriceService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestProductsDelete()
+        {
+            var service = new ProductService(this.StripeClient);
+            service.Delete("prod_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestProductsGet()
+        {
+            var options = new ProductListOptions { Limit = 3 };
+            var service = new ProductService(this.StripeClient);
+            StripeList<Product> products = service.List(options);
+        }
+
+        [Fact]
+        public void TestProductsGet2()
+        {
+            var service = new ProductService(this.StripeClient);
+            service.Get("prod_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestProductsPost()
+        {
+            var options = new ProductCreateOptions { Name = "Gold Special" };
+            var service = new ProductService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestProductsPost2()
+        {
+            var options = new ProductUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new ProductService(this.StripeClient);
+            service.Update("prod_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestProductsSearchGet()
+        {
+            var options = new ProductSearchOptions
+            {
+                Query = "active:'true' AND metadata['order_id']:'6735'",
+            };
+            var service = new ProductService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestPromotionCodesGet()
+        {
+            var options = new PromotionCodeListOptions { Limit = 3 };
+            var service = new PromotionCodeService(this.StripeClient);
+            StripeList<PromotionCode> promotionCodes = service.List(options);
+        }
+
+        [Fact]
+        public void TestPromotionCodesGet2()
+        {
+            var service = new PromotionCodeService(this.StripeClient);
+            service.Get("promo_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestPromotionCodesPost()
+        {
+            var options = new PromotionCodeCreateOptions
+            {
+                Coupon = "Z4OV52SU",
+            };
+            var service = new PromotionCodeService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestPromotionCodesPost2()
+        {
+            var options = new PromotionCodeUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new PromotionCodeService(this.StripeClient);
+            service.Update("promo_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestQuotesAcceptPost()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Accept("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesCancelPost()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Cancel("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesFinalizePost()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.FinalizeQuote("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesGet()
+        {
+            var options = new QuoteListOptions { Limit = 3 };
+            var service = new QuoteService(this.StripeClient);
+            StripeList<Quote> quotes = service.List(options);
+        }
+
+        [Fact]
+        public void TestQuotesGet2()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Get("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesLineItemsGet()
+        {
+            var service = new QuoteService(this.StripeClient);
+            StripeList<LineItem> lineItems = service.ListLineItems(
+                "qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesPdfGet()
+        {
+            var service = new QuoteService(this.StripeClient);
+            service.Pdf("qt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestQuotesPost()
+        {
+            var options = new QuoteCreateOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+                LineItems = new List<QuoteLineItemOptions>
+                {
+                    new QuoteLineItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                        Quantity = 2,
+                    },
+                },
+            };
+            var service = new QuoteService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestQuotesPost2()
+        {
+            var options = new QuoteUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new QuoteService(this.StripeClient);
+            service.Update("qt_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestRadarEarlyFraudWarningsGet()
+        {
+            var options = new Stripe.Radar.EarlyFraudWarningListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Radar.EarlyFraudWarningService(
+                this.StripeClient);
+            StripeList<Stripe.Radar.EarlyFraudWarning> earlyFraudWarnings = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestRadarEarlyFraudWarningsGet2()
+        {
+            var service = new Stripe.Radar.EarlyFraudWarningService(
+                this.StripeClient);
+            service.Get("issfr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRadarValueListItemsDelete()
+        {
+            var service = new Stripe.Radar.ValueListItemService(
+                this.StripeClient);
+            service.Delete("rsli_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRadarValueListItemsGet()
+        {
+            var options = new Stripe.Radar.ValueListItemListOptions
+            {
+                Limit = 3,
+                ValueList = "rsl_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.Radar.ValueListItemService(
+                this.StripeClient);
+            StripeList<Stripe.Radar.ValueListItem> valueListItems = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestRadarValueListItemsGet2()
+        {
+            var service = new Stripe.Radar.ValueListItemService(
+                this.StripeClient);
+            service.Get("rsli_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRadarValueListItemsPost()
+        {
+            var options = new Stripe.Radar.ValueListItemCreateOptions
+            {
+                ValueList = "rsl_xxxxxxxxxxxxx",
+                Value = "1.2.3.4",
+            };
+            var service = new Stripe.Radar.ValueListItemService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestRadarValueListsDelete()
+        {
+            var service = new Stripe.Radar.ValueListService(this.StripeClient);
+            service.Delete("rsl_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRadarValueListsGet()
+        {
+            var options = new Stripe.Radar.ValueListListOptions { Limit = 3 };
+            var service = new Stripe.Radar.ValueListService(this.StripeClient);
+            StripeList<Stripe.Radar.ValueList> valueLists = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestRadarValueListsGet2()
+        {
+            var service = new Stripe.Radar.ValueListService(this.StripeClient);
+            service.Get("rsl_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRadarValueListsPost()
+        {
+            var options = new Stripe.Radar.ValueListCreateOptions
+            {
+                Alias = "custom_ip_xxxxxxxxxxxxx",
+                Name = "Custom IP Blocklist",
+                ItemType = "ip_address",
+            };
+            var service = new Stripe.Radar.ValueListService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestRadarValueListsPost2()
+        {
+            var options = new Stripe.Radar.ValueListUpdateOptions
+            {
+                Name = "Updated IP Block List",
+            };
+            var service = new Stripe.Radar.ValueListService(this.StripeClient);
+            service.Update("rsl_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestRefundsCancelPost()
+        {
+            var service = new RefundService(this.StripeClient);
+            service.Cancel("re_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRefundsGet()
+        {
+            var options = new RefundListOptions { Limit = 3 };
+            var service = new RefundService(this.StripeClient);
+            StripeList<Refund> refunds = service.List(options);
+        }
+
+        [Fact]
+        public void TestRefundsGet2()
+        {
+            var service = new RefundService(this.StripeClient);
+            service.Get("re_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestRefundsPost()
+        {
+            var options = new RefundCreateOptions
+            {
+                Charge = "ch_xxxxxxxxxxxxx",
+            };
+            var service = new RefundService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestRefundsPost2()
+        {
+            var options = new RefundUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new RefundService(this.StripeClient);
+            service.Update("re_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestReportingReportRunsGet()
+        {
+            var options = new Stripe.Reporting.ReportRunListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Reporting.ReportRunService(
+                this.StripeClient);
+            StripeList<Stripe.Reporting.ReportRun> reportRuns = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestReportingReportRunsGet2()
+        {
+            var service = new Stripe.Reporting.ReportRunService(
+                this.StripeClient);
+            service.Get("frr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestReportingReportRunsPost()
+        {
+            var options = new Stripe.Reporting.ReportRunCreateOptions
+            {
+                ReportType = "balance.summary.1",
+                Parameters = new Stripe.Reporting.ReportRunParametersOptions
+                {
+                    IntervalStart = DateTimeOffset.FromUnixTimeSeconds(
+                        1522540800)
+                        .UtcDateTime,
+                    IntervalEnd = DateTimeOffset.FromUnixTimeSeconds(1525132800)
+                        .UtcDateTime,
+                },
+            };
+            var service = new Stripe.Reporting.ReportRunService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestReportingReportTypesGet()
+        {
+            var service = new Stripe.Reporting.ReportTypeService(
+                this.StripeClient);
+            StripeList<Stripe.Reporting.ReportType> reportTypes = service
+                .List();
+        }
+
+        [Fact]
+        public void TestReportingReportTypesGet2()
+        {
+            var service = new Stripe.Reporting.ReportTypeService(
+                this.StripeClient);
+            service.Get("balance.summary.1");
+        }
+
+        [Fact]
+        public void TestReviewsApprovePost()
+        {
+            var service = new ReviewService(this.StripeClient);
+            service.Approve("prv_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestReviewsGet()
+        {
+            var options = new ReviewListOptions { Limit = 3 };
+            var service = new ReviewService(this.StripeClient);
+            StripeList<Review> reviews = service.List(options);
+        }
+
+        [Fact]
+        public void TestReviewsGet2()
+        {
+            var service = new ReviewService(this.StripeClient);
+            service.Get("prv_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSetupAttemptsGet()
+        {
+            var options = new SetupAttemptListOptions
+            {
+                Limit = 3,
+                SetupIntent = "si_xyz",
+            };
+            var service = new SetupAttemptService(this.StripeClient);
+            StripeList<SetupAttempt> setupAttempts = service.List(options);
+        }
+
+        [Fact]
+        public void TestSetupIntentsCancelPost()
+        {
+            var service = new SetupIntentService(this.StripeClient);
+            service.Cancel("seti_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSetupIntentsConfirmPost()
+        {
+            var options = new SetupIntentConfirmOptions
+            {
+                PaymentMethod = "pm_card_visa",
+            };
+            var service = new SetupIntentService(this.StripeClient);
+            service.Confirm("seti_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSetupIntentsGet()
+        {
+            var options = new SetupIntentListOptions { Limit = 3 };
+            var service = new SetupIntentService(this.StripeClient);
+            StripeList<SetupIntent> setupIntents = service.List(options);
+        }
+
+        [Fact]
+        public void TestSetupIntentsGet2()
+        {
+            var service = new SetupIntentService(this.StripeClient);
+            service.Get("seti_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSetupIntentsPost()
+        {
+            var options = new SetupIntentCreateOptions
+            {
+                PaymentMethodTypes = new List<string> { "card" },
+            };
+            var service = new SetupIntentService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestSetupIntentsPost2()
+        {
+            var options = new SetupIntentUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "user_id", "3435453" },
+                },
+            };
+            var service = new SetupIntentService(this.StripeClient);
+            service.Update("seti_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSetupIntentsVerifyMicrodepositsPost()
+        {
+            var service = new SetupIntentService(this.StripeClient);
+            service.VerifyMicrodeposits("seti_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSetupIntentsVerifyMicrodepositsPost2()
+        {
+            var options = new SetupIntentVerifyMicrodepositsOptions
+            {
+                Amounts = new List<long?> { 32, 45 },
+            };
+            var service = new SetupIntentService(this.StripeClient);
+            service.VerifyMicrodeposits("seti_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestShippingRatesGet()
+        {
+            var service = new ShippingRateService(this.StripeClient);
+            StripeList<ShippingRate> shippingRates = service.List();
+        }
+
+        [Fact]
+        public void TestShippingRatesGet2()
+        {
+            var options = new ShippingRateListOptions { Limit = 3 };
+            var service = new ShippingRateService(this.StripeClient);
+            StripeList<ShippingRate> shippingRates = service.List(options);
+        }
+
+        [Fact]
+        public void TestShippingRatesGet3()
+        {
+            var service = new ShippingRateService(this.StripeClient);
+            service.Get("shr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestShippingRatesPost()
+        {
+            var options = new ShippingRateCreateOptions
+            {
+                DisplayName = "Sample Shipper",
+                FixedAmount = new ShippingRateFixedAmountOptions
+                {
+                    Currency = "usd",
+                    Amount = 400,
+                },
+                Type = "fixed_amount",
+            };
+            var service = new ShippingRateService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestShippingRatesPost2()
+        {
+            var options = new ShippingRateCreateOptions
+            {
+                DisplayName = "Ground shipping",
+                Type = "fixed_amount",
+                FixedAmount = new ShippingRateFixedAmountOptions
+                {
+                    Amount = 500,
+                    Currency = "usd",
+                },
+            };
+            var service = new ShippingRateService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestShippingRatesPost3()
+        {
+            var options = new ShippingRateUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new ShippingRateService(this.StripeClient);
+            service.Update("shr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSigmaScheduledQueryRunsGet()
+        {
+            var options = new Stripe.Sigma.ScheduledQueryRunListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Sigma.ScheduledQueryRunService(
+                this.StripeClient);
+            StripeList<Stripe.Sigma.ScheduledQueryRun> scheduledQueryRuns = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestSigmaScheduledQueryRunsGet2()
+        {
+            var service = new Stripe.Sigma.ScheduledQueryRunService(
+                this.StripeClient);
+            service.Get("sqr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSourcesGet()
+        {
+            var service = new SourceService(this.StripeClient);
+            service.Get("src_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSourcesGet2()
+        {
+            var service = new SourceService(this.StripeClient);
+            service.Get("src_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSourcesPost()
+        {
+            var options = new SourceUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new SourceService(this.StripeClient);
+            service.Update("src_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsDelete()
+        {
+            var service = new SubscriptionItemService(this.StripeClient);
+            service.Delete("si_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsGet()
+        {
+            var options = new SubscriptionItemListOptions
+            {
+                Subscription = "sub_xxxxxxxxxxxxx",
+            };
+            var service = new SubscriptionItemService(this.StripeClient);
+            StripeList<SubscriptionItem> subscriptionItems = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsGet2()
+        {
+            var service = new SubscriptionItemService(this.StripeClient);
+            service.Get("si_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsPost()
+        {
+            var options = new SubscriptionItemCreateOptions
+            {
+                Subscription = "sub_xxxxxxxxxxxxx",
+                Price = "price_xxxxxxxxxxxxx",
+                Quantity = 2,
+            };
+            var service = new SubscriptionItemService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsPost2()
+        {
+            var options = new SubscriptionItemUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new SubscriptionItemService(this.StripeClient);
+            service.Update("si_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsUsageRecordSummariesGet()
+        {
+            var options = new UsageRecordSummaryListOptions { Limit = 3 };
+            var service = new UsageRecordSummaryService(this.StripeClient);
+            StripeList<UsageRecordSummary> usageRecordSummaries = service.List(
+                "si_xxxxxxxxxxxxx",
+                options);
+        }
+
+        [Fact]
+        public void TestSubscriptionItemsUsageRecordsPost()
+        {
+            var options = new UsageRecordCreateOptions
+            {
+                Quantity = 100,
+                Timestamp = DateTimeOffset.FromUnixTimeSeconds(1571252444)
+                    .UtcDateTime,
+            };
+            var service = new UsageRecordService(this.StripeClient);
+            service.Create("si_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesCancelPost()
+        {
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            service.Cancel("sub_sched_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesGet()
+        {
+            var options = new SubscriptionScheduleListOptions { Limit = 3 };
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            StripeList<SubscriptionSchedule> subscriptionSchedules = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesGet2()
+        {
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            service.Get("sub_sched_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesPost()
+        {
+            var options = new SubscriptionScheduleCreateOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+                StartDate = DateTimeOffset.FromUnixTimeSeconds(1676070661)
+                    .UtcDateTime,
+                EndBehavior = "release",
+                Phases = new List<SubscriptionSchedulePhaseOptions>
+                {
+                    new SubscriptionSchedulePhaseOptions
+                    {
+                        Items = new List<SubscriptionSchedulePhaseItemOptions>
+                        {
+                            new SubscriptionSchedulePhaseItemOptions
+                            {
+                                Price = "price_xxxxxxxxxxxxx",
+                                Quantity = 1,
+                            },
+                        },
+                        Iterations = 12,
+                    },
+                },
+            };
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesPost2()
+        {
+            var options = new SubscriptionScheduleUpdateOptions
+            {
+                EndBehavior = "release",
+            };
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            service.Update("sub_sched_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSubscriptionSchedulesReleasePost()
+        {
+            var service = new SubscriptionScheduleService(this.StripeClient);
+            service.Release("sub_sched_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionsDelete()
+        {
+            var service = new SubscriptionService(this.StripeClient);
+            service.Cancel("sub_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionsDiscountDelete()
+        {
+            var service = new DiscountService(this.StripeClient);
+            service.DeleteSubscriptionDiscount("sub_xyz");
+        }
+
+        [Fact]
+        public void TestSubscriptionsGet()
+        {
+            var options = new SubscriptionListOptions { Limit = 3 };
+            var service = new SubscriptionService(this.StripeClient);
+            StripeList<Subscription> subscriptions = service.List(options);
+        }
+
+        [Fact]
+        public void TestSubscriptionsGet2()
+        {
+            var service = new SubscriptionService(this.StripeClient);
+            service.Get("sub_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestSubscriptionsPost()
+        {
+            var options = new SubscriptionCreateOptions
+            {
+                Customer = "cus_xxxxxxxxxxxxx",
+                Items = new List<SubscriptionItemOptions>
+                {
+                    new SubscriptionItemOptions
+                    {
+                        Price = "price_xxxxxxxxxxxxx",
+                    },
+                },
+            };
+            var service = new SubscriptionService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestSubscriptionsPost2()
+        {
+            var options = new SubscriptionUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new SubscriptionService(this.StripeClient);
+            service.Update("sub_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestSubscriptionsSearchGet()
+        {
+            var options = new SubscriptionSearchOptions
+            {
+                Query = "status:'active' AND metadata['order_id']:'6735'",
+            };
+            var service = new SubscriptionService(this.StripeClient);
+            service.Search(options);
+        }
+
+        [Fact]
+        public void TestTaxCalculationsLineItemsGet()
+        {
+            var service = new Stripe.Tax.CalculationService(this.StripeClient);
+            StripeList<Stripe.Tax.CalculationLineItem> calculationLineItems = service
+                .ListLineItems("xxx");
+        }
+
+        [Fact]
+        public void TestTaxCalculationsPost()
+        {
+            var options = new Stripe.Tax.CalculationCreateOptions
+            {
+                Currency = "usd",
+                LineItems = new List<Stripe.Tax.CalculationLineItemOptions>
+                {
+                    new Stripe.Tax.CalculationLineItemOptions
+                    {
+                        Amount = 1000,
+                        Reference = "L1",
+                    },
+                },
+                CustomerDetails = new Stripe.Tax.CalculationCustomerDetailsOptions
+                {
+                    Address = new AddressOptions
+                    {
+                        Line1 = "354 Oyster Point Blvd",
+                        City = "South San Francisco",
+                        State = "CA",
+                        PostalCode = "94080",
+                        Country = "US",
+                    },
+                    AddressSource = "shipping",
+                },
+            };
+            var service = new Stripe.Tax.CalculationService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTaxCodesGet()
+        {
+            var options = new TaxCodeListOptions { Limit = 3 };
+            var service = new TaxCodeService(this.StripeClient);
+            StripeList<TaxCode> taxCodes = service.List(options);
+        }
+
+        [Fact]
+        public void TestTaxCodesGet2()
+        {
+            var service = new TaxCodeService(this.StripeClient);
+            service.Get("txcd_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTaxRatesGet()
+        {
+            var options = new TaxRateListOptions { Limit = 3 };
+            var service = new TaxRateService(this.StripeClient);
+            StripeList<TaxRate> taxRates = service.List(options);
+        }
+
+        [Fact]
+        public void TestTaxRatesGet2()
+        {
+            var service = new TaxRateService(this.StripeClient);
+            service.Get("txr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTaxRatesPost()
+        {
+            var options = new TaxRateCreateOptions
+            {
+                DisplayName = "VAT",
+                Description = "VAT Germany",
+                Jurisdiction = "DE",
+                Percentage = 16M,
+                Inclusive = false,
+            };
+            var service = new TaxRateService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTaxRatesPost2()
+        {
+            var options = new TaxRateUpdateOptions { Active = false };
+            var service = new TaxRateService(this.StripeClient);
+            service.Update("txr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTaxTransactionsCreateFromCalculationPost()
+        {
+            var options = new Stripe.Tax.TransactionCreateFromCalculationOptions
+            {
+                Calculation = "xxx",
+                Reference = "yyy",
+            };
+            var service = new Stripe.Tax.TransactionService(this.StripeClient);
+            service.CreateFromCalculation(options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsDelete()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Delete("uc_123");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsDelete2()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Delete("tmc_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsGet()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            StripeList<Stripe.Terminal.Configuration> configurations = service
+                .List();
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsGet2()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Get("uc_123");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsGet3()
+        {
+            var options = new Stripe.Terminal.ConfigurationListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            StripeList<Stripe.Terminal.Configuration> configurations = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsGet4()
+        {
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Get("tmc_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsPost()
+        {
+            var options = new Stripe.Terminal.ConfigurationCreateOptions();
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsPost2()
+        {
+            var options = new Stripe.Terminal.ConfigurationUpdateOptions
+            {
+                Tipping = new Stripe.Terminal.ConfigurationTippingOptions
+                {
+                    Usd = new Stripe.Terminal.ConfigurationTippingUsdOptions
+                    {
+                        FixedAmounts = new List<long?> { 10 },
+                    },
+                },
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Update("uc_123", options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsPost3()
+        {
+            var options = new Stripe.Terminal.ConfigurationCreateOptions
+            {
+                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
+                {
+                    Splashscreen = "file_xxxxxxxxxxxxx",
+                },
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTerminalConfigurationsPost4()
+        {
+            var options = new Stripe.Terminal.ConfigurationUpdateOptions
+            {
+                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
+                {
+                    Splashscreen = "file_xxxxxxxxxxxxx",
+                },
+            };
+            var service = new Stripe.Terminal.ConfigurationService(
+                this.StripeClient);
+            service.Update("tmc_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTerminalConnectionTokensPost()
+        {
+            var options = new Stripe.Terminal.ConnectionTokenCreateOptions();
+            var service = new Stripe.Terminal.ConnectionTokenService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTerminalLocationsDelete()
+        {
+            var service = new Stripe.Terminal.LocationService(
+                this.StripeClient);
+            service.Delete("tml_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalLocationsGet()
+        {
+            var options = new Stripe.Terminal.LocationListOptions { Limit = 3 };
+            var service = new Stripe.Terminal.LocationService(
+                this.StripeClient);
+            StripeList<Stripe.Terminal.Location> locations = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTerminalLocationsGet2()
+        {
+            var service = new Stripe.Terminal.LocationService(
+                this.StripeClient);
+            service.Get("tml_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalLocationsPost()
+        {
+            var options = new Stripe.Terminal.LocationCreateOptions
+            {
+                DisplayName = "My First Store",
+                Address = new AddressOptions
+                {
+                    Line1 = "1234 Main Street",
+                    City = "San Francisco",
+                    PostalCode = "94111",
+                    State = "CA",
+                    Country = "US",
+                },
+            };
+            var service = new Stripe.Terminal.LocationService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTerminalLocationsPost2()
+        {
+            var options = new Stripe.Terminal.LocationUpdateOptions
+            {
+                DisplayName = "My First Store",
+            };
+            var service = new Stripe.Terminal.LocationService(
+                this.StripeClient);
+            service.Update("tml_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTerminalReadersCancelActionPost()
+        {
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.CancelAction("tmr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalReadersDelete()
+        {
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.Delete("tmr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalReadersGet()
+        {
+            var options = new Stripe.Terminal.ReaderListOptions { Limit = 3 };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            StripeList<Stripe.Terminal.Reader> readers = service.List(options);
+        }
+
+        [Fact]
+        public void TestTerminalReadersGet2()
+        {
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.Get("tmr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTerminalReadersPost()
+        {
+            var options = new Stripe.Terminal.ReaderCreateOptions
+            {
+                RegistrationCode = "puppies-plug-could",
+                Label = "Blue Rabbit",
+                Location = "tml_1234",
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTerminalReadersPost2()
+        {
+            var options = new Stripe.Terminal.ReaderUpdateOptions
+            {
+                Label = "Blue Rabbit",
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.Update("tmr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTerminalReadersProcessPaymentIntentPost()
+        {
+            var options = new Stripe.Terminal.ReaderProcessPaymentIntentOptions
+            {
+                PaymentIntent = "pi_xxxxxxxxxxxxx",
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.ProcessPaymentIntent("tmr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTerminalReadersProcessSetupIntentPost()
+        {
+            var options = new Stripe.Terminal.ReaderProcessSetupIntentOptions
+            {
+                SetupIntent = "seti_xxxxxxxxxxxxx",
+                CustomerConsentCollected = true,
+            };
+            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
+            service.ProcessSetupIntent("tmr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersCustomersFundCashBalancePost()
+        {
+            var options = new Stripe.TestHelpers.CustomerFundCashBalanceOptions
+            {
+                Amount = 30,
+                Currency = "eur",
+            };
+            var service = new Stripe.TestHelpers.CustomerService(
+                this.StripeClient);
+            service.FundCashBalance("cus_123", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersIssuingAuthorizationsCapturePost()
         {
             var options = new Stripe.TestHelpers.Issuing.AuthorizationCaptureOptions
             {
@@ -1395,7 +3493,28 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingAuthorizationServiceCreate()
+        public void TestTestHelpersIssuingAuthorizationsExpirePost()
+        {
+            var service = new Stripe.TestHelpers.Issuing.AuthorizationService(
+                this.StripeClient);
+            service.Expire("example_authorization");
+        }
+
+        [Fact]
+        public void TestTestHelpersIssuingAuthorizationsIncrementPost()
+        {
+            var options = new Stripe.TestHelpers.Issuing.AuthorizationIncrementOptions
+            {
+                IncrementAmount = 50,
+                IsAmountControllable = true,
+            };
+            var service = new Stripe.TestHelpers.Issuing.AuthorizationService(
+                this.StripeClient);
+            service.Increment("example_authorization", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersIssuingAuthorizationsPost()
         {
             var options = new Stripe.TestHelpers.Issuing.AuthorizationCreateOptions
             {
@@ -1439,57 +3558,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingAuthorizationServiceDecline()
-        {
-            var service = new Stripe.Issuing.AuthorizationService(
-                this.StripeClient);
-            service.Decline("iauth_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingAuthorizationServiceExpire()
-        {
-            var service = new Stripe.TestHelpers.Issuing.AuthorizationService(
-                this.StripeClient);
-            service.Expire("example_authorization");
-        }
-
-        [Fact]
-        public void TestIssuingAuthorizationServiceIncrement()
-        {
-            var options = new Stripe.TestHelpers.Issuing.AuthorizationIncrementOptions
-            {
-                IncrementAmount = 50,
-                IsAmountControllable = true,
-            };
-            var service = new Stripe.TestHelpers.Issuing.AuthorizationService(
-                this.StripeClient);
-            service.Increment("example_authorization", options);
-        }
-
-        [Fact]
-        public void TestIssuingAuthorizationServiceList()
-        {
-            var options = new Stripe.Issuing.AuthorizationListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Issuing.AuthorizationService(
-                this.StripeClient);
-            StripeList<Stripe.Issuing.Authorization> authorizations = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestIssuingAuthorizationServiceRetrieve()
-        {
-            var service = new Stripe.Issuing.AuthorizationService(
-                this.StripeClient);
-            service.Get("iauth_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingAuthorizationServiceReverse()
+        public void TestTestHelpersIssuingAuthorizationsReversePost()
         {
             var options = new Stripe.TestHelpers.Issuing.AuthorizationReverseOptions
             {
@@ -1501,97 +3570,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingAuthorizationServiceUpdate()
-        {
-            var options = new Stripe.Issuing.AuthorizationUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new Stripe.Issuing.AuthorizationService(
-                this.StripeClient);
-            service.Update("iauth_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestIssuingCardholderServiceCreate()
-        {
-            var options = new Stripe.Issuing.CardholderCreateOptions
-            {
-                Type = "individual",
-                Name = "Jenny Rosen",
-                Email = "jenny.rosen@example.com",
-                PhoneNumber = "+18888675309",
-                Billing = new Stripe.Issuing.CardholderBillingOptions
-                {
-                    Address = new AddressOptions
-                    {
-                        Line1 = "1234 Main Street",
-                        City = "San Francisco",
-                        State = "CA",
-                        Country = "US",
-                        PostalCode = "94111",
-                    },
-                },
-            };
-            var service = new Stripe.Issuing.CardholderService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestIssuingCardholderServiceList()
-        {
-            var options = new Stripe.Issuing.CardholderListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Issuing.CardholderService(
-                this.StripeClient);
-            StripeList<Stripe.Issuing.Cardholder> cardholders = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestIssuingCardholderServiceRetrieve()
-        {
-            var service = new Stripe.Issuing.CardholderService(
-                this.StripeClient);
-            service.Get("ich_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingCardholderServiceUpdate()
-        {
-            var options = new Stripe.Issuing.CardholderUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new Stripe.Issuing.CardholderService(
-                this.StripeClient);
-            service.Update("ich_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestIssuingCardServiceCreate()
-        {
-            var options = new Stripe.Issuing.CardCreateOptions
-            {
-                Cardholder = "ich_xxxxxxxxxxxxx",
-                Currency = "usd",
-                Type = "virtual",
-            };
-            var service = new Stripe.Issuing.CardService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestIssuingCardServiceDeliverCard()
+        public void TestTestHelpersIssuingCardsShippingDeliverPost()
         {
             var service = new Stripe.TestHelpers.Issuing.CardService(
                 this.StripeClient);
@@ -1599,7 +3578,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingCardServiceFailCard()
+        public void TestTestHelpersIssuingCardsShippingFailPost()
         {
             var service = new Stripe.TestHelpers.Issuing.CardService(
                 this.StripeClient);
@@ -1607,22 +3586,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingCardServiceList()
-        {
-            var options = new Stripe.Issuing.CardListOptions { Limit = 3 };
-            var service = new Stripe.Issuing.CardService(this.StripeClient);
-            StripeList<Stripe.Issuing.Card> cards = service.List(options);
-        }
-
-        [Fact]
-        public void TestIssuingCardServiceRetrieve()
-        {
-            var service = new Stripe.Issuing.CardService(this.StripeClient);
-            service.Get("ic_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingCardServiceReturnCard()
+        public void TestTestHelpersIssuingCardsShippingReturnPost()
         {
             var service = new Stripe.TestHelpers.Issuing.CardService(
                 this.StripeClient);
@@ -1630,7 +3594,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingCardServiceShipCard()
+        public void TestTestHelpersIssuingCardsShippingShipPost()
         {
             var service = new Stripe.TestHelpers.Issuing.CardService(
                 this.StripeClient);
@@ -1638,62 +3602,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingCardServiceUpdate()
-        {
-            var options = new Stripe.Issuing.CardUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new Stripe.Issuing.CardService(this.StripeClient);
-            service.Update("ic_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestIssuingDisputeServiceCreate()
-        {
-            var options = new Stripe.Issuing.DisputeCreateOptions
-            {
-                Transaction = "ipi_xxxxxxxxxxxxx",
-                Evidence = new Stripe.Issuing.DisputeEvidenceOptions
-                {
-                    Reason = "fraudulent",
-                    Fraudulent = new Stripe.Issuing.DisputeEvidenceFraudulentOptions
-                    {
-                        Explanation = "Purchase was unrecognized.",
-                    },
-                },
-            };
-            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestIssuingDisputeServiceList()
-        {
-            var options = new Stripe.Issuing.DisputeListOptions { Limit = 3 };
-            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
-            StripeList<Stripe.Issuing.Dispute> disputes = service.List(options);
-        }
-
-        [Fact]
-        public void TestIssuingDisputeServiceRetrieve()
-        {
-            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
-            service.Get("idp_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingDisputeServiceSubmit()
-        {
-            var service = new Stripe.Issuing.DisputeService(this.StripeClient);
-            service.Submit("idp_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingTransactionServiceCreateForceCapture()
+        public void TestTestHelpersIssuingTransactionsCreateForceCapturePost()
         {
             var options = new Stripe.TestHelpers.Issuing.TransactionCreateForceCaptureOptions
             {
@@ -1767,7 +3676,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingTransactionServiceCreateUnlinkedRefund()
+        public void TestTestHelpersIssuingTransactionsCreateUnlinkedRefundPost()
         {
             var options = new Stripe.TestHelpers.Issuing.TransactionCreateUnlinkedRefundOptions
             {
@@ -1841,20 +3750,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingTransactionServiceList()
-        {
-            var options = new Stripe.Issuing.TransactionListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Issuing.TransactionService(
-                this.StripeClient);
-            StripeList<Stripe.Issuing.Transaction> transactions = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestIssuingTransactionServiceRefund()
+        public void TestTestHelpersIssuingTransactionsRefundPost()
         {
             var options = new Stripe.TestHelpers.Issuing.TransactionRefundOptions
             {
@@ -1866,965 +3762,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestIssuingTransactionServiceRetrieve()
-        {
-            var service = new Stripe.Issuing.TransactionService(
-                this.StripeClient);
-            service.Get("ipi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestIssuingTransactionServiceUpdate()
-        {
-            var options = new Stripe.Issuing.TransactionUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new Stripe.Issuing.TransactionService(
-                this.StripeClient);
-            service.Update("ipi_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestLoginLinkServiceCreate()
-        {
-            var service = new LoginLinkService(this.StripeClient);
-            service.Create("acct_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestMandateServiceRetrieve()
-        {
-            var service = new MandateService(this.StripeClient);
-            service.Get("mandate_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceApplyCustomerBalance()
-        {
-            var service = new PaymentIntentService(this.StripeClient);
-            service.ApplyCustomerBalance("pi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceCancel()
-        {
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Cancel("pi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceCapture()
-        {
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Capture("pi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceConfirm()
-        {
-            var options = new PaymentIntentConfirmOptions
-            {
-                PaymentMethod = "pm_card_visa",
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Confirm("pi_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceCreate()
-        {
-            var options = new PaymentIntentCreateOptions
-            {
-                Amount = 1099,
-                Currency = "eur",
-                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
-                {
-                    Enabled = true,
-                },
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceCreate2()
-        {
-            var options = new PaymentIntentCreateOptions
-            {
-                Amount = 2000,
-                Currency = "usd",
-                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
-                {
-                    Enabled = true,
-                },
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceCreate3()
-        {
-            var options = new PaymentIntentCreateOptions
-            {
-                Amount = 200,
-                Currency = "usd",
-                PaymentMethodData = new PaymentIntentPaymentMethodDataOptions
-                {
-                    Type = "p24",
-                    P24 = new PaymentIntentPaymentMethodDataP24Options
-                    {
-                        Bank = "blik",
-                    },
-                },
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceIncrementAuthorization()
-        {
-            var options = new PaymentIntentIncrementAuthorizationOptions
-            {
-                Amount = 2099,
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.IncrementAuthorization("pi_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceList()
-        {
-            var options = new PaymentIntentListOptions { Limit = 3 };
-            var service = new PaymentIntentService(this.StripeClient);
-            StripeList<PaymentIntent> paymentintents = service.List(options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceRetrieve()
-        {
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Get("pi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceSearch()
-        {
-            var options = new PaymentIntentSearchOptions
-            {
-                Query = "status:'succeeded' AND metadata['order_id']:'6735'",
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Search(options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceUpdate()
-        {
-            var options = new PaymentIntentUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.Update("pi_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceVerifyMicrodeposits()
-        {
-            var service = new PaymentIntentService(this.StripeClient);
-            service.VerifyMicrodeposits("pi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentIntentServiceVerifyMicrodeposits2()
-        {
-            var options = new PaymentIntentVerifyMicrodepositsOptions
-            {
-                Amounts = new List<long?> { 32, 45 },
-            };
-            var service = new PaymentIntentService(this.StripeClient);
-            service.VerifyMicrodeposits("pi_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceCreate()
-        {
-            var options = new PaymentLinkCreateOptions
-            {
-                LineItems = new List<PaymentLinkLineItemOptions>
-                {
-                    new PaymentLinkLineItemOptions
-                    {
-                        Price = "price_xxxxxxxxxxxxx",
-                        Quantity = 1,
-                    },
-                },
-            };
-            var service = new PaymentLinkService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceCreate2()
-        {
-            var options = new PaymentLinkCreateOptions
-            {
-                LineItems = new List<PaymentLinkLineItemOptions>
-                {
-                    new PaymentLinkLineItemOptions
-                    {
-                        Price = "price_xxxxxxxxxxxxx",
-                        Quantity = 1,
-                    },
-                },
-            };
-            var service = new PaymentLinkService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceList()
-        {
-            var options = new PaymentLinkListOptions { Limit = 3 };
-            var service = new PaymentLinkService(this.StripeClient);
-            StripeList<PaymentLink> paymentlinks = service.List(options);
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceListLineItems()
-        {
-            var service = new PaymentLinkService(this.StripeClient);
-            service.ListLineItems("pl_xyz");
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceRetrieve()
-        {
-            var service = new PaymentLinkService(this.StripeClient);
-            service.Get("pl_xyz");
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceRetrieve2()
-        {
-            var service = new PaymentLinkService(this.StripeClient);
-            service.Get("plink_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentLinkServiceUpdate()
-        {
-            var options = new PaymentLinkUpdateOptions { Active = false };
-            var service = new PaymentLinkService(this.StripeClient);
-            service.Update("plink_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodConfigurationServiceCreate()
-        {
-            var options = new PaymentMethodConfigurationCreateOptions
-            {
-                AcssDebit = new PaymentMethodConfigurationAcssDebitOptions
-                {
-                    DisplayPreference = new PaymentMethodConfigurationAcssDebitDisplayPreferenceOptions
-                    {
-                        Preference = "none",
-                    },
-                },
-                Affirm = new PaymentMethodConfigurationAffirmOptions
-                {
-                    DisplayPreference = new PaymentMethodConfigurationAffirmDisplayPreferenceOptions
-                    {
-                        Preference = "none",
-                    },
-                },
-            };
-            var service = new PaymentMethodConfigurationService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodConfigurationServiceList()
-        {
-            var options = new PaymentMethodConfigurationListOptions
-            {
-                Application = "foo",
-            };
-            var service = new PaymentMethodConfigurationService(
-                this.StripeClient);
-            StripeList<PaymentMethodConfiguration> paymentmethodconfigurations = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodConfigurationServiceRetrieve()
-        {
-            var service = new PaymentMethodConfigurationService(
-                this.StripeClient);
-            service.Get("foo");
-        }
-
-        [Fact]
-        public void TestPaymentMethodConfigurationServiceUpdate()
-        {
-            var options = new PaymentMethodConfigurationUpdateOptions
-            {
-                AcssDebit = new PaymentMethodConfigurationAcssDebitOptions
-                {
-                    DisplayPreference = new PaymentMethodConfigurationAcssDebitDisplayPreferenceOptions
-                    {
-                        Preference = "on",
-                    },
-                },
-            };
-            var service = new PaymentMethodConfigurationService(
-                this.StripeClient);
-            service.Update("foo", options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceAttach()
-        {
-            var options = new PaymentMethodAttachOptions
-            {
-                Customer = "cus_xxxxxxxxxxxxx",
-            };
-            var service = new PaymentMethodService(this.StripeClient);
-            service.Attach("pm_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceCreate()
-        {
-            var options = new PaymentMethodCreateOptions
-            {
-                Type = "card",
-                Card = new PaymentMethodCardOptions
-                {
-                    Number = "4242424242424242",
-                    ExpMonth = 8,
-                    ExpYear = 2024,
-                    Cvc = "314",
-                },
-            };
-            var service = new PaymentMethodService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceDetach()
-        {
-            var service = new PaymentMethodService(this.StripeClient);
-            service.Detach("pm_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceList()
-        {
-            var options = new PaymentMethodListOptions
-            {
-                Customer = "cus_xxxxxxxxxxxxx",
-                Type = "card",
-            };
-            var service = new PaymentMethodService(this.StripeClient);
-            StripeList<PaymentMethod> paymentmethods = service.List(options);
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceRetrieve()
-        {
-            var service = new PaymentMethodService(this.StripeClient);
-            service.Get("pm_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPaymentMethodServiceUpdate()
-        {
-            var options = new PaymentMethodUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PaymentMethodService(this.StripeClient);
-            service.Update("pm_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPayoutServiceCancel()
-        {
-            var service = new PayoutService(this.StripeClient);
-            service.Cancel("po_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPayoutServiceCreate()
-        {
-            var options = new PayoutCreateOptions
-            {
-                Amount = 1100,
-                Currency = "usd",
-            };
-            var service = new PayoutService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPayoutServiceList()
-        {
-            var options = new PayoutListOptions { Limit = 3 };
-            var service = new PayoutService(this.StripeClient);
-            StripeList<Payout> payouts = service.List(options);
-        }
-
-        [Fact]
-        public void TestPayoutServiceRetrieve()
-        {
-            var service = new PayoutService(this.StripeClient);
-            service.Get("po_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPayoutServiceReverse()
-        {
-            var service = new PayoutService(this.StripeClient);
-            service.Reverse("po_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPayoutServiceUpdate()
-        {
-            var options = new PayoutUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PayoutService(this.StripeClient);
-            service.Update("po_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPersonServiceCreate()
-        {
-            var options = new PersonCreateOptions
-            {
-                FirstName = "Jane",
-                LastName = "Diaz",
-            };
-            var service = new PersonService(this.StripeClient);
-            service.Create("acct_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPersonServiceDelete()
-        {
-            var service = new PersonService(this.StripeClient);
-            service.Delete("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPersonServiceList()
-        {
-            var options = new PersonListOptions { Limit = 3 };
-            var service = new PersonService(this.StripeClient);
-            StripeList<Person> persons = service.List(
-                "acct_xxxxxxxxxxxxx",
-                options);
-        }
-
-        [Fact]
-        public void TestPersonServiceRetrieve()
-        {
-            var service = new PersonService(this.StripeClient);
-            service.Get("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPersonServiceUpdate()
-        {
-            var options = new PersonUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PersonService(this.StripeClient);
-            service.Update(
-                "acct_xxxxxxxxxxxxx",
-                "person_xxxxxxxxxxxxx",
-                options);
-        }
-
-        [Fact]
-        public void TestPlanServiceCreate()
-        {
-            var options = new PlanCreateOptions
-            {
-                Amount = 2000,
-                Currency = "usd",
-                Interval = "month",
-                Product = "prod_xxxxxxxxxxxxx",
-            };
-            var service = new PlanService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPlanServiceCreate2()
-        {
-            var options = new PlanCreateOptions
-            {
-                Amount = 2000,
-                Currency = "usd",
-                Interval = "month",
-                Product = new PlanProductOptions { Name = "My product" },
-            };
-            var service = new PlanService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPlanServiceDelete()
-        {
-            var service = new PlanService(this.StripeClient);
-            service.Delete("price_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPlanServiceList()
-        {
-            var options = new PlanListOptions { Limit = 3 };
-            var service = new PlanService(this.StripeClient);
-            StripeList<Plan> plans = service.List(options);
-        }
-
-        [Fact]
-        public void TestPlanServiceRetrieve()
-        {
-            var service = new PlanService(this.StripeClient);
-            service.Get("price_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPlanServiceUpdate()
-        {
-            var options = new PlanUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PlanService(this.StripeClient);
-            service.Update("price_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPriceServiceCreate()
-        {
-            var options = new PriceCreateOptions
-            {
-                UnitAmount = 2000,
-                Currency = "usd",
-                CurrencyOptions = new Dictionary<string, PriceCurrencyOptionsOptions>
-                {
-                    {
-                        "uah", new PriceCurrencyOptionsOptions
-                        {
-                            UnitAmount = 5000,
-                        }
-                    },
-                    {
-                        "eur", new PriceCurrencyOptionsOptions
-                        {
-                            UnitAmount = 1800,
-                        }
-                    },
-                },
-                Recurring = new PriceRecurringOptions { Interval = "month" },
-                Product = "prod_xxxxxxxxxxxxx",
-            };
-            var service = new PriceService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPriceServiceCreate2()
-        {
-            var options = new PriceCreateOptions
-            {
-                UnitAmount = 2000,
-                Currency = "usd",
-                Recurring = new PriceRecurringOptions { Interval = "month" },
-                Product = "prod_xxxxxxxxxxxxx",
-            };
-            var service = new PriceService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPriceServiceList()
-        {
-            var options = new PriceListOptions { Limit = 3 };
-            var service = new PriceService(this.StripeClient);
-            StripeList<Price> prices = service.List(options);
-        }
-
-        [Fact]
-        public void TestPriceServiceRetrieve()
-        {
-            var service = new PriceService(this.StripeClient);
-            service.Get("price_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPriceServiceSearch()
-        {
-            var options = new PriceSearchOptions
-            {
-                Query = "active:'true' AND metadata['order_id']:'6735'",
-            };
-            var service = new PriceService(this.StripeClient);
-            service.Search(options);
-        }
-
-        [Fact]
-        public void TestPriceServiceUpdate()
-        {
-            var options = new PriceUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PriceService(this.StripeClient);
-            service.Update("price_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestProductServiceCreate()
-        {
-            var options = new ProductCreateOptions { Name = "Gold Special" };
-            var service = new ProductService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestProductServiceDelete()
-        {
-            var service = new ProductService(this.StripeClient);
-            service.Delete("prod_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestProductServiceList()
-        {
-            var options = new ProductListOptions { Limit = 3 };
-            var service = new ProductService(this.StripeClient);
-            StripeList<Product> products = service.List(options);
-        }
-
-        [Fact]
-        public void TestProductServiceRetrieve()
-        {
-            var service = new ProductService(this.StripeClient);
-            service.Get("prod_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestProductServiceSearch()
-        {
-            var options = new ProductSearchOptions
-            {
-                Query = "active:'true' AND metadata['order_id']:'6735'",
-            };
-            var service = new ProductService(this.StripeClient);
-            service.Search(options);
-        }
-
-        [Fact]
-        public void TestProductServiceUpdate()
-        {
-            var options = new ProductUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new ProductService(this.StripeClient);
-            service.Update("prod_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestPromotionCodeServiceCreate()
-        {
-            var options = new PromotionCodeCreateOptions
-            {
-                Coupon = "Z4OV52SU",
-            };
-            var service = new PromotionCodeService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestPromotionCodeServiceList()
-        {
-            var options = new PromotionCodeListOptions { Limit = 3 };
-            var service = new PromotionCodeService(this.StripeClient);
-            StripeList<PromotionCode> promotioncodes = service.List(options);
-        }
-
-        [Fact]
-        public void TestPromotionCodeServiceRetrieve()
-        {
-            var service = new PromotionCodeService(this.StripeClient);
-            service.Get("promo_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestPromotionCodeServiceUpdate()
-        {
-            var options = new PromotionCodeUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new PromotionCodeService(this.StripeClient);
-            service.Update("promo_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestQuoteServiceAccept()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.Accept("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServiceCancel()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.Cancel("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServiceCreate()
-        {
-            var options = new QuoteCreateOptions
-            {
-                Customer = "cus_xxxxxxxxxxxxx",
-                LineItems = new List<QuoteLineItemOptions>
-                {
-                    new QuoteLineItemOptions
-                    {
-                        Price = "price_xxxxxxxxxxxxx",
-                        Quantity = 2,
-                    },
-                },
-            };
-            var service = new QuoteService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestQuoteServiceFinalizeQuote()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.FinalizeQuote("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServiceList()
-        {
-            var options = new QuoteListOptions { Limit = 3 };
-            var service = new QuoteService(this.StripeClient);
-            StripeList<Quote> quotes = service.List(options);
-        }
-
-        [Fact]
-        public void TestQuoteServiceListLineItems()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.ListLineItems("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServicePdf()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.Pdf("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServiceRetrieve()
-        {
-            var service = new QuoteService(this.StripeClient);
-            service.Get("qt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestQuoteServiceUpdate()
-        {
-            var options = new QuoteUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new QuoteService(this.StripeClient);
-            service.Update("qt_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestRadarEarlyFraudWarningServiceList()
-        {
-            var options = new Stripe.Radar.EarlyFraudWarningListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Radar.EarlyFraudWarningService(
-                this.StripeClient);
-            StripeList<Stripe.Radar.EarlyFraudWarning> earlyfraudwarnings = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestRadarEarlyFraudWarningServiceRetrieve()
-        {
-            var service = new Stripe.Radar.EarlyFraudWarningService(
-                this.StripeClient);
-            service.Get("issfr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRadarValueListItemServiceCreate()
-        {
-            var options = new Stripe.Radar.ValueListItemCreateOptions
-            {
-                ValueList = "rsl_xxxxxxxxxxxxx",
-                Value = "1.2.3.4",
-            };
-            var service = new Stripe.Radar.ValueListItemService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestRadarValueListItemServiceDelete()
-        {
-            var service = new Stripe.Radar.ValueListItemService(
-                this.StripeClient);
-            service.Delete("rsli_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRadarValueListItemServiceList()
-        {
-            var options = new Stripe.Radar.ValueListItemListOptions
-            {
-                Limit = 3,
-                ValueList = "rsl_xxxxxxxxxxxxx",
-            };
-            var service = new Stripe.Radar.ValueListItemService(
-                this.StripeClient);
-            StripeList<Stripe.Radar.ValueListItem> valuelistitems = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestRadarValueListItemServiceRetrieve()
-        {
-            var service = new Stripe.Radar.ValueListItemService(
-                this.StripeClient);
-            service.Get("rsli_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRadarValueListServiceCreate()
-        {
-            var options = new Stripe.Radar.ValueListCreateOptions
-            {
-                Alias = "custom_ip_xxxxxxxxxxxxx",
-                Name = "Custom IP Blocklist",
-                ItemType = "ip_address",
-            };
-            var service = new Stripe.Radar.ValueListService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestRadarValueListServiceDelete()
-        {
-            var service = new Stripe.Radar.ValueListService(this.StripeClient);
-            service.Delete("rsl_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRadarValueListServiceList()
-        {
-            var options = new Stripe.Radar.ValueListListOptions { Limit = 3 };
-            var service = new Stripe.Radar.ValueListService(this.StripeClient);
-            StripeList<Stripe.Radar.ValueList> valuelists = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestRadarValueListServiceRetrieve()
-        {
-            var service = new Stripe.Radar.ValueListService(this.StripeClient);
-            service.Get("rsl_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRadarValueListServiceUpdate()
-        {
-            var options = new Stripe.Radar.ValueListUpdateOptions
-            {
-                Name = "Updated IP Block List",
-            };
-            var service = new Stripe.Radar.ValueListService(this.StripeClient);
-            service.Update("rsl_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestRefundServiceCancel()
-        {
-            var service = new RefundService(this.StripeClient);
-            service.Cancel("re_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRefundServiceCreate()
-        {
-            var options = new RefundCreateOptions
-            {
-                Charge = "ch_xxxxxxxxxxxxx",
-            };
-            var service = new RefundService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestRefundServiceExpire()
+        public void TestTestHelpersRefundsExpirePost()
         {
             var service = new Stripe.TestHelpers.RefundService(
                 this.StripeClient);
@@ -2832,864 +3770,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestRefundServiceList()
-        {
-            var options = new RefundListOptions { Limit = 3 };
-            var service = new RefundService(this.StripeClient);
-            StripeList<Refund> refunds = service.List(options);
-        }
-
-        [Fact]
-        public void TestRefundServiceRetrieve()
-        {
-            var service = new RefundService(this.StripeClient);
-            service.Get("re_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestRefundServiceUpdate()
-        {
-            var options = new RefundUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new RefundService(this.StripeClient);
-            service.Update("re_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestReportingReportRunServiceCreate()
-        {
-            var options = new Stripe.Reporting.ReportRunCreateOptions
-            {
-                ReportType = "balance.summary.1",
-                Parameters = new Stripe.Reporting.ReportRunParametersOptions
-                {
-                    IntervalStart = DateTimeOffset.FromUnixTimeSeconds(
-                        1522540800)
-                        .UtcDateTime,
-                    IntervalEnd = DateTimeOffset.FromUnixTimeSeconds(1525132800)
-                        .UtcDateTime,
-                },
-            };
-            var service = new Stripe.Reporting.ReportRunService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestReportingReportRunServiceList()
-        {
-            var options = new Stripe.Reporting.ReportRunListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Reporting.ReportRunService(
-                this.StripeClient);
-            StripeList<Stripe.Reporting.ReportRun> reportruns = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestReportingReportRunServiceRetrieve()
-        {
-            var service = new Stripe.Reporting.ReportRunService(
-                this.StripeClient);
-            service.Get("frr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestReportingReportTypeServiceList()
-        {
-            var service = new Stripe.Reporting.ReportTypeService(
-                this.StripeClient);
-            StripeList<Stripe.Reporting.ReportType> reporttypes = service.List();
-        }
-
-        [Fact]
-        public void TestReportingReportTypeServiceRetrieve()
-        {
-            var service = new Stripe.Reporting.ReportTypeService(
-                this.StripeClient);
-            service.Get("balance.summary.1");
-        }
-
-        [Fact]
-        public void TestReviewServiceApprove()
-        {
-            var service = new ReviewService(this.StripeClient);
-            service.Approve("prv_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestReviewServiceList()
-        {
-            var options = new ReviewListOptions { Limit = 3 };
-            var service = new ReviewService(this.StripeClient);
-            StripeList<Review> reviews = service.List(options);
-        }
-
-        [Fact]
-        public void TestReviewServiceRetrieve()
-        {
-            var service = new ReviewService(this.StripeClient);
-            service.Get("prv_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSetupAttemptServiceList()
-        {
-            var options = new SetupAttemptListOptions
-            {
-                Limit = 3,
-                SetupIntent = "si_xyz",
-            };
-            var service = new SetupAttemptService(this.StripeClient);
-            StripeList<SetupAttempt> setupattempts = service.List(options);
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceCancel()
-        {
-            var service = new SetupIntentService(this.StripeClient);
-            service.Cancel("seti_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceConfirm()
-        {
-            var options = new SetupIntentConfirmOptions
-            {
-                PaymentMethod = "pm_card_visa",
-            };
-            var service = new SetupIntentService(this.StripeClient);
-            service.Confirm("seti_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceCreate()
-        {
-            var options = new SetupIntentCreateOptions
-            {
-                PaymentMethodTypes = new List<string> { "card" },
-            };
-            var service = new SetupIntentService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceList()
-        {
-            var options = new SetupIntentListOptions { Limit = 3 };
-            var service = new SetupIntentService(this.StripeClient);
-            StripeList<SetupIntent> setupintents = service.List(options);
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceRetrieve()
-        {
-            var service = new SetupIntentService(this.StripeClient);
-            service.Get("seti_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceUpdate()
-        {
-            var options = new SetupIntentUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "user_id", "3435453" },
-                },
-            };
-            var service = new SetupIntentService(this.StripeClient);
-            service.Update("seti_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceVerifyMicrodeposits()
-        {
-            var service = new SetupIntentService(this.StripeClient);
-            service.VerifyMicrodeposits("seti_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSetupIntentServiceVerifyMicrodeposits2()
-        {
-            var options = new SetupIntentVerifyMicrodepositsOptions
-            {
-                Amounts = new List<long?> { 32, 45 },
-            };
-            var service = new SetupIntentService(this.StripeClient);
-            service.VerifyMicrodeposits("seti_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestShippingRateServiceCreate()
-        {
-            var options = new ShippingRateCreateOptions
-            {
-                DisplayName = "Sample Shipper",
-                FixedAmount = new ShippingRateFixedAmountOptions
-                {
-                    Currency = "usd",
-                    Amount = 400,
-                },
-                Type = "fixed_amount",
-            };
-            var service = new ShippingRateService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestShippingRateServiceCreate2()
-        {
-            var options = new ShippingRateCreateOptions
-            {
-                DisplayName = "Ground shipping",
-                Type = "fixed_amount",
-                FixedAmount = new ShippingRateFixedAmountOptions
-                {
-                    Amount = 500,
-                    Currency = "usd",
-                },
-            };
-            var service = new ShippingRateService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestShippingRateServiceList()
-        {
-            var service = new ShippingRateService(this.StripeClient);
-            StripeList<ShippingRate> shippingrates = service.List();
-        }
-
-        [Fact]
-        public void TestShippingRateServiceList2()
-        {
-            var options = new ShippingRateListOptions { Limit = 3 };
-            var service = new ShippingRateService(this.StripeClient);
-            StripeList<ShippingRate> shippingrates = service.List(options);
-        }
-
-        [Fact]
-        public void TestShippingRateServiceRetrieve()
-        {
-            var service = new ShippingRateService(this.StripeClient);
-            service.Get("shr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestShippingRateServiceUpdate()
-        {
-            var options = new ShippingRateUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new ShippingRateService(this.StripeClient);
-            service.Update("shr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSigmaScheduledQueryRunServiceList()
-        {
-            var options = new Stripe.Sigma.ScheduledQueryRunListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Sigma.ScheduledQueryRunService(
-                this.StripeClient);
-            StripeList<Stripe.Sigma.ScheduledQueryRun> scheduledqueryruns = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestSigmaScheduledQueryRunServiceRetrieve()
-        {
-            var service = new Stripe.Sigma.ScheduledQueryRunService(
-                this.StripeClient);
-            service.Get("sqr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSourceServiceRetrieve()
-        {
-            var service = new SourceService(this.StripeClient);
-            service.Get("src_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSourceServiceRetrieve2()
-        {
-            var service = new SourceService(this.StripeClient);
-            service.Get("src_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSourceServiceUpdate()
-        {
-            var options = new SourceUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new SourceService(this.StripeClient);
-            service.Update("src_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSubscriptionItemServiceCreate()
-        {
-            var options = new SubscriptionItemCreateOptions
-            {
-                Subscription = "sub_xxxxxxxxxxxxx",
-                Price = "price_xxxxxxxxxxxxx",
-                Quantity = 2,
-            };
-            var service = new SubscriptionItemService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestSubscriptionItemServiceDelete()
-        {
-            var service = new SubscriptionItemService(this.StripeClient);
-            service.Delete("si_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionItemServiceList()
-        {
-            var options = new SubscriptionItemListOptions
-            {
-                Subscription = "sub_xxxxxxxxxxxxx",
-            };
-            var service = new SubscriptionItemService(this.StripeClient);
-            StripeList<SubscriptionItem> subscriptionitems = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestSubscriptionItemServiceRetrieve()
-        {
-            var service = new SubscriptionItemService(this.StripeClient);
-            service.Get("si_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionItemServiceUpdate()
-        {
-            var options = new SubscriptionItemUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new SubscriptionItemService(this.StripeClient);
-            service.Update("si_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSubscriptionScheduleServiceCancel()
-        {
-            var service = new SubscriptionScheduleService(this.StripeClient);
-            service.Cancel("sub_sched_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionScheduleServiceList()
-        {
-            var options = new SubscriptionScheduleListOptions { Limit = 3 };
-            var service = new SubscriptionScheduleService(this.StripeClient);
-            StripeList<SubscriptionSchedule> subscriptionschedules = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestSubscriptionScheduleServiceRelease()
-        {
-            var service = new SubscriptionScheduleService(this.StripeClient);
-            service.Release("sub_sched_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionScheduleServiceRetrieve()
-        {
-            var service = new SubscriptionScheduleService(this.StripeClient);
-            service.Get("sub_sched_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionScheduleServiceUpdate()
-        {
-            var options = new SubscriptionScheduleUpdateOptions
-            {
-                EndBehavior = "release",
-            };
-            var service = new SubscriptionScheduleService(this.StripeClient);
-            service.Update("sub_sched_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceCancel()
-        {
-            var service = new SubscriptionService(this.StripeClient);
-            service.Cancel("sub_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceCreate()
-        {
-            var options = new SubscriptionCreateOptions
-            {
-                Customer = "cus_xxxxxxxxxxxxx",
-                Items = new List<SubscriptionItemOptions>
-                {
-                    new SubscriptionItemOptions
-                    {
-                        Price = "price_xxxxxxxxxxxxx",
-                    },
-                },
-            };
-            var service = new SubscriptionService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceList()
-        {
-            var options = new SubscriptionListOptions { Limit = 3 };
-            var service = new SubscriptionService(this.StripeClient);
-            StripeList<Subscription> subscriptions = service.List(options);
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceRetrieve()
-        {
-            var service = new SubscriptionService(this.StripeClient);
-            service.Get("sub_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceSearch()
-        {
-            var options = new SubscriptionSearchOptions
-            {
-                Query = "status:'active' AND metadata['order_id']:'6735'",
-            };
-            var service = new SubscriptionService(this.StripeClient);
-            service.Search(options);
-        }
-
-        [Fact]
-        public void TestSubscriptionServiceUpdate()
-        {
-            var options = new SubscriptionUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new SubscriptionService(this.StripeClient);
-            service.Update("sub_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTaxCalculationServiceCreate()
-        {
-            var options = new Stripe.Tax.CalculationCreateOptions
-            {
-                Currency = "usd",
-                LineItems = new List<Stripe.Tax.CalculationLineItemOptions>
-                {
-                    new Stripe.Tax.CalculationLineItemOptions
-                    {
-                        Amount = 1000,
-                        Reference = "L1",
-                    },
-                },
-                CustomerDetails = new Stripe.Tax.CalculationCustomerDetailsOptions
-                {
-                    Address = new AddressOptions
-                    {
-                        Line1 = "354 Oyster Point Blvd",
-                        City = "South San Francisco",
-                        State = "CA",
-                        PostalCode = "94080",
-                        Country = "US",
-                    },
-                    AddressSource = "shipping",
-                },
-            };
-            var service = new Stripe.Tax.CalculationService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTaxCalculationServiceListLineItems()
-        {
-            var service = new Stripe.Tax.CalculationService(this.StripeClient);
-            service.ListLineItems("xxx");
-        }
-
-        [Fact]
-        public void TestTaxCodeServiceList()
-        {
-            var options = new TaxCodeListOptions { Limit = 3 };
-            var service = new TaxCodeService(this.StripeClient);
-            StripeList<TaxCode> taxcodes = service.List(options);
-        }
-
-        [Fact]
-        public void TestTaxCodeServiceRetrieve()
-        {
-            var service = new TaxCodeService(this.StripeClient);
-            service.Get("txcd_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTaxIdServiceCreate()
-        {
-            var options = new TaxIdCreateOptions
-            {
-                Type = "eu_vat",
-                Value = "DE123456789",
-            };
-            var service = new TaxIdService(this.StripeClient);
-            service.Create("cus_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTaxIdServiceDelete()
-        {
-            var service = new TaxIdService(this.StripeClient);
-            service.Delete("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTaxIdServiceList()
-        {
-            var options = new TaxIdListOptions { Limit = 3 };
-            var service = new TaxIdService(this.StripeClient);
-            StripeList<TaxId> taxids = service.List(
-                "cus_xxxxxxxxxxxxx",
-                options);
-        }
-
-        [Fact]
-        public void TestTaxIdServiceRetrieve()
-        {
-            var service = new TaxIdService(this.StripeClient);
-            service.Get("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTaxRateServiceCreate()
-        {
-            var options = new TaxRateCreateOptions
-            {
-                DisplayName = "VAT",
-                Description = "VAT Germany",
-                Jurisdiction = "DE",
-                Percentage = 16m,
-                Inclusive = false,
-            };
-            var service = new TaxRateService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTaxRateServiceList()
-        {
-            var options = new TaxRateListOptions { Limit = 3 };
-            var service = new TaxRateService(this.StripeClient);
-            StripeList<TaxRate> taxrates = service.List(options);
-        }
-
-        [Fact]
-        public void TestTaxRateServiceRetrieve()
-        {
-            var service = new TaxRateService(this.StripeClient);
-            service.Get("txr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTaxRateServiceUpdate()
-        {
-            var options = new TaxRateUpdateOptions { Active = false };
-            var service = new TaxRateService(this.StripeClient);
-            service.Update("txr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTaxTransactionServiceCreateFromCalculation()
-        {
-            var options = new Stripe.Tax.TransactionCreateFromCalculationOptions
-            {
-                Calculation = "xxx",
-                Reference = "yyy",
-            };
-            var service = new Stripe.Tax.TransactionService(this.StripeClient);
-            service.CreateFromCalculation(options);
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceCreate()
-        {
-            var options = new Stripe.Terminal.ConfigurationCreateOptions();
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceCreate2()
-        {
-            var options = new Stripe.Terminal.ConfigurationCreateOptions
-            {
-                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
-                {
-                    Splashscreen = "file_xxxxxxxxxxxxx",
-                },
-            };
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceDelete()
-        {
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Delete("uc_123");
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceDelete2()
-        {
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Delete("tmc_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceList()
-        {
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            StripeList<Stripe.Terminal.Configuration> configurations = service.List();
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceList2()
-        {
-            var options = new Stripe.Terminal.ConfigurationListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            StripeList<Stripe.Terminal.Configuration> configurations = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceRetrieve()
-        {
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Get("uc_123");
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceRetrieve2()
-        {
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Get("tmc_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceUpdate()
-        {
-            var options = new Stripe.Terminal.ConfigurationUpdateOptions
-            {
-                Tipping = new Stripe.Terminal.ConfigurationTippingOptions
-                {
-                    Usd = new Stripe.Terminal.ConfigurationTippingUsdOptions
-                    {
-                        FixedAmounts = new List<long?> { 10 },
-                    },
-                },
-            };
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Update("uc_123", options);
-        }
-
-        [Fact]
-        public void TestTerminalConfigurationServiceUpdate2()
-        {
-            var options = new Stripe.Terminal.ConfigurationUpdateOptions
-            {
-                BbposWiseposE = new Stripe.Terminal.ConfigurationBbposWiseposEOptions
-                {
-                    Splashscreen = "file_xxxxxxxxxxxxx",
-                },
-            };
-            var service = new Stripe.Terminal.ConfigurationService(
-                this.StripeClient);
-            service.Update("tmc_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTerminalLocationServiceCreate()
-        {
-            var options = new Stripe.Terminal.LocationCreateOptions
-            {
-                DisplayName = "My First Store",
-                Address = new AddressOptions
-                {
-                    Line1 = "1234 Main Street",
-                    City = "San Francisco",
-                    PostalCode = "94111",
-                    State = "CA",
-                    Country = "US",
-                },
-            };
-            var service = new Stripe.Terminal.LocationService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTerminalLocationServiceDelete()
-        {
-            var service = new Stripe.Terminal.LocationService(
-                this.StripeClient);
-            service.Delete("tml_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalLocationServiceList()
-        {
-            var options = new Stripe.Terminal.LocationListOptions { Limit = 3 };
-            var service = new Stripe.Terminal.LocationService(
-                this.StripeClient);
-            StripeList<Stripe.Terminal.Location> locations = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTerminalLocationServiceRetrieve()
-        {
-            var service = new Stripe.Terminal.LocationService(
-                this.StripeClient);
-            service.Get("tml_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalLocationServiceUpdate()
-        {
-            var options = new Stripe.Terminal.LocationUpdateOptions
-            {
-                DisplayName = "My First Store",
-            };
-            var service = new Stripe.Terminal.LocationService(
-                this.StripeClient);
-            service.Update("tml_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceCancelAction()
-        {
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.CancelAction("tmr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceCreate()
-        {
-            var options = new Stripe.Terminal.ReaderCreateOptions
-            {
-                RegistrationCode = "puppies-plug-could",
-                Label = "Blue Rabbit",
-                Location = "tml_1234",
-            };
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceDelete()
-        {
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Delete("tmr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceList()
-        {
-            var options = new Stripe.Terminal.ReaderListOptions { Limit = 3 };
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            StripeList<Stripe.Terminal.Reader> readers = service.List(options);
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceProcessPaymentIntent()
-        {
-            var options = new Stripe.Terminal.ReaderProcessPaymentIntentOptions
-            {
-                PaymentIntent = "pi_xxxxxxxxxxxxx",
-            };
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.ProcessPaymentIntent("tmr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceProcessSetupIntent()
-        {
-            var options = new Stripe.Terminal.ReaderProcessSetupIntentOptions
-            {
-                SetupIntent = "seti_xxxxxxxxxxxxx",
-                CustomerConsentCollected = true,
-            };
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.ProcessSetupIntent("tmr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceRetrieve()
-        {
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Get("tmr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTerminalReaderServiceUpdate()
-        {
-            var options = new Stripe.Terminal.ReaderUpdateOptions
-            {
-                Label = "Blue Rabbit",
-            };
-            var service = new Stripe.Terminal.ReaderService(this.StripeClient);
-            service.Update("tmr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTestHelpersTestClockServiceAdvance()
+        public void TestTestHelpersTestClocksAdvancePost()
         {
             var options = new Stripe.TestHelpers.TestClockAdvanceOptions
             {
@@ -3702,7 +3783,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceAdvance2()
+        public void TestTestHelpersTestClocksAdvancePost2()
         {
             var options = new Stripe.TestHelpers.TestClockAdvanceOptions
             {
@@ -3715,7 +3796,61 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceCreate()
+        public void TestTestHelpersTestClocksDelete()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Delete("clock_xyz");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksDelete2()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Delete("clock_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksGet()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            StripeList<Stripe.TestHelpers.TestClock> testClocks = service
+                .List();
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksGet2()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Get("clock_xyz");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksGet3()
+        {
+            var options = new Stripe.TestHelpers.TestClockListOptions
+            {
+                Limit = 3,
+            };
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            StripeList<Stripe.TestHelpers.TestClock> testClocks = service.List(
+                options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksGet4()
+        {
+            var service = new Stripe.TestHelpers.TestClockService(
+                this.StripeClient);
+            service.Get("clock_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTestHelpersTestClocksPost()
         {
             var options = new Stripe.TestHelpers.TestClockCreateOptions
             {
@@ -3729,7 +3864,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceCreate2()
+        public void TestTestHelpersTestClocksPost2()
         {
             var options = new Stripe.TestHelpers.TestClockCreateOptions
             {
@@ -3742,74 +3877,224 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceDelete()
+        public void TestTestHelpersTreasuryInboundTransfersFailPost()
         {
-            var service = new Stripe.TestHelpers.TestClockService(
-                this.StripeClient);
-            service.Delete("clock_xyz");
-        }
-
-        [Fact]
-        public void TestTestHelpersTestClockServiceDelete2()
-        {
-            var service = new Stripe.TestHelpers.TestClockService(
-                this.StripeClient);
-            service.Delete("clock_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTestHelpersTestClockServiceList()
-        {
-            var service = new Stripe.TestHelpers.TestClockService(
-                this.StripeClient);
-            StripeList<Stripe.TestHelpers.TestClock> testclocks = service.List();
-        }
-
-        [Fact]
-        public void TestTestHelpersTestClockServiceList2()
-        {
-            var options = new Stripe.TestHelpers.TestClockListOptions
+            var options = new Stripe.TestHelpers.Treasury.InboundTransferFailOptions
             {
-                Limit = 3,
+                FailureDetails = new Stripe.TestHelpers.Treasury.InboundTransferFailureDetailsOptions
+                {
+                    Code = "account_closed",
+                },
             };
-            var service = new Stripe.TestHelpers.TestClockService(
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
                 this.StripeClient);
-            StripeList<Stripe.TestHelpers.TestClock> testclocks = service.List(
-                options);
+            service.Fail("ibt_123", options);
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceRetrieve()
+        public void TestTestHelpersTreasuryInboundTransfersReturnPost()
         {
-            var service = new Stripe.TestHelpers.TestClockService(
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
                 this.StripeClient);
-            service.Get("clock_xyz");
+            service.ReturnInboundTransfer("ibt_123");
         }
 
         [Fact]
-        public void TestTestHelpersTestClockServiceRetrieve2()
+        public void TestTestHelpersTreasuryInboundTransfersSucceedPost()
         {
-            var service = new Stripe.TestHelpers.TestClockService(
+            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
                 this.StripeClient);
-            service.Get("clock_xxxxxxxxxxxxx");
+            service.Succeed("ibt_123");
         }
 
         [Fact]
-        public void TestTokenServiceRetrieve()
+        public void TestTestHelpersTreasuryOutboundTransfersFailPost()
+        {
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Fail("obt_123");
+        }
+
+        [Fact]
+        public void TestTestHelpersTreasuryOutboundTransfersPostPost()
+        {
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Post("obt_123");
+        }
+
+        [Fact]
+        public void TestTestHelpersTreasuryOutboundTransfersReturnPost()
+        {
+            var options = new Stripe.TestHelpers.Treasury.OutboundTransferReturnOutboundTransferOptions
+            {
+                ReturnedDetails = new Stripe.TestHelpers.Treasury.OutboundTransferReturnedDetailsOptions
+                {
+                    Code = "account_closed",
+                },
+            };
+            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.ReturnOutboundTransfer("obt_123", options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTreasuryReceivedCreditsPost()
+        {
+            var options = new Stripe.TestHelpers.Treasury.ReceivedCreditCreateOptions
+            {
+                FinancialAccount = "fa_123",
+                Network = "ach",
+                Amount = 1234,
+                Currency = "usd",
+            };
+            var service = new Stripe.TestHelpers.Treasury.ReceivedCreditService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTestHelpersTreasuryReceivedDebitsPost()
+        {
+            var options = new Stripe.TestHelpers.Treasury.ReceivedDebitCreateOptions
+            {
+                FinancialAccount = "fa_123",
+                Network = "ach",
+                Amount = 1234,
+                Currency = "usd",
+            };
+            var service = new Stripe.TestHelpers.Treasury.ReceivedDebitService(
+                this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensGet()
         {
             var service = new TokenService(this.StripeClient);
             service.Get("tok_xxxx");
         }
 
         [Fact]
-        public void TestTopupServiceCancel()
+        public void TestTokensPost()
+        {
+            var options = new TokenCreateOptions
+            {
+                Card = new TokenCardOptions
+                {
+                    Number = "4242424242424242",
+                    ExpMonth = "5",
+                    ExpYear = "2023",
+                    Cvc = "314",
+                },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensPost2()
+        {
+            var options = new TokenCreateOptions
+            {
+                BankAccount = new TokenBankAccountOptions
+                {
+                    Country = "US",
+                    Currency = "usd",
+                    AccountHolderName = "Jenny Rosen",
+                    AccountHolderType = "individual",
+                    RoutingNumber = "110000000",
+                    AccountNumber = "000123456789",
+                },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensPost3()
+        {
+            var options = new TokenCreateOptions
+            {
+                Pii = new TokenPiiOptions { IdNumber = "000000000" },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensPost4()
+        {
+            var options = new TokenCreateOptions
+            {
+                Account = new TokenAccountOptions
+                {
+                    Individual = new TokenAccountIndividualOptions
+                    {
+                        FirstName = "Jane",
+                        LastName = "Doe",
+                    },
+                    TosShownAndAccepted = true,
+                },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensPost5()
+        {
+            var options = new TokenCreateOptions
+            {
+                Person = new TokenPersonOptions
+                {
+                    FirstName = "Jane",
+                    LastName = "Doe",
+                    Relationship = new TokenPersonRelationshipOptions
+                    {
+                        Owner = true,
+                    },
+                },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTokensPost6()
+        {
+            var options = new TokenCreateOptions
+            {
+                CvcUpdate = new TokenCvcUpdateOptions { Cvc = "123" },
+            };
+            var service = new TokenService(this.StripeClient);
+            service.Create(options);
+        }
+
+        [Fact]
+        public void TestTopupsCancelPost()
         {
             var service = new TopupService(this.StripeClient);
             service.Cancel("tu_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestTopupServiceCreate()
+        public void TestTopupsGet()
+        {
+            var options = new TopupListOptions { Limit = 3 };
+            var service = new TopupService(this.StripeClient);
+            StripeList<Topup> topups = service.List(options);
+        }
+
+        [Fact]
+        public void TestTopupsGet2()
+        {
+            var service = new TopupService(this.StripeClient);
+            service.Get("tu_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTopupsPost()
         {
             var options = new TopupCreateOptions
             {
@@ -3823,22 +4108,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTopupServiceList()
-        {
-            var options = new TopupListOptions { Limit = 3 };
-            var service = new TopupService(this.StripeClient);
-            StripeList<Topup> topups = service.List(options);
-        }
-
-        [Fact]
-        public void TestTopupServiceRetrieve()
-        {
-            var service = new TopupService(this.StripeClient);
-            service.Get("tu_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTopupServiceUpdate()
+        public void TestTopupsPost2()
         {
             var options = new TopupUpdateOptions
             {
@@ -3852,46 +4122,22 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTransferReversalServiceCreate()
+        public void TestTransfersGet()
         {
-            var options = new TransferReversalCreateOptions { Amount = 100 };
-            var service = new TransferReversalService(this.StripeClient);
-            service.Create("tr_xxxxxxxxxxxxx", options);
+            var options = new TransferListOptions { Limit = 3 };
+            var service = new TransferService(this.StripeClient);
+            StripeList<Transfer> transfers = service.List(options);
         }
 
         [Fact]
-        public void TestTransferReversalServiceList()
+        public void TestTransfersGet2()
         {
-            var options = new TransferReversalListOptions { Limit = 3 };
-            var service = new TransferReversalService(this.StripeClient);
-            StripeList<TransferReversal> transferreversals = service.List(
-                "tr_xxxxxxxxxxxxx",
-                options);
+            var service = new TransferService(this.StripeClient);
+            service.Get("tr_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestTransferReversalServiceRetrieve()
-        {
-            var service = new TransferReversalService(this.StripeClient);
-            service.Get("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTransferReversalServiceUpdate()
-        {
-            var options = new TransferReversalUpdateOptions
-            {
-                Metadata = new Dictionary<string, string>
-                {
-                    { "order_id", "6735" },
-                },
-            };
-            var service = new TransferReversalService(this.StripeClient);
-            service.Update("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx", options);
-        }
-
-        [Fact]
-        public void TestTransferServiceCreate()
+        public void TestTransfersPost()
         {
             var options = new TransferCreateOptions
             {
@@ -3905,22 +4151,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTransferServiceList()
-        {
-            var options = new TransferListOptions { Limit = 3 };
-            var service = new TransferService(this.StripeClient);
-            StripeList<Transfer> transfers = service.List(options);
-        }
-
-        [Fact]
-        public void TestTransferServiceRetrieve()
-        {
-            var service = new TransferService(this.StripeClient);
-            service.Get("tr_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTransferServiceUpdate()
+        public void TestTransfersPost2()
         {
             var options = new TransferUpdateOptions
             {
@@ -3934,7 +4165,68 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryCreditReversalServiceCreate()
+        public void TestTransfersReversalsGet()
+        {
+            var options = new TransferReversalListOptions { Limit = 3 };
+            var service = new TransferReversalService(this.StripeClient);
+            StripeList<TransferReversal> transferReversals = service.List(
+                "tr_xxxxxxxxxxxxx",
+                options);
+        }
+
+        [Fact]
+        public void TestTransfersReversalsGet2()
+        {
+            var service = new TransferReversalService(this.StripeClient);
+            service.Get("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTransfersReversalsPost()
+        {
+            var options = new TransferReversalCreateOptions { Amount = 100 };
+            var service = new TransferReversalService(this.StripeClient);
+            service.Create("tr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTransfersReversalsPost2()
+        {
+            var options = new TransferReversalUpdateOptions
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    { "order_id", "6735" },
+                },
+            };
+            var service = new TransferReversalService(this.StripeClient);
+            service.Update("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx", options);
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalsGet()
+        {
+            var options = new Stripe.Treasury.CreditReversalListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.CreditReversalService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.CreditReversal> creditReversals = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalsGet2()
+        {
+            var service = new Stripe.Treasury.CreditReversalService(
+                this.StripeClient);
+            service.Get("credrev_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryCreditReversalsPost()
         {
             var options = new Stripe.Treasury.CreditReversalCreateOptions
             {
@@ -3946,29 +4238,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryCreditReversalServiceList()
+        public void TestTreasuryDebitReversalsGet()
         {
-            var options = new Stripe.Treasury.CreditReversalListOptions
+            var options = new Stripe.Treasury.DebitReversalListOptions
             {
                 FinancialAccount = "fa_xxxxxxxxxxxxx",
                 Limit = 3,
             };
-            var service = new Stripe.Treasury.CreditReversalService(
+            var service = new Stripe.Treasury.DebitReversalService(
                 this.StripeClient);
-            StripeList<Stripe.Treasury.CreditReversal> creditreversals = service.List(
-                options);
+            StripeList<Stripe.Treasury.DebitReversal> debitReversals = service
+                .List(options);
         }
 
         [Fact]
-        public void TestTreasuryCreditReversalServiceRetrieve()
+        public void TestTreasuryDebitReversalsGet2()
         {
-            var service = new Stripe.Treasury.CreditReversalService(
+            var service = new Stripe.Treasury.DebitReversalService(
                 this.StripeClient);
-            service.Get("credrev_xxxxxxxxxxxxx");
+            service.Get("debrev_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestTreasuryDebitReversalServiceCreate()
+        public void TestTreasuryDebitReversalsPost()
         {
             var options = new Stripe.Treasury.DebitReversalCreateOptions
             {
@@ -3980,29 +4272,36 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryDebitReversalServiceList()
+        public void TestTreasuryFinancialAccountsFeaturesGet()
         {
-            var options = new Stripe.Treasury.DebitReversalListOptions
+            var service = new Stripe.Treasury.FinancialAccountService(
+                this.StripeClient);
+            service.RetrieveFeatures("fa_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryFinancialAccountsGet()
+        {
+            var options = new Stripe.Treasury.FinancialAccountListOptions
             {
-                FinancialAccount = "fa_xxxxxxxxxxxxx",
                 Limit = 3,
             };
-            var service = new Stripe.Treasury.DebitReversalService(
+            var service = new Stripe.Treasury.FinancialAccountService(
                 this.StripeClient);
-            StripeList<Stripe.Treasury.DebitReversal> debitreversals = service.List(
-                options);
+            StripeList<Stripe.Treasury.FinancialAccount> financialAccounts = service
+                .List(options);
         }
 
         [Fact]
-        public void TestTreasuryDebitReversalServiceRetrieve()
+        public void TestTreasuryFinancialAccountsGet2()
         {
-            var service = new Stripe.Treasury.DebitReversalService(
+            var service = new Stripe.Treasury.FinancialAccountService(
                 this.StripeClient);
-            service.Get("debrev_xxxxxxxxxxxxx");
+            service.Get("fa_xxxxxxxxxxxxx");
         }
 
         [Fact]
-        public void TestTreasuryFinancialAccountServiceCreate()
+        public void TestTreasuryFinancialAccountsPost()
         {
             var options = new Stripe.Treasury.FinancialAccountCreateOptions
             {
@@ -4015,36 +4314,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryFinancialAccountServiceList()
-        {
-            var options = new Stripe.Treasury.FinancialAccountListOptions
-            {
-                Limit = 3,
-            };
-            var service = new Stripe.Treasury.FinancialAccountService(
-                this.StripeClient);
-            StripeList<Stripe.Treasury.FinancialAccount> financialaccounts = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTreasuryFinancialAccountServiceRetrieve()
-        {
-            var service = new Stripe.Treasury.FinancialAccountService(
-                this.StripeClient);
-            service.Get("fa_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTreasuryFinancialAccountServiceRetrieveFeatures()
-        {
-            var service = new Stripe.Treasury.FinancialAccountService(
-                this.StripeClient);
-            service.RetrieveFeatures("fa_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTreasuryFinancialAccountServiceUpdate()
+        public void TestTreasuryFinancialAccountsPost2()
         {
             var options = new Stripe.Treasury.FinancialAccountUpdateOptions
             {
@@ -4059,7 +4329,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryInboundTransferServiceCancel()
+        public void TestTreasuryInboundTransfersCancelPost()
         {
             var service = new Stripe.Treasury.InboundTransferService(
                 this.StripeClient);
@@ -4067,7 +4337,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryInboundTransferServiceCreate()
+        public void TestTreasuryInboundTransfersGet()
+        {
+            var options = new Stripe.Treasury.InboundTransferListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.InboundTransfer> inboundTransfers = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransfersGet2()
+        {
+            var service = new Stripe.Treasury.InboundTransferService(
+                this.StripeClient);
+            service.Get("ibt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryInboundTransfersPost()
         {
             var options = new Stripe.Treasury.InboundTransferCreateOptions
             {
@@ -4083,60 +4375,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryInboundTransferServiceFail()
-        {
-            var options = new Stripe.TestHelpers.Treasury.InboundTransferFailOptions
-            {
-                FailureDetails = new Stripe.TestHelpers.Treasury.InboundTransferFailureDetailsOptions
-                {
-                    Code = "account_closed",
-                },
-            };
-            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
-                this.StripeClient);
-            service.Fail("ibt_123", options);
-        }
-
-        [Fact]
-        public void TestTreasuryInboundTransferServiceList()
-        {
-            var options = new Stripe.Treasury.InboundTransferListOptions
-            {
-                FinancialAccount = "fa_xxxxxxxxxxxxx",
-                Limit = 3,
-            };
-            var service = new Stripe.Treasury.InboundTransferService(
-                this.StripeClient);
-            StripeList<Stripe.Treasury.InboundTransfer> inboundtransfers = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTreasuryInboundTransferServiceRetrieve()
-        {
-            var service = new Stripe.Treasury.InboundTransferService(
-                this.StripeClient);
-            service.Get("ibt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTreasuryInboundTransferServiceReturnInboundTransfer()
-        {
-            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
-                this.StripeClient);
-            service.ReturnInboundTransfer("ibt_123");
-        }
-
-        [Fact]
-        public void TestTreasuryInboundTransferServiceSucceed()
-        {
-            var service = new Stripe.TestHelpers.Treasury.InboundTransferService(
-                this.StripeClient);
-            service.Succeed("ibt_123");
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundPaymentServiceCancel()
+        public void TestTreasuryOutboundPaymentsCancelPost()
         {
             var service = new Stripe.Treasury.OutboundPaymentService(
                 this.StripeClient);
@@ -4144,7 +4383,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryOutboundPaymentServiceCreate()
+        public void TestTreasuryOutboundPaymentsGet()
+        {
+            var options = new Stripe.Treasury.OutboundPaymentListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.OutboundPayment> outboundPayments = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentsGet2()
+        {
+            var service = new Stripe.Treasury.OutboundPaymentService(
+                this.StripeClient);
+            service.Get("bot_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundPaymentsPost()
         {
             var options = new Stripe.Treasury.OutboundPaymentCreateOptions
             {
@@ -4161,29 +4422,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryOutboundPaymentServiceList()
-        {
-            var options = new Stripe.Treasury.OutboundPaymentListOptions
-            {
-                FinancialAccount = "fa_xxxxxxxxxxxxx",
-                Limit = 3,
-            };
-            var service = new Stripe.Treasury.OutboundPaymentService(
-                this.StripeClient);
-            StripeList<Stripe.Treasury.OutboundPayment> outboundpayments = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundPaymentServiceRetrieve()
-        {
-            var service = new Stripe.Treasury.OutboundPaymentService(
-                this.StripeClient);
-            service.Get("bot_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundTransferServiceCancel()
+        public void TestTreasuryOutboundTransfersCancelPost()
         {
             var service = new Stripe.Treasury.OutboundTransferService(
                 this.StripeClient);
@@ -4191,7 +4430,29 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryOutboundTransferServiceCreate()
+        public void TestTreasuryOutboundTransfersGet()
+        {
+            var options = new Stripe.Treasury.OutboundTransferListOptions
+            {
+                FinancialAccount = "fa_xxxxxxxxxxxxx",
+                Limit = 3,
+            };
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            StripeList<Stripe.Treasury.OutboundTransfer> outboundTransfers = service
+                .List(options);
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransfersGet2()
+        {
+            var service = new Stripe.Treasury.OutboundTransferService(
+                this.StripeClient);
+            service.Get("obt_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestTreasuryOutboundTransfersPost()
         {
             var options = new Stripe.Treasury.OutboundTransferCreateOptions
             {
@@ -4207,75 +4468,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryOutboundTransferServiceFail()
-        {
-            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
-                this.StripeClient);
-            service.Fail("obt_123");
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundTransferServiceList()
-        {
-            var options = new Stripe.Treasury.OutboundTransferListOptions
-            {
-                FinancialAccount = "fa_xxxxxxxxxxxxx",
-                Limit = 3,
-            };
-            var service = new Stripe.Treasury.OutboundTransferService(
-                this.StripeClient);
-            StripeList<Stripe.Treasury.OutboundTransfer> outboundtransfers = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundTransferServicePost()
-        {
-            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
-                this.StripeClient);
-            service.Post("obt_123");
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundTransferServiceRetrieve()
-        {
-            var service = new Stripe.Treasury.OutboundTransferService(
-                this.StripeClient);
-            service.Get("obt_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestTreasuryOutboundTransferServiceReturnOutboundTransfer()
-        {
-            var options = new Stripe.TestHelpers.Treasury.OutboundTransferReturnOutboundTransferOptions
-            {
-                ReturnedDetails = new Stripe.TestHelpers.Treasury.OutboundTransferReturnedDetailsOptions
-                {
-                    Code = "account_closed",
-                },
-            };
-            var service = new Stripe.TestHelpers.Treasury.OutboundTransferService(
-                this.StripeClient);
-            service.ReturnOutboundTransfer("obt_123", options);
-        }
-
-        [Fact]
-        public void TestTreasuryReceivedCreditServiceCreate()
-        {
-            var options = new Stripe.TestHelpers.Treasury.ReceivedCreditCreateOptions
-            {
-                FinancialAccount = "fa_123",
-                Network = "ach",
-                Amount = 1234,
-                Currency = "usd",
-            };
-            var service = new Stripe.TestHelpers.Treasury.ReceivedCreditService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTreasuryReceivedCreditServiceList()
+        public void TestTreasuryReceivedCreditsGet()
         {
             var options = new Stripe.Treasury.ReceivedCreditListOptions
             {
@@ -4284,12 +4477,12 @@ namespace StripeTests
             };
             var service = new Stripe.Treasury.ReceivedCreditService(
                 this.StripeClient);
-            StripeList<Stripe.Treasury.ReceivedCredit> receivedcredits = service.List(
-                options);
+            StripeList<Stripe.Treasury.ReceivedCredit> receivedCredits = service
+                .List(options);
         }
 
         [Fact]
-        public void TestTreasuryReceivedCreditServiceRetrieve()
+        public void TestTreasuryReceivedCreditsGet2()
         {
             var service = new Stripe.Treasury.ReceivedCreditService(
                 this.StripeClient);
@@ -4297,22 +4490,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryReceivedDebitServiceCreate()
-        {
-            var options = new Stripe.TestHelpers.Treasury.ReceivedDebitCreateOptions
-            {
-                FinancialAccount = "fa_123",
-                Network = "ach",
-                Amount = 1234,
-                Currency = "usd",
-            };
-            var service = new Stripe.TestHelpers.Treasury.ReceivedDebitService(
-                this.StripeClient);
-            service.Create(options);
-        }
-
-        [Fact]
-        public void TestTreasuryReceivedDebitServiceList()
+        public void TestTreasuryReceivedDebitsGet()
         {
             var options = new Stripe.Treasury.ReceivedDebitListOptions
             {
@@ -4321,12 +4499,12 @@ namespace StripeTests
             };
             var service = new Stripe.Treasury.ReceivedDebitService(
                 this.StripeClient);
-            StripeList<Stripe.Treasury.ReceivedDebit> receiveddebits = service.List(
-                options);
+            StripeList<Stripe.Treasury.ReceivedDebit> receivedDebits = service
+                .List(options);
         }
 
         [Fact]
-        public void TestTreasuryReceivedDebitServiceRetrieve()
+        public void TestTreasuryReceivedDebitsGet2()
         {
             var service = new Stripe.Treasury.ReceivedDebitService(
                 this.StripeClient);
@@ -4334,7 +4512,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryTransactionEntryServiceList()
+        public void TestTreasuryTransactionEntriesGet()
         {
             var options = new Stripe.Treasury.TransactionEntryListOptions
             {
@@ -4343,12 +4521,12 @@ namespace StripeTests
             };
             var service = new Stripe.Treasury.TransactionEntryService(
                 this.StripeClient);
-            StripeList<Stripe.Treasury.TransactionEntry> transactionentries = service.List(
-                options);
+            StripeList<Stripe.Treasury.TransactionEntry> transactionEntries = service
+                .List(options);
         }
 
         [Fact]
-        public void TestTreasuryTransactionEntryServiceRetrieve()
+        public void TestTreasuryTransactionEntriesGet2()
         {
             var service = new Stripe.Treasury.TransactionEntryService(
                 this.StripeClient);
@@ -4356,7 +4534,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryTransactionServiceList()
+        public void TestTreasuryTransactionsGet()
         {
             var options = new Stripe.Treasury.TransactionListOptions
             {
@@ -4370,7 +4548,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestTreasuryTransactionServiceRetrieve()
+        public void TestTreasuryTransactionsGet2()
         {
             var service = new Stripe.Treasury.TransactionService(
                 this.StripeClient);
@@ -4378,17 +4556,30 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestUsageRecordSummaryServiceList()
+        public void TestWebhookEndpointsDelete()
         {
-            var options = new UsageRecordSummaryListOptions { Limit = 3 };
-            var service = new UsageRecordSummaryService(this.StripeClient);
-            StripeList<UsageRecordSummary> usagerecordsummaries = service.List(
-                "si_xxxxxxxxxxxxx",
+            var service = new WebhookEndpointService(this.StripeClient);
+            service.Delete("we_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestWebhookEndpointsGet()
+        {
+            var options = new WebhookEndpointListOptions { Limit = 3 };
+            var service = new WebhookEndpointService(this.StripeClient);
+            StripeList<WebhookEndpoint> webhookEndpoints = service.List(
                 options);
         }
 
         [Fact]
-        public void TestWebhookEndpointServiceCreate()
+        public void TestWebhookEndpointsGet2()
+        {
+            var service = new WebhookEndpointService(this.StripeClient);
+            service.Get("we_xxxxxxxxxxxxx");
+        }
+
+        [Fact]
+        public void TestWebhookEndpointsPost()
         {
             var options = new WebhookEndpointCreateOptions
             {
@@ -4404,30 +4595,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void TestWebhookEndpointServiceDelete()
-        {
-            var service = new WebhookEndpointService(this.StripeClient);
-            service.Delete("we_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestWebhookEndpointServiceList()
-        {
-            var options = new WebhookEndpointListOptions { Limit = 3 };
-            var service = new WebhookEndpointService(this.StripeClient);
-            StripeList<WebhookEndpoint> webhookendpoints = service.List(
-                options);
-        }
-
-        [Fact]
-        public void TestWebhookEndpointServiceRetrieve()
-        {
-            var service = new WebhookEndpointService(this.StripeClient);
-            service.Get("we_xxxxxxxxxxxxx");
-        }
-
-        [Fact]
-        public void TestWebhookEndpointServiceUpdate()
+        public void TestWebhookEndpointsPost2()
         {
             var options = new WebhookEndpointUpdateOptions
             {


### PR DESCRIPTION
`[Create/Update/Delete]EntityAsync` methods are useful when manually maintaining the library but only add complexity for a generated one. Switch to use existing `RequestAsync`/`ListRequestAsync` methods.