### PR TITLE
Fix service call without explicit client (redo)

### DIFF
--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -60,7 +60,9 @@ namespace Stripe
 
         internal ApiRequestor Requestor
         {
-            get => this.requestor;
+#pragma warning disable CS0618 // Type or member is obsolete
+            get => this.requestor ?? new ApiRequestorAdapter(this.Client);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         internal T Request<T>(


### PR DESCRIPTION
### Why?
Re-application of https://github.com/stripe/stripe-dotnet/pull/2978 against master branch

### What?
- changed Service.cs to create a default Requestor if one is not set (using the ApiRequestorAdapter and the current set Client)