### PR TITLE
Fix user agent in .net sdks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|<Version>[.\-\d\w]+</Version>|<Version>$(VERSION)</Version>|' src/Stripe.net/Stripe.net.csproj
+	@perl -pi -e 's|Current = "[.\-\d\w]+";|Current = "$(VERSION)";|' src/Stripe.net/Constants/Version.cs
 
 codegen-format:
 	TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn

--- a/src/Stripe.net/Constants/Version.cs
+++ b/src/Stripe.net/Constants/Version.cs
@@ -1,0 +1,7 @@
+namespace Stripe
+{
+    internal class Version
+    {
+        public const string Current = "46.2.1";
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -27,7 +27,7 @@ namespace Stripe
 
         static StripeConfiguration()
         {
-            StripeNetVersion = new AssemblyName(typeof(StripeConfiguration).GetTypeInfo().Assembly.FullName).Version.ToString(3);
+            StripeNetVersion = Stripe.Version.Current;
         }
 
         /// <summary>API version used by Stripe.net.</summary>

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -110,8 +110,8 @@ namespace StripeTests
         /// <returns>-1 if a &gt; b, 1 if a &lt; b, 0 if a == b.</returns>
         private static int CompareVersions(string a, string b)
         {
-            var version1 = new Version(a);
-            var version2 = new Version(b);
+            var version1 = new System.Version(a);
+            var version2 = new System.Version(b);
             return version2.CompareTo(version1);
         }
 


### PR DESCRIPTION
Currently .NET SDKs rely on AssemblyName.Version to extract the version of Stripe SDK. This works for major releases but breaks for beta releases because how AssemblyVersion are calculated.
In a nutshell, a version `42.1.0-beta.1` would get converted to `42.1.0.0` in AssemblyName.Version. 

This new approach of storing SDK version as a constant is in-line with how we extract and update version in all our other SDKs. 