### PR TITLE
Add TargetFramework=net5.0 to codegen-format Makefile step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ update-version:
 	@perl -pi -e 's|<Version>[.\-\d\w]+</Version>|<Version>$(VERSION)</Version>|' src/Stripe.net/Stripe.net.csproj
 
 codegen-format:
-	dotnet format src/Stripe.net/Stripe.net.csproj --severity warn
+	TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn
 
 ci-test:
 	dotnet test --no-build src/StripeTests/StripeTests.csproj -c Release


### PR DESCRIPTION
### Why?
This SDK uses the `dotnet format` command to format source generated source code from our code generator. By default this command will attempt to run the formatter for each of the target frameworks in parallel; this was observed to sometimes cause compiler errors in the StripeTypeRegistry.cs file (specifically, it would duplicate the V2TypesToEventTypes dictionary). This PR fixes this by ensuring `dotnet format` only runs once for one framework

### What?
- added TargetFramework=net5.0 before running `dotnet format` to make sure formatting executes once against the net5.0 rules (which should be maximally compatible with our supported targets)