### PR TITLE
Create makefile.yml

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,51 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck
+            - name: Node.js ortamını kurun
+  kullanımlar: actions/setup-node@v4.1.0
+  ile:
+    # Npmrc'de always-auth'ı ayarlayın.
+    always-auth: # isteğe bağlı, varsayılan değer false
+    # Sürüm Kullanılacak sürümün belirtimi. Örnekler: 12.x, 10.15.1, >=10.15.0.
+    düğüm sürümü: # isteğe bağlı
+    # Kullanılacak sürümün Spec'ini içeren dosya. Örnekler: package.json, .nvmrc, .node-version, .tool-versions.
+    node-version-file: # isteğe bağlı
+    # Node'un kullanacağı hedef mimari. Örnekler: x86, x64. Varsayılan olarak sistem mimarisini kullanacaktır.
+    mimari: # isteğe bağlı
+    # Eylemin sürüm özelliğini karşılayan en son kullanılabilir sürümü denetlemesini istiyorsanız bu seçeneği ayarlayın.
+    son durumu kontrol et: # isteğe bağlı
+    # Auth için kurulacak isteğe bağlı kayıt defteri. Kayıt defterini proje düzeyinde .npmrc ve .yarnrc dosyasına ayarlayacak ve auth'ı env.NODE_AUTH_TOKEN'dan okuyacak şekilde ayarlayacaktır.
+    kayıt-url'si: # isteğe bağlı
+    # Kapsamlı kayıt defterlerine karşı kimlik doğrulama için isteğe bağlı kapsam. GitHub Paketleri kayıt defterini (https://npm.pkg.github.com/) kullanırken depo sahibine geri dönülecektir.
+    kapsam: # isteğe bağlı
+    # Node-versions'dan node dağıtımlarını çekmek için kullanılır. Varsayılan bir değer olduğundan, bu genellikle kullanıcı tarafından sağlanmaz. Bu eylemi github.com'da çalıştırırken, varsayılan değer yeterlidir. GHES'te çalıştırırken, hız sınırlaması yaşıyorsanız github.com için kişisel bir erişim belirteci geçirebilirsiniz.
+    token: # isteğe bağlı, varsayılan ${{ github.server_url == 'https://github.com' && github.token || '' }}
+    # Varsayılan dizinde önbelleğe alma için bir paket yöneticisi belirtmek için kullanılır. Desteklenen değerler: npm, yarn, pnpm.
+    önbellek: # isteğe bağlı
+    # Bir bağımlılık dosyasının yolunu belirtmek için kullanılır: package-lock.json, yarn.lock, vb. Birden fazla bağımlılığı önbelleğe almak için joker karakterleri veya dosya adları listesini destekler.
+    önbellek-bağımlılık-yolu: # isteğe bağlı
+          

--- a/OPENAPI_VERSION
+++ b/OPENAPI_VERSION
@@ -50,3 +50,65 @@ jobs:
     # Bir bağımlılık dosyasının yolunu belirtmek için kullanılır: package-lock.json, yarn.lock, vb. Birden fazla bağımlılığı önbelleğe almak için joker karakterleri veya dosya adları listesini destekler.
     önbellek-bağımlılık-yolu: # isteğe bağlı
 
+[
+    {
+        "txid": "e706e730dc0ce230d57e89fbdfee21efe2f815c0797895a90fe7824a3ae6d4e8",
+        "fee": 825,
+        "vsize": 164,
+        "value": 551232
+    },
+    {
+        "txid": "7826d86c4153e95c186f47a2f6ede72a22c742b8865918d49fb809583ea7c54d",
+        "fee": 338,
+        "vsize": 142,
+        "value": 10536
+    },
+    {
+        "txid": "e6dc8fe7da5cdd9b347bfdb130830ce6e8a151f9bc7c6ece23313565724849af",
+        "fee": 700,
+        "vsize": 348,
+        "value": 6934
+    },
+    {
+        "txid": "88f02df71a89a74de2f46e79467359861d1acff04ff9c6daaef09fe31ef2c276",
+        "fee": 320,
+        "vsize": 128,
+        "value": 650
+    },
+    {
+        "txid": "e1fc66d9914a81e515fe1a320c95711f50cfdc01ba24158f83b4ba54acf67add",
+        "fee": 288,
+        "vsize": 137,
+        "value": 618
+    },
+    {
+        "txid": "e63ed3d66942ef2542b8a9b238431e0c4375659ea9400e2e0c71570e6869c35a",
+        "fee": 465,
+        "vsize": 208,
+        "value": 920674
+    },
+    {
+        "txid": "f46ad6e7a5540da7c3d139540b3405f21f0731d0adfe675ba2e3e0f611707684",
+        "fee": 20526,
+        "vsize": 6829,
+        "value": 1463784
+    },
+    {
+        "txid": "bf7b5e8469b4bac4d15a2f3cfb2194e25890a54f398467763c652137ee48b9bc",
+        "fee": 4108,
+        "vsize": 313,
+        "value": 816007
+    },
+    {
+        "txid": "69c9d652058ced0d1647e90f7c036abece2c8d637a0acb0a40ed53c4d65e9afd",
+        "fee": 304,
+        "vsize": 151,
+        "value": 850
+    },
+    {
+        "txid": "66179d401920960822f8bf1c3809f66b1b8d97c43317e8f492b81429b0b2d2a6",
+        "fee": 6760,
+        "vsize": 517,
+        "value": 132235
+    }
+]

--- a/OPENAPI_VERSION
+++ b/OPENAPI_VERSION
@@ -1,1 +1,52 @@
 v1268
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck
+            - name: Node.js ortamını kurun
+  kullanımlar: actions/setup-node@v4.1.0
+  ile:
+    # Npmrc'de always-auth'ı ayarlayın.
+    always-auth: # isteğe bağlı, varsayılan değer false
+    # Sürüm Kullanılacak sürümün belirtimi. Örnekler: 12.x, 10.15.1, >=10.15.0.
+    düğüm sürümü: # isteğe bağlı
+    # Kullanılacak sürümün Spec'ini içeren dosya. Örnekler: package.json, .nvmrc, .node-version, .tool-versions.
+    node-version-file: # isteğe bağlı
+    # Node'un kullanacağı hedef mimari. Örnekler: x86, x64. Varsayılan olarak sistem mimarisini kullanacaktır.
+    mimari: # isteğe bağlı
+    # Eylemin sürüm özelliğini karşılayan en son kullanılabilir sürümü denetlemesini istiyorsanız bu seçeneği ayarlayın.
+    son durumu kontrol et: # isteğe bağlı
+    # Auth için kurulacak isteğe bağlı kayıt defteri. Kayıt defterini proje düzeyinde .npmrc ve .yarnrc dosyasına ayarlayacak ve auth'ı env.NODE_AUTH_TOKEN'dan okuyacak şekilde ayarlayacaktır.
+    kayıt-url'si: # isteğe bağlı
+    # Kapsamlı kayıt defterlerine karşı kimlik doğrulama için isteğe bağlı kapsam. GitHub Paketleri kayıt defterini (https://npm.pkg.github.com/) kullanırken depo sahibine geri dönülecektir.
+    kapsam: # isteğe bağlı
+    # Node-versions'dan node dağıtımlarını çekmek için kullanılır. Varsayılan bir değer olduğundan, bu genellikle kullanıcı tarafından sağlanmaz. Bu eylemi github.com'da çalıştırırken, varsayılan değer yeterlidir. GHES'te çalıştırırken, hız sınırlaması yaşıyorsanız github.com için kişisel bir erişim belirteci geçirebilirsiniz.
+    token: # isteğe bağlı, varsayılan ${{ github.server_url == 'https://github.com' && github.token || '' }}
+    # Varsayılan dizinde önbelleğe alma için bir paket yöneticisi belirtmek için kullanılır. Desteklenen değerler: npm, yarn, pnpm.
+    önbellek: # isteğe bağlı
+    # Bir bağımlılık dosyasının yolunu belirtmek için kullanılır: package-lock.json, yarn.lock, vb. Birden fazla bağımlılığı önbelleğe almak için joker karakterleri veya dosya adları listesini destekler.
+    önbellek-bağımlılık-yolu: # isteğe bağlı
+


### PR DESCRIPTION
name: Makefile CI

on:
  push:
    branches: [ "master" ]
  pull_request:
    branches: [ "master" ]

jobs:
  build:

    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v4

    - name: configure
      run: ./configure

    - name: Install dependencies
      run: make

    - name: Run check
      run: make check

    - name: Run distcheck run: make distcheck - name: Node.js ortamını kurun kullanımlar: actions/setup-node@v4.1.0 ile: # Npmrc'de always-auth'ı ayarlayın. always-auth: # isteğe bağlı, varsayılan değer false # Sürüm Kullanılacak sürümün belirtimi. Örnekler: 12.x, 10.15.1, >=10.15.0. düğüm sürümü: # isteğe bağlı # Kullanılacak sürümün Spec'ini içeren dosya. Örnekler: package.json, .nvmrc, .node-version, .tool-versions. node-version-file: # isteğe bağlı # Node'un kullanacağı hedef mimari. Örnekler: x86, x64. Varsayılan olarak sistem mimarisini kullanacaktır. mimari: # isteğe bağlı # Eylemin sürüm özelliğini karşılayan en son kullanılabilir sürümü denetlemesini istiyorsanız bu seçeneği ayarlayın. son durumu kontrol et: # isteğe bağlı # Auth için kurulacak isteğe bağlı kayıt defteri. Kayıt defterini proje düzeyinde .npmrc ve .yarnrc dosyasına ayarlayacak ve auth'ı env.NODE_AUTH_TOKEN'dan okuyacak şekilde ayarlayacaktır. kayıt-url'si: # isteğe bağlı # Kapsamlı kayıt defterlerine karşı kimlik doğrulama için isteğe bağlı kapsam. GitHub Paketleri kayıt defterini (https://npm.pkg.github.com/) kullanırken depo sahibine geri dönülecektir. kapsam: # isteğe bağlı # Node-versions'dan node dağıtımlarını çekmek için kullanılır. Varsayılan bir değer olduğundan, bu genellikle kullanıcı tarafından sağlanmaz. Bu eylemi github.com'da çalıştırırken, varsayılan değer yeterlidir. GHES'te çalıştırırken, hız sınırlaması yaşıyorsanız github.com için kişisel bir erişim belirteci geçirebilirsiniz. token: # isteğe bağlı, varsayılan ${{ github.server_url == 'https://github.com' && github.token || '' }} # Varsayılan dizinde önbelleğe alma için bir paket yöneticisi belirtmek için kullanılır. Desteklenen değerler: npm, yarn, pnpm. önbellek: # isteğe bağlı # Bir bağımlılık dosyasının yolunu belirtmek için kullanılır: package-lock.json, yarn.lock, vb. Birden fazla bağımlılığı önbelleğe almak için joker karakterleri veya dosya adları listesini destekler. önbellek-bağımlılık-yolu: # isteğe bağlı