### PR TITLE
Remove obsolete options classes

### DIFF
--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
@@ -1,9 +1,0 @@
-namespace Stripe
-{
-    using System;
-
-    [Obsolete]
-    public class SourceTransactionsGetOptions : BaseOptions
-    {
-    }
-}

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionsListOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionsListOptions.cs
@@ -1,9 +1,0 @@
-namespace Stripe
-{
-    using System;
-
-    [Obsolete("Use SourceTransactionListOptions instead.")]
-    public class SourceTransactionsListOptions : ListOptions
-    {
-    }
-}


### PR DESCRIPTION
### Why?
I noticed two options classes that we have marked as obsolete in this release but do not fit the pattern we've been using:
* SourceTransactionsListOptions was renamed to SourceTransactionListOptions and the old name is no longer being used
* SourceTransactionsGetOptions has not been referenced in the SDK for some time

In prep for the V2 release, rather than mark these as Obsolete, I think we should just delete them and note the removals in the migration guide.

### What?
- deleted classes SourceTransactionsGetOptions and SourceTransactionsListOptions