### PR TITLE
Pin ubuntu version in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
   build:
     name: Build and test
 
-    runs-on: ubuntu-latest
+    # TODO: this step is not compatible with ubuntu 24 LTS, so we pin the version here instead of using ubuntu-latest 
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: extractions/setup-just@v2


### PR DESCRIPTION
### Why?
Our build and test action ran on `ubuntu-latest`, which was recently upgraded to Ubuntu 24.04 (  https://github.com/actions/runner-images/commit/976232da217887825e7541c2635bf39cbbf22654).  This caused CI failures as Ubuntu 24.04 does not appear to ship with the same standard libraries and installed software.

### What?
- Changed runs-on value for Build and Test job to `ubuntu-22.04`
