### PR TITLE
Add justfile, remove coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@master
 
       - name: Setup .NET
@@ -47,7 +48,7 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run test suite
-        run: make ci-test
+        run: just ci-test
 
       - name: Collect coverage
         run: dotnet test --no-build -c Release -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
@@ -60,33 +61,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "commitBranch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
-      - name: Send code coverage report to coveralls.io
-        if: env.COVERALLS_REPO_TOKEN
-        run: |
-          export ARGS="--opencover \
-            -i src/StripeTests/coverage.netcoreapp3.1.opencover.xml \
-            --repoToken $COVERALLS_REPO_TOKEN \
-            --useRelativePaths \
-            --commitId $commitId \
-            --commitBranch $commitBranch \
-            --commitAuthor $commitAuthor \
-            --jobId $jobId"
-          if [ ! -z "${pullRequestId}" ];
-          then
-            export ARGS="$ARGS \
-              --pullRequest $pullRequestId"
-          fi
-          dotnet tool run csmacnz.Coveralls $ARGS
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          commitId: ${{ github.sha }}
-          commitAuthor: ${{ github.actor }}
-          jobId: ${{ github.run_id }}
-          pullRequestId: ${{ github.event.pull_request.number }}
-
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
-      - name: 'Upload Artifact'
+      - name: "Upload Artifact"
         uses: actions/upload-artifact@v4
         with:
           name: nuget
@@ -97,13 +74,13 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 8.0.x
-    - name: Run backcompat check
-      run: dotnet pack src/Stripe.net -p:RunBaselineCheck=true
+      - uses: actions/checkout@master
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.x
+      - name: Run backcompat check
+        run: dotnet pack src/Stripe.net -p:RunBaselineCheck=true
 
   publish:
     name: Publish
@@ -111,18 +88,18 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: nuget
-        path: nuget
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 8.0.x
-    - name: Publish NuGet packages to NuGet
-      run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org"
-    - uses: stripe/openapi/actions/notify-release@master
-      if: always()
-      with:
-        bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget
+          path: nuget
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.x
+      - name: Publish NuGet packages to NuGet
+        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org"
+      - uses: stripe/openapi/actions/notify-release@master
+        if: always()
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install just
-
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@master
 
       - name: Setup .NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
       - name: Run test suite
         run: just ci-test
 
-      # commented out because it's slow, but it's here if we want it
-      # - name: Verify formatting
-      #   run: just format-check
-
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
       - name: "Upload Artifact"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,6 @@ jobs:
       - name: Run test suite
         run: just ci-test
 
-      - name: Collect coverage
-        run: dotnet test --no-build -c Release -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
-
-      - name: Get branch name (merge)
-        if: github.event_name != 'pull_request'
-        run: echo "commitBranch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-
-      - name: Get branch name (pull request)
-        if: github.event_name == 'pull_request'
-        run: echo "commitBranch=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
       - name: "Upload Artifact"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Run test suite
         run: just ci-test
 
+      # commented out because it's slow, but it's here if we want it
+      # - name: Verify formatting
+      #   run: just format-check
+
       - name: Pack
         run: dotnet pack src/Stripe.net -c Release --no-build --output nuget
       - name: "Upload Artifact"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: extractions/setup-just@v2
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install just
+
       - uses: actions/checkout@master
 
       - name: Setup .NET

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# NOTE: this file is deprecated and slated for deletion; prefer using the equivalent `just` commands.
+
 .PHONY: update-version codegen-format test ci-test
 update-version:
 	@echo "$(VERSION)" > VERSION

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ From within Visual Studio:
 
 1. Open the Solution Explorer.
 2. Right-click on a project within your solution.
-3. Click on *Manage NuGet Packages...*
-4. Click on the *Browse* tab and search for "Stripe.net".
+3. Click on _Manage NuGet Packages..._
+4. Click on the _Browse_ tab and search for "Stripe.net".
 5. Click on the Stripe.net package, select the appropriate version in the
-   right-tab and click *Install*.
+   right-tab and click _Install_.
 
 ## Documentation
 
@@ -49,7 +49,7 @@ Stripe authenticates API requests using your account’s secret key, which you c
 
 Use `StripeConfiguration.ApiKey` property to set the secret key.
 
-``` C#
+```C#
 StripeConfiguration.ApiKey = "sk_test_...";
 ```
 
@@ -57,7 +57,7 @@ StripeConfiguration.ApiKey = "sk_test_...";
 
 The `Create` method of the service class can be used to create a new resource:
 
-``` C#
+```C#
 var options = new CustomerCreateOptions
 {
     Email = "customer@example.com"
@@ -74,7 +74,7 @@ Console.WriteLine(customer.Email);
 
 The `Retrieve` method of the service class can be used to retrieve a resource:
 
-``` C#
+```C#
 var service = new CustomerService();
 Customer customer = service.Get("cus_1234");
 
@@ -320,10 +320,13 @@ go install github.com/stripe/stripe-mock@latest
 stripe-mock
 ```
 
+Lastly, we use [just](https://github.com/casey/just) for running common development tasks. You can also read the `justfile` and run those commands directly.
+
 Run all tests from the `src/StripeTests` directory:
 
 ```sh
-dotnet test src
+just test
+# or: dotnet test src
 ```
 
 Run some tests, filtering by name:
@@ -343,7 +346,8 @@ must be formatted before PRs are submitted, otherwise CI will fail. Run the
 formatter with:
 
 ```sh
-dotnet format src/Stripe.net.sln
+just format
+# or: dotnet format src/Stripe.net.sln
 ```
 
 For any requests, bug or comments, please [open an issue][issues] or [submit a

--- a/justfile
+++ b/justfile
@@ -19,6 +19,7 @@ ci-test: (_test "--no-build" "" "Release")
 
 # ⭐ format all files
 format *args:
+    # This sets TargetFramework because of a race condition in dotnet format when it tries to format to multiple targets at a time, which could lead to code with compiler errors after it completes
     TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn {{args}}
 
 # for backwards compatibility; ideally removed later

--- a/justfile
+++ b/justfile
@@ -5,21 +5,19 @@ import? '../sdk-codegen/justfile'
 _default:
     just --list --unsorted
 
-# base test command
+# base test command that other, more specific commands use
 [no-quiet]
+[no-exit-message]
 _test no_build framework config:
     dotnet test {{no_build}} {{framework}} src/StripeTests/StripeTests.csproj -c {{config}}
 
-# run tests in debug mode
-[group('useful')]
+# ⭐ run tests in debug mode
 test: (_test "" "-f net8.0" "Debug")
 
 # skip build and don't specify the dotnet framework
-[group('CI')]
 ci-test: (_test "--no-build" "" "Release")
 
-# format files as needed
-[group('useful')]
+# ⭐ format all files
 format *options:
     TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn {{options}}
 
@@ -28,7 +26,6 @@ format *options:
 alias codegen-format := format
 
 # verify, but don't modify, the project's formatting
-[group('CI')]
 format-check: (format "--verify-no-changes")
 
 # called by tooling

--- a/justfile
+++ b/justfile
@@ -18,8 +18,8 @@ test: (_test "" "-f net8.0" "Debug")
 ci-test: (_test "--no-build" "" "Release")
 
 # ⭐ format all files
-format *options:
-    TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn {{options}}
+format *args:
+    TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn {{args}}
 
 # for backwards compatibility; ideally removed later
 [private]

--- a/justfile
+++ b/justfile
@@ -11,12 +11,15 @@ _test no_build framework config:
     dotnet test {{no_build}} {{framework}} src/StripeTests/StripeTests.csproj -c {{config}}
 
 # run tests in debug mode
+[group('useful')]
 test: (_test "" "-f net8.0" "Debug")
 
 # skip build and don't specify the dotnet framework
+[group('CI')]
 ci-test: (_test "--no-build" "" "Release")
 
 # format files as needed
+[group('useful')]
 format *options:
     TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn {{options}}
 
@@ -25,6 +28,7 @@ format *options:
 alias codegen-format := format
 
 # verify, but don't modify, the project's formatting
+[group('CI')]
 format-check: (format "--verify-no-changes")
 
 # called by tooling

--- a/justfile
+++ b/justfile
@@ -1,0 +1,26 @@
+set quiet
+
+_default:
+    just --list
+
+test no_build="" config="Debug":
+    dotnet test {{no_build}} -f net8.0 src/StripeTests/StripeTests.csproj -c {{config}}
+
+# skip build and test in release mode
+ci-test: (test "--no-build" "Release")
+# skip build and test in debug mode
+ci-test-debug: (test "--no-build")
+
+format:
+    TargetFramework=net5.0 dotnet format src/Stripe.net/Stripe.net.csproj --severity warn
+
+update-version:
+    echo "$(VERSION)" > VERSION
+    perl -pi -e 's|<Version>[.\-\d\w]+</Version>|<Version>$(VERSION)</Version>|' src/Stripe.net/Stripe.net.csproj
+    perl -pi -e 's|Current = "[.\-\d\w]+";|Current = "$(VERSION)";|' src/Stripe.net/Constants/Version.cs
+
+_self_validate:
+    #!/usr/bin/env python
+    just print("{{justfile()}}")
+    # could also do this in JQ?
+    # just --dump --dump-format json | jq '.recipes | keys'

--- a/justfile
+++ b/justfile
@@ -1,9 +1,12 @@
+set quiet
+
 import? '../sdk-codegen/justfile'
 
 _default:
     just --list --unsorted
 
 # base test command
+[no-quiet]
 _test no_build framework config:
     dotnet test {{no_build}} {{framework}} src/StripeTests/StripeTests.csproj -c {{config}}
 
@@ -26,7 +29,7 @@ format-check: (format "--verify-no-changes")
 
 # called by tooling
 [private]
-@update-version version:
+update-version version:
     echo "{{ version }}" > VERSION
     perl -pi -e 's|<Version>[.\-\d\w]+</Version>|<Version>{{ version }}</Version>|' src/Stripe.net/Stripe.net.csproj
     perl -pi -e 's|Current = "[.\-\d\w]+";|Current = "{{ version }}";|' src/Stripe.net/Constants/Version.cs


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In an effort to modernize and simplify our local tooling, we're moving our dev commands from makefiles to [justfiles](https://github.com/casey/just). This is intended to be mostly a drop-in replacement, but some command names may change per standardization efforts.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added justfile
- added warning line to top of makefile
- updated readme
- tweaked CI to use `just`
- removed all the coveralls-related code from CI
- updated readme to mention `just` (& an alternative)

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2325](https://go/j/DEVSDK-2325)