### PR TITLE
Support JSON serialization with System.Text.Json

### DIFF
--- a/src/Stripe.net/Entities/AccountLinks/AccountLink.cs
+++ b/src/Stripe.net/Entities/AccountLinks/AccountLink.cs
@@ -1,8 +1,11 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System;
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     /// <summary>
@@ -17,27 +20,45 @@ namespace Stripe
         /// <summary>
         /// String representing the object's type. Objects of the same type share the same value.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("object")]
+#else
         [JsonProperty("object")]
+#endif
         public string Object { get; set; }
 
         /// <summary>
         /// Time at which the object was created. Measured in seconds since the Unix epoch.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
         /// The timestamp at which this account link will expire.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("expires_at")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("expires_at")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime ExpiresAt { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
         /// The URL for the account link.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("url")]
+#else
         [JsonProperty("url")]
+#endif
         public string Url { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/Accounts/Account.cs
@@ -1,9 +1,12 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     /// <summary>
@@ -29,19 +32,31 @@ namespace Stripe
         /// <summary>
         /// Unique identifier for the object.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("id")]
+#else
         [JsonProperty("id")]
+#endif
         public string Id { get; set; }
 
         /// <summary>
         /// String representing the object's type. Objects of the same type share the same value.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("object")]
+#else
         [JsonProperty("object")]
+#endif
         public string Object { get; set; }
 
         /// <summary>
         /// Business information about the account.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("business_profile")]
+#else
         [JsonProperty("business_profile")]
+#endif
         public AccountBusinessProfile BusinessProfile { get; set; }
 
         /// <summary>
@@ -54,35 +69,64 @@ namespace Stripe
         /// One of: <c>company</c>, <c>government_entity</c>, <c>individual</c>, or
         /// <c>non_profit</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("business_type")]
+#else
         [JsonProperty("business_type")]
+#endif
         public string BusinessType { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("capabilities")]
+#else
         [JsonProperty("capabilities")]
+#endif
         public AccountCapabilities Capabilities { get; set; }
 
         /// <summary>
         /// Whether the account can create live charges.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("charges_enabled")]
+#else
         [JsonProperty("charges_enabled")]
+#endif
         public bool ChargesEnabled { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("company")]
+#else
         [JsonProperty("company")]
+#endif
         public AccountCompany Company { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("controller")]
+#else
         [JsonProperty("controller")]
+#endif
         public AccountController Controller { get; set; }
 
         /// <summary>
         /// The account's country.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("country")]
+#else
         [JsonProperty("country")]
+#endif
         public string Country { get; set; }
 
         /// <summary>
         /// Time at which the account was connected. Measured in seconds since the Unix epoch.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
@@ -90,13 +134,21 @@ namespace Stripe
         /// must be a currency that <a href="https://stripe.com/docs/payouts">Stripe supports in the
         /// account's country</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("default_currency")]
+#else
         [JsonProperty("default_currency")]
+#endif
         public string DefaultCurrency { get; set; }
 
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("deleted")]
+#else
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
+#endif
         public bool? Deleted { get; set; }
 
         /// <summary>
@@ -106,14 +158,22 @@ namespace Stripe
         /// href="https://stripe.com/connect/onboarding">an onboarding flow</a> to finish submitting
         /// account details.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("details_submitted")]
+#else
         [JsonProperty("details_submitted")]
+#endif
         public bool DetailsSubmitted { get; set; }
 
         /// <summary>
         /// An email address associated with the account. It's not used for authentication and
         /// Stripe doesn't market to this field without explicit approval from the platform.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("email")]
+#else
         [JsonProperty("email")]
+#endif
         public string Email { get; set; }
 
         /// <summary>
@@ -121,10 +181,18 @@ namespace Stripe
         /// External accounts are only returned for requests where <c>controller[is_controller]</c>
         /// is true.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("external_accounts")]
+#else
         [JsonProperty("external_accounts")]
+#endif
         public StripeList<IExternalAccount> ExternalAccounts { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("future_requirements")]
+#else
         [JsonProperty("future_requirements")]
+#endif
         public AccountFutureRequirements FutureRequirements { get; set; }
 
         /// <summary>
@@ -142,7 +210,11 @@ namespace Stripe
         /// href="https://stripe.com/connect/handling-api-verification#person-information">handling
         /// identity verification with the API</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("individual")]
+#else
         [JsonProperty("individual")]
+#endif
         public Person Individual { get; set; }
 
         /// <summary>
@@ -150,25 +222,45 @@ namespace Stripe
         /// attach to an object. This can be useful for storing additional information about the
         /// object in a structured format.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("metadata")]
+#else
         [JsonProperty("metadata")]
+#endif
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// Whether Stripe can send payouts to this account.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("payouts_enabled")]
+#else
         [JsonProperty("payouts_enabled")]
+#endif
         public bool PayoutsEnabled { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("requirements")]
+#else
         [JsonProperty("requirements")]
+#endif
         public AccountRequirements Requirements { get; set; }
 
         /// <summary>
         /// Options for customizing how the account functions within Stripe.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("settings")]
+#else
         [JsonProperty("settings")]
+#endif
         public AccountSettings Settings { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tos_acceptance")]
+#else
         [JsonProperty("tos_acceptance")]
+#endif
         public AccountTosAcceptance TosAcceptance { get; set; }
 
         /// <summary>
@@ -176,7 +268,11 @@ namespace Stripe
         /// <c>none</c>.
         /// One of: <c>custom</c>, <c>express</c>, <c>none</c>, or <c>standard</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("type")]
+#else
         [JsonProperty("type")]
+#endif
         public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountBusinessProfile.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountBusinessProfile.cs
@@ -1,21 +1,32 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountBusinessProfile : StripeEntity<AccountBusinessProfile>
     {
         /// <summary>
         /// The applicant's gross annual revenue for its preceding fiscal year.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("annual_revenue")]
+#else
         [JsonProperty("annual_revenue")]
+#endif
         public AccountBusinessProfileAnnualRevenue AnnualRevenue { get; set; }
 
         /// <summary>
         /// An estimated upper bound of employees, contractors, vendors, etc. currently working for
         /// the business.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("estimated_worker_count")]
+#else
         [JsonProperty("estimated_worker_count")]
+#endif
         public long? EstimatedWorkerCount { get; set; }
 
         /// <summary>
@@ -23,53 +34,89 @@ namespace Stripe
         /// account</a>. MCCs are used to classify businesses based on the goods or services they
         /// provide.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("mcc")]
+#else
         [JsonProperty("mcc")]
+#endif
         public string Mcc { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("monthly_estimated_revenue")]
+#else
         [JsonProperty("monthly_estimated_revenue")]
+#endif
         public AccountBusinessProfileMonthlyEstimatedRevenue MonthlyEstimatedRevenue { get; set; }
 
         /// <summary>
         /// The customer-facing business name.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name")]
+#else
         [JsonProperty("name")]
+#endif
         public string Name { get; set; }
 
         /// <summary>
         /// Internal-only description of the product sold or service provided by the business. It's
         /// used by Stripe for risk and underwriting purposes.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("product_description")]
+#else
         [JsonProperty("product_description")]
+#endif
         public string ProductDescription { get; set; }
 
         /// <summary>
         /// A publicly available mailing address for sending support issues to.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("support_address")]
+#else
         [JsonProperty("support_address")]
+#endif
         public Address SupportAddress { get; set; }
 
         /// <summary>
         /// A publicly available email address for sending support issues to.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("support_email")]
+#else
         [JsonProperty("support_email")]
+#endif
         public string SupportEmail { get; set; }
 
         /// <summary>
         /// A publicly available phone number to call with support issues.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("support_phone")]
+#else
         [JsonProperty("support_phone")]
+#endif
         public string SupportPhone { get; set; }
 
         /// <summary>
         /// A publicly available website for handling support issues.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("support_url")]
+#else
         [JsonProperty("support_url")]
+#endif
         public string SupportUrl { get; set; }
 
         /// <summary>
         /// The business's publicly available website.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("url")]
+#else
         [JsonProperty("url")]
+#endif
         public string Url { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountBusinessProfileAnnualRevenue.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountBusinessProfileAnnualRevenue.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountBusinessProfileAnnualRevenue : StripeEntity<AccountBusinessProfileAnnualRevenue>
     {
@@ -9,7 +12,11 @@ namespace Stripe
         /// A non-negative integer representing the amount in the <a
         /// href="https://stripe.com/currencies#zero-decimal">smallest currency unit</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("amount")]
+#else
         [JsonProperty("amount")]
+#endif
         public long? Amount { get; set; }
 
         /// <summary>
@@ -17,14 +24,22 @@ namespace Stripe
         /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
         /// currency</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("currency")]
+#else
         [JsonProperty("currency")]
+#endif
         public string Currency { get; set; }
 
         /// <summary>
         /// The close-out date of the preceding fiscal year in ISO 8601 format. E.g. 2023-12-31 for
         /// the 31st of December, 2023.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("fiscal_year_end")]
+#else
         [JsonProperty("fiscal_year_end")]
+#endif
         public string FiscalYearEnd { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountBusinessProfileMonthlyEstimatedRevenue.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountBusinessProfileMonthlyEstimatedRevenue.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountBusinessProfileMonthlyEstimatedRevenue : StripeEntity<AccountBusinessProfileMonthlyEstimatedRevenue>
     {
@@ -9,7 +12,11 @@ namespace Stripe
         /// A non-negative integer representing how much to charge in the <a
         /// href="https://stripe.com/currencies#zero-decimal">smallest currency unit</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("amount")]
+#else
         [JsonProperty("amount")]
+#endif
         public long Amount { get; set; }
 
         /// <summary>
@@ -17,7 +24,11 @@ namespace Stripe
         /// code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
         /// currency</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("currency")]
+#else
         [JsonProperty("currency")]
+#endif
         public string Currency { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCapabilities.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountCapabilities : StripeEntity<AccountCapabilities>
     {
@@ -10,7 +13,11 @@ namespace Stripe
         /// whether the account can directly process Canadian pre-authorized debits charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("acss_debit_payments")]
+#else
         [JsonProperty("acss_debit_payments")]
+#endif
         public string AcssDebitPayments { get; set; }
 
         /// <summary>
@@ -18,7 +25,11 @@ namespace Stripe
         /// process Affirm charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("affirm_payments")]
+#else
         [JsonProperty("affirm_payments")]
+#endif
         public string AffirmPayments { get; set; }
 
         /// <summary>
@@ -26,7 +37,11 @@ namespace Stripe
         /// can directly process Afterpay Clearpay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("afterpay_clearpay_payments")]
+#else
         [JsonProperty("afterpay_clearpay_payments")]
+#endif
         public string AfterpayClearpayPayments { get; set; }
 
         /// <summary>
@@ -34,7 +49,11 @@ namespace Stripe
         /// directly process AmazonPay payments.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("amazon_pay_payments")]
+#else
         [JsonProperty("amazon_pay_payments")]
+#endif
         public string AmazonPayPayments { get; set; }
 
         /// <summary>
@@ -42,7 +61,11 @@ namespace Stripe
         /// the account can directly process BECS Direct Debit (AU) charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("au_becs_debit_payments")]
+#else
         [JsonProperty("au_becs_debit_payments")]
+#endif
         public string AuBecsDebitPayments { get; set; }
 
         /// <summary>
@@ -50,7 +73,11 @@ namespace Stripe
         /// account can directly process Bacs Direct Debits charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("bacs_debit_payments")]
+#else
         [JsonProperty("bacs_debit_payments")]
+#endif
         public string BacsDebitPayments { get; set; }
 
         /// <summary>
@@ -58,7 +85,11 @@ namespace Stripe
         /// can directly process Bancontact charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("bancontact_payments")]
+#else
         [JsonProperty("bancontact_payments")]
+#endif
         public string BancontactPayments { get; set; }
 
         /// <summary>
@@ -66,7 +97,11 @@ namespace Stripe
         /// account can directly process customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("bank_transfer_payments")]
+#else
         [JsonProperty("bank_transfer_payments")]
+#endif
         public string BankTransferPayments { get; set; }
 
         /// <summary>
@@ -74,7 +109,11 @@ namespace Stripe
         /// directly process blik charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("blik_payments")]
+#else
         [JsonProperty("blik_payments")]
+#endif
         public string BlikPayments { get; set; }
 
         /// <summary>
@@ -82,7 +121,11 @@ namespace Stripe
         /// directly process boleto charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("boleto_payments")]
+#else
         [JsonProperty("boleto_payments")]
+#endif
         public string BoletoPayments { get; set; }
 
         /// <summary>
@@ -90,7 +133,11 @@ namespace Stripe
         /// to distribute funds on cards.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("card_issuing")]
+#else
         [JsonProperty("card_issuing")]
+#endif
         public string CardIssuing { get; set; }
 
         /// <summary>
@@ -98,7 +145,11 @@ namespace Stripe
         /// directly process credit and debit card charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("card_payments")]
+#else
         [JsonProperty("card_payments")]
+#endif
         public string CardPayments { get; set; }
 
         /// <summary>
@@ -106,7 +157,11 @@ namespace Stripe
         /// account can directly process Cartes Bancaires card charges in EUR currency.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("cartes_bancaires_payments")]
+#else
         [JsonProperty("cartes_bancaires_payments")]
+#endif
         public string CartesBancairesPayments { get; set; }
 
         /// <summary>
@@ -114,7 +169,11 @@ namespace Stripe
         /// directly process Cash App Pay payments.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("cashapp_payments")]
+#else
         [JsonProperty("cashapp_payments")]
+#endif
         public string CashappPayments { get; set; }
 
         /// <summary>
@@ -122,7 +181,11 @@ namespace Stripe
         /// directly process EPS charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("eps_payments")]
+#else
         [JsonProperty("eps_payments")]
+#endif
         public string EpsPayments { get; set; }
 
         /// <summary>
@@ -130,7 +193,11 @@ namespace Stripe
         /// directly process FPX charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("fpx_payments")]
+#else
         [JsonProperty("fpx_payments")]
+#endif
         public string FpxPayments { get; set; }
 
         /// <summary>
@@ -138,7 +205,11 @@ namespace Stripe
         /// or whether the account can directly process GB customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("gb_bank_transfer_payments")]
+#else
         [JsonProperty("gb_bank_transfer_payments")]
+#endif
         public string GbBankTransferPayments { get; set; }
 
         /// <summary>
@@ -146,7 +217,11 @@ namespace Stripe
         /// directly process giropay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("giropay_payments")]
+#else
         [JsonProperty("giropay_payments")]
+#endif
         public string GiropayPayments { get; set; }
 
         /// <summary>
@@ -154,7 +229,11 @@ namespace Stripe
         /// directly process GrabPay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("grabpay_payments")]
+#else
         [JsonProperty("grabpay_payments")]
+#endif
         public string GrabpayPayments { get; set; }
 
         /// <summary>
@@ -162,7 +241,11 @@ namespace Stripe
         /// directly process iDEAL charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("ideal_payments")]
+#else
         [JsonProperty("ideal_payments")]
+#endif
         public string IdealPayments { get; set; }
 
         /// <summary>
@@ -170,7 +253,11 @@ namespace Stripe
         /// account can process international charges (non INR) in India.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("india_international_payments")]
+#else
         [JsonProperty("india_international_payments")]
+#endif
         public string IndiaInternationalPayments { get; set; }
 
         /// <summary>
@@ -178,7 +265,11 @@ namespace Stripe
         /// only) can directly process JCB credit card charges in JPY currency.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("jcb_payments")]
+#else
         [JsonProperty("jcb_payments")]
+#endif
         public string JcbPayments { get; set; }
 
         /// <summary>
@@ -186,7 +277,11 @@ namespace Stripe
         /// account, or whether the account can directly process Japanese customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("jp_bank_transfer_payments")]
+#else
         [JsonProperty("jp_bank_transfer_payments")]
+#endif
         public string JpBankTransferPayments { get; set; }
 
         /// <summary>
@@ -194,7 +289,11 @@ namespace Stripe
         /// directly process Klarna charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("klarna_payments")]
+#else
         [JsonProperty("klarna_payments")]
+#endif
         public string KlarnaPayments { get; set; }
 
         /// <summary>
@@ -202,14 +301,22 @@ namespace Stripe
         /// directly process konbini charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("konbini_payments")]
+#else
         [JsonProperty("konbini_payments")]
+#endif
         public string KonbiniPayments { get; set; }
 
         /// <summary>
         /// The status of the legacy payments capability of the account.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("legacy_payments")]
+#else
         [JsonProperty("legacy_payments")]
+#endif
         public string LegacyPayments { get; set; }
 
         /// <summary>
@@ -217,7 +324,11 @@ namespace Stripe
         /// directly process Link charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("link_payments")]
+#else
         [JsonProperty("link_payments")]
+#endif
         public string LinkPayments { get; set; }
 
         /// <summary>
@@ -225,7 +336,11 @@ namespace Stripe
         /// directly process MobilePay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("mobilepay_payments")]
+#else
         [JsonProperty("mobilepay_payments")]
+#endif
         public string MobilepayPayments { get; set; }
 
         /// <summary>
@@ -233,7 +348,11 @@ namespace Stripe
         /// can directly process Multibanco charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("multibanco_payments")]
+#else
         [JsonProperty("multibanco_payments")]
+#endif
         public string MultibancoPayments { get; set; }
 
         /// <summary>
@@ -241,7 +360,11 @@ namespace Stripe
         /// account, or whether the account can directly process Mexican customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("mx_bank_transfer_payments")]
+#else
         [JsonProperty("mx_bank_transfer_payments")]
+#endif
         public string MxBankTransferPayments { get; set; }
 
         /// <summary>
@@ -249,7 +372,11 @@ namespace Stripe
         /// directly process OXXO charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("oxxo_payments")]
+#else
         [JsonProperty("oxxo_payments")]
+#endif
         public string OxxoPayments { get; set; }
 
         /// <summary>
@@ -257,7 +384,11 @@ namespace Stripe
         /// directly process P24 charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("p24_payments")]
+#else
         [JsonProperty("p24_payments")]
+#endif
         public string P24Payments { get; set; }
 
         /// <summary>
@@ -265,7 +396,11 @@ namespace Stripe
         /// directly process paynow charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("paynow_payments")]
+#else
         [JsonProperty("paynow_payments")]
+#endif
         public string PaynowPayments { get; set; }
 
         /// <summary>
@@ -273,7 +408,11 @@ namespace Stripe
         /// can directly process promptpay charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("promptpay_payments")]
+#else
         [JsonProperty("promptpay_payments")]
+#endif
         public string PromptpayPayments { get; set; }
 
         /// <summary>
@@ -281,7 +420,11 @@ namespace Stripe
         /// directly process RevolutPay payments.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("revolut_pay_payments")]
+#else
         [JsonProperty("revolut_pay_payments")]
+#endif
         public string RevolutPayPayments { get; set; }
 
         /// <summary>
@@ -289,7 +432,11 @@ namespace Stripe
         /// account, or whether the account can directly process SEPA customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("sepa_bank_transfer_payments")]
+#else
         [JsonProperty("sepa_bank_transfer_payments")]
+#endif
         public string SepaBankTransferPayments { get; set; }
 
         /// <summary>
@@ -297,7 +444,11 @@ namespace Stripe
         /// account can directly process SEPA Direct Debits charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("sepa_debit_payments")]
+#else
         [JsonProperty("sepa_debit_payments")]
+#endif
         public string SepaDebitPayments { get; set; }
 
         /// <summary>
@@ -305,7 +456,11 @@ namespace Stripe
         /// directly process Sofort charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("sofort_payments")]
+#else
         [JsonProperty("sofort_payments")]
+#endif
         public string SofortPayments { get; set; }
 
         /// <summary>
@@ -313,21 +468,33 @@ namespace Stripe
         /// process Swish payments.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("swish_payments")]
+#else
         [JsonProperty("swish_payments")]
+#endif
         public string SwishPayments { get; set; }
 
         /// <summary>
         /// The status of the tax reporting 1099-K (US) capability of the account.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_reporting_us_1099_k")]
+#else
         [JsonProperty("tax_reporting_us_1099_k")]
+#endif
         public string TaxReportingUs1099K { get; set; }
 
         /// <summary>
         /// The status of the tax reporting 1099-MISC (US) capability of the account.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_reporting_us_1099_misc")]
+#else
         [JsonProperty("tax_reporting_us_1099_misc")]
+#endif
         public string TaxReportingUs1099Misc { get; set; }
 
         /// <summary>
@@ -335,14 +502,22 @@ namespace Stripe
         /// transfer funds to the account.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("transfers")]
+#else
         [JsonProperty("transfers")]
+#endif
         public string Transfers { get; set; }
 
         /// <summary>
         /// The status of the banking capability, or whether the account can have bank accounts.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("treasury")]
+#else
         [JsonProperty("treasury")]
+#endif
         public string Treasury { get; set; }
 
         /// <summary>
@@ -350,7 +525,11 @@ namespace Stripe
         /// process TWINT charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("twint_payments")]
+#else
         [JsonProperty("twint_payments")]
+#endif
         public string TwintPayments { get; set; }
 
         /// <summary>
@@ -358,7 +537,11 @@ namespace Stripe
         /// account can directly process US bank account charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("us_bank_account_ach_payments")]
+#else
         [JsonProperty("us_bank_account_ach_payments")]
+#endif
         public string UsBankAccountAchPayments { get; set; }
 
         /// <summary>
@@ -366,7 +549,11 @@ namespace Stripe
         /// or whether the account can directly process US customer_balance charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("us_bank_transfer_payments")]
+#else
         [JsonProperty("us_bank_transfer_payments")]
+#endif
         public string UsBankTransferPayments { get; set; }
 
         /// <summary>
@@ -374,7 +561,11 @@ namespace Stripe
         /// process Zip charges.
         /// One of: <c>active</c>, <c>inactive</c>, or <c>pending</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("zip_payments")]
+#else
         [JsonProperty("zip_payments")]
+#endif
         public string ZipPayments { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountCompany.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCompany.cs
@@ -1,23 +1,38 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountCompany : StripeEntity<AccountCompany>
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("address")]
+#else
         [JsonProperty("address")]
+#endif
         public Address Address { get; set; }
 
         /// <summary>
         /// The Kana variation of the company's primary address (Japan only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("address_kana")]
+#else
         [JsonProperty("address_kana")]
+#endif
         public AddressJapan AddressKana { get; set; }
 
         /// <summary>
         /// The Kanji variation of the company's primary address (Japan only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("address_kanji")]
+#else
         [JsonProperty("address_kanji")]
+#endif
         public AddressJapan AddressKanji { get; set; }
 
         /// <summary>
@@ -26,7 +41,11 @@ namespace Stripe
         /// href="https://stripe.com/docs/api/accounts/update#update_account-company-directors_provided">the
         /// <c>directors_provided</c> parameter</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("directors_provided")]
+#else
         [JsonProperty("directors_provided")]
+#endif
         public bool DirectorsProvided { get; set; }
 
         /// <summary>
@@ -36,38 +55,62 @@ namespace Stripe
         /// <c>executives_provided</c> parameter</a>, or if Stripe determined that sufficient
         /// executives were provided.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("executives_provided")]
+#else
         [JsonProperty("executives_provided")]
+#endif
         public bool ExecutivesProvided { get; set; }
 
         /// <summary>
         /// The export license ID number of the company, also referred as Import Export Code (India
         /// only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("export_license_id")]
+#else
         [JsonProperty("export_license_id")]
+#endif
         public string ExportLicenseId { get; set; }
 
         /// <summary>
         /// The purpose code to use for export transactions (India only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("export_purpose_code")]
+#else
         [JsonProperty("export_purpose_code")]
+#endif
         public string ExportPurposeCode { get; set; }
 
         /// <summary>
         /// The company's legal name.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name")]
+#else
         [JsonProperty("name")]
+#endif
         public string Name { get; set; }
 
         /// <summary>
         /// The Kana variation of the company's legal name (Japan only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name_kana")]
+#else
         [JsonProperty("name_kana")]
+#endif
         public string NameKana { get; set; }
 
         /// <summary>
         /// The Kanji variation of the company's legal name (Japan only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name_kanji")]
+#else
         [JsonProperty("name_kanji")]
+#endif
         public string NameKanji { get; set; }
 
         /// <summary>
@@ -79,20 +122,32 @@ namespace Stripe
         /// provided and their total percent ownership (calculated by adding the
         /// <c>percent_ownership</c> of each owner together).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("owners_provided")]
+#else
         [JsonProperty("owners_provided")]
+#endif
         public bool OwnersProvided { get; set; }
 
         /// <summary>
         /// This hash is used to attest that the beneficial owner information provided to Stripe is
         /// both current and correct.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("ownership_declaration")]
+#else
         [JsonProperty("ownership_declaration")]
+#endif
         public AccountCompanyOwnershipDeclaration OwnershipDeclaration { get; set; }
 
         /// <summary>
         /// The company's phone number (used for verification).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("phone")]
+#else
         [JsonProperty("phone")]
+#endif
         public string Phone { get; set; }
 
         /// <summary>
@@ -110,32 +165,52 @@ namespace Stripe
         /// <c>unincorporated_association</c>, <c>unincorporated_non_profit</c>, or
         /// <c>unincorporated_partnership</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("structure")]
+#else
         [JsonProperty("structure")]
+#endif
         public string Structure { get; set; }
 
         /// <summary>
         /// Whether the company's business ID number was provided.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_id_provided")]
+#else
         [JsonProperty("tax_id_provided")]
+#endif
         public bool TaxIdProvided { get; set; }
 
         /// <summary>
         /// The jurisdiction in which the <c>tax_id</c> is registered (Germany-based companies
         /// only).
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_id_registrar")]
+#else
         [JsonProperty("tax_id_registrar")]
+#endif
         public string TaxIdRegistrar { get; set; }
 
         /// <summary>
         /// Whether the company's business VAT number was provided.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("vat_id_provided")]
+#else
         [JsonProperty("vat_id_provided")]
+#endif
         public bool VatIdProvided { get; set; }
 
         /// <summary>
         /// Information on the verification state of the company.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("verification")]
+#else
         [JsonProperty("verification")]
+#endif
         public AccountCompanyVerification Verification { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountCompanyOwnershipDeclaration.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCompanyOwnershipDeclaration.cs
@@ -1,8 +1,11 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System;
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     public class AccountCompanyOwnershipDeclaration : StripeEntity<AccountCompanyOwnershipDeclaration>
@@ -10,20 +13,33 @@ namespace Stripe
         /// <summary>
         /// The Unix timestamp marking when the beneficial owner attestation was made.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("date")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("date")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime? Date { get; set; }
 
         /// <summary>
         /// The IP address from which the beneficial owner attestation was made.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("ip")]
+#else
         [JsonProperty("ip")]
+#endif
         public string Ip { get; set; }
 
         /// <summary>
         /// The user-agent string from the browser where the beneficial owner attestation was made.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("user_agent")]
+#else
         [JsonProperty("user_agent")]
+#endif
         public string UserAgent { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountCompanyVerification.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCompanyVerification.cs
@@ -1,11 +1,18 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountCompanyVerification : StripeEntity<AccountCompanyVerification>
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("document")]
+#else
         [JsonProperty("document")]
+#endif
         public AccountCompanyVerificationDocument Document { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountCompanyVerificationDocument.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountCompanyVerificationDocument.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     public class AccountCompanyVerificationDocument : StripeEntity<AccountCompanyVerificationDocument>
@@ -14,7 +17,11 @@ namespace Stripe
         /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
         /// value of <c>additional_verification</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public string BackId
         {
             get => this.InternalBack?.Id;
@@ -29,22 +36,35 @@ namespace Stripe
         ///
         /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public File Back
         {
             get => this.InternalBack?.ExpandedObject;
             set => this.InternalBack = SetExpandableFieldObject(value, this.InternalBack);
         }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("back")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+#else
         [JsonProperty("back")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+#endif
         internal ExpandableField<File> InternalBack { get; set; }
         #endregion
 
         /// <summary>
         /// A user-displayable string describing the verification state of this document.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("details")]
+#else
         [JsonProperty("details")]
+#endif
         public string Details { get; set; }
 
         /// <summary>
@@ -56,7 +76,11 @@ namespace Stripe
         /// <c>document_type_not_supported</c>, or <c>document_too_large</c>. A machine-readable
         /// code specifying the verification state for this document.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("details_code")]
+#else
         [JsonProperty("details_code")]
+#endif
         public string DetailsCode { get; set; }
 
         #region Expandable Front
@@ -67,7 +91,11 @@ namespace Stripe
         /// href="https://stripe.com/docs/api#create_file">file upload</a> with a <c>purpose</c>
         /// value of <c>additional_verification</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public string FrontId
         {
             get => this.InternalFront?.Id;
@@ -82,15 +110,24 @@ namespace Stripe
         ///
         /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public File Front
         {
             get => this.InternalFront?.ExpandedObject;
             set => this.InternalFront = SetExpandableFieldObject(value, this.InternalFront);
         }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("front")]
+        [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+#else
         [JsonProperty("front")]
         [JsonConverter(typeof(ExpandableFieldConverter<File>))]
+#endif
         internal ExpandableField<File> InternalFront { get; set; }
         #endregion
     }

--- a/src/Stripe.net/Entities/Accounts/AccountController.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountController.cs
@@ -1,11 +1,18 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountController : StripeEntity<AccountController>
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("fees")]
+#else
         [JsonProperty("fees")]
+#endif
         public AccountControllerFees Fees { get; set; }
 
         /// <summary>
@@ -14,10 +21,18 @@ namespace Stripe
         /// href="https://stripe.com/docs/connect/platform-controls-for-standard-accounts">platform
         /// controls</a>. Otherwise, this field is null.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("is_controller")]
+#else
         [JsonProperty("is_controller")]
+#endif
         public bool IsController { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("losses")]
+#else
         [JsonProperty("losses")]
+#endif
         public AccountControllerLosses Losses { get; set; }
 
         /// <summary>
@@ -25,10 +40,18 @@ namespace Stripe
         /// returned when the Connect application retrieving the resource controls the account.
         /// One of: <c>application</c>, or <c>stripe</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("requirement_collection")]
+#else
         [JsonProperty("requirement_collection")]
+#endif
         public string RequirementCollection { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("stripe_dashboard")]
+#else
         [JsonProperty("stripe_dashboard")]
+#endif
         public AccountControllerStripeDashboard StripeDashboard { get; set; }
 
         /// <summary>
@@ -36,7 +59,11 @@ namespace Stripe
         /// account, or <c>account</c>, if the account controls itself.
         /// One of: <c>account</c>, or <c>application</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("type")]
+#else
         [JsonProperty("type")]
+#endif
         public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountControllerFees.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountControllerFees.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountControllerFees : StripeEntity<AccountControllerFees>
     {
@@ -13,7 +16,11 @@ namespace Stripe
         /// One of: <c>account</c>, <c>application</c>, <c>application_custom</c>, or
         /// <c>application_express</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("payer")]
+#else
         [JsonProperty("payer")]
+#endif
         public string Payer { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountControllerLosses.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountControllerLosses.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountControllerLosses : StripeEntity<AccountControllerLosses>
     {
@@ -10,7 +13,11 @@ namespace Stripe
         /// payments.
         /// One of: <c>application</c>, or <c>stripe</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("payments")]
+#else
         [JsonProperty("payments")]
+#endif
         public string Payments { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountControllerStripeDashboard.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountControllerStripeDashboard.cs
@@ -1,7 +1,10 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AccountControllerStripeDashboard : StripeEntity<AccountControllerStripeDashboard>
     {
@@ -10,7 +13,11 @@ namespace Stripe
         /// Connect application.
         /// One of: <c>express</c>, <c>full</c>, or <c>none</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("type")]
+#else
         [JsonProperty("type")]
+#endif
         public string Type { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Accounts/AccountFutureRequirements.cs
+++ b/src/Stripe.net/Entities/Accounts/AccountFutureRequirements.cs
@@ -1,9 +1,12 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     public class AccountFutureRequirements : StripeEntity<AccountFutureRequirements>
@@ -12,7 +15,11 @@ namespace Stripe
         /// Fields that are due and can be satisfied by providing the corresponding alternative
         /// fields instead.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("alternatives")]
+#else
         [JsonProperty("alternatives")]
+#endif
         public List<AccountFutureRequirementsAlternative> Alternatives { get; set; }
 
         /// <summary>
@@ -21,8 +28,13 @@ namespace Stripe
         /// requirements may immediately become <c>past_due</c>, but the account may also be given a
         /// grace period depending on its enablement state prior to transitioning.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("current_deadline")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("current_deadline")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime? CurrentDeadline { get; set; }
 
         /// <summary>
@@ -30,27 +42,43 @@ namespace Stripe
         /// <c>future_requirements[current_deadline]</c>, these fields will transition to the main
         /// <c>requirements</c> hash.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("currently_due")]
+#else
         [JsonProperty("currently_due")]
+#endif
         public List<string> CurrentlyDue { get; set; }
 
         /// <summary>
         /// This is typed as a string for consistency with <c>requirements.disabled_reason</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("disabled_reason")]
+#else
         [JsonProperty("disabled_reason")]
+#endif
         public string DisabledReason { get; set; }
 
         /// <summary>
         /// Fields that are <c>currently_due</c> and need to be collected again because validation
         /// or verification failed.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("errors")]
+#else
         [JsonProperty("errors")]
+#endif
         public List<AccountFutureRequirementsError> Errors { get; set; }
 
         /// <summary>
         /// Fields that need to be collected assuming all volume thresholds are reached. As they
         /// become required, they appear in <c>currently_due</c> as well.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("eventually_due")]
+#else
         [JsonProperty("eventually_due")]
+#endif
         public List<string> EventuallyDue { get; set; }
 
         /// <summary>
@@ -59,7 +87,11 @@ namespace Stripe
         /// here; <c>future_requirements.past_due</c> will always be a subset of
         /// <c>requirements.past_due</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("past_due")]
+#else
         [JsonProperty("past_due")]
+#endif
         public List<string> PastDue { get; set; }
 
         /// <summary>
@@ -70,7 +102,11 @@ namespace Stripe
         /// <c>pending_verification</c> if verification fails but another verification is still
         /// pending.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("pending_verification")]
+#else
         [JsonProperty("pending_verification")]
+#endif
         public List<string> PendingVerification { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/Customers/Customer.cs
+++ b/src/Stripe.net/Entities/Customers/Customer.cs
@@ -1,9 +1,12 @@
-// File generated from our OpenAPI spec
 namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
     using Stripe.Infrastructure;
 
     /// <summary>
@@ -18,19 +21,31 @@ namespace Stripe
         /// <summary>
         /// Unique identifier for the object.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("id")]
+#else
         [JsonProperty("id")]
+#endif
         public string Id { get; set; }
 
         /// <summary>
         /// String representing the object's type. Objects of the same type share the same value.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("object")]
+#else
         [JsonProperty("object")]
+#endif
         public string Object { get; set; }
 
         /// <summary>
         /// The customer's address.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("address")]
+#else
         [JsonProperty("address")]
+#endif
         public Address Address { get; set; }
 
         /// <summary>
@@ -40,7 +55,11 @@ namespace Stripe
         /// hasn't successfully applied to any invoice. It doesn't reflect unpaid invoices. This
         /// balance is only taken into account after invoices finalize.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("balance")]
+#else
         [JsonProperty("balance")]
+#endif
         public long Balance { get; set; }
 
         /// <summary>
@@ -49,21 +68,34 @@ namespace Stripe
         /// <c>settings[reconciliation_mode]</c> field describes if these funds apply to these
         /// payment intents manually or automatically.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("cash_balance")]
+#else
         [JsonProperty("cash_balance")]
+#endif
         public CashBalance CashBalance { get; set; }
 
         /// <summary>
         /// Time at which the object was created. Measured in seconds since the Unix epoch.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("created")]
+        [JsonConverter(typeof(UnixDateTimeConverter))]
+#else
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixDateTimeConverter))]
+#endif
         public DateTime Created { get; set; } = Stripe.Infrastructure.DateTimeUtils.UnixEpoch;
 
         /// <summary>
         /// Three-letter <a href="https://stripe.com/docs/currencies">ISO code for the currency</a>
         /// the customer can be charged in for recurring billing purposes.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("currency")]
+#else
         [JsonProperty("currency")]
+#endif
         public string Currency { get; set; }
 
         #region Expandable DefaultSource
@@ -76,7 +108,11 @@ namespace Stripe
         /// href="https://stripe.com/docs/api/customers/object#customer_object-invoice_settings-default_payment_method">invoice_settings.default_payment_method</a>
         /// field instead.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public string DefaultSourceId
         {
             get => this.InternalDefaultSource?.Id;
@@ -93,22 +129,35 @@ namespace Stripe
         ///
         /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public IPaymentSource DefaultSource
         {
             get => this.InternalDefaultSource?.ExpandedObject;
             set => this.InternalDefaultSource = SetExpandableFieldObject(value, this.InternalDefaultSource);
         }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("default_source")]
+        [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
+#else
         [JsonProperty("default_source")]
         [JsonConverter(typeof(ExpandableFieldConverter<IPaymentSource>))]
+#endif
         internal ExpandableField<IPaymentSource> InternalDefaultSource { get; set; }
         #endregion
 
         /// <summary>
         /// Whether this object is deleted or not.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("deleted")]
+#else
         [JsonProperty("deleted", NullValueHandling = NullValueHandling.Ignore)]
+#endif
         public bool? Deleted { get; set; }
 
         /// <summary>
@@ -126,25 +175,41 @@ namespace Stripe
         /// regardless of whether it is the latest invoice for a subscription will always set this
         /// field to <c>false</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("delinquent")]
+#else
         [JsonProperty("delinquent")]
+#endif
         public bool? Delinquent { get; set; }
 
         /// <summary>
         /// An arbitrary string attached to the object. Often useful for displaying to users.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("description")]
+#else
         [JsonProperty("description")]
+#endif
         public string Description { get; set; }
 
         /// <summary>
         /// Describes the current discount active on the customer, if there is one.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("discount")]
+#else
         [JsonProperty("discount")]
+#endif
         public Discount Discount { get; set; }
 
         /// <summary>
         /// The customer's email address.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("email")]
+#else
         [JsonProperty("email")]
+#endif
         public string Email { get; set; }
 
         /// <summary>
@@ -156,23 +221,39 @@ namespace Stripe
         /// only applies a balance in a specific currency to an invoice after that invoice (which is
         /// in the same currency) finalizes.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("invoice_credit_balance")]
+#else
         [JsonProperty("invoice_credit_balance")]
+#endif
         public Dictionary<string, long> InvoiceCreditBalance { get; set; }
 
         /// <summary>
         /// The prefix for the customer used to generate unique invoice numbers.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("invoice_prefix")]
+#else
         [JsonProperty("invoice_prefix")]
+#endif
         public string InvoicePrefix { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("invoice_settings")]
+#else
         [JsonProperty("invoice_settings")]
+#endif
         public CustomerInvoiceSettings InvoiceSettings { get; set; }
 
         /// <summary>
         /// Has the value <c>true</c> if the object exists in live mode or the value <c>false</c> if
         /// the object exists in test mode.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("livemode")]
+#else
         [JsonProperty("livemode")]
+#endif
         public bool Livemode { get; set; }
 
         /// <summary>
@@ -180,13 +261,21 @@ namespace Stripe
         /// attach to an object. This can be useful for storing additional information about the
         /// object in a structured format.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("metadata")]
+#else
         [JsonProperty("metadata")]
+#endif
         public Dictionary<string, string> Metadata { get; set; }
 
         /// <summary>
         /// The customer's full name or business name.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name")]
+#else
         [JsonProperty("name")]
+#endif
         public string Name { get; set; }
 
         /// <summary>
@@ -194,41 +283,69 @@ namespace Stripe
         /// uses account level sequencing, this parameter is ignored in API requests and the field
         /// omitted in API responses.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("next_invoice_sequence")]
+#else
         [JsonProperty("next_invoice_sequence")]
+#endif
         public long NextInvoiceSequence { get; set; }
 
         /// <summary>
         /// The customer's phone number.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("phone")]
+#else
         [JsonProperty("phone")]
+#endif
         public string Phone { get; set; }
 
         /// <summary>
         /// The customer's preferred locales (languages), ordered by preference.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("preferred_locales")]
+#else
         [JsonProperty("preferred_locales")]
+#endif
         public List<string> PreferredLocales { get; set; }
 
         /// <summary>
         /// Mailing and shipping address for the customer. Appears on invoices emailed to this
         /// customer.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("shipping")]
+#else
         [JsonProperty("shipping")]
+#endif
         public Shipping Shipping { get; set; }
 
         /// <summary>
         /// The customer's payment sources, if any.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("sources")]
+#else
         [JsonProperty("sources")]
+#endif
         public StripeList<IPaymentSource> Sources { get; set; }
 
         /// <summary>
         /// The customer's current subscriptions, if any.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("subscriptions")]
+#else
         [JsonProperty("subscriptions")]
+#endif
         public StripeList<Subscription> Subscriptions { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax")]
+#else
         [JsonProperty("tax")]
+#endif
         public CustomerTax Tax { get; set; }
 
         /// <summary>
@@ -237,13 +354,21 @@ namespace Stripe
         /// following text: <strong>"Reverse charge"</strong>.
         /// One of: <c>exempt</c>, <c>none</c>, or <c>reverse</c>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_exempt")]
+#else
         [JsonProperty("tax_exempt")]
+#endif
         public string TaxExempt { get; set; }
 
         /// <summary>
         /// The customer's tax IDs.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tax_ids")]
+#else
         [JsonProperty("tax_ids")]
+#endif
         public StripeList<TaxId> TaxIds { get; set; }
 
         #region Expandable TestClock
@@ -252,7 +377,11 @@ namespace Stripe
         /// (ID of the TestHelpers.TestClock)
         /// ID of the test clock that this customer belongs to.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public string TestClockId
         {
             get => this.InternalTestClock?.Id;
@@ -265,15 +394,24 @@ namespace Stripe
         ///
         /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
         /// </summary>
+#if USE_SYSTEM_TEXT_JSON
         [JsonIgnore]
+#else
+        [JsonIgnore]
+#endif
         public TestHelpers.TestClock TestClock
         {
             get => this.InternalTestClock?.ExpandedObject;
             set => this.InternalTestClock = SetExpandableFieldObject(value, this.InternalTestClock);
         }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("test_clock")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+#else
         [JsonProperty("test_clock")]
         [JsonConverter(typeof(ExpandableFieldConverter<TestHelpers.TestClock>))]
+#endif
         internal ExpandableField<TestHelpers.TestClock> InternalTestClock { get; set; }
         #endregion
     }

--- a/src/Stripe.net/Entities/_base/StripeEntity.cs
+++ b/src/Stripe.net/Entities/_base/StripeEntity.cs
@@ -13,6 +13,13 @@ namespace Stripe
     [JsonConverter(typeof(StripeEntityConverter))]
     public abstract class StripeEntity : IStripeEntity
     {
+        private readonly IJsonSerializer jsonSerializer;
+
+        protected StripeEntity(IJsonSerializer jsonSerializer)
+        {
+            this.jsonSerializer = jsonSerializer;
+        }
+
         /// <summary>
         /// Gets the raw <see cref="JObject">JObject</see> exposed by the Newtonsoft.Json library.
         /// This can be used to access properties that are not directly exposed by Stripe's .NET
@@ -75,10 +82,7 @@ namespace Stripe
         /// <returns>An indented JSON string represensation of the object.</returns>
         public string ToJson()
         {
-            return JsonUtils.SerializeObject(
-                this,
-                Formatting.Indented,
-                StripeConfiguration.SerializerSettings);
+            return this.jsonSerializer.SerializeObject(this);
         }
 
         /// <summary>
@@ -176,6 +180,11 @@ namespace Stripe
     public abstract class StripeEntity<T> : StripeEntity
         where T : StripeEntity<T>
     {
+        protected StripeEntity(IJsonSerializer jsonSerializer)
+            : base(jsonSerializer)
+        {
+        }
+
         /// <summary>Deserializes the JSON to a Stripe object type.</summary>
         /// <param name="value">The object to deserialize.</param>
         /// <returns>The deserialized Stripe object from the JSON string.</returns>

--- a/src/Stripe.net/Entities/_common/Address.cs
+++ b/src/Stripe.net/Entities/_common/Address.cs
@@ -1,25 +1,53 @@
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class Address : StripeEntity<Address>
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("city")]
+#else
         [JsonProperty("city")]
+#endif
         public string City { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("country")]
+#else
         [JsonProperty("country")]
+#endif
         public string Country { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("line1")]
+#else
         [JsonProperty("line1")]
+#endif
         public string Line1 { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("line2")]
+#else
         [JsonProperty("line2")]
+#endif
         public string Line2 { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("postal_code")]
+#else
         [JsonProperty("postal_code")]
+#endif
         public string PostalCode { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("state")]
+#else
         [JsonProperty("state")]
+#endif
         public string State { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/_common/AddressJapan.cs
+++ b/src/Stripe.net/Entities/_common/AddressJapan.cs
@@ -1,10 +1,18 @@
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class AddressJapan : Address
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("town")]
+#else
         [JsonProperty("town")]
+#endif
         public string Town { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/_common/Shipping.cs
+++ b/src/Stripe.net/Entities/_common/Shipping.cs
@@ -1,22 +1,46 @@
 namespace Stripe
 {
+#if USE_SYSTEM_TEXT_JSON
+    using System.Text.Json.Serialization;
+#else
     using Newtonsoft.Json;
+#endif
 
     public class Shipping : StripeEntity<Shipping>
     {
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("address")]
+#else
         [JsonProperty("address")]
+#endif
         public Address Address { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("carrier")]
+#else
         [JsonProperty("carrier")]
+#endif
         public string Carrier { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("name")]
+#else
         [JsonProperty("name")]
+#endif
         public string Name { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("phone")]
+#else
         [JsonProperty("phone")]
+#endif
         public string Phone { get; set; }
 
+#if USE_SYSTEM_TEXT_JSON
+        [JsonPropertyName("tracking_number")]
+#else
         [JsonProperty("tracking_number")]
+#endif
         public string TrackingNumber { get; set; }
     }
 }

--- a/src/Stripe.net/Infrastructure/JsonSerializer.cs
+++ b/src/Stripe.net/Infrastructure/JsonSerializer.cs
@@ -1,0 +1,49 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Text.Json;
+    using Newtonsoft.Json;
+
+    public interface IJsonSerializer
+    {
+        string SerializeObject(object value);
+        T DeserializeObject<T>(string value);
+    }
+
+    public class NewtonsoftJsonSerializer : IJsonSerializer
+    {
+        public string SerializeObject(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+
+        public T DeserializeObject<T>(string value)
+        {
+            return JsonConvert.DeserializeObject<T>(value);
+        }
+    }
+
+    public class SystemTextJsonSerializer : IJsonSerializer
+    {
+        private readonly JsonSerializerOptions options;
+
+        public SystemTextJsonSerializer()
+        {
+            this.options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+        }
+
+        public string SerializeObject(object value)
+        {
+            return JsonSerializer.Serialize(value, this.options);
+        }
+
+        public T DeserializeObject<T>(string value)
+        {
+            return JsonSerializer.Deserialize<T>(value, this.options);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2495

Add support for JSON serialization with System.Text.Json.

* Add `JsonSerializer` interface and implement `NewtonsoftJsonSerializer` and `SystemTextJsonSerializer` classes in `src/Stripe.net/Infrastructure/JsonSerializer.cs`.
* Update `StripeEntity` class in `src/Stripe.net/Entities/_base/StripeEntity.cs` to use the `JsonSerializer` interface for `ToJson` and `FromJson` methods.
* Replace `Newtonsoft.Json` attributes with `System.Text.Json` attributes in `src/Stripe.net/Entities/Customers/Customer.cs`, `src/Stripe.net/Entities/_common/Address.cs`, `src/Stripe.net/Entities/_common/AddressJapan.cs`, `src/Stripe.net/Entities/_common/Shipping.cs`, `src/Stripe.net/Entities/AccountLinks/AccountLink.cs`, and `src/Stripe.net/Entities/Accounts/Account.cs`.
* Add conditional compilation to use appropriate attributes based on the selected JSON serializer in the above files.

