### PR TITLE
Fixed supported frameworks in project description and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/stripe/stripe-dotnet/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-dotnet/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
-The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 2.0+, and .NET Framework 4.6.1+.
+The official [Stripe][stripe] .NET library, supporting .NET Standard 2.0+, .NET Core 3.1+, and .NET Framework 4.6.1+.
 
 ## Installation
 

--- a/src/Stripe.net/Stripe.net.csproj
+++ b/src/Stripe.net/Stripe.net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Stripe.net is a sync/async .NET 4.6.1+ client, and a portable class library for the Stripe API.  (Official Library)</Description>
+    <Description>Stripe.net is a sync/async client and portable class library for the Stripe API, supporting .NET Standard 2.0+, .NET Core 3.1+, and .NET Framework 4.6.1+. (Official Library)</Description>
     <Version>47.2.0</Version>
     <LangVersion>8</LangVersion>
     <Authors>Stripe, Jayme Davis</Authors>


### PR DESCRIPTION
### Why?
A user reported in https://github.com/stripe/stripe-dotnet/issues/3005 that our NuGet description and our readme were inconsistent, and that it was causing confusion.  While investigating, I also noticed that our stated supported frameworks did not match what was configured inside the Stripe.net.csproj file.  This PR fixes both of these issues.

### What?
- corrected our readme to accurate describe the .NET versions we support (replaced Core 2.0+ with Core 3.1+)
- updated the Stripe.net.csproj project description to match
