### PR TITLE
Add tests for AddBetaVersion edge cases 

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -260,6 +260,11 @@ namespace Stripe
             ApiVersion = $"{ApiVersion}; {betaName}={betaVersion}";
         }
 
+        internal static void ClearBetaVersion()
+        {
+            ApiVersion = Stripe.ApiVersion.Current;
+        }
+
         private static StripeClient BuildDefaultStripeClient()
         {
             if (ApiKey != null && ApiKey.Length == 0)

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -93,8 +93,6 @@ namespace StripeTests
                 StripeConfiguration.ApiKey = origApiKey;
             }
         }
-
-        [Fact]
         public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedOnceOnly()
         {
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
@@ -102,6 +100,15 @@ namespace StripeTests
 
             var exception = Record.Exception(() => StripeConfiguration.AddBetaVersion("feature_beta", "v2"));
             Assert.NotNull(exception);
+        }
+
+        public void StripeClient_Getter_ShouldAllowSecondBetaVersionsToBeAdded()
+        {
+            StripeConfiguration.AddBetaVersion("feature_beta", "v3");
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
+
+            StripeConfiguration.AddBetaVersion("next_feature_beta", "v4");
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v3; next_feature_beta=v4", StripeConfiguration.ApiVersion);
         }
     }
 }

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -93,6 +93,8 @@ namespace StripeTests
                 StripeConfiguration.ApiKey = origApiKey;
             }
         }
+
+        [Fact]
         public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedOnceOnly()
         {
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
@@ -102,6 +104,7 @@ namespace StripeTests
             Assert.NotNull(exception);
         }
 
+        [Fact]
         public void StripeClient_Getter_ShouldAllowSecondBetaVersionsToBeAdded()
         {
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -97,6 +97,7 @@ namespace StripeTests
         [Fact]
         public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedOnceOnly()
         {
+            StripeConfiguration.ClearBetaVersion();
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
             Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
 
@@ -107,6 +108,7 @@ namespace StripeTests
         [Fact]
         public void StripeClient_Getter_ShouldAllowSecondBetaVersionsToBeAdded()
         {
+            StripeConfiguration.ClearBetaVersion();
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
             Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
 


### PR DESCRIPTION
### Why
Follow up to https://github.com/stripe/stripe-dotnet/pull/3011.  After fixing https://github.com/stripe/stripe-java/pull/1913, I double checked the other SDKs that were modified as part of that work.  The dotnet SDK is implemented correctly but it did not have unit tests for all of the edge cases in `AddBetaVersion`.  This PR implements the tests for these edge cases.

### What
- added tests to ensure AddBetaVersion can be called multiple times for different beta versions