### PR TITLE
Add Custom requests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,18 @@ If your beta feature requires a `Stripe-Version` header to be sent, set the `Str
 StripeConfiguration.AddBetaVersion("feature_beta", "v3");
 ```
 
+### Custom requests
+
+If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `RawRequestAsync` method on `StripeClient`.
+
+```C#
+StripeClient client = new StripeClient();
+StripeResponse response = await client.RawRequestAsync(HttpMethod.Get, "/v1/accounts/acc_123");
+
+// Optionally use Deserialize to convert the response to strongly-typed object.
+Account account = client.Deserialize<Account>(response.Content)
+```
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the Stripe .NET client library. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.


### PR DESCRIPTION
### Why?
The new release of the SDK adds methods to issue custom requests to support using the SDK to access pre-release or undocumented API endpoints.  This PR updates the README to document how this is used.

### What?
- added Custom requests section to readme with an example