### PR TITLE
Add .NET 9.0 Support

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100-rc.2.24474.11",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Examples/ExampleWebApp.csproj
+++ b/src/Examples/ExampleWebApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
   </PropertyGroup>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
   </PropertyGroup>

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Stripe.net is a sync/async .NET 4.6.1+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
-    <Version>48.0.0-rc</Version>
+    <Version>48.0.0</Version>
     <LangVersion>8</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>
     <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
@@ -56,7 +56,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <Description>Stripe.net is a sync/async .NET 4.6.1+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
-    <Version>47.0.0</Version>
+    <Version>48.0.0-rc</Version>
     <LangVersion>8</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
     <PackageTags>stripe;payment;credit;cards;money;gateway;paypal;braintree</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/stripe/stripe-dotnet</PackageProjectUrl>
@@ -54,6 +54,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0-rc.2.24473.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/StripeTests/StripeTests.csproj
+++ b/src/StripeTests/StripeTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>


### PR DESCRIPTION
This PR adds a new `net9.0` compilation target and also updates the `HttpClient` configuration in `SystemNetHttpClient` to use a `SocketsHttpHandler` to configure TLS1.2 support due to `ServicePointManager.SecurityProtocol` becoming obsolete.