### PR TITLE
Update upload artifact version in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nuget
           path: nuget/


### PR DESCRIPTION
v2 has been deprecated for a while, and no longer works. This unblocks CI and releases.

Failure logs:
![image](https://github.com/user-attachments/assets/de8d431c-d3b8-4ae5-bb44-10ce0cc2f626)
