### PR TITLE
urlencode ids in url paths

### DIFF
--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -78,7 +79,7 @@ namespace Stripe
         /// </summary>
         public virtual Account Delete(string id, AccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Delete, $"/v1/accounts/{id}", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -99,7 +100,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Account> DeleteAsync(string id, AccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Delete, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -107,7 +108,7 @@ namespace Stripe
         /// </summary>
         public virtual Account Get(string id, AccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Get, $"/v1/accounts/{id}", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Account> GetAsync(string id, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -169,7 +170,7 @@ namespace Stripe
         /// </summary>
         public virtual Account Reject(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{id}/reject", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(id)}/reject", options, requestOptions);
         }
 
         /// <summary>
@@ -183,7 +184,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Account> RejectAsync(string id, AccountRejectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{id}/reject", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(id)}/reject", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -210,7 +211,7 @@ namespace Stripe
         /// </summary>
         public virtual Account Update(string id, AccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{id}", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -237,7 +238,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Account> UpdateAsync(string id, AccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         public virtual Account GetSelf(RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplePayDomain Delete(string id, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{id}", options, requestOptions);
+            return this.Request<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplePayDomain> DeleteAsync(string id, ApplePayDomainDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplePayDomain>(HttpMethod.Delete, $"/v1/apple_pay/domains/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplePayDomain Get(string id, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{id}", options, requestOptions);
+            return this.Request<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplePayDomain> GetAsync(string id, ApplePayDomainGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplePayDomain>(HttpMethod.Get, $"/v1/apple_pay/domains/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -39,7 +40,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplicationFeeRefund Create(string parentId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds", options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplicationFeeRefund> CreateAsync(string parentId, ApplicationFeeRefundCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplicationFeeRefund Get(string parentId, string id, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -76,7 +77,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplicationFeeRefund> GetAsync(string parentId, string id, ApplicationFeeRefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<ApplicationFeeRefund> List(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds", options, requestOptions);
+            return this.Request<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<ApplicationFeeRefund>> ListAsync(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ApplicationFeeRefund>>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -109,7 +110,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<ApplicationFeeRefund> ListAutoPaging(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<ApplicationFeeRefund>($"/v1/application_fees/{parentId}/refunds", options, requestOptions);
+            return this.ListRequestAutoPaging<ApplicationFeeRefund>($"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions);
         }
 
         /// <summary>
@@ -120,7 +121,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<ApplicationFeeRefund> ListAutoPagingAsync(string parentId, ApplicationFeeRefundListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<ApplicationFeeRefund>($"/v1/application_fees/{parentId}/refunds", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ApplicationFeeRefund>($"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -131,7 +132,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplicationFeeRefund Update(string parentId, string id, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions);
+            return this.Request<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplicationFeeRefund> UpdateAsync(string parentId, string id, ApplicationFeeRefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{parentId}/refunds/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFeeRefund>(HttpMethod.Post, $"/v1/application_fees/{WebUtility.UrlEncode(parentId)}/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual ApplicationFee Get(string id, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{id}", options, requestOptions);
+            return this.Request<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ApplicationFee> GetAsync(string id, ApplicationFeeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ApplicationFee>(HttpMethod.Get, $"/v1/application_fees/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Stripe
         /// </summary>
         public virtual BalanceTransaction Get(string id, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{id}", options, requestOptions);
+            return this.Request<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<BalanceTransaction> GetAsync(string id, BalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<BalanceTransaction>(HttpMethod.Get, $"/v1/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Billing/Alerts/AlertService.cs
+++ b/src/Stripe.net/Services/Billing/Alerts/AlertService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Billing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Alert Activate(string id, AlertActivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/activate", options, requestOptions);
+            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/activate", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Alert> ActivateAsync(string id, AlertActivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/activate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/activate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Alert Archive(string id, AlertArchiveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/archive", options, requestOptions);
+            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/archive", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Alert> ArchiveAsync(string id, AlertArchiveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/archive", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/archive", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Alert Deactivate(string id, AlertDeactivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/deactivate", options, requestOptions);
+            return this.Request<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Alert> DeactivateAsync(string id, AlertDeactivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{id}/deactivate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Alert>(HttpMethod.Post, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Alert Get(string id, AlertGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Alert>(HttpMethod.Get, $"/v1/billing/alerts/{id}", options, requestOptions);
+            return this.Request<Alert>(HttpMethod.Get, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Alert> GetAsync(string id, AlertGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Alert>(HttpMethod.Get, $"/v1/billing/alerts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Alert>(HttpMethod.Get, $"/v1/billing/alerts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Billing/MeterEventSummaries/MeterEventSummaryService.cs
+++ b/src/Stripe.net/Services/Billing/MeterEventSummaries/MeterEventSummaryService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Billing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual StripeList<MeterEventSummary> List(string parentId, MeterEventSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<MeterEventSummary>>(HttpMethod.Get, $"/v1/billing/meters/{parentId}/event_summaries", options, requestOptions);
+            return this.Request<StripeList<MeterEventSummary>>(HttpMethod.Get, $"/v1/billing/meters/{WebUtility.UrlEncode(parentId)}/event_summaries", options, requestOptions);
         }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<StripeList<MeterEventSummary>> ListAsync(string parentId, MeterEventSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<MeterEventSummary>>(HttpMethod.Get, $"/v1/billing/meters/{parentId}/event_summaries", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<MeterEventSummary>>(HttpMethod.Get, $"/v1/billing/meters/{WebUtility.UrlEncode(parentId)}/event_summaries", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual IEnumerable<MeterEventSummary> ListAutoPaging(string parentId, MeterEventSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<MeterEventSummary>($"/v1/billing/meters/{parentId}/event_summaries", options, requestOptions);
+            return this.ListRequestAutoPaging<MeterEventSummary>($"/v1/billing/meters/{WebUtility.UrlEncode(parentId)}/event_summaries", options, requestOptions);
         }
 
         /// <summary>
@@ -51,7 +52,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual IAsyncEnumerable<MeterEventSummary> ListAutoPagingAsync(string parentId, MeterEventSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<MeterEventSummary>($"/v1/billing/meters/{parentId}/event_summaries", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<MeterEventSummary>($"/v1/billing/meters/{WebUtility.UrlEncode(parentId)}/event_summaries", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Billing/Meters/MeterService.cs
+++ b/src/Stripe.net/Services/Billing/Meters/MeterService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Billing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Meter Deactivate(string id, MeterDeactivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}/deactivate", options, requestOptions);
+            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Meter> DeactivateAsync(string id, MeterDeactivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}/deactivate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Meter Get(string id, MeterGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Meter>(HttpMethod.Get, $"/v1/billing/meters/{id}", options, requestOptions);
+            return this.Request<Meter>(HttpMethod.Get, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Meter> GetAsync(string id, MeterGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Meter>(HttpMethod.Get, $"/v1/billing/meters/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Meter>(HttpMethod.Get, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Meter Reactivate(string id, MeterReactivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}/reactivate", options, requestOptions);
+            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}/reactivate", options, requestOptions);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Meter> ReactivateAsync(string id, MeterReactivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}/reactivate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}/reactivate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Meter Update(string id, MeterUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}", options, requestOptions);
+            return this.Request<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe.Billing
         /// </summary>
         public virtual Task<Meter> UpdateAsync(string id, MeterUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Meter>(HttpMethod.Post, $"/v1/billing/meters/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.BillingPortal
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -49,7 +50,7 @@ namespace Stripe.BillingPortal
         /// </summary>
         public virtual Configuration Get(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{id}", options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -58,7 +59,7 @@ namespace Stripe.BillingPortal
         /// </summary>
         public virtual Task<Configuration> GetAsync(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/billing_portal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe.BillingPortal
         /// </summary>
         public virtual Configuration Update(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{id}", options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Stripe.BillingPortal
         /// </summary>
         public virtual Task<Configuration> UpdateAsync(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/billing_portal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Capabilities/CapabilityService.cs
+++ b/src/Stripe.net/Services/Capabilities/CapabilityService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual Capability Get(string parentId, string id, CapabilityGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Capability>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions);
+            return this.Request<Capability>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Capability> GetAsync(string parentId, string id, CapabilityGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Capability>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Capability>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<Capability> List(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities", options, requestOptions);
+            return this.Request<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<Capability>> ListAsync(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{parentId}/capabilities", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Capability>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<Capability> ListAutoPaging(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<Capability>($"/v1/accounts/{parentId}/capabilities", options, requestOptions);
+            return this.ListRequestAutoPaging<Capability>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<Capability> ListAutoPagingAsync(string parentId, CapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<Capability>($"/v1/accounts/{parentId}/capabilities", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Capability>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Stripe
         /// </summary>
         public virtual Capability Update(string parentId, string id, CapabilityUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Capability>(HttpMethod.Post, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions);
+            return this.Request<Capability>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Capability> UpdateAsync(string parentId, string id, CapabilityUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Capability>(HttpMethod.Post, $"/v1/accounts/{parentId}/capabilities/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Capability>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CashBalances/CashBalanceService.cs
+++ b/src/Stripe.net/Services/CashBalances/CashBalanceService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace Stripe
         /// </summary>
         public virtual CashBalance Get(string parentId, CashBalanceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CashBalance>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance", options, requestOptions);
+            return this.Request<CashBalance>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance", options, requestOptions);
         }
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CashBalance> GetAsync(string parentId, CashBalanceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CashBalance>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CashBalance>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +42,7 @@ namespace Stripe
         /// </summary>
         public virtual CashBalance Update(string parentId, CashBalanceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<CashBalance>(HttpMethod.Post, $"/v1/customers/{parentId}/cash_balance", options, requestOptions);
+            return this.Request<CashBalance>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance", options, requestOptions);
         }
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CashBalance> UpdateAsync(string parentId, CashBalanceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CashBalance>(HttpMethod.Post, $"/v1/customers/{parentId}/cash_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CashBalance>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance", options, requestOptions, cancellationToken);
         }
 
         [Obsolete("This method is deprecated and will be removed in a future release")]

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -40,7 +41,7 @@ namespace Stripe
         /// </summary>
         public virtual Charge Capture(string id, ChargeCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{id}/capture", options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{WebUtility.UrlEncode(id)}/capture", options, requestOptions);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Charge> CaptureAsync(string id, ChargeCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{id}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{WebUtility.UrlEncode(id)}/capture", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -90,7 +91,7 @@ namespace Stripe
         /// </summary>
         public virtual Charge Get(string id, ChargeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Charge>(HttpMethod.Get, $"/v1/charges/{id}", options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Get, $"/v1/charges/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Charge> GetAsync(string id, ChargeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Charge>(HttpMethod.Get, $"/v1/charges/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Get, $"/v1/charges/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -198,7 +199,7 @@ namespace Stripe
         /// </summary>
         public virtual Charge Update(string id, ChargeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{id}", options, requestOptions);
+            return this.Request<Charge>(HttpMethod.Post, $"/v1/charges/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -207,7 +208,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Charge> UpdateAsync(string id, ChargeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Charge>(HttpMethod.Post, $"/v1/charges/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Checkout
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -49,7 +50,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Session Expire(string id, SessionExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}/expire", options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/expire", options, requestOptions);
         }
 
         /// <summary>
@@ -60,7 +61,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Task<Session> ExpireAsync(string id, SessionExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/expire", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Session Get(string id, SessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{id}", options, requestOptions);
+            return this.Request<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -76,7 +77,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Task<Session> GetAsync(string id, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual StripeList<LineItem> ListLineItems(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{id}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -128,7 +129,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"/v1/checkout/sessions/{id}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -148,7 +149,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, SessionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/checkout/sessions/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -156,7 +157,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Session Update(string id, SessionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}", options, requestOptions);
+            return this.Request<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -164,7 +165,7 @@ namespace Stripe.Checkout
         /// </summary>
         public virtual Task<Session> UpdateAsync(string id, SessionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Post, $"/v1/checkout/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Climate/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Climate/Orders/OrderService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Climate
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -34,7 +35,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Order Cancel(string id, OrderCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Order>(HttpMethod.Post, $"/v1/climate/orders/{id}/cancel", options, requestOptions);
+            return this.Request<Order>(HttpMethod.Post, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Task<Order> CancelAsync(string id, OrderCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Order>(HttpMethod.Post, $"/v1/climate/orders/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Order>(HttpMethod.Post, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Order Get(string id, OrderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Order>(HttpMethod.Get, $"/v1/climate/orders/{id}", options, requestOptions);
+            return this.Request<Order>(HttpMethod.Get, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Task<Order> GetAsync(string id, OrderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Order>(HttpMethod.Get, $"/v1/climate/orders/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Order>(HttpMethod.Get, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Order Update(string id, OrderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Order>(HttpMethod.Post, $"/v1/climate/orders/{id}", options, requestOptions);
+            return this.Request<Order>(HttpMethod.Post, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Task<Order> UpdateAsync(string id, OrderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Order>(HttpMethod.Post, $"/v1/climate/orders/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Order>(HttpMethod.Post, $"/v1/climate/orders/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Climate/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Climate/Products/ProductService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Climate
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Product Get(string id, ProductGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Product>(HttpMethod.Get, $"/v1/climate/products/{id}", options, requestOptions);
+            return this.Request<Product>(HttpMethod.Get, $"/v1/climate/products/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Task<Product> GetAsync(string id, ProductGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Product>(HttpMethod.Get, $"/v1/climate/products/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Get, $"/v1/climate/products/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Climate/Suppliers/SupplierService.cs
+++ b/src/Stripe.net/Services/Climate/Suppliers/SupplierService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Climate
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Supplier Get(string id, SupplierGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Supplier>(HttpMethod.Get, $"/v1/climate/suppliers/{id}", options, requestOptions);
+            return this.Request<Supplier>(HttpMethod.Get, $"/v1/climate/suppliers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Climate
         /// </summary>
         public virtual Task<Supplier> GetAsync(string id, SupplierGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Supplier>(HttpMethod.Get, $"/v1/climate/suppliers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Supplier>(HttpMethod.Get, $"/v1/climate/suppliers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/ConfirmationTokens/ConfirmationTokenService.cs
+++ b/src/Stripe.net/Services/ConfirmationTokens/ConfirmationTokenService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace Stripe
         /// </summary>
         public virtual ConfirmationToken Get(string id, ConfirmationTokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ConfirmationToken>(HttpMethod.Get, $"/v1/confirmation_tokens/{id}", options, requestOptions);
+            return this.Request<ConfirmationToken>(HttpMethod.Get, $"/v1/confirmation_tokens/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -34,7 +35,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ConfirmationToken> GetAsync(string id, ConfirmationTokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ConfirmationToken>(HttpMethod.Get, $"/v1/confirmation_tokens/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ConfirmationToken>(HttpMethod.Get, $"/v1/confirmation_tokens/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe
         /// </summary>
         public virtual CountrySpec Get(string id, CountrySpecGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{id}", options, requestOptions);
+            return this.Request<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CountrySpec> GetAsync(string id, CountrySpecGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CountrySpec>(HttpMethod.Get, $"/v1/country_specs/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -72,7 +73,7 @@ namespace Stripe
         /// </summary>
         public virtual Coupon Delete(string id, CouponDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Coupon>(HttpMethod.Delete, $"/v1/coupons/{id}", options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Delete, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Coupon> DeleteAsync(string id, CouponDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Coupon>(HttpMethod.Delete, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Delete, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace Stripe
         /// </summary>
         public virtual Coupon Get(string id, CouponGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Coupon>(HttpMethod.Get, $"/v1/coupons/{id}", options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Get, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -99,7 +100,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Coupon> GetAsync(string id, CouponGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Coupon>(HttpMethod.Get, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Get, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace Stripe
         /// </summary>
         public virtual Coupon Update(string id, CouponUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Coupon>(HttpMethod.Post, $"/v1/coupons/{id}", options, requestOptions);
+            return this.Request<Coupon>(HttpMethod.Post, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -149,7 +150,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Coupon> UpdateAsync(string id, CouponUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Coupon>(HttpMethod.Post, $"/v1/coupons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Coupon>(HttpMethod.Post, $"/v1/coupons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe
         /// </summary>
         public virtual CustomerBalanceTransaction Create(string parentId, CustomerBalanceTransactionCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CustomerBalanceTransaction> CreateAsync(string parentId, CustomerBalanceTransactionCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace Stripe
         /// </summary>
         public virtual CustomerBalanceTransaction Get(string parentId, string id, CustomerBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -58,7 +59,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CustomerBalanceTransaction> GetAsync(string parentId, string id, CustomerBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<CustomerBalanceTransaction> List(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
+            return this.Request<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions);
         }
 
         /// <summary>
@@ -76,7 +77,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<CustomerBalanceTransaction>> ListAsync(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CustomerBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<CustomerBalanceTransaction> ListAutoPaging(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CustomerBalanceTransaction>($"/v1/customers/{parentId}/balance_transactions", options, requestOptions);
+            return this.ListRequestAutoPaging<CustomerBalanceTransaction>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<CustomerBalanceTransaction> ListAutoPagingAsync(string parentId, CustomerBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CustomerBalanceTransaction>($"/v1/customers/{parentId}/balance_transactions", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CustomerBalanceTransaction>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Stripe
         /// </summary>
         public virtual CustomerBalanceTransaction Update(string parentId, string id, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions);
+            return this.Request<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CustomerBalanceTransaction> UpdateAsync(string parentId, string id, CustomerBalanceTransactionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{parentId}/balance_transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerBalanceTransaction>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual CustomerCashBalanceTransaction Get(string parentId, string id, CustomerCashBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions/{id}", options, requestOptions);
+            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<CustomerCashBalanceTransaction> GetAsync(string parentId, string id, CustomerCashBalanceTransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<CustomerCashBalanceTransaction> List(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions);
+            return this.Request<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions", options, requestOptions);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<CustomerCashBalanceTransaction>> ListAsync(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CustomerCashBalanceTransaction>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +66,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<CustomerCashBalanceTransaction> ListAutoPaging(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CustomerCashBalanceTransaction>($"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions);
+            return this.ListRequestAutoPaging<CustomerCashBalanceTransaction>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions", options, requestOptions);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<CustomerCashBalanceTransaction> ListAutoPagingAsync(string parentId, CustomerCashBalanceTransactionListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CustomerCashBalanceTransaction>($"/v1/customers/{parentId}/cash_balance_transactions", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CustomerCashBalanceTransaction>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/cash_balance_transactions", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -52,7 +53,7 @@ namespace Stripe
         /// </summary>
         public virtual FundingInstructions CreateFundingInstructions(string id, CustomerCreateFundingInstructionsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{id}/funding_instructions", options, requestOptions);
+            return this.Request<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(id)}/funding_instructions", options, requestOptions);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<FundingInstructions> CreateFundingInstructionsAsync(string id, CustomerCreateFundingInstructionsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{id}/funding_instructions", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FundingInstructions>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(id)}/funding_instructions", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe
         /// </summary>
         public virtual Customer Delete(string id, CustomerDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Customer>(HttpMethod.Delete, $"/v1/customers/{id}", options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Delete, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Customer> DeleteAsync(string id, CustomerDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Customer>(HttpMethod.Delete, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Delete, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -90,7 +91,7 @@ namespace Stripe
         /// </summary>
         public virtual Customer Get(string id, CustomerGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Customer>(HttpMethod.Get, $"/v1/customers/{id}", options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Customer> GetAsync(string id, CustomerGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Customer>(HttpMethod.Get, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<PaymentMethod> ListPaymentMethods(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{id}/payment_methods", options, requestOptions);
+            return this.Request<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(id)}/payment_methods", options, requestOptions);
         }
 
         /// <summary>
@@ -150,7 +151,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<PaymentMethod>> ListPaymentMethodsAsync(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{id}/payment_methods", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<PaymentMethod>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(id)}/payment_methods", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -158,7 +159,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<PaymentMethod> ListPaymentMethodsAutoPaging(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<PaymentMethod>($"/v1/customers/{id}/payment_methods", options, requestOptions);
+            return this.ListRequestAutoPaging<PaymentMethod>($"/v1/customers/{WebUtility.UrlEncode(id)}/payment_methods", options, requestOptions);
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<PaymentMethod> ListPaymentMethodsAutoPagingAsync(string id, CustomerListPaymentMethodsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<PaymentMethod>($"/v1/customers/{id}/payment_methods", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<PaymentMethod>($"/v1/customers/{WebUtility.UrlEncode(id)}/payment_methods", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethod RetrievePaymentMethod(string parentId, string id, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{parentId}/payment_methods/{id}", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -182,7 +183,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethod> RetrievePaymentMethodAsync(string parentId, string id, CustomerRetrievePaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{parentId}/payment_methods/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -253,7 +254,7 @@ namespace Stripe
         /// </summary>
         public virtual Customer Update(string id, CustomerUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Customer>(HttpMethod.Post, $"/v1/customers/{id}", options, requestOptions);
+            return this.Request<Customer>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -272,7 +273,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Customer> UpdateAsync(string id, CustomerUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Customer>(HttpMethod.Post, $"/v1/customers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Customer>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace Stripe
         /// </summary>
         public virtual Dispute Close(string id, DisputeCloseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}/close", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{WebUtility.UrlEncode(id)}/close", options, requestOptions);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Dispute> CloseAsync(string id, DisputeCloseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}/close", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{WebUtility.UrlEncode(id)}/close", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Stripe
         /// </summary>
         public virtual Dispute Get(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Get, $"/v1/disputes/{id}", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Get, $"/v1/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Dispute> GetAsync(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/disputes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace Stripe
         /// </summary>
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Dispute> UpdateAsync(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Entitlements/ActiveEntitlements/ActiveEntitlementService.cs
+++ b/src/Stripe.net/Services/Entitlements/ActiveEntitlements/ActiveEntitlementService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Entitlements
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual ActiveEntitlement Get(string id, ActiveEntitlementGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ActiveEntitlement>(HttpMethod.Get, $"/v1/entitlements/active_entitlements/{id}", options, requestOptions);
+            return this.Request<ActiveEntitlement>(HttpMethod.Get, $"/v1/entitlements/active_entitlements/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual Task<ActiveEntitlement> GetAsync(string id, ActiveEntitlementGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ActiveEntitlement>(HttpMethod.Get, $"/v1/entitlements/active_entitlements/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ActiveEntitlement>(HttpMethod.Get, $"/v1/entitlements/active_entitlements/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Entitlements/Features/FeatureService.cs
+++ b/src/Stripe.net/Services/Entitlements/Features/FeatureService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Entitlements
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual Feature Get(string id, FeatureGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Feature>(HttpMethod.Get, $"/v1/entitlements/features/{id}", options, requestOptions);
+            return this.Request<Feature>(HttpMethod.Get, $"/v1/entitlements/features/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual Task<Feature> GetAsync(string id, FeatureGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Feature>(HttpMethod.Get, $"/v1/entitlements/features/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Feature>(HttpMethod.Get, $"/v1/entitlements/features/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual Feature Update(string id, FeatureUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Feature>(HttpMethod.Post, $"/v1/entitlements/features/{id}", options, requestOptions);
+            return this.Request<Feature>(HttpMethod.Post, $"/v1/entitlements/features/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe.Entitlements
         /// </summary>
         public virtual Task<Feature> UpdateAsync(string id, FeatureUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Feature>(HttpMethod.Post, $"/v1/entitlements/features/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Feature>(HttpMethod.Post, $"/v1/entitlements/features/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual Event Get(string id, EventGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Event>(HttpMethod.Get, $"/v1/events/{id}", options, requestOptions);
+            return this.Request<Event>(HttpMethod.Get, $"/v1/events/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Event> GetAsync(string id, EventGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Event>(HttpMethod.Get, $"/v1/events/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Event>(HttpMethod.Get, $"/v1/events/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe
         /// </summary>
         public virtual IExternalAccount Create(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<IExternalAccount> CreateAsync(string parentId, ExternalAccountCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace Stripe
         /// </summary>
         public virtual IExternalAccount Delete(string parentId, string id, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<IExternalAccount> DeleteAsync(string parentId, string id, ExternalAccountDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe
         /// </summary>
         public virtual IExternalAccount Get(string parentId, string id, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<IExternalAccount> GetAsync(string parentId, string id, ExternalAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<IExternalAccount> List(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
+            return this.Request<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<IExternalAccount>> ListAsync(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<IExternalAccount>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<IExternalAccount> ListAutoPaging(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<IExternalAccount>($"/v1/accounts/{parentId}/external_accounts", options, requestOptions);
+            return this.ListRequestAutoPaging<IExternalAccount>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<IExternalAccount> ListAutoPagingAsync(string parentId, ExternalAccountListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<IExternalAccount>($"/v1/accounts/{parentId}/external_accounts", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<IExternalAccount>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -121,7 +122,7 @@ namespace Stripe
         /// </summary>
         public virtual IExternalAccount Update(string parentId, string id, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions);
+            return this.Request<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -139,7 +140,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<IExternalAccount> UpdateAsync(string parentId, string id, ExternalAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{parentId}/external_accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<IExternalAccount>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/external_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual FileLink Get(string id, FileLinkGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FileLink>(HttpMethod.Get, $"/v1/file_links/{id}", options, requestOptions);
+            return this.Request<FileLink>(HttpMethod.Get, $"/v1/file_links/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<FileLink> GetAsync(string id, FileLinkGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FileLink>(HttpMethod.Get, $"/v1/file_links/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FileLink>(HttpMethod.Get, $"/v1/file_links/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual FileLink Update(string id, FileLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<FileLink>(HttpMethod.Post, $"/v1/file_links/{id}", options, requestOptions);
+            return this.Request<FileLink>(HttpMethod.Post, $"/v1/file_links/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<FileLink> UpdateAsync(string id, FileLinkUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FileLink>(HttpMethod.Post, $"/v1/file_links/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FileLink>(HttpMethod.Post, $"/v1/file_links/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -72,7 +73,7 @@ namespace Stripe
         /// </summary>
         public virtual File Get(string id, FileGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<File>(HttpMethod.Get, $"/v1/files/{id}", options, requestOptions);
+            return this.Request<File>(HttpMethod.Get, $"/v1/files/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<File> GetAsync(string id, FileGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<File>(HttpMethod.Get, $"/v1/files/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<File>(HttpMethod.Get, $"/v1/files/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
@@ -3,6 +3,7 @@ namespace Stripe.FinancialConnections
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Account Disconnect(string id, AccountDisconnectOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/disconnect", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/disconnect", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Account> DisconnectAsync(string id, AccountDisconnectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/disconnect", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/disconnect", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Account Get(string id, AccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Account> GetAsync(string id, AccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Get, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual StripeList<AccountOwner> ListOwners(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}/owners", options, requestOptions);
+            return this.Request<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/owners", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<StripeList<AccountOwner>> ListOwnersAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{id}/owners", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<AccountOwner>>(HttpMethod.Get, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/owners", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual IEnumerable<AccountOwner> ListOwnersAutoPaging(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<AccountOwner>($"/v1/financial_connections/accounts/{id}/owners", options, requestOptions);
+            return this.ListRequestAutoPaging<AccountOwner>($"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/owners", options, requestOptions);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual IAsyncEnumerable<AccountOwner> ListOwnersAutoPagingAsync(string id, AccountListOwnersOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<AccountOwner>($"/v1/financial_connections/accounts/{id}/owners", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<AccountOwner>($"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/owners", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Account Refresh(string id, AccountRefreshOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/refresh", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/refresh", options, requestOptions);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Account> RefreshAsync(string id, AccountRefreshOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/refresh", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/refresh", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Account Subscribe(string id, AccountSubscribeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/subscribe", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/subscribe", options, requestOptions);
         }
 
         /// <summary>
@@ -152,7 +153,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Account> SubscribeAsync(string id, AccountSubscribeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/subscribe", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/subscribe", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -161,7 +162,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Account Unsubscribe(string id, AccountUnsubscribeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/unsubscribe", options, requestOptions);
+            return this.Request<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/unsubscribe", options, requestOptions);
         }
 
         /// <summary>
@@ -170,7 +171,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Account> UnsubscribeAsync(string id, AccountUnsubscribeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{id}/unsubscribe", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Account>(HttpMethod.Post, $"/v1/financial_connections/accounts/{WebUtility.UrlEncode(id)}/unsubscribe", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.FinancialConnections
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,7 +46,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Session Get(string id, SessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{id}", options, requestOptions);
+            return this.Request<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Session> GetAsync(string id, SessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Session>(HttpMethod.Get, $"/v1/financial_connections/sessions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/FinancialConnections/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Transactions/TransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.FinancialConnections
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Transaction>(HttpMethod.Get, $"/v1/financial_connections/transactions/{id}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/financial_connections/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.FinancialConnections
         /// </summary>
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/financial_connections/transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/financial_connections/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Forwarding/Requests/RequestService.cs
+++ b/src/Stripe.net/Services/Forwarding/Requests/RequestService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Forwarding
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,7 +46,7 @@ namespace Stripe.Forwarding
         /// </summary>
         public virtual Request Get(string id, RequestGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Request>(HttpMethod.Get, $"/v1/forwarding/requests/{id}", options, requestOptions);
+            return this.Request<Request>(HttpMethod.Get, $"/v1/forwarding/requests/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Stripe.Forwarding
         /// </summary>
         public virtual Task<Request> GetAsync(string id, RequestGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Request>(HttpMethod.Get, $"/v1/forwarding/requests/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Request>(HttpMethod.Get, $"/v1/forwarding/requests/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Identity
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual VerificationReport Get(string id, VerificationReportGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{id}", options, requestOptions);
+            return this.Request<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual Task<VerificationReport> GetAsync(string id, VerificationReportGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationReport>(HttpMethod.Get, $"/v1/identity/verification_reports/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Identity
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -34,7 +35,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual VerificationSession Cancel(string id, VerificationSessionCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/cancel", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual Task<VerificationSession> CancelAsync(string id, VerificationSessionCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual VerificationSession Get(string id, VerificationSessionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{id}", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual Task<VerificationSession> GetAsync(string id, VerificationSessionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Get, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -164,7 +165,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual VerificationSession Redact(string id, VerificationSessionRedactOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/redact", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}/redact", options, requestOptions);
         }
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual Task<VerificationSession> RedactAsync(string id, VerificationSessionRedactOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}/redact", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}/redact", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -203,7 +204,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual VerificationSession Update(string id, VerificationSessionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}", options, requestOptions);
+            return this.Request<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -214,7 +215,7 @@ namespace Stripe.Identity
         /// </summary>
         public virtual Task<VerificationSession> UpdateAsync(string id, VerificationSessionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<VerificationSession>(HttpMethod.Post, $"/v1/identity/verification_sessions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -53,7 +54,7 @@ namespace Stripe
         /// </summary>
         public virtual InvoiceItem Delete(string id, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{id}", options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<InvoiceItem> DeleteAsync(string id, InvoiceItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Delete, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace Stripe
         /// </summary>
         public virtual InvoiceItem Get(string id, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{id}", options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<InvoiceItem> GetAsync(string id, InvoiceItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Get, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace Stripe
         /// </summary>
         public virtual InvoiceItem Update(string id, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{id}", options, requestOptions);
+            return this.Request<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -133,7 +134,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<InvoiceItem> UpdateAsync(string id, InvoiceItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InvoiceItem>(HttpMethod.Post, $"/v1/invoiceitems/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice AddLines(string id, InvoiceAddLinesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/add_lines", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/add_lines", options, requestOptions);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> AddLinesAsync(string id, InvoiceAddLinesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/add_lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/add_lines", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice Delete(string id, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Delete, $"/v1/invoices/{id}", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Delete, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -146,7 +147,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> DeleteAsync(string id, InvoiceDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Delete, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Delete, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -156,7 +157,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice FinalizeInvoice(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/finalize", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/finalize", options, requestOptions);
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> FinalizeInvoiceAsync(string id, InvoiceFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/finalize", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/finalize", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice Get(string id, InvoiceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Get, $"/v1/invoices/{id}", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Get, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -182,7 +183,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> GetAsync(string id, InvoiceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Get, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Get, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -232,7 +233,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<InvoiceLineItem> ListLineItems(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{id}/lines", options, requestOptions);
+            return this.Request<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{WebUtility.UrlEncode(id)}/lines", options, requestOptions);
         }
 
         /// <summary>
@@ -242,7 +243,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<InvoiceLineItem>> ListLineItemsAsync(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{id}/lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<InvoiceLineItem>>(HttpMethod.Get, $"/v1/invoices/{WebUtility.UrlEncode(id)}/lines", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -252,7 +253,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<InvoiceLineItem> ListLineItemsAutoPaging(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<InvoiceLineItem>($"/v1/invoices/{id}/lines", options, requestOptions);
+            return this.ListRequestAutoPaging<InvoiceLineItem>($"/v1/invoices/{WebUtility.UrlEncode(id)}/lines", options, requestOptions);
         }
 
         /// <summary>
@@ -262,7 +263,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<InvoiceLineItem> ListLineItemsAutoPagingAsync(string id, InvoiceListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"/v1/invoices/{id}/lines", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<InvoiceLineItem>($"/v1/invoices/{WebUtility.UrlEncode(id)}/lines", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -311,7 +312,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice MarkUncollectible(string id, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/mark_uncollectible", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/mark_uncollectible", options, requestOptions);
         }
 
         /// <summary>
@@ -320,7 +321,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> MarkUncollectibleAsync(string id, InvoiceMarkUncollectibleOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/mark_uncollectible", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/mark_uncollectible", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -332,7 +333,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice Pay(string id, InvoicePayOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/pay", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/pay", options, requestOptions);
         }
 
         /// <summary>
@@ -344,7 +345,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> PayAsync(string id, InvoicePayOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/pay", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/pay", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -353,7 +354,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice RemoveLines(string id, InvoiceRemoveLinesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/remove_lines", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/remove_lines", options, requestOptions);
         }
 
         /// <summary>
@@ -362,7 +363,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> RemoveLinesAsync(string id, InvoiceRemoveLinesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/remove_lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/remove_lines", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -429,7 +430,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice SendInvoice(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/send", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/send", options, requestOptions);
         }
 
         /// <summary>
@@ -444,7 +445,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> SendInvoiceAsync(string id, InvoiceSendOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/send", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/send", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -517,7 +518,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice Update(string id, InvoiceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -532,7 +533,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> UpdateAsync(string id, InvoiceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -541,7 +542,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice UpdateLines(string id, InvoiceUpdateLinesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/update_lines", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/update_lines", options, requestOptions);
         }
 
         /// <summary>
@@ -550,7 +551,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> UpdateLinesAsync(string id, InvoiceUpdateLinesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/update_lines", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/update_lines", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -568,7 +569,7 @@ namespace Stripe
         /// </summary>
         public virtual Invoice VoidInvoice(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/void", options, requestOptions);
+            return this.Request<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/void", options, requestOptions);
         }
 
         /// <summary>
@@ -586,7 +587,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Invoice> VoidInvoiceAsync(string id, InvoiceVoidOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{id}/void", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Invoice>(HttpMethod.Post, $"/v1/invoices/{WebUtility.UrlEncode(id)}/void", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace Stripe.Issuing
         [Obsolete("This method is deprecated, please refer to the description for details.")]
         public virtual Authorization Approve(string id, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/approve", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}/approve", options, requestOptions);
         }
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace Stripe.Issuing
         [Obsolete("This method is deprecated, please refer to the description for details.")]
         public virtual Task<Authorization> ApproveAsync(string id, AuthorizationApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}/approve", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.Issuing
         [Obsolete("This method is deprecated, please refer to the description for details.")]
         public virtual Authorization Decline(string id, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/decline", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}/decline", options, requestOptions);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace Stripe.Issuing
         [Obsolete("This method is deprecated, please refer to the description for details.")]
         public virtual Task<Authorization> DeclineAsync(string id, AuthorizationDeclineOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}/decline", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}/decline", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Authorization Get(string id, AuthorizationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{id}", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Authorization> GetAsync(string id, AuthorizationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Get, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Authorization Update(string id, AuthorizationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}", options, requestOptions);
+            return this.Request<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Authorization> UpdateAsync(string id, AuthorizationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Authorization>(HttpMethod.Post, $"/v1/issuing/authorizations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Cardholder Get(string id, CardholderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{id}", options, requestOptions);
+            return this.Request<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Cardholder> GetAsync(string id, CardholderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Cardholder>(HttpMethod.Get, $"/v1/issuing/cardholders/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Cardholder Update(string id, CardholderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{id}", options, requestOptions);
+            return this.Request<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Cardholder> UpdateAsync(string id, CardholderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Cardholder>(HttpMethod.Post, $"/v1/issuing/cardholders/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Card Get(string id, CardGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Card>(HttpMethod.Get, $"/v1/issuing/cards/{id}", options, requestOptions);
+            return this.Request<Card>(HttpMethod.Get, $"/v1/issuing/cards/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Card> GetAsync(string id, CardGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Card>(HttpMethod.Get, $"/v1/issuing/cards/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Get, $"/v1/issuing/cards/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -99,7 +100,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Card Update(string id, CardUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Card>(HttpMethod.Post, $"/v1/issuing/cards/{id}", options, requestOptions);
+            return this.Request<Card>(HttpMethod.Post, $"/v1/issuing/cards/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Card> UpdateAsync(string id, CardUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/issuing/cards/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Card>(HttpMethod.Post, $"/v1/issuing/cards/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -54,7 +55,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Dispute Get(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{id}", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Dispute> GetAsync(string id, DisputeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Get, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -113,7 +114,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Dispute Submit(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}/submit", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}/submit", options, requestOptions);
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Dispute> SubmitAsync(string id, DisputeSubmitOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}/submit", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}/submit", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Dispute Update(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}", options, requestOptions);
+            return this.Request<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Dispute> UpdateAsync(string id, DisputeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Dispute>(HttpMethod.Post, $"/v1/issuing/disputes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
+++ b/src/Stripe.net/Services/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual PersonalizationDesign Get(string id, PersonalizationDesignGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PersonalizationDesign>(HttpMethod.Get, $"/v1/issuing/personalization_designs/{id}", options, requestOptions);
+            return this.Request<PersonalizationDesign>(HttpMethod.Get, $"/v1/issuing/personalization_designs/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<PersonalizationDesign> GetAsync(string id, PersonalizationDesignGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PersonalizationDesign>(HttpMethod.Get, $"/v1/issuing/personalization_designs/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PersonalizationDesign>(HttpMethod.Get, $"/v1/issuing/personalization_designs/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual PersonalizationDesign Update(string id, PersonalizationDesignUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PersonalizationDesign>(HttpMethod.Post, $"/v1/issuing/personalization_designs/{id}", options, requestOptions);
+            return this.Request<PersonalizationDesign>(HttpMethod.Post, $"/v1/issuing/personalization_designs/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<PersonalizationDesign> UpdateAsync(string id, PersonalizationDesignUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PersonalizationDesign>(HttpMethod.Post, $"/v1/issuing/personalization_designs/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PersonalizationDesign>(HttpMethod.Post, $"/v1/issuing/personalization_designs/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/PhysicalBundles/PhysicalBundleService.cs
+++ b/src/Stripe.net/Services/Issuing/PhysicalBundles/PhysicalBundleService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual PhysicalBundle Get(string id, PhysicalBundleGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PhysicalBundle>(HttpMethod.Get, $"/v1/issuing/physical_bundles/{id}", options, requestOptions);
+            return this.Request<PhysicalBundle>(HttpMethod.Get, $"/v1/issuing/physical_bundles/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<PhysicalBundle> GetAsync(string id, PhysicalBundleGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PhysicalBundle>(HttpMethod.Get, $"/v1/issuing/physical_bundles/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PhysicalBundle>(HttpMethod.Get, $"/v1/issuing/physical_bundles/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Token Get(string id, TokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{id}", options, requestOptions);
+            return this.Request<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Token> GetAsync(string id, TokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/issuing/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Token Update(string id, TokenUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{id}", options, requestOptions);
+            return this.Request<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Token> UpdateAsync(string id, TokenUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Post, $"/v1/issuing/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Issuing
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{id}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/issuing/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Transaction Update(string id, TransactionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{id}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace Stripe.Issuing
         /// </summary>
         public virtual Task<Transaction> UpdateAsync(string id, TransactionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Post, $"/v1/issuing/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/LoginLinks/LoginLinkService.cs
+++ b/src/Stripe.net/Services/LoginLinks/LoginLinkService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe
         /// </summary>
         public virtual LoginLink Create(string parentId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<LoginLink>(HttpMethod.Post, $"/v1/accounts/{parentId}/login_links", options, requestOptions);
+            return this.Request<LoginLink>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/login_links", options, requestOptions);
         }
 
         /// <summary>
@@ -44,7 +45,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<LoginLink> CreateAsync(string parentId, LoginLinkCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<LoginLink>(HttpMethod.Post, $"/v1/accounts/{parentId}/login_links", options, requestOptions, cancellationToken);
+            return this.RequestAsync<LoginLink>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/login_links", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Mandates/MandateService.cs
+++ b/src/Stripe.net/Services/Mandates/MandateService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace Stripe
         /// </summary>
         public virtual Mandate Get(string id, MandateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Mandate>(HttpMethod.Get, $"/v1/mandates/{id}", options, requestOptions);
+            return this.Request<Mandate>(HttpMethod.Get, $"/v1/mandates/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -34,7 +35,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Mandate> GetAsync(string id, MandateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Mandate>(HttpMethod.Get, $"/v1/mandates/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Mandate>(HttpMethod.Get, $"/v1/mandates/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent ApplyCustomerBalance(string id, PaymentIntentApplyCustomerBalanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/apply_customer_balance", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/apply_customer_balance", options, requestOptions);
         }
 
         /// <summary>
@@ -41,7 +42,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> ApplyCustomerBalanceAsync(string id, PaymentIntentApplyCustomerBalanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/apply_customer_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/apply_customer_balance", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent Cancel(string id, PaymentIntentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/cancel", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> CancelAsync(string id, PaymentIntentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -96,7 +97,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent Capture(string id, PaymentIntentCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/capture", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/capture", options, requestOptions);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> CaptureAsync(string id, PaymentIntentCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/capture", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -137,7 +138,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent Confirm(string id, PaymentIntentConfirmOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/confirm", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/confirm", options, requestOptions);
         }
 
         /// <summary>
@@ -163,7 +164,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> ConfirmAsync(string id, PaymentIntentConfirmOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/confirm", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/confirm", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -215,7 +216,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent Get(string id, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{id}", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -231,7 +232,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> GetAsync(string id, PaymentIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Get, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -264,7 +265,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent IncrementAuthorization(string id, PaymentIntentIncrementAuthorizationOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/increment_authorization", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/increment_authorization", options, requestOptions);
         }
 
         /// <summary>
@@ -297,7 +298,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> IncrementAuthorizationAsync(string id, PaymentIntentIncrementAuthorizationOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/increment_authorization", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/increment_authorization", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -395,7 +396,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent Update(string id, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -409,7 +410,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> UpdateAsync(string id, PaymentIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -417,7 +418,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentIntent VerifyMicrodeposits(string id, PaymentIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/verify_microdeposits", options, requestOptions);
+            return this.Request<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/verify_microdeposits", options, requestOptions);
         }
 
         /// <summary>
@@ -425,7 +426,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentIntent> VerifyMicrodepositsAsync(string id, PaymentIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{id}/verify_microdeposits", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentIntent>(HttpMethod.Post, $"/v1/payment_intents/{WebUtility.UrlEncode(id)}/verify_microdeposits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentLink Get(string id, PaymentLinkGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{id}", options, requestOptions);
+            return this.Request<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentLink> GetAsync(string id, PaymentLinkGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentLink>(HttpMethod.Get, $"/v1/payment_links/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -96,7 +97,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<LineItem> ListLineItems(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{id}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -106,7 +107,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/payment_links/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"/v1/payment_links/{id}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/payment_links/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, PaymentLinkListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/payment_links/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/payment_links/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentLink Update(string id, PaymentLinkUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{id}", options, requestOptions);
+            return this.Request<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentLink> UpdateAsync(string id, PaymentLinkUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentLink>(HttpMethod.Post, $"/v1/payment_links/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
+++ b/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethodConfiguration Get(string id, PaymentMethodConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{id}", options, requestOptions);
+            return this.Request<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethodConfiguration> GetAsync(string id, PaymentMethodConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Get, $"/v1/payment_method_configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethodConfiguration Update(string id, PaymentMethodConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{id}", options, requestOptions);
+            return this.Request<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethodConfiguration> UpdateAsync(string id, PaymentMethodConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodConfiguration>(HttpMethod.Post, $"/v1/payment_method_configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
+++ b/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethodDomain Get(string id, PaymentMethodDomainGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{id}", options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethodDomain> GetAsync(string id, PaymentMethodDomainGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Get, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethodDomain Update(string id, PaymentMethodDomainUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}", options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethodDomain> UpdateAsync(string id, PaymentMethodDomainUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -121,7 +122,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethodDomain Validate(string id, PaymentMethodDomainValidateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}/validate", options, requestOptions);
+            return this.Request<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}/validate", options, requestOptions);
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethodDomain> ValidateAsync(string id, PaymentMethodDomainValidateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{id}/validate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethodDomain>(HttpMethod.Post, $"/v1/payment_method_domains/{WebUtility.UrlEncode(id)}/validate", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethod Attach(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/attach", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}/attach", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethod> AttachAsync(string id, PaymentMethodAttachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/attach", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}/attach", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethod Detach(string id, PaymentMethodDetachOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/detach", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}/detach", options, requestOptions);
         }
 
         /// <summary>
@@ -120,7 +121,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethod> DetachAsync(string id, PaymentMethodDetachOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}/detach", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}/detach", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -131,7 +132,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethod Get(string id, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{id}", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethod> GetAsync(string id, PaymentMethodGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Get, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -195,7 +196,7 @@ namespace Stripe
         /// </summary>
         public virtual PaymentMethod Update(string id, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}", options, requestOptions);
+            return this.Request<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -204,7 +205,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PaymentMethod> UpdateAsync(string id, PaymentMethodUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PaymentMethod>(HttpMethod.Post, $"/v1/payment_methods/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace Stripe
         /// </summary>
         public virtual Payout Cancel(string id, PayoutCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/cancel", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Payout> CancelAsync(string id, PayoutCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace Stripe
         /// </summary>
         public virtual Payout Get(string id, PayoutGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Payout>(HttpMethod.Get, $"/v1/payouts/{id}", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Get, $"/v1/payouts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Payout> GetAsync(string id, PayoutGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Payout>(HttpMethod.Get, $"/v1/payouts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Get, $"/v1/payouts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -152,7 +153,7 @@ namespace Stripe
         /// </summary>
         public virtual Payout Reverse(string id, PayoutReverseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/reverse", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}/reverse", options, requestOptions);
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Payout> ReverseAsync(string id, PayoutReverseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}/reverse", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}/reverse", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -176,7 +177,7 @@ namespace Stripe
         /// </summary>
         public virtual Payout Update(string id, PayoutUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{id}", options, requestOptions);
+            return this.Request<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -186,7 +187,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Payout> UpdateAsync(string id, PayoutUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Payout>(HttpMethod.Post, $"/v1/payouts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Persons/PersonService.cs
+++ b/src/Stripe.net/Services/Persons/PersonService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe
         /// </summary>
         public virtual Person Create(string parentId, PersonCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons", options, requestOptions);
+            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Person> CreateAsync(string parentId, PersonCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -50,7 +51,7 @@ namespace Stripe
         /// </summary>
         public virtual Person Delete(string parentId, string id, PersonDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Person>(HttpMethod.Delete, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
+            return this.Request<Person>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Person> DeleteAsync(string parentId, string id, PersonDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Person>(HttpMethod.Delete, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Delete, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Stripe
         /// </summary>
         public virtual Person Get(string parentId, string id, PersonGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Person>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
+            return this.Request<Person>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Person> GetAsync(string parentId, string id, PersonGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Person>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<Person> List(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons", options, requestOptions);
+            return this.Request<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions);
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<Person>> ListAsync(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<Person>>(HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<Person> ListAutoPaging(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<Person>($"/v1/accounts/{parentId}/persons", options, requestOptions);
+            return this.ListRequestAutoPaging<Person>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions);
         }
 
         /// <summary>
@@ -113,7 +114,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<Person> ListAutoPagingAsync(string parentId, PersonListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<Person>($"/v1/accounts/{parentId}/persons", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Person>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -121,7 +122,7 @@ namespace Stripe
         /// </summary>
         public virtual Person Update(string parentId, string id, PersonUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions);
+            return this.Request<Person>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -129,7 +130,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Person> UpdateAsync(string parentId, string id, PersonUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{parentId}/persons/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Person>(HttpMethod.Post, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/persons/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -52,7 +53,7 @@ namespace Stripe
         /// </summary>
         public virtual Plan Delete(string id, PlanDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Plan>(HttpMethod.Delete, $"/v1/plans/{id}", options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Delete, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Plan> DeleteAsync(string id, PlanDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Plan>(HttpMethod.Delete, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Delete, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Stripe
         /// </summary>
         public virtual Plan Get(string id, PlanGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Plan>(HttpMethod.Get, $"/v1/plans/{id}", options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Get, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Plan> GetAsync(string id, PlanGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Plan>(HttpMethod.Get, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Get, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace Stripe
         /// </summary>
         public virtual Plan Update(string id, PlanUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Plan>(HttpMethod.Post, $"/v1/plans/{id}", options, requestOptions);
+            return this.Request<Plan>(HttpMethod.Post, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -129,7 +130,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Plan> UpdateAsync(string id, PlanUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Plan>(HttpMethod.Post, $"/v1/plans/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Plan>(HttpMethod.Post, $"/v1/plans/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Prices/PriceService.cs
+++ b/src/Stripe.net/Services/Prices/PriceService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -49,7 +50,7 @@ namespace Stripe
         /// </summary>
         public virtual Price Get(string id, PriceGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Price>(HttpMethod.Get, $"/v1/prices/{id}", options, requestOptions);
+            return this.Request<Price>(HttpMethod.Get, $"/v1/prices/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Price> GetAsync(string id, PriceGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Price>(HttpMethod.Get, $"/v1/prices/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Price>(HttpMethod.Get, $"/v1/prices/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -158,7 +159,7 @@ namespace Stripe
         /// </summary>
         public virtual Price Update(string id, PriceUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Price>(HttpMethod.Post, $"/v1/prices/{id}", options, requestOptions);
+            return this.Request<Price>(HttpMethod.Post, $"/v1/prices/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -167,7 +168,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Price> UpdateAsync(string id, PriceUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Price>(HttpMethod.Post, $"/v1/prices/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Price>(HttpMethod.Post, $"/v1/prices/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ProductFeatures/ProductFeatureService.cs
+++ b/src/Stripe.net/Services/ProductFeatures/ProductFeatureService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Stripe
         /// </summary>
         public virtual ProductFeature Create(string parentId, ProductFeatureCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ProductFeature>(HttpMethod.Post, $"/v1/products/{parentId}/features", options, requestOptions);
+            return this.Request<ProductFeature>(HttpMethod.Post, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ProductFeature> CreateAsync(string parentId, ProductFeatureCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ProductFeature>(HttpMethod.Post, $"/v1/products/{parentId}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ProductFeature>(HttpMethod.Post, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual ProductFeature Delete(string parentId, string id, ProductFeatureDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ProductFeature>(HttpMethod.Delete, $"/v1/products/{parentId}/features/{id}", options, requestOptions);
+            return this.Request<ProductFeature>(HttpMethod.Delete, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ProductFeature> DeleteAsync(string parentId, string id, ProductFeatureDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ProductFeature>(HttpMethod.Delete, $"/v1/products/{parentId}/features/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ProductFeature>(HttpMethod.Delete, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe
         /// </summary>
         public virtual ProductFeature Get(string parentId, string id, ProductFeatureGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ProductFeature>(HttpMethod.Get, $"/v1/products/{parentId}/features/{id}", options, requestOptions);
+            return this.Request<ProductFeature>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ProductFeature> GetAsync(string parentId, string id, ProductFeatureGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ProductFeature>(HttpMethod.Get, $"/v1/products/{parentId}/features/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ProductFeature>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<ProductFeature> List(string parentId, ProductFeatureListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<ProductFeature>>(HttpMethod.Get, $"/v1/products/{parentId}/features", options, requestOptions);
+            return this.Request<StripeList<ProductFeature>>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions);
         }
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<ProductFeature>> ListAsync(string parentId, ProductFeatureListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<ProductFeature>>(HttpMethod.Get, $"/v1/products/{parentId}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<ProductFeature>>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<ProductFeature> ListAutoPaging(string parentId, ProductFeatureListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<ProductFeature>($"/v1/products/{parentId}/features", options, requestOptions);
+            return this.ListRequestAutoPaging<ProductFeature>($"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<ProductFeature> ListAutoPagingAsync(string parentId, ProductFeatureListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<ProductFeature>($"/v1/products/{parentId}/features", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<ProductFeature>($"/v1/products/{WebUtility.UrlEncode(parentId)}/features", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -50,7 +51,7 @@ namespace Stripe
         /// </summary>
         public virtual Product Delete(string id, ProductDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Product>(HttpMethod.Delete, $"/v1/products/{id}", options, requestOptions);
+            return this.Request<Product>(HttpMethod.Delete, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -60,7 +61,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Product> DeleteAsync(string id, ProductDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Product>(HttpMethod.Delete, $"/v1/products/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Delete, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual Product Get(string id, ProductGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Product>(HttpMethod.Get, $"/v1/products/{id}", options, requestOptions);
+            return this.Request<Product>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -80,7 +81,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Product> GetAsync(string id, ProductGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Product>(HttpMethod.Get, $"/v1/products/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Get, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -177,7 +178,7 @@ namespace Stripe
         /// </summary>
         public virtual Product Update(string id, ProductUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Product>(HttpMethod.Post, $"/v1/products/{id}", options, requestOptions);
+            return this.Request<Product>(HttpMethod.Post, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -186,7 +187,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Product> UpdateAsync(string id, ProductUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Product>(HttpMethod.Post, $"/v1/products/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Product>(HttpMethod.Post, $"/v1/products/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -51,7 +52,7 @@ namespace Stripe
         /// </summary>
         public virtual PromotionCode Get(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{id}", options, requestOptions);
+            return this.Request<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PromotionCode> GetAsync(string id, PromotionCodeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PromotionCode>(HttpMethod.Get, $"/v1/promotion_codes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Stripe
         /// </summary>
         public virtual PromotionCode Update(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{id}", options, requestOptions);
+            return this.Request<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<PromotionCode> UpdateAsync(string id, PromotionCodeUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<PromotionCode>(HttpMethod.Post, $"/v1/promotion_codes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Quotes/QuoteService.cs
+++ b/src/Stripe.net/Services/Quotes/QuoteService.cs
@@ -4,6 +4,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe
         /// </summary>
         public virtual Quote Accept(string id, QuoteAcceptOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/accept", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/accept", options, requestOptions);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Quote> AcceptAsync(string id, QuoteAcceptOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/accept", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/accept", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace Stripe
         /// </summary>
         public virtual Quote Cancel(string id, QuoteCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/cancel", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Quote> CancelAsync(string id, QuoteCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Stripe
         /// </summary>
         public virtual Quote FinalizeQuote(string id, QuoteFinalizeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/finalize", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/finalize", options, requestOptions);
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Quote> FinalizeQuoteAsync(string id, QuoteFinalizeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}/finalize", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}/finalize", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace Stripe
         /// </summary>
         public virtual Quote Get(string id, QuoteGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Quote>(HttpMethod.Get, $"/v1/quotes/{id}", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -109,7 +110,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Quote> GetAsync(string id, QuoteGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Quote>(HttpMethod.Get, $"/v1/quotes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -152,7 +153,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<LineItem> ListComputedUpfrontLineItems(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/computed_upfront_line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -163,7 +164,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<LineItem>> ListComputedUpfrontLineItemsAsync(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/computed_upfront_line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<LineItem> ListComputedUpfrontLineItemsAutoPaging(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{WebUtility.UrlEncode(id)}/computed_upfront_line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -185,7 +186,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<LineItem> ListComputedUpfrontLineItemsAutoPagingAsync(string id, QuoteListComputedUpfrontLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{id}/computed_upfront_line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{WebUtility.UrlEncode(id)}/computed_upfront_line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -195,7 +196,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<LineItem> ListLineItems(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/line_items", options, requestOptions);
+            return this.Request<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -205,7 +206,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<LineItem>> ListLineItemsAsync(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<LineItem>>(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -215,7 +216,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<LineItem> ListLineItemsAutoPaging(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{id}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<LineItem>($"/v1/quotes/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -225,7 +226,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<LineItem> ListLineItemsAutoPagingAsync(string id, QuoteListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<LineItem>($"/v1/quotes/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -241,7 +242,7 @@ namespace Stripe
                 requestOptions.BaseUrl = this.Client.FilesBase;
             }
 
-            return this.RequestStreaming(HttpMethod.Get, $"/v1/quotes/{id}/pdf", options, requestOptions);
+            return this.RequestStreaming(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/pdf", options, requestOptions);
         }
 
         /// <summary>
@@ -257,7 +258,7 @@ namespace Stripe
                 requestOptions.BaseUrl = this.Client.FilesBase;
             }
 
-            return this.RequestStreamingAsync(HttpMethod.Get, $"/v1/quotes/{id}/pdf", options, requestOptions, cancellationToken);
+            return this.RequestStreamingAsync(HttpMethod.Get, $"/v1/quotes/{WebUtility.UrlEncode(id)}/pdf", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -265,7 +266,7 @@ namespace Stripe
         /// </summary>
         public virtual Quote Update(string id, QuoteUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{id}", options, requestOptions);
+            return this.Request<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -273,7 +274,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Quote> UpdateAsync(string id, QuoteUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Quote>(HttpMethod.Post, $"/v1/quotes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Radar
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual EarlyFraudWarning Get(string id, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{id}", options, requestOptions);
+            return this.Request<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<EarlyFraudWarning> GetAsync(string id, EarlyFraudWarningGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EarlyFraudWarning>(HttpMethod.Get, $"/v1/radar/early_fraud_warnings/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Radar
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual ValueListItem Delete(string id, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{id}", options, requestOptions);
+            return this.Request<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<ValueListItem> DeleteAsync(string id, ValueListItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueListItem>(HttpMethod.Delete, $"/v1/radar/value_list_items/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual ValueListItem Get(string id, ValueListItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{id}", options, requestOptions);
+            return this.Request<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<ValueListItem> GetAsync(string id, ValueListItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueListItem>(HttpMethod.Get, $"/v1/radar/value_list_items/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Radar
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual ValueList Delete(string id, ValueListDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{id}", options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<ValueList> DeleteAsync(string id, ValueListDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Delete, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +66,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual ValueList Get(string id, ValueListGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{id}", options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<ValueList> GetAsync(string id, ValueListGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Get, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual ValueList Update(string id, ValueListUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{id}", options, requestOptions);
+            return this.Request<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -129,7 +130,7 @@ namespace Stripe.Radar
         /// </summary>
         public virtual Task<ValueList> UpdateAsync(string id, ValueListUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ValueList>(HttpMethod.Post, $"/v1/radar/value_lists/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace Stripe
         /// </summary>
         public virtual Refund Cancel(string id, RefundCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{id}/cancel", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -44,7 +45,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Refund> CancelAsync(string id, RefundCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Stripe
         /// </summary>
         public virtual Refund Get(string id, RefundGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Refund>(HttpMethod.Get, $"/v1/refunds/{id}", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Get, $"/v1/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Refund> GetAsync(string id, RefundGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Refund>(HttpMethod.Get, $"/v1/refunds/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Get, $"/v1/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Stripe
         /// </summary>
         public virtual Refund Update(string id, RefundUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{id}", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -162,7 +163,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Refund> UpdateAsync(string id, RefundUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/refunds/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Reporting
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace Stripe.Reporting
         /// </summary>
         public virtual ReportRun Get(string id, ReportRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{id}", options, requestOptions);
+            return this.Request<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe.Reporting
         /// </summary>
         public virtual Task<ReportRun> GetAsync(string id, ReportRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReportRun>(HttpMethod.Get, $"/v1/reporting/report_runs/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Reporting
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Reporting
         /// </summary>
         public virtual ReportType Get(string id, ReportTypeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{id}", options, requestOptions);
+            return this.Request<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe.Reporting
         /// </summary>
         public virtual Task<ReportType> GetAsync(string id, ReportTypeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReportType>(HttpMethod.Get, $"/v1/reporting/report_types/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual Review Approve(string id, ReviewApproveOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Review>(HttpMethod.Post, $"/v1/reviews/{id}/approve", options, requestOptions);
+            return this.Request<Review>(HttpMethod.Post, $"/v1/reviews/{WebUtility.UrlEncode(id)}/approve", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Review> ApproveAsync(string id, ReviewApproveOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Review>(HttpMethod.Post, $"/v1/reviews/{id}/approve", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Review>(HttpMethod.Post, $"/v1/reviews/{WebUtility.UrlEncode(id)}/approve", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual Review Get(string id, ReviewGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Review>(HttpMethod.Get, $"/v1/reviews/{id}", options, requestOptions);
+            return this.Request<Review>(HttpMethod.Get, $"/v1/reviews/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Review> GetAsync(string id, ReviewGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Review>(HttpMethod.Get, $"/v1/reviews/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Review>(HttpMethod.Get, $"/v1/reviews/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -37,7 +38,7 @@ namespace Stripe
         /// </summary>
         public virtual SetupIntent Cancel(string id, SetupIntentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/cancel", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SetupIntent> CancelAsync(string id, SetupIntentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual SetupIntent Confirm(string id, SetupIntentConfirmOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/confirm", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/confirm", options, requestOptions);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SetupIntent> ConfirmAsync(string id, SetupIntentConfirmOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/confirm", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/confirm", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -128,7 +129,7 @@ namespace Stripe
         /// </summary>
         public virtual SetupIntent Get(string id, SetupIntentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{id}", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SetupIntent> GetAsync(string id, SetupIntentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Get, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -184,7 +185,7 @@ namespace Stripe
         /// </summary>
         public virtual SetupIntent Update(string id, SetupIntentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SetupIntent> UpdateAsync(string id, SetupIntentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -200,7 +201,7 @@ namespace Stripe
         /// </summary>
         public virtual SetupIntent VerifyMicrodeposits(string id, SetupIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/verify_microdeposits", options, requestOptions);
+            return this.Request<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/verify_microdeposits", options, requestOptions);
         }
 
         /// <summary>
@@ -208,7 +209,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SetupIntent> VerifyMicrodepositsAsync(string id, SetupIntentVerifyMicrodepositsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{id}/verify_microdeposits", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SetupIntent>(HttpMethod.Post, $"/v1/setup_intents/{WebUtility.UrlEncode(id)}/verify_microdeposits", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
+++ b/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual ShippingRate Get(string id, ShippingRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{id}", options, requestOptions);
+            return this.Request<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ShippingRate> GetAsync(string id, ShippingRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ShippingRate>(HttpMethod.Get, $"/v1/shipping_rates/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual ShippingRate Update(string id, ShippingRateUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{id}", options, requestOptions);
+            return this.Request<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<ShippingRate> UpdateAsync(string id, ShippingRateUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ShippingRate>(HttpMethod.Post, $"/v1/shipping_rates/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Sigma
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Sigma
         /// </summary>
         public virtual ScheduledQueryRun Get(string id, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{id}", options, requestOptions);
+            return this.Request<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Sigma
         /// </summary>
         public virtual Task<ScheduledQueryRun> GetAsync(string id, ScheduledQueryRunGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ScheduledQueryRun>(HttpMethod.Get, $"/v1/sigma/scheduled_query_runs/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -50,7 +51,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionItem Delete(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{id}", options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionItem> DeleteAsync(string id, SubscriptionItemDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Delete, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionItem Get(string id, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{id}", options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -75,7 +76,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionItem> GetAsync(string id, SubscriptionItemGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Get, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionItem Update(string id, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{id}", options, requestOptions);
+            return this.Request<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionItem> UpdateAsync(string id, SubscriptionItemUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionItem>(HttpMethod.Post, $"/v1/subscription_items/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionSchedule Cancel(string id, SubscriptionScheduleCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/cancel", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionSchedule> CancelAsync(string id, SubscriptionScheduleCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionSchedule Get(string id, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{id}", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -80,7 +81,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionSchedule> GetAsync(string id, SubscriptionScheduleGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Get, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionSchedule Release(string id, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/release", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}/release", options, requestOptions);
         }
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionSchedule> ReleaseAsync(string id, SubscriptionScheduleReleaseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}/release", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}/release", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -146,7 +147,7 @@ namespace Stripe
         /// </summary>
         public virtual SubscriptionSchedule Update(string id, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}", options, requestOptions);
+            return this.Request<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -154,7 +155,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<SubscriptionSchedule> UpdateAsync(string id, SubscriptionScheduleUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<SubscriptionSchedule>(HttpMethod.Post, $"/v1/subscription_schedules/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual Subscription Cancel(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{id}", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Subscription> CancelAsync(string id, SubscriptionCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Delete, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace Stripe
         /// </summary>
         public virtual Subscription Get(string id, SubscriptionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{id}", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Subscription> GetAsync(string id, SubscriptionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Get, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -172,7 +173,7 @@ namespace Stripe
         /// </summary>
         public virtual Subscription Resume(string id, SubscriptionResumeOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}/resume", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}/resume", options, requestOptions);
         }
 
         /// <summary>
@@ -185,7 +186,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Subscription> ResumeAsync(string id, SubscriptionResumeOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}/resume", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}/resume", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -292,7 +293,7 @@ namespace Stripe
         /// </summary>
         public virtual Subscription Update(string id, SubscriptionUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}", options, requestOptions);
+            return this.Request<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -347,7 +348,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Subscription> UpdateAsync(string id, SubscriptionUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Subscription>(HttpMethod.Post, $"/v1/subscriptions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
+++ b/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Tax
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -44,7 +45,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Calculation Get(string id, CalculationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Calculation>(HttpMethod.Get, $"/v1/tax/calculations/{id}", options, requestOptions);
+            return this.Request<Calculation>(HttpMethod.Get, $"/v1/tax/calculations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<Calculation> GetAsync(string id, CalculationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Calculation>(HttpMethod.Get, $"/v1/tax/calculations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Calculation>(HttpMethod.Get, $"/v1/tax/calculations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual StripeList<CalculationLineItem> ListLineItems(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{id}/line_items", options, requestOptions);
+            return this.Request<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<StripeList<CalculationLineItem>> ListLineItemsAsync(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<CalculationLineItem>>(HttpMethod.Get, $"/v1/tax/calculations/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual IEnumerable<CalculationLineItem> ListLineItemsAutoPaging(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<CalculationLineItem>($"/v1/tax/calculations/{id}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<CalculationLineItem>($"/v1/tax/calculations/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual IAsyncEnumerable<CalculationLineItem> ListLineItemsAutoPagingAsync(string id, CalculationListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<CalculationLineItem>($"/v1/tax/calculations/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<CalculationLineItem>($"/v1/tax/calculations/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Registrations/RegistrationService.cs
+++ b/src/Stripe.net/Services/Tax/Registrations/RegistrationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Tax
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Registration Get(string id, RegistrationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Registration>(HttpMethod.Get, $"/v1/tax/registrations/{id}", options, requestOptions);
+            return this.Request<Registration>(HttpMethod.Get, $"/v1/tax/registrations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<Registration> GetAsync(string id, RegistrationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Registration>(HttpMethod.Get, $"/v1/tax/registrations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Registration>(HttpMethod.Get, $"/v1/tax/registrations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -97,7 +98,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Registration Update(string id, RegistrationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Registration>(HttpMethod.Post, $"/v1/tax/registrations/{id}", options, requestOptions);
+            return this.Request<Registration>(HttpMethod.Post, $"/v1/tax/registrations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<Registration> UpdateAsync(string id, RegistrationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Registration>(HttpMethod.Post, $"/v1/tax/registrations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Registration>(HttpMethod.Post, $"/v1/tax/registrations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Tax
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -61,7 +62,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{id}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/tax/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual StripeList<TransactionLineItem> ListLineItems(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{id}/line_items", options, requestOptions);
+            return this.Request<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual Task<StripeList<TransactionLineItem>> ListLineItemsAsync(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TransactionLineItem>>(HttpMethod.Get, $"/v1/tax/transactions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual IEnumerable<TransactionLineItem> ListLineItemsAutoPaging(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<TransactionLineItem>($"/v1/tax/transactions/{id}/line_items", options, requestOptions);
+            return this.ListRequestAutoPaging<TransactionLineItem>($"/v1/tax/transactions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace Stripe.Tax
         /// </summary>
         public virtual IAsyncEnumerable<TransactionLineItem> ListLineItemsAutoPagingAsync(string id, TransactionListLineItemsOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<TransactionLineItem>($"/v1/tax/transactions/{id}/line_items", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TransactionLineItem>($"/v1/tax/transactions/{WebUtility.UrlEncode(id)}/line_items", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
+++ b/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxCode Get(string id, TaxCodeGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{id}", options, requestOptions);
+            return this.Request<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxCode> GetAsync(string id, TaxCodeGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxCode>(HttpMethod.Get, $"/v1/tax_codes/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxId Create(string parentId, TaxIdCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxId>(HttpMethod.Post, $"/v1/customers/{parentId}/tax_ids", options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxId> CreateAsync(string parentId, TaxIdCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxId>(HttpMethod.Post, $"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Post, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxId Delete(string parentId, string id, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxId>(HttpMethod.Delete, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Delete, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxId> DeleteAsync(string parentId, string id, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxId>(HttpMethod.Delete, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Delete, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxId Delete(string parentId, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxId>(HttpMethod.Delete, $"/v1/tax_ids/{parentId}", options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Delete, $"/v1/tax_ids/{WebUtility.UrlEncode(parentId)}", options, requestOptions);
         }
 
         /// <summary>
@@ -86,7 +87,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxId> DeleteAsync(string parentId, TaxIdDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxId>(HttpMethod.Delete, $"/v1/tax_ids/{parentId}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Delete, $"/v1/tax_ids/{WebUtility.UrlEncode(parentId)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxId Get(string parentId, string id, TaxIdGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxId>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxId> GetAsync(string parentId, string id, TaxIdGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxId>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxId Get(string parentId, TaxIdGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxId>(HttpMethod.Get, $"/v1/tax_ids/{parentId}", options, requestOptions);
+            return this.Request<TaxId>(HttpMethod.Get, $"/v1/tax_ids/{WebUtility.UrlEncode(parentId)}", options, requestOptions);
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxId> GetAsync(string parentId, TaxIdGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxId>(HttpMethod.Get, $"/v1/tax_ids/{parentId}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxId>(HttpMethod.Get, $"/v1/tax_ids/{WebUtility.UrlEncode(parentId)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<TaxId> List(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids", options, requestOptions);
+            return this.Request<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions);
         }
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<TaxId>> ListAsync(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TaxId>>(HttpMethod.Get, $"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -142,7 +143,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<TaxId> ListAutoPaging(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<TaxId>($"/v1/customers/{parentId}/tax_ids", options, requestOptions);
+            return this.ListRequestAutoPaging<TaxId>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions);
         }
 
         /// <summary>
@@ -150,7 +151,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<TaxId> ListAutoPagingAsync(string parentId, TaxIdListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<TaxId>($"/v1/customers/{parentId}/tax_ids", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TaxId>($"/v1/customers/{WebUtility.UrlEncode(parentId)}/tax_ids", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxRate Get(string id, TaxRateGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{id}", options, requestOptions);
+            return this.Request<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxRate> GetAsync(string id, TaxRateGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxRate>(HttpMethod.Get, $"/v1/tax_rates/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Stripe
         /// </summary>
         public virtual TaxRate Update(string id, TaxRateUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{id}", options, requestOptions);
+            return this.Request<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -106,7 +107,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TaxRate> UpdateAsync(string id, TaxRateUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TaxRate>(HttpMethod.Post, $"/v1/tax_rates/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Terminal
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Configuration Delete(string id, ConfigurationDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{id}", options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Configuration> DeleteAsync(string id, ConfigurationDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Delete, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Configuration Get(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{id}", options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Configuration> GetAsync(string id, ConfigurationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Get, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Configuration Update(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{id}", options, requestOptions);
+            return this.Request<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Configuration> UpdateAsync(string id, ConfigurationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Configuration>(HttpMethod.Post, $"/v1/terminal/configurations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Terminal
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -51,7 +52,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Location Delete(string id, LocationDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{id}", options, requestOptions);
+            return this.Request<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Location> DeleteAsync(string id, LocationDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Delete, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Location Get(string id, LocationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Location>(HttpMethod.Get, $"/v1/terminal/locations/{id}", options, requestOptions);
+            return this.Request<Location>(HttpMethod.Get, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -75,7 +76,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Location> GetAsync(string id, LocationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Location>(HttpMethod.Get, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Get, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Location Update(string id, LocationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Location>(HttpMethod.Post, $"/v1/terminal/locations/{id}", options, requestOptions);
+            return this.Request<Location>(HttpMethod.Post, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Location> UpdateAsync(string id, LocationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Location>(HttpMethod.Post, $"/v1/terminal/locations/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Location>(HttpMethod.Post, $"/v1/terminal/locations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Terminal
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader CancelAction(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/cancel_action", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/cancel_action", options, requestOptions);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> CancelActionAsync(string id, ReaderCancelActionOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/cancel_action", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/cancel_action", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader Delete(string id, ReaderDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{id}", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> DeleteAsync(string id, ReaderDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Delete, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader Get(string id, ReaderGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{id}", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> GetAsync(string id, ReaderGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Get, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader ProcessPaymentIntent(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_payment_intent", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/process_payment_intent", options, requestOptions);
         }
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> ProcessPaymentIntentAsync(string id, ReaderProcessPaymentIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_payment_intent", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/process_payment_intent", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader ProcessSetupIntent(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_setup_intent", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/process_setup_intent", options, requestOptions);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> ProcessSetupIntentAsync(string id, ReaderProcessSetupIntentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/process_setup_intent", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/process_setup_intent", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -159,7 +160,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader RefundPayment(string id, ReaderRefundPaymentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/refund_payment", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/refund_payment", options, requestOptions);
         }
 
         /// <summary>
@@ -167,7 +168,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> RefundPaymentAsync(string id, ReaderRefundPaymentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/refund_payment", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/refund_payment", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -175,7 +176,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader SetReaderDisplay(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/set_reader_display", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/set_reader_display", options, requestOptions);
         }
 
         /// <summary>
@@ -183,7 +184,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> SetReaderDisplayAsync(string id, ReaderSetReaderDisplayOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}/set_reader_display", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}/set_reader_display", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Reader Update(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}", options, requestOptions);
+            return this.Request<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -201,7 +202,7 @@ namespace Stripe.Terminal
         /// </summary>
         public virtual Task<Reader> UpdateAsync(string id, ReaderUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Reader>(HttpMethod.Post, $"/v1/terminal/readers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual CustomerCashBalanceTransaction FundCashBalance(string id, CustomerFundCashBalanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{id}/fund_cash_balance", options, requestOptions);
+            return this.Request<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{WebUtility.UrlEncode(id)}/fund_cash_balance", options, requestOptions);
         }
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Task<CustomerCashBalanceTransaction> FundCashBalanceAsync(string id, CustomerFundCashBalanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{id}/fund_cash_balance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CustomerCashBalanceTransaction>(HttpMethod.Post, $"/v1/test_helpers/customers/{WebUtility.UrlEncode(id)}/fund_cash_balance", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Issuing
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Authorization Capture(string id, AuthorizationCaptureOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/capture", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/capture", options, requestOptions);
         }
 
         /// <summary>
@@ -34,7 +35,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Authorization> CaptureAsync(string id, AuthorizationCaptureOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/capture", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/capture", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -58,7 +59,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Authorization Expire(string id, AuthorizationExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/expire", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/expire", options, requestOptions);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Authorization> ExpireAsync(string id, AuthorizationExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/expire", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -75,7 +76,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Authorization FinalizeAmount(string id, AuthorizationFinalizeAmountOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/finalize_amount", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/finalize_amount", options, requestOptions);
         }
 
         /// <summary>
@@ -84,7 +85,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Authorization> FinalizeAmountAsync(string id, AuthorizationFinalizeAmountOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/finalize_amount", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/finalize_amount", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Authorization Increment(string id, AuthorizationIncrementOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/increment", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/increment", options, requestOptions);
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Authorization> IncrementAsync(string id, AuthorizationIncrementOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/increment", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/increment", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Authorization Reverse(string id, AuthorizationReverseOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/reverse", options, requestOptions);
+            return this.Request<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/reverse", options, requestOptions);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Authorization> ReverseAsync(string id, AuthorizationReverseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{id}/reverse", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Authorization>(HttpMethod.Post, $"/v1/test_helpers/issuing/authorizations/{WebUtility.UrlEncode(id)}/reverse", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Issuing
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Card DeliverCard(string id, CardDeliverCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/deliver", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/deliver", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Card> DeliverCardAsync(string id, CardDeliverCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/deliver", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/deliver", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Card FailCard(string id, CardFailCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/fail", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/fail", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Card> FailCardAsync(string id, CardFailCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/fail", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Card ReturnCard(string id, CardReturnCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/return", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/return", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Card> ReturnCardAsync(string id, CardReturnCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/return", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Card ShipCard(string id, CardShipCardOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/ship", options, requestOptions);
+            return this.Request<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/ship", options, requestOptions);
         }
 
         /// <summary>
@@ -90,7 +91,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Card> ShipCardAsync(string id, CardShipCardOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{id}/shipping/ship", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Card>(HttpMethod.Post, $"/v1/test_helpers/issuing/cards/{WebUtility.UrlEncode(id)}/shipping/ship", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Issuing
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.PersonalizationDesign Activate(string id, PersonalizationDesignActivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/activate", options, requestOptions);
+            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/activate", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.PersonalizationDesign> ActivateAsync(string id, PersonalizationDesignActivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/activate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/activate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.PersonalizationDesign Deactivate(string id, PersonalizationDesignDeactivateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/deactivate", options, requestOptions);
+            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.PersonalizationDesign> DeactivateAsync(string id, PersonalizationDesignDeactivateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/deactivate", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/deactivate", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.PersonalizationDesign Reject(string id, PersonalizationDesignRejectOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/reject", options, requestOptions);
+            return this.Request<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/reject", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.PersonalizationDesign> RejectAsync(string id, PersonalizationDesignRejectOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{id}/reject", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.PersonalizationDesign>(HttpMethod.Post, $"/v1/test_helpers/issuing/personalization_designs/{WebUtility.UrlEncode(id)}/reject", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Issuing
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -58,7 +59,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Stripe.Issuing.Transaction Refund(string id, TransactionRefundOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{id}/refund", options, requestOptions);
+            return this.Request<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{WebUtility.UrlEncode(id)}/refund", options, requestOptions);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Stripe.TestHelpers.Issuing
         /// </summary>
         public virtual Task<Stripe.Issuing.Transaction> RefundAsync(string id, TransactionRefundOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{id}/refund", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Issuing.Transaction>(HttpMethod.Post, $"/v1/test_helpers/issuing/transactions/{WebUtility.UrlEncode(id)}/refund", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Refund Expire(string id, RefundExpireOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{id}/expire", options, requestOptions);
+            return this.Request<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{WebUtility.UrlEncode(id)}/expire", options, requestOptions);
         }
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Task<Refund> ExpireAsync(string id, RefundExpireOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{id}/expire", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Refund>(HttpMethod.Post, $"/v1/test_helpers/refunds/{WebUtility.UrlEncode(id)}/expire", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Terminal
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Terminal
         /// </summary>
         public virtual Stripe.Terminal.Reader PresentPaymentMethod(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{id}/present_payment_method", options, requestOptions);
+            return this.Request<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{WebUtility.UrlEncode(id)}/present_payment_method", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Terminal
         /// </summary>
         public virtual Task<Stripe.Terminal.Reader> PresentPaymentMethodAsync(string id, ReaderPresentPaymentMethodOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{id}/present_payment_method", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Terminal.Reader>(HttpMethod.Post, $"/v1/test_helpers/terminal/readers/{WebUtility.UrlEncode(id)}/present_payment_method", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
@@ -3,6 +3,7 @@ namespace Stripe.TestHelpers
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual TestClock Advance(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{id}/advance", options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}/advance", options, requestOptions);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Task<TestClock> AdvanceAsync(string id, TestClockAdvanceOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{id}/advance", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Post, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}/advance", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual TestClock Delete(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Task<TestClock> DeleteAsync(string id, TestClockDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Delete, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -80,7 +81,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual TestClock Get(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions);
+            return this.Request<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace Stripe.TestHelpers
         /// </summary>
         public virtual Task<TestClock> GetAsync(string id, TestClockGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TestClock>(HttpMethod.Get, $"/v1/test_helpers/test_clocks/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Treasury
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.InboundTransfer Fail(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/fail", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.InboundTransfer> FailAsync(string id, InboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/fail", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.InboundTransfer ReturnInboundTransfer(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/return", options, requestOptions);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.InboundTransfer> ReturnInboundTransferAsync(string id, InboundTransferReturnInboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/return", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +66,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.InboundTransfer Succeed(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/succeed", options, requestOptions);
+            return this.Request<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/succeed", options, requestOptions);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.InboundTransfer> SucceedAsync(string id, InboundTransferSucceedOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{id}/succeed", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.InboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/succeed", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Treasury
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundPayment Fail(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/fail", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundPayment> FailAsync(string id, OutboundPaymentFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/fail", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundPayment Post(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/post", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/post", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundPayment> PostAsync(string id, OutboundPaymentPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/post", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/post", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundPayment ReturnOutboundPayment(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/return", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundPayment> ReturnOutboundPaymentAsync(string id, OutboundPaymentReturnOutboundPaymentOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/return", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundPayment Update(string id, OutboundPaymentUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundPayment> UpdateAsync(string id, OutboundPaymentUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundPayment>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_payments/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -2,6 +2,7 @@
 namespace Stripe.TestHelpers.Treasury
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,7 +28,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundTransfer Fail(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/fail", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/fail", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundTransfer> FailAsync(string id, OutboundTransferFailOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/fail", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/fail", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundTransfer Post(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/post", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/post", options, requestOptions);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundTransfer> PostAsync(string id, OutboundTransferPostOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/post", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/post", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundTransfer ReturnOutboundTransfer(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/return", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/return", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundTransfer> ReturnOutboundTransferAsync(string id, OutboundTransferReturnOutboundTransferOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}/return", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/return", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -82,7 +83,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Stripe.Treasury.OutboundTransfer Update(string id, OutboundTransferUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}", options, requestOptions);
+            return this.Request<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Stripe.TestHelpers.Treasury
         /// </summary>
         public virtual Task<Stripe.Treasury.OutboundTransfer> UpdateAsync(string id, OutboundTransferUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Stripe.Treasury.OutboundTransfer>(HttpMethod.Post, $"/v1/test_helpers/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -53,7 +54,7 @@ namespace Stripe
         /// </summary>
         public virtual Token Get(string id, TokenGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Token>(HttpMethod.Get, $"/v1/tokens/{id}", options, requestOptions);
+            return this.Request<Token>(HttpMethod.Get, $"/v1/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Token> GetAsync(string id, TokenGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/tokens/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Token>(HttpMethod.Get, $"/v1/tokens/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Stripe
         /// </summary>
         public virtual Topup Cancel(string id, TopupCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{id}/cancel", options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Topup> CancelAsync(string id, TopupCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe
         /// </summary>
         public virtual Topup Get(string id, TopupGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Topup>(HttpMethod.Get, $"/v1/topups/{id}", options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Get, $"/v1/topups/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Topup> GetAsync(string id, TopupGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Topup>(HttpMethod.Get, $"/v1/topups/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Get, $"/v1/topups/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace Stripe
         /// </summary>
         public virtual Topup Update(string id, TopupUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{id}", options, requestOptions);
+            return this.Request<Topup>(HttpMethod.Post, $"/v1/topups/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Topup> UpdateAsync(string id, TopupUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Topup>(HttpMethod.Post, $"/v1/topups/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -37,7 +38,7 @@ namespace Stripe
         /// </summary>
         public virtual TransferReversal Create(string parentId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals", options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions);
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TransferReversal> CreateAsync(string parentId, TransferReversalCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Stripe
         /// </summary>
         public virtual TransferReversal Get(string parentId, string id, TransferReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TransferReversal> GetAsync(string parentId, string id, TransferReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<TransferReversal> List(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals", options, requestOptions);
+            return this.Request<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions);
         }
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<TransferReversal>> ListAsync(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<TransferReversal>>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -105,7 +106,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<TransferReversal> ListAutoPaging(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<TransferReversal>($"/v1/transfers/{parentId}/reversals", options, requestOptions);
+            return this.ListRequestAutoPaging<TransferReversal>($"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<TransferReversal> ListAutoPagingAsync(string parentId, TransferReversalListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<TransferReversal>($"/v1/transfers/{parentId}/reversals", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<TransferReversal>($"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace Stripe
         /// </summary>
         public virtual TransferReversal Update(string parentId, string id, TransferReversalUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions);
+            return this.Request<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -138,7 +139,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<TransferReversal> UpdateAsync(string parentId, string id, TransferReversalUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{parentId}/reversals/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransferReversal>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(parentId)}/reversals/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -54,7 +55,7 @@ namespace Stripe
         /// </summary>
         public virtual Transfer Get(string id, TransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Transfer>(HttpMethod.Get, $"/v1/transfers/{id}", options, requestOptions);
+            return this.Request<Transfer>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Transfer> GetAsync(string id, TransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transfer>(HttpMethod.Get, $"/v1/transfers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transfer>(HttpMethod.Get, $"/v1/transfers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace Stripe
         /// </summary>
         public virtual Transfer Update(string id, TransferUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<Transfer>(HttpMethod.Post, $"/v1/transfers/{id}", options, requestOptions);
+            return this.Request<Transfer>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -122,7 +123,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<Transfer> UpdateAsync(string id, TransferUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transfer>(HttpMethod.Post, $"/v1/transfers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transfer>(HttpMethod.Post, $"/v1/transfers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -47,7 +48,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual CreditReversal Get(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{id}", options, requestOptions);
+            return this.Request<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<CreditReversal> GetAsync(string id, CreditReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<CreditReversal>(HttpMethod.Get, $"/v1/treasury/credit_reversals/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,7 +46,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual DebitReversal Get(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{id}", options, requestOptions);
+            return this.Request<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<DebitReversal> GetAsync(string id, DebitReversalGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<DebitReversal>(HttpMethod.Get, $"/v1/treasury/debit_reversals/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual FinancialAccount Get(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}", options, requestOptions);
+            return this.Request<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<FinancialAccount> GetAsync(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccount>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -96,7 +97,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual FinancialAccountFeatures RetrieveFeatures(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions);
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}/features", options, requestOptions);
         }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<FinancialAccountFeatures> RetrieveFeaturesAsync(string id, FinancialAccountRetrieveFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Get, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}/features", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual FinancialAccount Update(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}", options, requestOptions);
+            return this.Request<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -120,7 +121,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<FinancialAccount> UpdateAsync(string id, FinancialAccountUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccount>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -128,7 +129,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual FinancialAccountFeatures UpdateFeatures(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions);
+            return this.Request<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}/features", options, requestOptions);
         }
 
         /// <summary>
@@ -136,7 +137,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<FinancialAccountFeatures> UpdateFeaturesAsync(string id, FinancialAccountUpdateFeaturesOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{id}/features", options, requestOptions, cancellationToken);
+            return this.RequestAsync<FinancialAccountFeatures>(HttpMethod.Post, $"/v1/treasury/financial_accounts/{WebUtility.UrlEncode(id)}/features", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual InboundTransfer Cancel(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{id}/cancel", options, requestOptions);
+            return this.Request<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<InboundTransfer> CancelAsync(string id, InboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InboundTransfer>(HttpMethod.Post, $"/v1/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual InboundTransfer Get(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{id}", options, requestOptions);
+            return this.Request<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<InboundTransfer> GetAsync(string id, InboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<InboundTransfer>(HttpMethod.Get, $"/v1/treasury/inbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual OutboundPayment Cancel(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{id}/cancel", options, requestOptions);
+            return this.Request<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<OutboundPayment> CancelAsync(string id, OutboundPaymentCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundPayment>(HttpMethod.Post, $"/v1/treasury/outbound_payments/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual OutboundPayment Get(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{id}", options, requestOptions);
+            return this.Request<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<OutboundPayment> GetAsync(string id, OutboundPaymentGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundPayment>(HttpMethod.Get, $"/v1/treasury/outbound_payments/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual OutboundTransfer Cancel(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{id}/cancel", options, requestOptions);
+            return this.Request<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions);
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<OutboundTransfer> CancelAsync(string id, OutboundTransferCancelOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{id}/cancel", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundTransfer>(HttpMethod.Post, $"/v1/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}/cancel", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual OutboundTransfer Get(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{id}", options, requestOptions);
+            return this.Request<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<OutboundTransfer> GetAsync(string id, OutboundTransferGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<OutboundTransfer>(HttpMethod.Get, $"/v1/treasury/outbound_transfers/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual ReceivedCredit Get(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{id}", options, requestOptions);
+            return this.Request<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<ReceivedCredit> GetAsync(string id, ReceivedCreditGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReceivedCredit>(HttpMethod.Get, $"/v1/treasury/received_credits/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual ReceivedDebit Get(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{id}", options, requestOptions);
+            return this.Request<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -38,7 +39,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<ReceivedDebit> GetAsync(string id, ReceivedDebitGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<ReceivedDebit>(HttpMethod.Get, $"/v1/treasury/received_debits/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual TransactionEntry Get(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{id}", options, requestOptions);
+            return this.Request<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<TransactionEntry> GetAsync(string id, TransactionEntryGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<TransactionEntry>(HttpMethod.Get, $"/v1/treasury/transaction_entries/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
@@ -3,6 +3,7 @@ namespace Stripe.Treasury
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Transaction Get(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{id}", options, requestOptions);
+            return this.Request<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Stripe.Treasury
         /// </summary>
         public virtual Task<Transaction> GetAsync(string id, TransactionGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Transaction>(HttpMethod.Get, $"/v1/treasury/transactions/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/UsageRecordSummaries/UsageRecordSummaryService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace Stripe
         /// </summary>
         public virtual StripeList<UsageRecordSummary> List(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions);
+            return this.Request<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_record_summaries", options, requestOptions);
         }
 
         /// <summary>
@@ -51,7 +52,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<StripeList<UsageRecordSummary>> ListAsync(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions, cancellationToken);
+            return this.RequestAsync<StripeList<UsageRecordSummary>>(HttpMethod.Get, $"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_record_summaries", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Stripe
         /// </summary>
         public virtual IEnumerable<UsageRecordSummary> ListAutoPaging(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<UsageRecordSummary>($"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions);
+            return this.ListRequestAutoPaging<UsageRecordSummary>($"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_record_summaries", options, requestOptions);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace Stripe
         /// </summary>
         public virtual IAsyncEnumerable<UsageRecordSummary> ListAutoPagingAsync(string parentId, UsageRecordSummaryListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<UsageRecordSummary>($"/v1/subscription_items/{parentId}/usage_record_summaries", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<UsageRecordSummary>($"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_record_summaries", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
+++ b/src/Stripe.net/Services/UsageRecords/UsageRecordService.cs
@@ -2,6 +2,7 @@
 namespace Stripe
 {
     using System;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,7 +46,7 @@ namespace Stripe
         /// </summary>
         public virtual UsageRecord Create(string parentId, UsageRecordCreateOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{parentId}/usage_records", options, requestOptions);
+            return this.Request<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_records", options, requestOptions);
         }
 
         /// <summary>
@@ -72,7 +73,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<UsageRecord> CreateAsync(string parentId, UsageRecordCreateOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{parentId}/usage_records", options, requestOptions, cancellationToken);
+            return this.RequestAsync<UsageRecord>(HttpMethod.Post, $"/v1/subscription_items/{WebUtility.UrlEncode(parentId)}/usage_records", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -63,7 +64,7 @@ namespace Stripe
         /// </summary>
         public virtual WebhookEndpoint Delete(string id, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{id}", options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<WebhookEndpoint> DeleteAsync(string id, WebhookEndpointDeleteOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Delete, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace Stripe
         /// </summary>
         public virtual WebhookEndpoint Get(string id, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{id}", options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -89,7 +90,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<WebhookEndpoint> GetAsync(string id, WebhookEndpointGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Get, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -130,7 +131,7 @@ namespace Stripe
         /// </summary>
         public virtual WebhookEndpoint Update(string id, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{id}", options, requestOptions);
+            return this.Request<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
@@ -139,7 +140,7 @@ namespace Stripe
         /// </summary>
         public virtual Task<WebhookEndpoint> UpdateAsync(string id, WebhookEndpointUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{id}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<WebhookEndpoint>(HttpMethod.Post, $"/v1/webhook_endpoints/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -250,6 +250,7 @@ namespace Stripe
             RequestOptions requestOptions)
             where T : IStripeEntity
         {
+            Console.WriteLine("calling " + path);
             return this.RequestAsync<T>(method, path, options, requestOptions)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -250,7 +250,6 @@ namespace Stripe
             RequestOptions requestOptions)
             where T : IStripeEntity
         {
-            Console.WriteLine("calling " + path);
             return this.RequestAsync<T>(method, path, options, requestOptions)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }


### PR DESCRIPTION
This was a regression from https://github.com/stripe/stripe-dotnet/pull/2791

## Changelog

- id strings passed to service methods (like `PaymentMethodService.Get("...")`) are now correctly URL Encoded