### PR TITLE
Do not allow setting API Version directly on StripeConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
   * Add support for `Bank` on `TreasuryFinancialAccountFeaturesFinancialAddressesAbaOptions`, `TreasuryFinancialAccountFeaturesFinancialAddressesAba`, and `TreasuryFinancialAccountFinancialAddressesAbaOptions`
 * [#3004](https://github.com/stripe/stripe-dotnet/pull/3004) Ramya/merge dotnet beta
 
+## 46.2.1 - 2024-10-18
+* [#3008](https://github.com/stripe/stripe-dotnet/pull/3008) update object tags for meter-related classes
+  
+  - fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.
+* [#3007](https://github.com/stripe/stripe-dotnet/pull/3007) Fixes ApiRequestorAdapter requests with BaseAddress other than Api
+  - fixes bug where OAuthTokenService created without an explicit StripeClient accesses the wrong base url
+  
+* [#3003](https://github.com/stripe/stripe-dotnet/pull/3003) Cleaned up examples and added documentation
+
 ## 46.2.0 - 2024-10-09
 * [#3002](https://github.com/stripe/stripe-dotnet/pull/3002) Add ConfigureAwait calls to async calls that are awaited
   * Fixes issue [#2998](https://github.com/stripe/stripe-dotnet/issues/2998) that was introduced in v46

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -38,7 +38,7 @@ namespace Stripe
         public static string ApiVersion
         {
             get => apiVersion;
-            set
+            private set
             {
                 apiVersion = value;
                 TrimmedApiVersion = StringUtils.TrimApiVersion(value);

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -24,7 +24,6 @@ namespace Stripe
         private static int maxNetworkRetries = SystemNetHttpClient.DefaultMaxNumberRetries;
 
         private static IStripeClient stripeClient;
-        private static string apiVersion;
 
         static StripeConfiguration()
         {
@@ -32,17 +31,11 @@ namespace Stripe
             ApiVersion = Stripe.ApiVersion.Current;
         }
 
-        internal static string TrimmedApiVersion { get; private set; }
-
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion
         {
-            get => apiVersion;
-            private set
-            {
-                apiVersion = value;
-                TrimmedApiVersion = StringUtils.TrimApiVersion(value);
-            }
+            get;
+            private set;
         }
 
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -17,6 +17,22 @@ namespace Stripe
 
         public const int DefaultTimeTolerance = 300;
 
+        public static bool IsCompatibleApiVersion(string eventApiVersion)
+        {
+            // If the event api version is from before we started adding
+            // a release train, there's no way its compatible with this
+            // version
+            if (!eventApiVersion.Contains("."))
+            {
+                return false;
+            }
+
+            // versions are yyyy-MM-dd.train
+            var eventReleaseTrain = eventApiVersion.Split('.')[1];
+            var currentReleaseTrain = ApiVersion.Current.Split('.')[1];
+            return eventReleaseTrain == currentReleaseTrain;
+        }
+
         /// <summary>
         /// Parses a JSON string from a Stripe webhook into a <see cref="Event"/> object.
         /// </summary>
@@ -42,7 +58,7 @@ namespace Stripe
                 StripeConfiguration.SerializerSettings);
 
             if (throwOnApiVersionMismatch &&
-                stripeEvent.ApiVersion != StripeConfiguration.TrimmedApiVersion)
+                !IsCompatibleApiVersion(stripeEvent.ApiVersion))
             {
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -63,7 +63,7 @@ namespace Stripe
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "
                     + $"{StripeConfiguration.StripeNetVersion} expects API version "
-                    + $"{StripeConfiguration.TrimmedApiVersion}. We recommend that you create a "
+                    + $"{ApiVersion.Current}. We recommend that you create a "
                     + "WebhookEndpoint with this API version. Otherwise, you can disable this "
                     + "exception by passing `throwOnApiVersionMismatch: false` to "
                     + "`Stripe.EventUtility.ParseEvent` or `Stripe.EventUtility.ConstructEvent`, "

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -97,10 +97,8 @@ namespace StripeTests
         [Fact]
         public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedOnceOnly()
         {
-            StripeConfiguration.ApiVersion = "2024-02-26";
-
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
-            Assert.Equal("2024-02-26; feature_beta=v3", StripeConfiguration.ApiVersion);
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
 
             var exception = Record.Exception(() => StripeConfiguration.AddBetaVersion("feature_beta", "v2"));
             Assert.NotNull(exception);

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -237,28 +237,5 @@ namespace StripeTests
 
             Assert.Contains("No API key provided.", exception.Message);
         }
-
-        [Fact]
-        public void CanModifyApiVersion()
-        {
-            string oldVersion = StripeConfiguration.ApiVersion;
-            try
-            {
-                StripeConfiguration.ApiVersion = "2022-08-01; feature_in_beta=v3";
-                var request = new StripeRequest(
-                    this.stripeClient,
-                    HttpMethod.Get,
-                    "/get",
-                    new TestOptions { String = "string!" },
-                    new RequestOptions());
-
-                Assert.True(request.StripeHeaders.ContainsKey("Stripe-Version"));
-                Assert.Equal("2022-08-01; feature_in_beta=v3", request.StripeHeaders["Stripe-Version"]);
-            }
-            finally
-            {
-                StripeConfiguration.ApiVersion = oldVersion;
-            }
-        }
     }
 }

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -83,39 +83,18 @@ namespace StripeTests
         public void AcceptsExpectedApiVersion()
         {
             var evt = Event.FromJson(this.json);
-            evt.ApiVersion = StripeConfiguration.TrimmedApiVersion;
+            evt.ApiVersion = ApiVersion.Current;
             var serialized = evt.ToJson();
 
             evt = EventUtility.ParseEvent(serialized);
-            Assert.Equal(StripeConfiguration.TrimmedApiVersion, evt.ApiVersion);
-        }
-
-        [Fact]
-        public void AcceptsExpectedApiVersionWhenConfiguredWithBeta()
-        {
-            string oldVersion = StripeConfiguration.ApiVersion;
-            try
-            {
-                StripeConfiguration.ApiVersion = "2022-08-02; feature_in_beta=v3";
-
-                var evt = Event.FromJson(this.json);
-                evt.ApiVersion = "2022-08-02";
-                var serialized = evt.ToJson();
-
-                evt = EventUtility.ParseEvent(serialized);
-                Assert.Equal("2022-08-02", evt.ApiVersion);
-            }
-            finally
-            {
-                StripeConfiguration.ApiVersion = oldVersion;
-            }
+            Assert.Equal(ApiVersion.Current, evt.ApiVersion);
         }
 
         [Fact]
         public void AcceptsNewApiVersionInExpectedReleaseTrain()
         {
             var evt = Event.FromJson(this.json);
-            var expectedReleaseTrain = StripeConfiguration.ApiVersion.Split('.')[1];
+            var expectedReleaseTrain = StripeConfiguration.TrimmedApiVersion.Split('.')[1];
             evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
             var serialized = evt.ToJson();
 

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -94,7 +94,7 @@ namespace StripeTests
         public void AcceptsNewApiVersionInExpectedReleaseTrain()
         {
             var evt = Event.FromJson(this.json);
-            var expectedReleaseTrain = StripeConfiguration.TrimmedApiVersion.Split('.')[1];
+            var expectedReleaseTrain = ApiVersion.Current.Split('.')[1];
             evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
             var serialized = evt.ToJson();
 

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -112,12 +112,37 @@ namespace StripeTests
         }
 
         [Fact]
-        public void ThrowsOnApiVersionMismatch()
+        public void AcceptsNewApiVersionInExpectedReleaseTrain()
+        {
+            var evt = Event.FromJson(this.json);
+            var expectedReleaseTrain = StripeConfiguration.ApiVersion.Split('.')[1];
+            evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
+            var serialized = evt.ToJson();
+
+            evt = EventUtility.ParseEvent(serialized);
+            Assert.EndsWith($".{expectedReleaseTrain}", evt.ApiVersion);
+        }
+
+        [Fact]
+        public void ThrowsOnLegacyApiVersionMismatch()
         {
             var exception = Assert.Throws<StripeException>(() =>
                 EventUtility.ParseEvent(this.json));
 
             Assert.Contains("Received event with API version 2017-05-25", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsOnReleaseTrainMismatch()
+        {
+            var evt = Event.FromJson(this.json);
+            evt.ApiVersion = "2999-10-10.the_larch";
+            var serialized = evt.ToJson();
+
+            var exception = Assert.Throws<StripeException>(() =>
+                EventUtility.ParseEvent(serialized));
+
+            Assert.Contains("Received event with API version 2999-10-10.the_larch", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
## Why?

When we introduced beta SDKs, we allowed users to directly update the global configuration for API Version since they needed to pass beta headers in #2561. We soon realized that was not safe and was error prone if users didnt pass in the right format and so introduced a helper method in https://github.com/stripe/stripe-dotnet/pull/2855 and advertised that as the right way of doing things in the README

Proper deserialization of classes from Events can be guaranteed only when the Webhook API version matches the API version used to generate the SDKs. Therefore, in this PR we are dropping the ability to directly update the API version.

## What?

- Resolving merge conflicts coming from running the auto merge tool after #3010
- Make the setter on StripeConfiguration.ApiVersion private
- Remove tests that tested the setting of StripeConfiguration.ApiVersion

## Changelog
* `StripeConfiguration.ApiVersion` is no longer settable. If you were using this to set the beta headers, use the helper method `StripeConfiguration.AddBetaVersion()` instead.

