### PR TITLE
Add net8.0 to test project TargetFrameworks

### DIFF
--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>


### PR DESCRIPTION
Without this, doing
```
dotnet test -f net8.0 src/StripeTests
```
is a no-op.