### PR TITLE
Added Livemode and Reason properties to ThinEvent

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
+++ b/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
@@ -27,6 +27,12 @@ namespace Stripe
         [JsonProperty("created")]
         public DateTime Created { get; internal set; }
 
+        /// <summary>
+        /// Livemode indicates if the event is from a production(true) or test(false) account.
+        /// </summary>
+        [JsonProperty("livemode")]
+        public bool Livemode { get; internal set; }
+
 #nullable enable
         /// <summary>
         /// [Optional] Authentication context needed to fetch the event or related object.

--- a/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
+++ b/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
@@ -2,6 +2,7 @@ namespace Stripe
 {
     using System;
     using Newtonsoft.Json;
+    using Stripe.V2;
 
     /// <summary>
     /// A pushed thin event.  Use this the Id with the <see cref="Stripe.V2.Core.EventService"/>
@@ -34,6 +35,12 @@ namespace Stripe
         public bool Livemode { get; internal set; }
 
 #nullable enable
+        /// <summary>
+        /// [Optional] Reason for the event.
+        /// </summary>
+        [JsonProperty("reason")]
+        public EventReason? Reason { get; internal set; }
+
         /// <summary>
         /// [Optional] Authentication context needed to fetch the event or related object.
         /// </summary>

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -108,6 +108,22 @@ namespace StripeTests.V2
                 ""livemode"": false,
               }";
 
+        private static string v2KnownEventWithReasonPayload =
+            @"{
+                ""id"": ""evt_234"",
+                ""object"": ""event"",
+                ""type"": ""v1.billing.meter.no_meter_found"",
+                ""created"": ""2022-02-15T00:27:45.330Z"",
+                ""livemode"": true,
+                ""reason"": {
+                    ""type"": ""a.b.c"",
+                    ""request"": {
+                        ""id"": ""r_123"",
+                        ""idempotency_key"": ""key""
+                    }
+                }
+              }";
+
         private StripeClient stripeClient;
 
         public EventTest(MockHttpClientFixture mockHttpClientFixture)
@@ -219,6 +235,23 @@ namespace StripeTests.V2
             Assert.False(baseThinEvent.Livemode);
             Assert.Null(baseThinEvent.Context);
             Assert.Null(baseThinEvent.RelatedObject);
+        }
+
+        [Fact]
+        public void ParseThinEventWithReason()
+        {
+            var baseThinEvent = this.stripeClient.ParseThinEvent(v2KnownEventWithReasonPayload, GenerateSigHeader(v2KnownEventWithReasonPayload), WebhookSecret);
+            Assert.NotNull(baseThinEvent);
+            Assert.Equal("evt_234", baseThinEvent.Id);
+            Assert.Equal("v1.billing.meter.no_meter_found", baseThinEvent.Type);
+            Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), baseThinEvent.Created);
+            Assert.True(baseThinEvent.Livemode);
+            Assert.Null(baseThinEvent.Context);
+            Assert.Null(baseThinEvent.RelatedObject);
+            Assert.NotNull(baseThinEvent.Reason);
+            Assert.Equal("a.b.c", baseThinEvent.Reason.Type);
+            Assert.Equal("r_123", baseThinEvent.Reason.Request.Id);
+            Assert.Equal("key", baseThinEvent.Reason.Request.IdempotencyKey);
         }
 
         [Fact]

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -23,6 +23,7 @@ namespace StripeTests.V2
                   ""object"": ""event"",
                   ""type"": ""this.event.doesnt.exist"",
                   ""created"": ""2022-02-15T00:27:45.330Z"",
+                  ""livemode"": true,
                   ""related_object"": {
                     ""id"": ""fa_123"",
                     ""type"": ""financial_account"",
@@ -43,6 +44,7 @@ namespace StripeTests.V2
                 ""object"": ""event"",
                 ""type"": ""v1.billing.meter.no_meter_found"",
                 ""created"": ""2022-02-15T00:27:45.330Z"",
+                ""livemode"": true,
               }";
 
         private static string v2KnownEventPayload =
@@ -52,6 +54,7 @@ namespace StripeTests.V2
                 ""type"": ""v1.billing.meter.error_report_triggered"",
                 ""created"": ""2022-02-15T00:27:45.330Z"",
                 ""context"": ""context 123"",
+                ""livemode"": true,
                 ""related_object"": {
                   ""id"": ""me_123"",
                   ""type"": ""billing.meter"",
@@ -67,6 +70,7 @@ namespace StripeTests.V2
                   ""type"": ""v1.billing.meter.error_report_triggered"",
                   ""created"": ""2022-02-15T00:27:45.330Z"",
                   ""context"": ""context 123"",
+                  ""livemode"": true,
                   ""related_object"": {
                     ""id"": ""me_123"",
                     ""type"": ""billing.meter"",
@@ -94,6 +98,15 @@ namespace StripeTests.V2
                     }
                   }
                 }";
+
+        private static string v2KnownEventLivemodeFalsePayload =
+            @"{
+                ""id"": ""evt_234"",
+                ""object"": ""event"",
+                ""type"": ""v1.billing.meter.no_meter_found"",
+                ""created"": ""2022-02-15T00:27:45.330Z"",
+                ""livemode"": false,
+              }";
 
         private StripeClient stripeClient;
 
@@ -162,6 +175,7 @@ namespace StripeTests.V2
             Assert.Equal("evt_234", baseThinEvent.Id);
             Assert.Equal("v1.billing.meter.no_meter_found", baseThinEvent.Type);
             Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), baseThinEvent.Created);
+            Assert.True(baseThinEvent.Livemode);
             Assert.Null(baseThinEvent.Context);
             Assert.Null(baseThinEvent.RelatedObject);
         }
@@ -174,6 +188,7 @@ namespace StripeTests.V2
             Assert.Equal("evt_234", baseThinEvent.Id);
             Assert.Equal("v1.billing.meter.error_report_triggered", baseThinEvent.Type);
             Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), baseThinEvent.Created);
+            Assert.True(baseThinEvent.Livemode);
             Assert.Equal("context 123", baseThinEvent.Context);
             Assert.NotNull(baseThinEvent.RelatedObject);
             Assert.Equal("me_123", baseThinEvent.RelatedObject.Id);
@@ -191,6 +206,19 @@ namespace StripeTests.V2
             Assert.Equal("this.event.doesnt.exist", stripeEvent.Type);
             Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), stripeEvent.Created);
             Assert.Equal(this.stripeClient.Requestor, stripeEvent.Requestor);
+        }
+
+        [Fact]
+        public void ParseThinEventWithLivemodeFalse()
+        {
+            var baseThinEvent = this.stripeClient.ParseThinEvent(v2KnownEventLivemodeFalsePayload, GenerateSigHeader(v2KnownEventLivemodeFalsePayload), WebhookSecret);
+            Assert.NotNull(baseThinEvent);
+            Assert.Equal("evt_234", baseThinEvent.Id);
+            Assert.Equal("v1.billing.meter.no_meter_found", baseThinEvent.Type);
+            Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), baseThinEvent.Created);
+            Assert.False(baseThinEvent.Livemode);
+            Assert.Null(baseThinEvent.Context);
+            Assert.Null(baseThinEvent.RelatedObject);
         }
 
         [Fact]


### PR DESCRIPTION
### Why?
The thin event payload has a boolean property called livemode that we need represented in the ThinEvent C# class.  This PR adds this property and adds tests to verify it works correctly.

### What?
- add Livemode and Reason properties to ThinEvent.cs
- add livemode json property to V2/EventTest.cs test data
- update tests to verify livemode is parsed
- added test for livemode: false
- added test for reason

### See also
http://go/j/DEVSDK-2217

## Changelog

* Update the class for `ThinEvent` to include `Livemode ` and `Reason`