### PR TITLE
Fixes ApiRequestorAdapter requests with BaseAddress other than Api

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/ApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/ApiRequestor.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.IO;
     using System.Net.Http;
     using System.Threading;
@@ -37,6 +38,23 @@ namespace Stripe
         /// <summary>Gets the <see cref="IHttpClient"/> used to send HTTP requests.</summary>
         /// <value>The <see cref="IHttpClient"/> used to send HTTP requests.</value>
         public virtual IHttpClient HttpClient { get; }
+
+        internal string GetBaseUrl(BaseAddress baseAddress)
+        {
+            switch (baseAddress)
+            {
+                case BaseAddress.Api:
+                    return this.ApiBase;
+                case BaseAddress.Files:
+                    return this.FilesBase;
+                case BaseAddress.Connect:
+                    return this.ConnectBase;
+                case BaseAddress.MeterEvents:
+                    return this.MeterEventsBase;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(baseAddress), baseAddress, null);
+            }
+        }
 
         /// <summary>Sends a request to Stripe's API as an asynchronous operation.</summary>
         /// <typeparam name="T">Type of the Stripe entity returned by the API.</typeparam>

--- a/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
+++ b/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
@@ -1,5 +1,6 @@
 namespace Stripe
 {
+    using System;
     using System.IO;
     using System.Net.Http;
     using System.Threading;
@@ -45,6 +46,12 @@ namespace Stripe
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
+            if (baseAddress != BaseAddress.Api)
+            {
+                requestOptions ??= new RequestOptions();
+                requestOptions.BaseUrl = this.GetBaseUrl(baseAddress);
+            }
+
             return this.client.RequestAsync<T>(method, path, options, requestOptions, cancellationToken);
         }
 

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -217,7 +217,7 @@ namespace Stripe
             ApiMode apiMode)
         {
             var uri = StripeRequest.BuildUri(
-                this.GetBaseUrl(baseAddress),
+                requestOptions?.BaseUrl ?? this.GetBaseUrl(baseAddress),
                 method,
                 path,
                 options,
@@ -258,23 +258,6 @@ namespace Stripe
             obj.StripeResponse = response;
 
             return obj;
-        }
-
-        private string GetBaseUrl(BaseAddress baseAddress)
-        {
-            switch (baseAddress)
-            {
-                case BaseAddress.Api:
-                    return this.ApiBase;
-                case BaseAddress.Files:
-                    return this.FilesBase;
-                case BaseAddress.Connect:
-                    return this.ConnectBase;
-                case BaseAddress.MeterEvents:
-                    return this.MeterEventsBase;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(baseAddress), baseAddress, null);
-            }
         }
 
         /// <summary>Sends a request to Stripe's API as a synchronous operation.</summary>

--- a/src/Stripe.net/Services/_base/Service.cs
+++ b/src/Stripe.net/Services/_base/Service.cs
@@ -61,7 +61,7 @@ namespace Stripe
         internal ApiRequestor Requestor
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            get => this.requestor ?? new ApiRequestorAdapter(this.Client);
+            get => this.requestor ?? ApiRequestorAdapter.Adapt(this.Client);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 

--- a/src/StripeTests/Infrastructure/Public/ApiRequestorAdapterTest.cs
+++ b/src/StripeTests/Infrastructure/Public/ApiRequestorAdapterTest.cs
@@ -1,0 +1,115 @@
+namespace StripeTests
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Stripe;
+    using Xunit;
+
+    public class ApiRequestorAdapterTest : BaseStripeTest
+    {
+        public ApiRequestorAdapterTest()
+        {
+        }
+
+        [Fact]
+        public async Task RequestAsync_BaseAddressApi()
+        {
+            var httpClient = new DummyHttpClient();
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            httpClient.Response = response;
+
+            var stripeClient = new StripeClient(
+                new StripeClientOptions
+                {
+                    ApiKey = "sk_test_123",
+                    HttpClient = httpClient,
+                });
+
+            var underTest = new ApiRequestorAdapter(stripeClient);
+            await underTest.RequestAsync<Charge>(
+                BaseAddress.Api,
+                HttpMethod.Post,
+                "/v1/charges",
+                new BaseOptions(),
+                null);
+
+            Assert.Equal("https://api.stripe.com/v1/charges", httpClient.LastRequest.Uri.ToString());
+        }
+
+        [Fact]
+        public async Task RequestAsync_BaseAddressConnect()
+        {
+            var httpClient = new DummyHttpClient();
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            httpClient.Response = response;
+
+            var stripeClient = new StripeClient(
+                new StripeClientOptions
+                {
+                    ApiKey = "sk_test_123",
+                    HttpClient = httpClient,
+                });
+
+            var underTest = new ApiRequestorAdapter(stripeClient);
+            await underTest.RequestAsync<Charge>(
+                BaseAddress.Connect,
+                HttpMethod.Post,
+                "/v1/charges",
+                new BaseOptions(),
+                null);
+
+            Assert.Equal("https://connect.stripe.com/v1/charges", httpClient.LastRequest.Uri.ToString());
+        }
+
+        [Fact]
+        public async Task RequestAsync_BaseAddressFiles()
+        {
+            var httpClient = new DummyHttpClient();
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            httpClient.Response = response;
+
+            var stripeClient = new StripeClient(
+                new StripeClientOptions
+                {
+                    ApiKey = "sk_test_123",
+                    HttpClient = httpClient,
+                });
+
+            var underTest = new ApiRequestorAdapter(stripeClient);
+            await underTest.RequestAsync<Charge>(
+                BaseAddress.Files,
+                HttpMethod.Post,
+                "/v1/charges",
+                new BaseOptions(),
+                null);
+
+            Assert.Equal("https://files.stripe.com/v1/charges", httpClient.LastRequest.Uri.ToString());
+        }
+
+        [Fact]
+        public async Task RequestAsync_BaseAddressMeterEvents()
+        {
+            var httpClient = new DummyHttpClient();
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            httpClient.Response = response;
+
+            var stripeClient = new StripeClient(
+                new StripeClientOptions
+                {
+                    ApiKey = "sk_test_123",
+                    HttpClient = httpClient,
+                });
+
+            var underTest = new ApiRequestorAdapter(stripeClient);
+            await underTest.RequestAsync<Charge>(
+                BaseAddress.MeterEvents,
+                HttpMethod.Post,
+                "/v1/charges",
+                new BaseOptions(),
+                null);
+
+            Assert.Equal("https://meter-events.stripe.com/v1/charges", httpClient.LastRequest.Uri.ToString());
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/DummyHttpClient.cs
+++ b/src/StripeTests/Infrastructure/Public/DummyHttpClient.cs
@@ -1,0 +1,43 @@
+namespace StripeTests
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Stripe;
+
+    public class DummyHttpClient : IHttpClient
+    {
+        public StripeResponse Response { get; set; }
+
+        public StripeStreamedResponse StreamedResponse { get; set; }
+
+        public StripeRequest LastRequest { get; set; }
+
+        public Task<StripeResponse> MakeRequestAsync(
+            StripeRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            this.LastRequest = request;
+
+            if (this.Response == null)
+            {
+                throw new StripeTestException("Response is null");
+            }
+
+            return Task.FromResult<StripeResponse>(this.Response);
+        }
+
+        public Task<StripeStreamedResponse> MakeStreamingRequestAsync(
+            StripeRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            this.LastRequest = request;
+
+            if (this.StreamedResponse == null)
+            {
+                throw new StripeTestException("StreamedResponse is null");
+            }
+
+            return Task.FromResult(this.StreamedResponse);
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
+++ b/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
@@ -642,43 +642,6 @@ namespace StripeTests
             Assert.Equal(typeof(Foo), deserialized.GetType());
         }
 
-        private class DummyHttpClient : IHttpClient
-        {
-            public StripeResponse Response { get; set; }
-
-            public StripeStreamedResponse StreamedResponse { get; set; }
-
-            public StripeRequest LastRequest { get; set; }
-
-            public Task<StripeResponse> MakeRequestAsync(
-                StripeRequest request,
-                CancellationToken cancellationToken = default)
-            {
-                this.LastRequest = request;
-
-                if (this.Response == null)
-                {
-                    throw new StripeTestException("Response is null");
-                }
-
-                return Task.FromResult<StripeResponse>(this.Response);
-            }
-
-            public Task<StripeStreamedResponse> MakeStreamingRequestAsync(
-                StripeRequest request,
-                CancellationToken cancellationToken = default)
-            {
-                this.LastRequest = request;
-
-                if (this.StreamedResponse == null)
-                {
-                    throw new StripeTestException("StreamedResponse is null");
-                }
-
-                return Task.FromResult(this.StreamedResponse);
-            }
-        }
-
         private class Foo : StripeEntity<Foo>
         {
             [JsonProperty("bar")]

--- a/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
+++ b/src/StripeTests/Services/OAuth/OAuthTokenServiceTest.cs
@@ -112,6 +112,28 @@ namespace StripeTests
             Assert.Equal("acct_test_token", oauthToken.StripeUserId);
         }
 
+        // Tests the "Old" way of instantiating the service and calling Create
+        // to make sure we maintain backwards compatibility
+        [Fact]
+        public void Create_Legacy()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = GetResourceAsString("oauth_fixtures.token_response.json");
+            this.StubRequest(HttpMethod.Post, "/oauth/token", HttpStatusCode.OK, json);
+
+            StripeConfiguration.ApiKey = "sk_test_123";
+            StripeConfiguration.StripeClient = new StripeClient(
+                "sk_test_123",
+                httpClient: new SystemNetHttpClient(
+                    new HttpClient(this.MockHttpClientFixture.MockHandler.Object)));
+
+            var service = new OAuthTokenService();
+            var oauthToken = service.Create(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/token", host: "connect.stripe.com");
+            Assert.NotNull(oauthToken);
+            Assert.Equal("acct_test_token", oauthToken.StripeUserId);
+        }
+
         [Fact]
         public void Create_Error()
         {
@@ -137,6 +159,28 @@ namespace StripeTests
             this.AssertRequest(HttpMethod.Post, "/oauth/token", host: "connect.stripe.com");
             Assert.NotNull(oauthToken);
             Assert.Equal("sk_test_access_token", oauthToken.AccessToken);
+        }
+
+        // Tests the "Old" way of instantiating the service and calling Create
+        // to make sure we maintain backwards compatibility
+        [Fact]
+        public async Task CreateAsync_Legacy()
+        {
+            // stripe-mock doesn't support OAuth endpoints, so stub the request
+            var json = GetResourceAsString("oauth_fixtures.token_response.json");
+            this.StubRequest(HttpMethod.Post, "/oauth/token", HttpStatusCode.OK, json);
+
+            StripeConfiguration.ApiKey = "sk_test_123";
+            StripeConfiguration.StripeClient = new StripeClient(
+                "sk_test_123",
+                httpClient: new SystemNetHttpClient(
+                    new HttpClient(this.MockHttpClientFixture.MockHandler.Object)));
+
+            var service = new OAuthTokenService();
+            var oauthToken = await service.CreateAsync(this.createOptions);
+            this.AssertRequest(HttpMethod.Post, "/oauth/token", host: "connect.stripe.com");
+            Assert.NotNull(oauthToken);
+            Assert.Equal("acct_test_token", oauthToken.StripeUserId);
         }
 
         [Fact]


### PR DESCRIPTION
### Why?
v46 of the SDK introduced a service accessors into `StripeClient` and a internal ApiRequestor classes for implementing the actual request issuing and response parsing logic used by the service classes.  The `ApiRequestorAdapter` class is used to support older-style SDK usage patterns, e.g.
```csharp
var svc = new CustomerService();
var customer = svc.Get("cust_...");
```
and also to support any custom implementations of `IStripeClient`.  When a service is created directly like this, Stripe.net wraps the `StripeConfiguration.StripeClient` client object with this adapter to adapt the client to an ApiRequestor.

A user reported a problem with using the OAuthTokenService service with the pattern described above (https://github.com/stripe/stripe-dotnet/issues/3006) where the SDK was not using the correct API base address.  The root issue appears to be that BaseAddress specified by the OAuthTokenService.Create method is getting replaced with the API base address when it passes through the ApiRequestorAdapter, because the IStripeClient `RequestAsync` method does not accept a BaseAddress argument.  To fix this would introduce a breaking change in `IStripeClient`; this PR implements a backwards compatible fix by utilizing the `RequestOption.BaseUrl` property.

### What?
- changes `ApiRequestorAdapter` to set the `RequestOptions.BaseUrl` if the `baseAddress` argument is anything other than API
- change s`LiveApiRequestor` `MakeStripeRequest` to use the `BaseUrl` to override `baseAddress`, if BaseUrl is specified
- adds unit tests for ApiRequestorAdapter RequestAsync with different base addresses
- adds unit tests for OAuthTokenService Create and CreateAsync using the older-style instantiation pattern

## Changelog

