### PR TITLE
Fix V2 list options base class

### DIFF
--- a/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationListOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationListOptions.cs
@@ -4,7 +4,7 @@ namespace Stripe.V2.Core
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
-    public class EventDestinationListOptions : ListOptions
+    public class EventDestinationListOptions : V2.ListOptions
     {
         /// <summary>
         /// Additional fields to include in the response. Currently supports

--- a/src/Stripe.net/Services/V2/Core/Events/EventListOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Events/EventListOptions.cs
@@ -3,7 +3,7 @@ namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 
-    public class EventListOptions : ListOptions
+    public class EventListOptions : V2.ListOptions
     {
         /// <summary>
         /// Primary object ID used to retrieve related events.

--- a/src/Stripe.net/Services/_base/V2/ListOptions.cs
+++ b/src/Stripe.net/Services/_base/V2/ListOptions.cs
@@ -1,0 +1,13 @@
+namespace Stripe.V2
+{
+    using Newtonsoft.Json;
+
+    public class ListOptions : BaseOptions
+    {
+        /// <summary>
+        /// A limit on the number of objects to be returned, between 1 and 100.
+        /// </summary>
+        [JsonProperty("limit")]
+        public long? Limit { get; set; }
+    }
+}


### PR DESCRIPTION
### Why
API V2 lists have different semantics than lists in V1.  In this SDK, we utilize a ListOptions base class to hold common options.  We need to introduce a V2 specific ListOptions base class to ensure the V2 list semantics are correctly represented.  This PR introduces this base class and updates V2 list options subclasses to derive from it instead of the v1 ListOptions class.

### What
- added ListOptions in the Stripe.V2 namespace (in _base/V2/ListOptions.cs, close to the V1 ListOptions file)
- updated V2 EventListOptions and EventDestinationListOptions to derive from V2.ListOptions