### PR TITLE
Stop using deprecated versions of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nuget
           path: nuget/
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: nuget
         path: nuget


### PR DESCRIPTION
Reaction to https://github.com/stripe/stripe-dotnet/pull/2959

Based on the [migration guide](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md), we need to update to actions/upload-artifact as well. Therefore creating this PR that overrides the automated one from dependabot