### PR TITLE
Update webhook API version validation

### DIFF
--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -17,6 +17,22 @@ namespace Stripe
 
         public const int DefaultTimeTolerance = 300;
 
+        public static bool IsCompatibleApiVersion(string eventApiVersion)
+        {
+            // If the event api version is from before we started adding
+            // a release train, there's no way its compatible with this
+            // version
+            if (eventApiVersion.IndexOf(".") < 0)
+            {
+                return false;
+            }
+
+            // versions are yyyy-MM-dd.train
+            var eventReleaseTrain = eventApiVersion.Split('.')[1];
+            var currentReleaseTrain = ApiVersion.Current.Split('.')[1];
+            return eventReleaseTrain == currentReleaseTrain;
+        }
+
         /// <summary>
         /// Parses a JSON string from a Stripe webhook into a <see cref="Event"/> object.
         /// </summary>
@@ -42,7 +58,7 @@ namespace Stripe
                 StripeConfiguration.SerializerSettings);
 
             if (throwOnApiVersionMismatch &&
-                stripeEvent.ApiVersion != StripeConfiguration.ApiVersion)
+                !IsCompatibleApiVersion(stripeEvent.ApiVersion))
             {
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -22,7 +22,7 @@ namespace Stripe
             // If the event api version is from before we started adding
             // a release train, there's no way its compatible with this
             // version
-            if (eventApiVersion.IndexOf(".") < 0)
+            if (!eventApiVersion.Contains("."))
             {
                 return false;
             }

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -90,12 +90,37 @@ namespace StripeTests
         }
 
         [Fact]
-        public void ThrowsOnApiVersionMismatch()
+        public void AcceptsNewApiVersionInExpectedReleaseTrain()
+        {
+            var evt = Event.FromJson(this.json);
+            var expectedReleaseTrain = StripeConfiguration.ApiVersion.Split('.')[1];
+            evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
+            var serialized = evt.ToJson();
+
+            evt = EventUtility.ParseEvent(serialized);
+            Assert.EndsWith($".{expectedReleaseTrain}", evt.ApiVersion);
+        }
+
+        [Fact]
+        public void ThrowsOnLegacyApiVersionMismatch()
         {
             var exception = Assert.Throws<StripeException>(() =>
                 EventUtility.ParseEvent(this.json));
 
             Assert.Contains("Received event with API version 2017-05-25", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsOnReleaseTrainMismatch()
+        {
+            var evt = Event.FromJson(this.json);
+            evt.ApiVersion = "2999-10-10.the_larch";
+            var serialized = evt.ToJson();
+
+            var exception = Assert.Throws<StripeException>(() =>
+                EventUtility.ParseEvent(serialized));
+
+            Assert.Contains("Received event with API version 2999-10-10.the_larch", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
### Why
[Stripe API versions now contain two parts](https://stripe.com/blog/introducing-stripes-new-api-release-process): a date part (as before) and an identifier.  The SDKs validate that webhook events received are in the shape expected by the pinned version in the SDK but going forward, that will be true for different versions with the same identifier.  For example, the September API release was 2024-09-30.acacia, and we expect that webhook events sent with version 2024-09-30.acacia will be compatible with an SDK pinned to 2025-10-28.acacia.  This PR updates the version checking logic to make sure we don't reject webhook events incorrectly.

### What
- replaced api version equality check in EventUtility with IsCompatibleApiVersion which will test if the release identifier of the webhook event matches the pinned version or return false for any event api version that does not have a release identifier
- updated tests to match

## Changelog
- Update webhook event processing to accept events from any API version within the supported major release