### PR TITLE
Add version back to the beta csproj

### DIFF
--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Stripe.net is a sync/async .NET 4.6.1+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
-    <Version></Version>
+    <Version>46.2.0-beta.2</Version>
     <LangVersion>8</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>
     <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>


### PR DESCRIPTION
## Why?

Releases aren't working in beta because this version was removed, confusing nuget publishing.