### PR TITLE
Remove debug build and test from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: make ci-test
 
       - name: Collect coverage
-        run: dotnet test --no-build -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
+        run: dotnet test --no-build -c Release -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated
 
       - name: Get branch name (merge)
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,10 @@ jobs:
       - name: Build Release
         run: dotnet build src -c Release /p:ContinuousIntegrationBuild=true
 
-      - name: Build Debug
-        run: dotnet build src -c Debug
-
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run test suite
         run: make ci-test
-
-      - name: Run test suite (Debug)
-        run: make ci-test-debug
 
       - name: Collect coverage
         run: dotnet test --no-build -c Debug -f netcoreapp3.1 src/StripeTests/StripeTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=CompilerGenerated


### PR DESCRIPTION
### Why?
Currently, our CI workflow builds and tests the debug and release configurations of the .NET project.  This could be useful if we publish the Debug configuration and if there are implementation differences between Debug and release, but as of now this does not apply to our SDK.  Removing these steps will save time when building and publishing the SDK.

If we add #if DEBUG conditionals or any other changes that would apply to one configuration but not the other, we should revisit this.

### What?
- removed debug build and run debug test suite steps from ci.yml


