### PR TITLE
Update date fields to use DateTime type

### DIFF
--- a/src/Stripe.net/Entities/Accounts/AccountSettingsCardIssuingTosAcceptance.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountSettingsCardIssuingTosAcceptance.cs
@@ -1,7 +1,9 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class AccountSettingsCardIssuingTosAcceptance : StripeEntity<AccountSettingsCardIssuingTosAcceptance>
     {
@@ -10,7 +12,8 @@ namespace Stripe
         /// agreement.
         /// </summary>
         [JsonProperty("date")]
-        public long? Date { get; set; }
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? Date { get; set; }
 
         /// <summary>
         /// The IP address from which the account representative accepted the service agreement.

--- a/src/Stripe.net/Entities/Accounts/AccountSettingsTreasuryTosAcceptance.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountSettingsTreasuryTosAcceptance.cs
@@ -1,7 +1,9 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class AccountSettingsTreasuryTosAcceptance : StripeEntity<AccountSettingsTreasuryTosAcceptance>
     {
@@ -10,7 +12,8 @@ namespace Stripe
         /// agreement.
         /// </summary>
         [JsonProperty("date")]
-        public long? Date { get; set; }
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? Date { get; set; }
 
         /// <summary>
         /// The IP address from which the account representative accepted the service agreement.

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionPixDisplayQrCode.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextActionPixDisplayQrCode.cs
@@ -1,7 +1,9 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class PaymentIntentNextActionPixDisplayQrCode : StripeEntity<PaymentIntentNextActionPixDisplayQrCode>
     {
@@ -16,7 +18,8 @@ namespace Stripe
         /// The date (unix timestamp) when the PIX expires.
         /// </summary>
         [JsonProperty("expires_at")]
-        public long ExpiresAt { get; set; }
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime ExpiresAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
         /// The URL to the hosted pix instructions page, which allows customers to view the pix QR

--- a/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsPix.cs
+++ b/src/Stripe.net/Entities/PaymentIntents/PaymentIntentPaymentMethodOptionsPix.cs
@@ -1,7 +1,9 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class PaymentIntentPaymentMethodOptionsPix : StripeEntity<PaymentIntentPaymentMethodOptionsPix>
     {
@@ -15,7 +17,8 @@ namespace Stripe
         /// The timestamp at which the Pix expires.
         /// </summary>
         [JsonProperty("expires_at")]
-        public long? ExpiresAt { get; set; }
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? ExpiresAt { get; set; }
 
         /// <summary>
         /// Indicates that you intend to make future payments with this PaymentIntent's payment

--- a/src/Stripe.net/Services/Tax/Calculations/CalculationCreateOptions.cs
+++ b/src/Stripe.net/Services/Tax/Calculations/CalculationCreateOptions.cs
@@ -1,8 +1,10 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Tax
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 
     public class CalculationCreateOptions : BaseOptions
     {
@@ -45,6 +47,7 @@ namespace Stripe.Tax
         /// past, and up to 48 hours in the future.
         /// </summary>
         [JsonProperty("tax_date")]
-        public long? TaxDate { get; set; }
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+        public DateTime? TaxDate { get; set; }
     }
 }


### PR DESCRIPTION


## Changelog

Change the type of the below date fields from `long` to `DateTime` 
- `AccountSettingsCardIssuingTosAcceptance.Date`
- `AccountSettingsTreasuryTosAcceptance.Date`
- `PaymentIntentNextActionPixDisplayQrCode.ExpiresAt`
- `PaymentIntentPaymentMethodOptionsPix.ExpiresAt`
- `CalculationCreateOptions.TaxDate`
