### PR TITLE
Run compat check only in pull-requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
 
   compat:
     name: Compat
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
Otherwise, it tries to check compatibility during the release and fails.