### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -103,7 +103,6 @@ namespace Stripe
                 { "line_item", typeof(InvoiceLineItem) },
                 { "login_link", typeof(LoginLink) },
                 { "mandate", typeof(Mandate) },
-                { "margin", typeof(Margin) },
                 { "payment_intent", typeof(PaymentIntent) },
                 { "payment_link", typeof(PaymentLink) },
                 { "payment_method", typeof(PaymentMethod) },

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -103,6 +103,7 @@ namespace Stripe
                 { "line_item", typeof(InvoiceLineItem) },
                 { "login_link", typeof(LoginLink) },
                 { "mandate", typeof(Mandate) },
+                { "margin", typeof(Margin) },
                 { "payment_intent", typeof(PaymentIntent) },
                 { "payment_link", typeof(PaymentLink) },
                 { "payment_method", typeof(PaymentMethod) },
@@ -178,9 +179,12 @@ namespace Stripe
             new Dictionary<string, Type>
             {
                 // V2ObjectsToTypes: The beginning of the section generated from our OpenAPI spec
-                { "billing.meter_event", typeof(V2.Billing.MeterEvent) },
-                { "billing.meter_event_adjustment", typeof(V2.Billing.MeterEventAdjustment) },
-                { "billing.meter_event_session", typeof(V2.Billing.MeterEventSession) },
+                { "v2.billing.meter_event", typeof(V2.Billing.MeterEvent) },
+                {
+                    "v2.billing.meter_event_adjustment", typeof(
+                    V2.Billing.MeterEventAdjustment)
+                },
+                { "v2.billing.meter_event_session", typeof(V2.Billing.MeterEventSession) },
                 { "v2.core.event", typeof(V2.Event) },
 
                 // V2ObjectsToTypes: The end of the section generated from our OpenAPI spec

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -79,7 +79,7 @@ namespace StripeTests
                     HttpMethod.Post,
                     "/v2/billing/meter_event_session",
                     System.Net.HttpStatusCode.OK,
-                    "{\"id\": \"mes_123\",\"object\":\"billing.meter_event_session\"}");
+                    "{\"id\": \"mes_123\",\"object\":\"v2.billing.meter_event_session\"}");
 
             var rawResponse = await this.stripeClient.RawRequestAsync(
                 HttpMethod.Post,


### PR DESCRIPTION
CI failures are expected because stripe-mock doesn't yet have the changes these this PR is responding to

## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.