### PR TITLE
Run tests on net8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ ci-test:
 	dotnet test src/StripeTests/StripeTests.csproj -c Debug
 
 test:
-	dotnet test -f net7.0 src/StripeTests/StripeTests.csproj -c Debug
+	dotnet test -f net8.0 src/StripeTests/StripeTests.csproj -c Debug


### PR DESCRIPTION
The default .NET version in this repo and shared infrastructure was updated to 8, but the quick test run that Codegen CI uses still runs on 7.

Bump it to 8 as well.