### PR TITLE
Add ConfigureAwait calls to async calls that are awaited

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ dotnet_style_qualification_for_method = true
 
 # IDE0003: Remove qualification
 dotnet_style_qualification_for_field = true
+
+[src/Stripe.net/**/*.cs]
+
+dotnet_diagnostic.CA2007.severity = error

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -151,7 +151,7 @@ namespace Stripe
             CancellationToken cancellationToken = default)
             where T : IStripeEntity
         {
-            return await this.Requestor.RequestAsync<T>(BaseAddress.Api, method, path, options, requestOptions, cancellationToken);
+            return await this.Requestor.RequestAsync<T>(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -162,7 +162,7 @@ namespace Stripe
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
-            return await this.Requestor.RequestStreamingAsync(BaseAddress.Api, method, path, options, requestOptions, cancellationToken);
+            return await this.Requestor.RequestStreamingAsync(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Sends a request to Stripe's API as a synchronous operation.</summary>
@@ -196,7 +196,7 @@ namespace Stripe
             RawRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return await this.Requestor.RawRequestAsync(method, path, content, requestOptions, cancellationToken);
+            return await this.Requestor.RawRequestAsync(method, path, content, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -281,7 +281,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             while (true)
             {
@@ -315,7 +315,7 @@ namespace Stripe
                     page.NextPageUrl,
                     new BaseOptions(),
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -358,7 +358,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             options = options ?? new ListOptions();
             bool iterateBackward = false;
@@ -417,7 +417,7 @@ namespace Stripe
                     url,
                     options,
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -498,7 +498,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             options = options ?? new SearchOptions();
 
@@ -532,7 +532,7 @@ namespace Stripe
                     url,
                     options,
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
### Why?
A user reported an issue with Stripe.net v46 where it would deadlock when executing a synchronous Get call on one of the services.  After investigating, it looks like this call passes through several async calls that are missing ConfigureAsync(false) calls.  ConfigureAsync(false) instructs the .NET task to not continue in the context captured when it is created; this is important because if that context is blocked (i.e. because we are synchronously waiting for a response), it will deadlock.

This problem was observed and subsequently reproduced on Windows using .NET Framework, and affects services created without using `StripeClient` (`StripeClient` accessed services work as expected).

### What?
- added `ConfigureAwait(false)` calls to all async/await methods that did not have them
- enabled CA2007 warning (as an error) for src/Stripe.net which will alert to any async calls that do not call ConfigureAwait

Verified this fix by running the following in a ASP.NET Framework app, inside the Home page request handler, and confirming that Get does return and the program does proceed:
```csharp
var svc = new LocationService();
svc.Get("tml_...", null, new Stripe.RequestOptions { ApiKey = "sk_test_..." });
```
