### PR TITLE
Explicitly define paths in manually maintained services

### DIFF
--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -29,72 +29,72 @@ namespace Stripe
 
         public virtual BankAccount Create(string parentId, BankAccountCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<BankAccount>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions);
         }
 
         public virtual Task<BankAccount> CreateAsync(string parentId, BankAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<BankAccount>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Delete(string parentId, string id, BankAccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<BankAccount>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<BankAccount> DeleteAsync(string parentId, string id, BankAccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<BankAccount>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Get(string parentId, string id, BankAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<BankAccount>(HttpMethod.Get, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<BankAccount> GetAsync(string parentId, string id, BankAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<BankAccount>(HttpMethod.Get, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<BankAccount> List(string parentId, BankAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options ?? new BankAccountListOptions(), requestOptions);
+            return this.Request<StripeList<BankAccount>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new BankAccountListOptions(), requestOptions);
         }
 
         public virtual Task<StripeList<BankAccount>> ListAsync(string parentId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<BankAccount>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<BankAccount> ListAutoPaging(string parentId, BankAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options ?? new BankAccountListOptions(), requestOptions);
+            return this.ListRequestAutoPaging<BankAccount>($"/v1/customers/{parentId}/sources", options ?? new BankAccountListOptions(), requestOptions);
         }
 
         public virtual IAsyncEnumerable<BankAccount> ListAutoPagingAsync(string parentId, BankAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<BankAccount>($"/v1/customers/{parentId}/sources", options ?? new BankAccountListOptions(), requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Update(string parentId, string id, BankAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<BankAccount>(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<BankAccount> UpdateAsync(string parentId, string id, BankAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<BankAccount>(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual BankAccount Verify(string parentId, string id, BankAccountVerifyOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(parentId, id)}/verify", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}/verify", options, requestOptions);
         }
 
         public virtual Task<BankAccount> VerifyAsync(string parentId, string id, BankAccountVerifyOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(parentId, id)}/verify", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}/verify", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -13,7 +13,6 @@ namespace Stripe
         INestedRetrievable<BankAccount, BankAccountGetOptions>,
         INestedUpdatable<BankAccount, BankAccountUpdateOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public BankAccountService()
             : base(null)
         {
@@ -96,6 +95,5 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}/verify", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -13,7 +13,6 @@ namespace Stripe
         INestedRetrievable<Card, CardGetOptions>,
         INestedUpdatable<Card, CardUpdateOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public CardService()
             : base(null)
         {
@@ -86,6 +85,5 @@ namespace Stripe
         {
             return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -28,62 +29,62 @@ namespace Stripe
 
         public virtual Card Create(string parentId, CardCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateNestedEntity(parentId, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions);
         }
 
         public virtual Task<Card> CreateAsync(string parentId, CardCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateNestedEntityAsync(parentId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/customers/{parentId}/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Card Delete(string parentId, string id, CardDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<Card> DeleteAsync(string parentId, string id, CardDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Delete, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Card Get(string parentId, string id, CardGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Get, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<Card> GetAsync(string parentId, string id, CardGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Get, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Card> List(string parentId, CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(parentId, options ?? new CardListOptions(), requestOptions);
+            return this.Request<StripeList<Card>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new CardListOptions(), requestOptions);
         }
 
         public virtual Task<StripeList<Card>> ListAsync(string parentId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(parentId, options ?? new CardListOptions(), requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Card>>(HttpMethod.Get, $"/v1/customers/{parentId}/sources", options ?? new CardListOptions(), requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Card> ListAutoPaging(string parentId, CardListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(parentId, options ?? new CardListOptions(), requestOptions);
+            return this.ListRequestAutoPaging<Card>($"/v1/customers/{parentId}/sources", options ?? new CardListOptions(), requestOptions);
         }
 
         public virtual IAsyncEnumerable<Card> ListAutoPagingAsync(string parentId, CardListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(parentId, options ?? new CardListOptions(), requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Card>($"/v1/customers/{parentId}/sources", options ?? new CardListOptions(), requestOptions, cancellationToken);
         }
 
         public virtual Card Update(string parentId, string id, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateNestedEntity(parentId, id, options, requestOptions);
+            return this.Request<Card>(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<Card> UpdateAsync(string parentId, string id, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateNestedEntityAsync(parentId, id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/customers/{parentId}/sources/{id}", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -12,7 +12,6 @@ namespace Stripe
         IRetrievable<CreditNote, CreditNoteGetOptions>,
         IUpdatable<CreditNote, CreditNoteUpdateOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public CreditNoteService()
             : base(null)
         {
@@ -135,6 +134,5 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"/v1/credit_notes/{id}/void", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -28,112 +28,112 @@ namespace Stripe
 
         public virtual CreditNote Create(CreditNoteCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<CreditNote>(HttpMethod.Post, $"/v1/credit_notes", options, requestOptions);
         }
 
         public virtual Task<CreditNote> CreateAsync(CreditNoteCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditNote>(HttpMethod.Post, $"/v1/credit_notes", options, requestOptions, cancellationToken);
         }
 
         public virtual CreditNote Get(string id, CreditNoteGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<CreditNote>(HttpMethod.Get, $"/v1/credit_notes/{id}", options, requestOptions);
         }
 
         public virtual Task<CreditNote> GetAsync(string id, CreditNoteGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditNote>(HttpMethod.Get, $"/v1/credit_notes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditNote> List(CreditNoteListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<CreditNote>>(HttpMethod.Get, $"/v1/credit_notes", options, requestOptions);
         }
 
         public virtual Task<StripeList<CreditNote>> ListAsync(CreditNoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CreditNote>>(HttpMethod.Get, $"/v1/credit_notes", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CreditNote> ListAutoPaging(CreditNoteListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<CreditNote>($"/v1/credit_notes", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CreditNote> ListAutoPagingAsync(CreditNoteListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CreditNote>($"/v1/credit_notes", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditNoteLineItem> ListLineItems(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions);
+            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"/v1/credit_notes/{id}/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<CreditNoteLineItem>> ListLineItemsAsync(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"/v1/credit_notes/{id}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CreditNoteLineItem> ListLineItemsAutoPaging(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<CreditNoteLineItem>($"/v1/credit_notes/{id}/lines", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CreditNoteLineItem> ListLineItemsAutoPagingAsync(string id, CreditNoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"/v1/credit_notes/{id}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<CreditNoteLineItem> ListPreviewLineItems(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("preview")}/lines", options, requestOptions);
+            return this.Request<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"/v1/credit_notes/preview/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<CreditNoteLineItem>> ListPreviewLineItemsAsync(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("preview")}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CreditNoteLineItem>>(HttpMethod.Get, $"/v1/credit_notes/preview/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<CreditNoteLineItem> ListPreviewLineItemsAutoPaging(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<CreditNoteLineItem>($"/v1/credit_notes/preview/lines", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<CreditNoteLineItem> ListPreviewLineItemsAutoPagingAsync(CreditNoteListPreviewLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"{this.InstanceUrl("preview")}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CreditNoteLineItem>($"/v1/credit_notes/preview/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual CreditNote Preview(CreditNotePreviewOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Get, $"{this.ClassUrl()}/preview", options, requestOptions);
+            return this.Request(HttpMethod.Get, $"/v1/credit_notes/preview", options, requestOptions);
         }
 
         public virtual Task<CreditNote> PreviewAsync(CreditNotePreviewOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Get, $"{this.ClassUrl()}/preview", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, $"/v1/credit_notes/preview", options, requestOptions, cancellationToken);
         }
 
         public virtual CreditNote Update(string id, CreditNoteUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<CreditNote>(HttpMethod.Post, $"/v1/credit_notes/{id}", options, requestOptions);
         }
 
         public virtual Task<CreditNote> UpdateAsync(string id, CreditNoteUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditNote>(HttpMethod.Post, $"/v1/credit_notes/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual CreditNote VoidCreditNote(string id, CreditNoteVoidOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/credit_notes/{id}/void", options, requestOptions);
         }
 
         public virtual Task<CreditNote> VoidCreditNoteAsync(string id, CreditNoteVoidOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/credit_notes/{id}/void", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -34,7 +35,7 @@ namespace Stripe
             requestOptions = requestOptions ?? new RequestOptions();
             requestOptions.StripeVersion = options.StripeVersion;
 
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<EphemeralKey>(HttpMethod.Post, $"/v1/ephemeral_keys", options, requestOptions);
         }
 
         public virtual Task<EphemeralKey> CreateAsync(EphemeralKeyCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
@@ -44,17 +45,17 @@ namespace Stripe
             requestOptions = requestOptions ?? new RequestOptions();
             requestOptions.StripeVersion = options.StripeVersion;
 
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<EphemeralKey>(HttpMethod.Post, $"/v1/ephemeral_keys", options, requestOptions, cancellationToken);
         }
 
         public virtual EphemeralKey Delete(string id, EphemeralKeyDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<EphemeralKey>(HttpMethod.Delete, $"/v1/ephemeral_keys/{id}", options, requestOptions);
         }
 
         public virtual Task<EphemeralKey> DeleteAsync(string id, EphemeralKeyDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<EphemeralKey>(HttpMethod.Delete, $"/v1/ephemeral_keys/{id}", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -9,7 +9,6 @@ namespace Stripe
         ICreatable<EphemeralKey, EphemeralKeyCreateOptions>,
         IDeletable<EphemeralKey, EphemeralKeyDeleteOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public EphemeralKeyService()
             : base(null)
         {
@@ -57,6 +56,5 @@ namespace Stripe
         {
             return this.RequestAsync<EphemeralKey>(HttpMethod.Delete, $"/v1/ephemeral_keys/{id}", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -27,43 +28,43 @@ namespace Stripe
         public virtual File Create(FileCreateOptions options, RequestOptions requestOptions = null)
         {
             requestOptions = this.SetupRequestOptionsForFilesRequest(requestOptions);
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<File>(HttpMethod.Post, $"/v1/files", options, requestOptions);
         }
 
         public virtual Task<File> CreateAsync(FileCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             requestOptions = this.SetupRequestOptionsForFilesRequest(requestOptions);
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<File>(HttpMethod.Post, $"/v1/files", options, requestOptions, cancellationToken);
         }
 
         public virtual File Get(string id, FileGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<File>(HttpMethod.Get, $"/v1/files/{id}", options, requestOptions);
         }
 
         public virtual Task<File> GetAsync(string id, FileGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<File>(HttpMethod.Get, $"/v1/files/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<File> List(FileListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<File>>(HttpMethod.Get, $"/v1/files", options, requestOptions);
         }
 
         public virtual Task<StripeList<File>> ListAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<File>>(HttpMethod.Get, $"/v1/files", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<File> ListAutoPaging(FileListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<File>($"/v1/files", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<File> ListAutoPagingAsync(FileListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<File>($"/v1/files", options, requestOptions, cancellationToken);
         }
 
         private RequestOptions SetupRequestOptionsForFilesRequest(RequestOptions requestOptions)

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -11,7 +11,6 @@ namespace Stripe
         IListable<File, FileListOptions>,
         IRetrievable<File, FileGetOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public FileService()
             : base(null)
         {
@@ -82,6 +81,5 @@ namespace Stripe
 
             return requestOptions;
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -29,182 +29,182 @@ namespace Stripe
 
         public virtual Invoice Create(InvoiceCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices", options, requestOptions);
         }
 
         public virtual Task<Invoice> CreateAsync(InvoiceCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Delete(string id, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.DeleteEntity(id, options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Delete, $"/v1/invoices/{id}", options, requestOptions);
         }
 
         public virtual Task<Invoice> DeleteAsync(string id, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.DeleteEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Delete, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice FinalizeInvoice(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/invoices/{id}/finalize", options, requestOptions);
         }
 
         public virtual Task<Invoice> FinalizeInvoiceAsync(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/finalize", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/finalize", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Get(string id, InvoiceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Get, $"/v1/invoices/{id}", options, requestOptions);
         }
 
         public virtual Task<Invoice> GetAsync(string id, InvoiceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Get, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Invoice> List(InvoiceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntities(options, requestOptions);
+            return this.Request<StripeList<Invoice>>(HttpMethod.Get, $"/v1/invoices", options, requestOptions);
         }
 
         public virtual Task<StripeList<Invoice>> ListAsync(InvoiceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Invoice>>(HttpMethod.Get, $"/v1/invoices", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Invoice> ListAutoPaging(InvoiceListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListEntitiesAutoPaging(options, requestOptions);
+            return this.ListRequestAutoPaging<Invoice>($"/v1/invoices", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Invoice> ListAutoPagingAsync(InvoiceListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListEntitiesAutoPagingAsync(options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Invoice>($"/v1/invoices", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InvoiceLineItem> ListLineItems(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions);
+            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{id}/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{id}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InvoiceLineItem> ListLineItemsAutoPaging(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<InvoiceLineItem>($"/v1/invoices/{id}/lines", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<InvoiceLineItem> ListLineItemsAutoPagingAsync(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl(id)}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"/v1/invoices/{id}/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<InvoiceLineItem> ListUpcomingLineItems(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
+            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/upcoming/lines", options, requestOptions);
         }
 
         public virtual Task<StripeList<InvoiceLineItem>> ListUpcomingLineItemsAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/upcoming/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPaging(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<InvoiceLineItem>($"/v1/invoices/upcoming/lines", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<InvoiceLineItem> ListUpcomingLineItemsAutoPagingAsync(UpcomingInvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"{this.InstanceUrl("upcoming")}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"/v1/invoices/upcoming/lines", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice MarkUncollectible(string id, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/mark_uncollectible", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/invoices/{id}/mark_uncollectible", options, requestOptions);
         }
 
         public virtual Task<Invoice> MarkUncollectibleAsync(string id, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/mark_uncollectible", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/mark_uncollectible", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Pay(string id, InvoicePayOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/pay", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/invoices/{id}/pay", options, requestOptions);
         }
 
         public virtual Task<Invoice> PayAsync(string id, InvoicePayOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/pay", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/pay", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeSearchResult<Invoice> Search(InvoiceSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeSearchResult<Invoice>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.Request<StripeSearchResult<Invoice>>(HttpMethod.Get, $"/v1/invoices/search", options, requestOptions);
         }
 
         public virtual Task<StripeSearchResult<Invoice>> SearchAsync(InvoiceSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeSearchResult<Invoice>>(HttpMethod.Get, $"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeSearchResult<Invoice>>(HttpMethod.Get, $"/v1/invoices/search", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<Invoice> SearchAutoPaging(InvoiceSearchOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.SearchRequestAutoPaging<Invoice>($"{this.InstanceUrl("search")}", options, requestOptions);
+            return this.SearchRequestAutoPaging<Invoice>($"/v1/invoices/search", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<Invoice> SearchAutoPagingAsync(InvoiceSearchOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.SearchRequestAutoPagingAsync<Invoice>($"{this.InstanceUrl("search")}", options, requestOptions, cancellationToken);
+            return this.SearchRequestAutoPagingAsync<Invoice>($"/v1/invoices/search", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice SendInvoice(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/send", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/invoices/{id}/send", options, requestOptions);
         }
 
         public virtual Task<Invoice> SendInvoiceAsync(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/send", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/send", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Upcoming(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions);
+            return this.Request(HttpMethod.Get, $"/v1/invoices/upcoming", options, requestOptions);
         }
 
         public virtual Task<Invoice> UpcomingAsync(UpcomingInvoiceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Get, $"{this.InstanceUrl("upcoming")}", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Get, $"/v1/invoices/upcoming", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice Update(string id, InvoiceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}", options, requestOptions);
         }
 
         public virtual Task<Invoice> UpdateAsync(string id, InvoiceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Invoice VoidInvoice(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/invoices/{id}/void", options, requestOptions);
         }
 
         public virtual Task<Invoice> VoidInvoiceAsync(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync(HttpMethod.Post, $"{this.InstanceUrl(id)}/void", options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/void", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -13,7 +13,6 @@ namespace Stripe
         IRetrievable<Invoice, InvoiceGetOptions>,
         IUpdatable<Invoice, InvoiceUpdateOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public InvoiceService()
             : base(null)
         {
@@ -206,6 +205,5 @@ namespace Stripe
         {
             return this.RequestAsync(HttpMethod.Post, $"/v1/invoices/{id}/void", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -9,7 +9,6 @@ namespace Stripe
     public class OAuthTokenService : Service<OAuthToken>,
         ICreatable<OAuthToken, OAuthTokenCreateOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public OAuthTokenService()
             : base(null)
         {
@@ -110,6 +109,5 @@ namespace Stripe
 
             return options;
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -42,13 +42,13 @@ namespace Stripe
         public virtual OAuthToken Create(OAuthTokenCreateOptions options, RequestOptions requestOptions = null)
         {
             options = this.SetupOAuthTokenCreateOptions(options);
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<OAuthToken>(HttpMethod.Post, "/oauth/token", options, requestOptions);
         }
 
         public virtual Task<OAuthToken> CreateAsync(OAuthTokenCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             options = this.SetupOAuthTokenCreateOptions(options);
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<OAuthToken>(HttpMethod.Post, "/oauth/token", options, requestOptions, cancellationToken);
         }
 
         public virtual OAuthDeauthorize Deauthorize(OAuthDeauthorizeOptions options, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -9,7 +9,6 @@ namespace Stripe
     public class SourceTransactionService : ServiceNested<SourceTransaction>,
         INestedListable<SourceTransaction, SourceTransactionsListOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public SourceTransactionService()
             : base(null)
         {
@@ -42,6 +41,5 @@ namespace Stripe
         {
             return this.ListRequestAutoPagingAsync<SourceTransaction>($"/v1/sources/{sourceId}/source_transactions", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -24,22 +25,22 @@ namespace Stripe
 
         public virtual StripeList<SourceTransaction> List(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntities(sourceId, options, requestOptions);
+            return this.Request<StripeList<SourceTransaction>>(HttpMethod.Get, $"/v1/sources/{sourceId}/source_transactions", options, requestOptions);
         }
 
         public virtual Task<StripeList<SourceTransaction>> ListAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAsync(sourceId, options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<SourceTransaction>>(HttpMethod.Get, $"/v1/sources/{sourceId}/source_transactions", options, requestOptions, cancellationToken);
         }
 
         public virtual IEnumerable<SourceTransaction> ListAutoPaging(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListNestedEntitiesAutoPaging(sourceId, options, requestOptions);
+            return this.ListRequestAutoPaging<SourceTransaction>($"/v1/sources/{sourceId}/source_transactions", options, requestOptions);
         }
 
         public virtual IAsyncEnumerable<SourceTransaction> ListAutoPagingAsync(string sourceId, SourceTransactionsListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListNestedEntitiesAutoPagingAsync(sourceId, options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<SourceTransaction>($"/v1/sources/{sourceId}/source_transactions", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -12,7 +12,6 @@ namespace Stripe
         IUpdatable<Source, SourceUpdateOptions>,
         INestedListable<Source, SourceListOptions>
     {
-#pragma warning disable CS0618 // Type or member is obsolete
         public SourceService()
             : base(null)
         {
@@ -105,6 +104,5 @@ namespace Stripe
         {
             return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/sources/{id}/verify", options, requestOptions, cancellationToken);
         }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -38,12 +38,12 @@ namespace Stripe
 
         public virtual Source Create(SourceCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.CreateEntity(options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"/v1/sources", options, requestOptions);
         }
 
         public virtual Task<Source> CreateAsync(SourceCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.CreateEntityAsync(options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/sources", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Detach(string parentId, string id, SourceDetachOptions options = null, RequestOptions requestOptions = null)
@@ -58,12 +58,12 @@ namespace Stripe
 
         public virtual Source Get(string id, SourceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.GetEntity(id, options, requestOptions);
+            return this.Request<Source>(HttpMethod.Get, $"/v1/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<Source> GetAsync(string id, SourceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.GetEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Get, $"/v1/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual StripeList<Source> List(string parentId, SourceListOptions options = null, RequestOptions requestOptions = null)
@@ -88,22 +88,22 @@ namespace Stripe
 
         public virtual Source Update(string id, SourceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.UpdateEntity(id, options, requestOptions);
+            return this.Request(HttpMethod.Post, $"/v1/sources/{id}", options, requestOptions);
         }
 
         public virtual Task<Source> UpdateAsync(string id, SourceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.UpdateEntityAsync(id, options, requestOptions, cancellationToken);
+            return this.RequestAsync(HttpMethod.Post, $"/v1/sources/{id}", options, requestOptions, cancellationToken);
         }
 
         public virtual Source Verify(string id, SourceVerifyOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Source>(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify", options, requestOptions);
+            return this.Request<Source>(HttpMethod.Post, $"/v1/sources/{id}/verify", options, requestOptions);
         }
 
         public virtual Task<Source> VerifyAsync(string id, SourceVerifyOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Source>(HttpMethod.Post, $"{this.InstanceUrl(id)}/verify", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Source>(HttpMethod.Post, $"/v1/sources/{id}/verify", options, requestOptions, cancellationToken);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
     }


### PR DESCRIPTION
In [#2971](https://github.com/stripe/stripe-dotnet/pull/2791) we switch codegenerated methods to avoid helpers like `CreateEntityAsync` and `InstanceUrl` and instead define their paths directly.

Unfortunately the library contains several files that, for one reason or another, aren't code-generated and are manually maintained. This PR makes the analogous change in these files.