### PR TITLE
Ramya/merge dotnet beta

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ dotnet_style_qualification_for_field = true
 
 [CHANGELOG.md]
 trim_trailing_whitespace = false
+[src/Stripe.net/**/*.cs]
+
+dotnet_diagnostic.CA2007.severity = error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 46.2.0 - 2024-10-09
+* [#3002](https://github.com/stripe/stripe-dotnet/pull/3002) Add ConfigureAwait calls to async calls that are awaited
+  * Fixes issue [#2998](https://github.com/stripe/stripe-dotnet/issues/2998) that was introduced in v46
+
 ## 46.2.0-beta.3 - 2024-10-08
 * [#2975](https://github.com/stripe/stripe-dotnet/pull/2975) Update generated code for beta
   * Add support for `SubmitCard` test helper method on resource `Issuing.Card`

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ update-version:
 	@perl -pi -e 's|<Version>[.\-\d\w]+</Version>|<Version>$(VERSION)</Version>|' src/Stripe.net/Stripe.net.csproj
 
 codegen-format:
-	dotnet format src/Stripe.net/Stripe.net.csproj --severity warn
+	TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn
 
 ci-test:
 	dotnet test --no-build src/StripeTests/StripeTests.csproj -c Release

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -151,7 +151,7 @@ namespace Stripe
             CancellationToken cancellationToken = default)
             where T : IStripeEntity
         {
-            return await this.Requestor.RequestAsync<T>(BaseAddress.Api, method, path, options, requestOptions, cancellationToken);
+            return await this.Requestor.RequestAsync<T>(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -162,7 +162,7 @@ namespace Stripe
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
-            return await this.Requestor.RequestStreamingAsync(BaseAddress.Api, method, path, options, requestOptions, cancellationToken);
+            return await this.Requestor.RequestStreamingAsync(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Sends a request to Stripe's API as a synchronous operation.</summary>
@@ -196,7 +196,7 @@ namespace Stripe
             RawRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return await this.Requestor.RawRequestAsync(method, path, content, requestOptions, cancellationToken);
+            return await this.Requestor.RawRequestAsync(method, path, content, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -281,7 +281,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             while (true)
             {
@@ -315,7 +315,7 @@ namespace Stripe
                     page.NextPageUrl,
                     new BaseOptions(),
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -358,7 +358,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             options = options ?? new ListOptions();
             bool iterateBackward = false;
@@ -417,7 +417,7 @@ namespace Stripe
                     url,
                     options,
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -498,7 +498,7 @@ namespace Stripe
                 url,
                 options,
                 requestOptions,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             options = options ?? new SearchOptions();
 
@@ -532,7 +532,7 @@ namespace Stripe
                     url,
                     options,
                     requestOptions,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Code gen for .NET (beta) was failing as the automerge tool could not figure out what to do with the merge conflicts in the file .editorconfig

This PR contains changes from running the merge script and resolving merge conflicts manually