### PR TITLE
Remove deprecated events

### DIFF
--- a/src/Stripe.net/Constants/Events.cs
+++ b/src/Stripe.net/Constants/Events.cs
@@ -1,8 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    using System;
-
     public static class Events
     {
         /// <summary>
@@ -524,13 +522,6 @@ namespace Stripe
         public const string InvoiceItemDeleted = "invoiceitem.deleted";
 
         /// <summary>
-        /// The "invoiceitem.updated" event is deprecated and will be removed in the next major
-        /// version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string InvoiceItemUpdated = "invoiceitem.updated";
-
-        /// <summary>
         /// Occurs whenever an authorization is created.
         /// </summary>
         public const string IssuingAuthorizationCreated = "issuing_authorization.created";
@@ -616,12 +607,6 @@ namespace Stripe
         /// Occurs whenever a Mandate is updated.
         /// </summary>
         public const string MandateUpdated = "mandate.updated";
-
-        /// <summary>
-        /// The "order.created" event is deprecated and will be removed in the next major version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string OrderCreated = "order.created";
 
         /// <summary>
         /// Occurs when a PaymentIntent has funds to be captured. Check the <c>amount_capturable</c>
@@ -839,27 +824,6 @@ namespace Stripe
         public const string RadarEarlyFraudWarningUpdated = "radar.early_fraud_warning.updated";
 
         /// <summary>
-        /// The "recipient.created" event is deprecated and will be removed in the next major
-        /// version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string RecipientCreated = "recipient.created";
-
-        /// <summary>
-        /// The "recipient.deleted" event is deprecated and will be removed in the next major
-        /// version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string RecipientDeleted = "recipient.deleted";
-
-        /// <summary>
-        /// The "recipient.updated" event is deprecated and will be removed in the next major
-        /// version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string RecipientUpdated = "recipient.updated";
-
-        /// <summary>
         /// Occurs whenever a refund from a customer's cash balance is created.
         /// </summary>
         public const string RefundCreated = "refund.created";
@@ -925,24 +889,6 @@ namespace Stripe
         /// Occurs whenever a Sigma scheduled query run finishes.
         /// </summary>
         public const string SigmaScheduledQueryRunCreated = "sigma.scheduled_query_run.created";
-
-        /// <summary>
-        /// The "sku.created" event is deprecated and will be removed in the next major version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string SkuCreated = "sku.created";
-
-        /// <summary>
-        /// The "sku.deleted" event is deprecated and will be removed in the next major version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string SkuDeleted = "sku.deleted";
-
-        /// <summary>
-        /// The "sku.updated" event is deprecated and will be removed in the next major version.
-        /// </summary>
-        [Obsolete("This event is deprecated and going to be removed")]
-        public const string SkuUpdated = "sku.updated";
 
         /// <summary>
         /// Occurs whenever a source is canceled.

--- a/src/Stripe.net/Entities/Climate/Suppliers/Supplier.cs
+++ b/src/Stripe.net/Entities/Climate/Suppliers/Supplier.cs
@@ -48,8 +48,8 @@ namespace Stripe.Climate
 
         /// <summary>
         /// The scientific pathway used for carbon removal.
-        /// One of: <c>biomass_carbon_removal_and_storage</c>, <c>direct_air_capture</c>,
-        /// <c>enhanced_weathering</c>, or <c>various</c>.
+        /// One of: <c>biomass_carbon_removal_and_storage</c>, <c>direct_air_capture</c>, or
+        /// <c>enhanced_weathering</c>.
         /// </summary>
         [JsonProperty("removal_pathway")]
         public string RemovalPathway { get; set; }

--- a/src/Stripe.net/Entities/Events/Event.cs
+++ b/src/Stripe.net/Entities/Events/Event.cs
@@ -206,10 +206,7 @@ namespace Stripe
         /// <c>treasury.outbound_transfer.failed</c>, <c>treasury.outbound_transfer.posted</c>,
         /// <c>treasury.outbound_transfer.returned</c>, <c>treasury.received_credit.created</c>,
         /// <c>treasury.received_credit.failed</c>, <c>treasury.received_credit.succeeded</c>,
-        /// <c>treasury.received_debit.created</c>, <c>invoiceitem.updated</c>,
-        /// <c>order.created</c>, <c>recipient.created</c>, <c>recipient.deleted</c>,
-        /// <c>recipient.updated</c>, <c>sku.created</c>, <c>sku.deleted</c>, <c>sku.updated</c>, or
-        /// <c>ping</c>.
+        /// <c>treasury.received_debit.created</c>, or <c>ping</c>.
         /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointCreateOptions.cs
@@ -164,10 +164,7 @@ namespace Stripe
         /// <c>treasury.outbound_transfer.failed</c>, <c>treasury.outbound_transfer.posted</c>,
         /// <c>treasury.outbound_transfer.returned</c>, <c>treasury.received_credit.created</c>,
         /// <c>treasury.received_credit.failed</c>, <c>treasury.received_credit.succeeded</c>,
-        /// <c>treasury.received_debit.created</c>, <c>invoiceitem.updated</c>,
-        /// <c>order.created</c>, <c>recipient.created</c>, <c>recipient.deleted</c>,
-        /// <c>recipient.updated</c>, <c>sku.created</c>, <c>sku.deleted</c>, <c>sku.updated</c>, or
-        /// <c>ping</c>.
+        /// <c>treasury.received_debit.created</c>, or <c>ping</c>.
         /// </summary>
         [JsonProperty("enabled_events")]
         public List<string> EnabledEvents { get; set; }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointUpdateOptions.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointUpdateOptions.cs
@@ -131,10 +131,7 @@ namespace Stripe
         /// <c>treasury.outbound_transfer.failed</c>, <c>treasury.outbound_transfer.posted</c>,
         /// <c>treasury.outbound_transfer.returned</c>, <c>treasury.received_credit.created</c>,
         /// <c>treasury.received_credit.failed</c>, <c>treasury.received_credit.succeeded</c>,
-        /// <c>treasury.received_debit.created</c>, <c>invoiceitem.updated</c>,
-        /// <c>order.created</c>, <c>recipient.created</c>, <c>recipient.deleted</c>,
-        /// <c>recipient.updated</c>, <c>sku.created</c>, <c>sku.deleted</c>, <c>sku.updated</c>, or
-        /// <c>ping</c>.
+        /// <c>treasury.received_debit.created</c>, or <c>ping</c>.
         /// </summary>
         [JsonProperty("enabled_events")]
         public List<string> EnabledEvents { get; set; }


### PR DESCRIPTION
Below Event types were removed from the API in the last year

[On Sept 22, 2023](https://docs.stripe.com/changelog#september-22,-2023)

> Remove support for values order.created, recipient.created, recipient.deleted, recipient.updated, sku.created, sku.deleted, and sku.updated from enum Event.type

[On Sept 4th, 2023](https://docs.stripe.com/changelog#september-4,-2023)

> Remove support for value invoiceitem.updated from enum Event.type

And the enum Climate.Supplier.removal_pathway was updated on [Dec 6th , 2023](https://docs.stripe.com/changelog#december-6,-2023)

> Remove support for value various from enum Climate.Supplier.removal_pathway

This PR removes the same from the SDKs

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1740



