### PR TITLE
Deprecate ServiceNested class

### DIFF
--- a/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityService.cs
+++ b/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountCapabilityService : ServiceNested<Capability>,
+    public class AccountCapabilityService : Service,
         INestedListable<Capability, AccountCapabilityListOptions>,
         INestedRetrievable<Capability, AccountCapabilityGetOptions>,
         INestedUpdatable<Capability, AccountCapabilityUpdateOptions>

--- a/src/Stripe.net/Services/AccountExternalAccounts/AccountExternalAccountService.cs
+++ b/src/Stripe.net/Services/AccountExternalAccounts/AccountExternalAccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountExternalAccountService : ServiceNested<IExternalAccount>,
+    public class AccountExternalAccountService : Service,
         INestedCreatable<IExternalAccount, AccountExternalAccountCreateOptions>,
         INestedDeletable<IExternalAccount, AccountExternalAccountDeleteOptions>,
         INestedListable<IExternalAccount, AccountExternalAccountListOptions>,

--- a/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
+++ b/src/Stripe.net/Services/AccountLinks/AccountLinkService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountLinkService : Service<AccountLink>,
+    public class AccountLinkService : Service,
         ICreatable<AccountLink, AccountLinkCreateOptions>
     {
         public AccountLinkService()

--- a/src/Stripe.net/Services/AccountLoginLinks/AccountLoginLinkService.cs
+++ b/src/Stripe.net/Services/AccountLoginLinks/AccountLoginLinkService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountLoginLinkService : ServiceNested<LoginLink>,
+    public class AccountLoginLinkService : Service,
         INestedCreatable<LoginLink, AccountLoginLinkCreateOptions>
     {
         public AccountLoginLinkService()

--- a/src/Stripe.net/Services/AccountPersons/AccountPersonService.cs
+++ b/src/Stripe.net/Services/AccountPersons/AccountPersonService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountPersonService : ServiceNested<Person>,
+    public class AccountPersonService : Service,
         INestedCreatable<Person, AccountPersonCreateOptions>,
         INestedDeletable<Person, AccountPersonDeleteOptions>,
         INestedListable<Person, AccountPersonListOptions>,

--- a/src/Stripe.net/Services/AccountSessions/AccountSessionService.cs
+++ b/src/Stripe.net/Services/AccountSessions/AccountSessionService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountSessionService : Service<AccountSession>,
+    public class AccountSessionService : Service,
         ICreatable<AccountSession, AccountSessionCreateOptions>
     {
         public AccountSessionService()

--- a/src/Stripe.net/Services/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/Accounts/AccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountService : Service<Account>,
+    public class AccountService : Service,
         ICreatable<Account, AccountCreateOptions>,
         IDeletable<Account, AccountDeleteOptions>,
         IListable<Account, AccountListOptions>,

--- a/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
+++ b/src/Stripe.net/Services/ApplePayDomains/ApplePayDomainService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ApplePayDomainService : Service<ApplePayDomain>,
+    public class ApplePayDomainService : Service,
         ICreatable<ApplePayDomain, ApplePayDomainCreateOptions>,
         IDeletable<ApplePayDomain, ApplePayDomainDeleteOptions>,
         IListable<ApplePayDomain, ApplePayDomainListOptions>,

--- a/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
+++ b/src/Stripe.net/Services/ApplicationFeeRefunds/ApplicationFeeRefundService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ApplicationFeeRefundService : ServiceNested<ApplicationFeeRefund>,
+    public class ApplicationFeeRefundService : Service,
         INestedCreatable<ApplicationFeeRefund, ApplicationFeeRefundCreateOptions>,
         INestedListable<ApplicationFeeRefund, ApplicationFeeRefundListOptions>,
         INestedRetrievable<ApplicationFeeRefund, ApplicationFeeRefundGetOptions>,

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ApplicationFeeService : Service<ApplicationFee>,
+    public class ApplicationFeeService : Service,
         IListable<ApplicationFee, ApplicationFeeListOptions>,
         IRetrievable<ApplicationFee, ApplicationFeeGetOptions>
     {

--- a/src/Stripe.net/Services/Apps/Secrets/SecretService.cs
+++ b/src/Stripe.net/Services/Apps/Secrets/SecretService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Apps
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SecretService : Service<Secret>,
+    public class SecretService : Service,
         ICreatable<Secret, SecretCreateOptions>,
         IListable<Secret, SecretListOptions>
     {

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class BalanceTransactionService : Service<BalanceTransaction>,
+    public class BalanceTransactionService : Service,
         IListable<BalanceTransaction, BalanceTransactionListOptions>,
         IRetrievable<BalanceTransaction, BalanceTransactionGetOptions>
     {

--- a/src/Stripe.net/Services/Balances/BalanceService.cs
+++ b/src/Stripe.net/Services/Balances/BalanceService.cs
@@ -6,8 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class BalanceService : Service<Balance>,
-        ISingletonRetrievable<Balance>
+    public class BalanceService : Service, ISingletonRetrievable<Balance>
     {
         public BalanceService()
         {

--- a/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
+++ b/src/Stripe.net/Services/BankAccounts/BankAccountService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class BankAccountService : ServiceNested<BankAccount>,
+    public class BankAccountService : Service,
         INestedCreatable<BankAccount, BankAccountCreateOptions>,
         INestedDeletable<BankAccount, BankAccountDeleteOptions>,
         INestedListable<BankAccount, BankAccountListOptions>,

--- a/src/Stripe.net/Services/Billing/Alerts/AlertService.cs
+++ b/src/Stripe.net/Services/Billing/Alerts/AlertService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AlertService : Service<Alert>,
+    public class AlertService : Service,
         ICreatable<Alert, AlertCreateOptions>,
         IListable<Alert, AlertListOptions>,
         IRetrievable<Alert, AlertGetOptions>

--- a/src/Stripe.net/Services/Billing/CreditBalanceSummaries/CreditBalanceSummaryService.cs
+++ b/src/Stripe.net/Services/Billing/CreditBalanceSummaries/CreditBalanceSummaryService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CreditBalanceSummaryService : Service<CreditBalanceSummary>,
+    public class CreditBalanceSummaryService : Service,
         ISingletonRetrievable<CreditBalanceSummary>
     {
         public CreditBalanceSummaryService()

--- a/src/Stripe.net/Services/Billing/CreditBalanceTransactions/CreditBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/Billing/CreditBalanceTransactions/CreditBalanceTransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CreditBalanceTransactionService : Service<CreditBalanceTransaction>,
+    public class CreditBalanceTransactionService : Service,
         IListable<CreditBalanceTransaction, CreditBalanceTransactionListOptions>,
         IRetrievable<CreditBalanceTransaction, CreditBalanceTransactionGetOptions>
     {

--- a/src/Stripe.net/Services/Billing/CreditGrants/CreditGrantService.cs
+++ b/src/Stripe.net/Services/Billing/CreditGrants/CreditGrantService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CreditGrantService : Service<CreditGrant>,
+    public class CreditGrantService : Service,
         ICreatable<CreditGrant, CreditGrantCreateOptions>,
         IListable<CreditGrant, CreditGrantListOptions>,
         IRetrievable<CreditGrant, CreditGrantGetOptions>,

--- a/src/Stripe.net/Services/Billing/MeterEventAdjustments/MeterEventAdjustmentService.cs
+++ b/src/Stripe.net/Services/Billing/MeterEventAdjustments/MeterEventAdjustmentService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class MeterEventAdjustmentService : Service<MeterEventAdjustment>,
+    public class MeterEventAdjustmentService : Service,
         ICreatable<MeterEventAdjustment, MeterEventAdjustmentCreateOptions>
     {
         public MeterEventAdjustmentService()

--- a/src/Stripe.net/Services/Billing/MeterEventSummaries/MeterEventSummaryService.cs
+++ b/src/Stripe.net/Services/Billing/MeterEventSummaries/MeterEventSummaryService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class MeterEventSummaryService : ServiceNested<MeterEventSummary>,
+    public class MeterEventSummaryService : Service,
         INestedListable<MeterEventSummary, MeterEventSummaryListOptions>
     {
         public MeterEventSummaryService()

--- a/src/Stripe.net/Services/Billing/MeterEvents/MeterEventService.cs
+++ b/src/Stripe.net/Services/Billing/MeterEvents/MeterEventService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class MeterEventService : Service<MeterEvent>,
+    public class MeterEventService : Service,
         ICreatable<MeterEvent, MeterEventCreateOptions>
     {
         public MeterEventService()

--- a/src/Stripe.net/Services/Billing/Meters/MeterService.cs
+++ b/src/Stripe.net/Services/Billing/Meters/MeterService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Billing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class MeterService : Service<Meter>,
+    public class MeterService : Service,
         ICreatable<Meter, MeterCreateOptions>,
         IListable<Meter, MeterListOptions>,
         IRetrievable<Meter, MeterGetOptions>,

--- a/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Configurations/ConfigurationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.BillingPortal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ConfigurationService : Service<Configuration>,
+    public class ConfigurationService : Service,
         ICreatable<Configuration, ConfigurationCreateOptions>,
         IListable<Configuration, ConfigurationListOptions>,
         IRetrievable<Configuration, ConfigurationGetOptions>,

--- a/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/BillingPortal/Sessions/SessionService.cs
@@ -6,7 +6,7 @@ namespace Stripe.BillingPortal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SessionService : Service<Session>,
+    public class SessionService : Service,
         ICreatable<Session, SessionCreateOptions>
     {
         public SessionService()

--- a/src/Stripe.net/Services/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Cards/CardService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CardService : ServiceNested<Card>,
+    public class CardService : Service,
         INestedCreatable<Card, CardCreateOptions>,
         INestedDeletable<Card, CardDeleteOptions>,
         INestedListable<Card, CardListOptions>,

--- a/src/Stripe.net/Services/Charges/ChargeService.cs
+++ b/src/Stripe.net/Services/Charges/ChargeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ChargeService : Service<Charge>,
+    public class ChargeService : Service,
         ICreatable<Charge, ChargeCreateOptions>,
         IListable<Charge, ChargeListOptions>,
         IRetrievable<Charge, ChargeGetOptions>,

--- a/src/Stripe.net/Services/Checkout/SessionLineItems/SessionLineItemService.cs
+++ b/src/Stripe.net/Services/Checkout/SessionLineItems/SessionLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Checkout
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SessionLineItemService : ServiceNested<LineItem>,
+    public class SessionLineItemService : Service,
         INestedListable<LineItem, SessionLineItemListOptions>
     {
         public SessionLineItemService()

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Checkout
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class SessionService : Service<Session>,
+    public partial class SessionService : Service,
         ICreatable<Session, SessionCreateOptions>,
         IListable<Session, SessionListOptions>,
         IRetrievable<Session, SessionGetOptions>,

--- a/src/Stripe.net/Services/Climate/Orders/OrderService.cs
+++ b/src/Stripe.net/Services/Climate/Orders/OrderService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Climate
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class OrderService : Service<Order>,
+    public class OrderService : Service,
         ICreatable<Order, OrderCreateOptions>,
         IListable<Order, OrderListOptions>,
         IRetrievable<Order, OrderGetOptions>,

--- a/src/Stripe.net/Services/Climate/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Climate/Products/ProductService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Climate
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ProductService : Service<Product>,
+    public class ProductService : Service,
         IListable<Product, ProductListOptions>,
         IRetrievable<Product, ProductGetOptions>
     {

--- a/src/Stripe.net/Services/Climate/Suppliers/SupplierService.cs
+++ b/src/Stripe.net/Services/Climate/Suppliers/SupplierService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Climate
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SupplierService : Service<Supplier>,
+    public class SupplierService : Service,
         IListable<Supplier, SupplierListOptions>,
         IRetrievable<Supplier, SupplierGetOptions>
     {

--- a/src/Stripe.net/Services/ConfirmationTokens/ConfirmationTokenService.cs
+++ b/src/Stripe.net/Services/ConfirmationTokens/ConfirmationTokenService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ConfirmationTokenService : Service<ConfirmationToken>,
+    public class ConfirmationTokenService : Service,
         IRetrievable<ConfirmationToken, ConfirmationTokenGetOptions>
     {
         public ConfirmationTokenService()

--- a/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
+++ b/src/Stripe.net/Services/CountrySpecs/CountrySpecService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CountrySpecService : Service<CountrySpec>,
+    public class CountrySpecService : Service,
         IListable<CountrySpec, CountrySpecListOptions>,
         IRetrievable<CountrySpec, CountrySpecGetOptions>
     {

--- a/src/Stripe.net/Services/Coupons/CouponService.cs
+++ b/src/Stripe.net/Services/Coupons/CouponService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CouponService : Service<Coupon>,
+    public class CouponService : Service,
         ICreatable<Coupon, CouponCreateOptions>,
         IDeletable<Coupon, CouponDeleteOptions>,
         IListable<Coupon, CouponListOptions>,

--- a/src/Stripe.net/Services/CreditNotePreviewLines/CreditNotePreviewLinesService.cs
+++ b/src/Stripe.net/Services/CreditNotePreviewLines/CreditNotePreviewLinesService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CreditNotePreviewLinesService : ServiceNested<CreditNoteLineItem>
+    public class CreditNotePreviewLinesService : Service
     {
         public CreditNotePreviewLinesService()
         {

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class CreditNoteService : Service<CreditNote>,
+    public partial class CreditNoteService : Service,
         ICreatable<CreditNote, CreditNoteCreateOptions>,
         IListable<CreditNote, CreditNoteListOptions>,
         IRetrievable<CreditNote, CreditNoteGetOptions>,

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteService.partial.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteService.partial.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class CreditNoteService : Service<CreditNote>,
+    public partial class CreditNoteService : Service,
         ICreatable<CreditNote, CreditNoteCreateOptions>,
         IListable<CreditNote, CreditNoteListOptions>,
         IRetrievable<CreditNote, CreditNoteGetOptions>,

--- a/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerBalanceTransactions/CustomerBalanceTransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerBalanceTransactionService : ServiceNested<CustomerBalanceTransaction>,
+    public class CustomerBalanceTransactionService : Service,
         INestedCreatable<CustomerBalanceTransaction, CustomerBalanceTransactionCreateOptions>,
         INestedListable<CustomerBalanceTransaction, CustomerBalanceTransactionListOptions>,
         INestedRetrievable<CustomerBalanceTransaction, CustomerBalanceTransactionGetOptions>,

--- a/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
+++ b/src/Stripe.net/Services/CustomerCashBalanceTransactions/CustomerCashBalanceTransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerCashBalanceTransactionService : ServiceNested<CustomerCashBalanceTransaction>,
+    public class CustomerCashBalanceTransactionService : Service,
         INestedListable<CustomerCashBalanceTransaction, CustomerCashBalanceTransactionListOptions>,
         INestedRetrievable<CustomerCashBalanceTransaction, CustomerCashBalanceTransactionGetOptions>
     {

--- a/src/Stripe.net/Services/CustomerCashBalances/CustomerCashBalanceService.cs
+++ b/src/Stripe.net/Services/CustomerCashBalances/CustomerCashBalanceService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerCashBalanceService : ServiceNested<CashBalance>
+    public class CustomerCashBalanceService : Service
     {
         public CustomerCashBalanceService()
         {

--- a/src/Stripe.net/Services/CustomerFundingInstructions/CustomerFundingInstructionsService.cs
+++ b/src/Stripe.net/Services/CustomerFundingInstructions/CustomerFundingInstructionsService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerFundingInstructionsService : ServiceNested<FundingInstructions>
+    public class CustomerFundingInstructionsService : Service
     {
         public CustomerFundingInstructionsService()
         {

--- a/src/Stripe.net/Services/CustomerPaymentMethods/CustomerPaymentMethodService.cs
+++ b/src/Stripe.net/Services/CustomerPaymentMethods/CustomerPaymentMethodService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerPaymentMethodService : ServiceNested<PaymentMethod>,
+    public class CustomerPaymentMethodService : Service,
         INestedListable<PaymentMethod, CustomerPaymentMethodListOptions>,
         INestedRetrievable<PaymentMethod, CustomerPaymentMethodGetOptions>
     {

--- a/src/Stripe.net/Services/CustomerPaymentSources/CustomerPaymentSourceService.cs
+++ b/src/Stripe.net/Services/CustomerPaymentSources/CustomerPaymentSourceService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerPaymentSourceService : ServiceNested<IPaymentSource>,
+    public class CustomerPaymentSourceService : Service,
         INestedCreatable<IPaymentSource, CustomerPaymentSourceCreateOptions>,
         INestedDeletable<IPaymentSource, CustomerPaymentSourceDeleteOptions>,
         INestedListable<IPaymentSource, CustomerPaymentSourceListOptions>,

--- a/src/Stripe.net/Services/CustomerSessions/CustomerSessionService.cs
+++ b/src/Stripe.net/Services/CustomerSessions/CustomerSessionService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerSessionService : Service<CustomerSession>,
+    public class CustomerSessionService : Service,
         ICreatable<CustomerSession, CustomerSessionCreateOptions>
     {
         public CustomerSessionService()

--- a/src/Stripe.net/Services/CustomerTaxIds/CustomerTaxIdService.cs
+++ b/src/Stripe.net/Services/CustomerTaxIds/CustomerTaxIdService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerTaxIdService : ServiceNested<TaxId>,
+    public class CustomerTaxIdService : Service,
         INestedCreatable<TaxId, CustomerTaxIdCreateOptions>,
         INestedDeletable<TaxId, CustomerTaxIdDeleteOptions>,
         INestedListable<TaxId, CustomerTaxIdListOptions>,

--- a/src/Stripe.net/Services/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/Customers/CustomerService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class CustomerService : Service<Customer>,
+    public partial class CustomerService : Service,
         ICreatable<Customer, CustomerCreateOptions>,
         IDeletable<Customer, CustomerDeleteOptions>,
         IListable<Customer, CustomerListOptions>,

--- a/src/Stripe.net/Services/Discounts/DiscountService.cs
+++ b/src/Stripe.net/Services/Discounts/DiscountService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class DiscountService : Service<Discount>
+    public class DiscountService : Service
     {
         public DiscountService()
             : base()

--- a/src/Stripe.net/Services/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class DisputeService : Service<Dispute>,
+    public class DisputeService : Service,
         IListable<Dispute, DisputeListOptions>,
         IRetrievable<Dispute, DisputeGetOptions>,
         IUpdatable<Dispute, DisputeUpdateOptions>

--- a/src/Stripe.net/Services/Entitlements/ActiveEntitlements/ActiveEntitlementService.cs
+++ b/src/Stripe.net/Services/Entitlements/ActiveEntitlements/ActiveEntitlementService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Entitlements
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ActiveEntitlementService : Service<ActiveEntitlement>,
+    public class ActiveEntitlementService : Service,
         IListable<ActiveEntitlement, ActiveEntitlementListOptions>,
         IRetrievable<ActiveEntitlement, ActiveEntitlementGetOptions>
     {

--- a/src/Stripe.net/Services/Entitlements/Features/FeatureService.cs
+++ b/src/Stripe.net/Services/Entitlements/Features/FeatureService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Entitlements
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class FeatureService : Service<Feature>,
+    public class FeatureService : Service,
         ICreatable<Feature, FeatureCreateOptions>,
         IListable<Feature, FeatureListOptions>,
         IRetrievable<Feature, FeatureGetOptions>,

--- a/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
+++ b/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class EphemeralKeyService : Service<EphemeralKey>,
+    public class EphemeralKeyService : Service,
         ICreatable<EphemeralKey, EphemeralKeyCreateOptions>,
         IDeletable<EphemeralKey, EphemeralKeyDeleteOptions>
     {

--- a/src/Stripe.net/Services/Events/EventService.cs
+++ b/src/Stripe.net/Services/Events/EventService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class EventService : Service<Event>,
+    public class EventService : Service,
         IListable<Event, EventListOptions>,
         IRetrievable<Event, EventGetOptions>
     {

--- a/src/Stripe.net/Services/FileLinks/FileLinkService.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class FileLinkService : Service<FileLink>,
+    public class FileLinkService : Service,
         ICreatable<FileLink, FileLinkCreateOptions>,
         IListable<FileLink, FileLinkListOptions>,
         IRetrievable<FileLink, FileLinkGetOptions>,

--- a/src/Stripe.net/Services/Files/FileService.cs
+++ b/src/Stripe.net/Services/Files/FileService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class FileService : Service<File>,
+    public class FileService : Service,
         ICreatable<File, FileCreateOptions>,
         IListable<File, FileListOptions>,
         IRetrievable<File, FileGetOptions>

--- a/src/Stripe.net/Services/FinancialConnections/AccountOwners/AccountOwnerService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/AccountOwners/AccountOwnerService.cs
@@ -8,7 +8,7 @@ namespace Stripe.FinancialConnections
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AccountOwnerService : ServiceNested<AccountOwner>,
+    public class AccountOwnerService : Service,
         INestedListable<AccountOwner, AccountOwnerListOptions>
     {
         public AccountOwnerService()

--- a/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Accounts/AccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe.FinancialConnections
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class AccountService : Service<Account>,
+    public partial class AccountService : Service,
         IListable<Account, AccountListOptions>,
         IRetrievable<Account, AccountGetOptions>
     {

--- a/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Sessions/SessionService.cs
@@ -7,7 +7,7 @@ namespace Stripe.FinancialConnections
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SessionService : Service<Session>,
+    public class SessionService : Service,
         ICreatable<Session, SessionCreateOptions>,
         IRetrievable<Session, SessionGetOptions>
     {

--- a/src/Stripe.net/Services/FinancialConnections/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/FinancialConnections/Transactions/TransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.FinancialConnections
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransactionService : Service<Transaction>,
+    public class TransactionService : Service,
         IListable<Transaction, TransactionListOptions>,
         IRetrievable<Transaction, TransactionGetOptions>
     {

--- a/src/Stripe.net/Services/Forwarding/Requests/RequestService.cs
+++ b/src/Stripe.net/Services/Forwarding/Requests/RequestService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Forwarding
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class RequestService : Service<Request>,
+    public class RequestService : Service,
         ICreatable<Request, RequestCreateOptions>,
         IListable<Request, RequestListOptions>,
         IRetrievable<Request, RequestGetOptions>

--- a/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Identity
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class VerificationReportService : Service<VerificationReport>,
+    public class VerificationReportService : Service,
         IListable<VerificationReport, VerificationReportListOptions>,
         IRetrievable<VerificationReport, VerificationReportGetOptions>
     {

--- a/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
+++ b/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Identity
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class VerificationSessionService : Service<VerificationSession>,
+    public class VerificationSessionService : Service,
         ICreatable<VerificationSession, VerificationSessionCreateOptions>,
         IListable<VerificationSession, VerificationSessionListOptions>,
         IRetrievable<VerificationSession, VerificationSessionGetOptions>,

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class InvoiceItemService : Service<InvoiceItem>,
+    public class InvoiceItemService : Service,
         ICreatable<InvoiceItem, InvoiceItemCreateOptions>,
         IDeletable<InvoiceItem, InvoiceItemDeleteOptions>,
         IListable<InvoiceItem, InvoiceItemListOptions>,

--- a/src/Stripe.net/Services/InvoiceLineItems/InvoiceLineItemService.cs
+++ b/src/Stripe.net/Services/InvoiceLineItems/InvoiceLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class InvoiceLineItemService : ServiceNested<InvoiceLineItem>,
+    public class InvoiceLineItemService : Service,
         INestedListable<InvoiceLineItem, InvoiceLineItemListOptions>,
         INestedUpdatable<InvoiceLineItem, InvoiceLineItemUpdateOptions>
     {

--- a/src/Stripe.net/Services/InvoiceRenderingTemplates/InvoiceRenderingTemplateService.cs
+++ b/src/Stripe.net/Services/InvoiceRenderingTemplates/InvoiceRenderingTemplateService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class InvoiceRenderingTemplateService : Service<InvoiceRenderingTemplate>,
+    public class InvoiceRenderingTemplateService : Service,
         IListable<InvoiceRenderingTemplate, InvoiceRenderingTemplateListOptions>,
         IRetrievable<InvoiceRenderingTemplate, InvoiceRenderingTemplateGetOptions>
     {

--- a/src/Stripe.net/Services/InvoiceUpcomingLines/InvoiceUpcomingLinesService.cs
+++ b/src/Stripe.net/Services/InvoiceUpcomingLines/InvoiceUpcomingLinesService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class InvoiceUpcomingLinesService : ServiceNested<InvoiceLineItem>
+    public class InvoiceUpcomingLinesService : Service
     {
         public InvoiceUpcomingLinesService()
         {

--- a/src/Stripe.net/Services/Invoices/InvoiceService.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class InvoiceService : Service<Invoice>,
+    public partial class InvoiceService : Service,
         ICreatable<Invoice, InvoiceCreateOptions>,
         IDeletable<Invoice, InvoiceDeleteOptions>,
         IListable<Invoice, InvoiceListOptions>,

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class AuthorizationService : Service<Authorization>,
+    public class AuthorizationService : Service,
         IListable<Authorization, AuthorizationListOptions>,
         IRetrievable<Authorization, AuthorizationGetOptions>,
         IUpdatable<Authorization, AuthorizationUpdateOptions>

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CardholderService : Service<Cardholder>,
+    public class CardholderService : Service,
         ICreatable<Cardholder, CardholderCreateOptions>,
         IListable<Cardholder, CardholderListOptions>,
         IRetrievable<Cardholder, CardholderGetOptions>,

--- a/src/Stripe.net/Services/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CardService : Service<Card>,
+    public class CardService : Service,
         ICreatable<Card, CardCreateOptions>,
         IListable<Card, CardListOptions>,
         IRetrievable<Card, CardGetOptions>,

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class DisputeService : Service<Dispute>,
+    public class DisputeService : Service,
         ICreatable<Dispute, DisputeCreateOptions>,
         IListable<Dispute, DisputeListOptions>,
         IRetrievable<Dispute, DisputeGetOptions>,

--- a/src/Stripe.net/Services/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
+++ b/src/Stripe.net/Services/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PersonalizationDesignService : Service<PersonalizationDesign>,
+    public class PersonalizationDesignService : Service,
         ICreatable<PersonalizationDesign, PersonalizationDesignCreateOptions>,
         IListable<PersonalizationDesign, PersonalizationDesignListOptions>,
         IRetrievable<PersonalizationDesign, PersonalizationDesignGetOptions>,

--- a/src/Stripe.net/Services/Issuing/PhysicalBundles/PhysicalBundleService.cs
+++ b/src/Stripe.net/Services/Issuing/PhysicalBundles/PhysicalBundleService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PhysicalBundleService : Service<PhysicalBundle>,
+    public class PhysicalBundleService : Service,
         IListable<PhysicalBundle, PhysicalBundleListOptions>,
         IRetrievable<PhysicalBundle, PhysicalBundleGetOptions>
     {

--- a/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Issuing/Tokens/TokenService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TokenService : Service<Token>,
+    public class TokenService : Service,
         IListable<Token, TokenListOptions>,
         IRetrievable<Token, TokenGetOptions>,
         IUpdatable<Token, TokenUpdateOptions>

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Issuing
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransactionService : Service<Transaction>,
+    public class TransactionService : Service,
         IListable<Transaction, TransactionListOptions>,
         IRetrievable<Transaction, TransactionGetOptions>,
         IUpdatable<Transaction, TransactionUpdateOptions>

--- a/src/Stripe.net/Services/Mandates/MandateService.cs
+++ b/src/Stripe.net/Services/Mandates/MandateService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class MandateService : Service<Mandate>,
+    public class MandateService : Service,
         IRetrievable<Mandate, MandateGetOptions>
     {
         public MandateService()

--- a/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
+++ b/src/Stripe.net/Services/OAuth/OAuthTokenService.cs
@@ -6,7 +6,7 @@ namespace Stripe
     using System.Threading.Tasks;
     using Stripe.Infrastructure.FormEncoding;
 
-    public class OAuthTokenService : Service<OAuthToken>,
+    public class OAuthTokenService : Service,
         ICreatable<OAuthToken, OAuthTokenCreateOptions>
     {
         public OAuthTokenService()

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentIntentService : Service<PaymentIntent>,
+    public class PaymentIntentService : Service,
         ICreatable<PaymentIntent, PaymentIntentCreateOptions>,
         IListable<PaymentIntent, PaymentIntentListOptions>,
         IRetrievable<PaymentIntent, PaymentIntentGetOptions>,

--- a/src/Stripe.net/Services/PaymentLinkLineItems/PaymentLinkLineItemService.cs
+++ b/src/Stripe.net/Services/PaymentLinkLineItems/PaymentLinkLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentLinkLineItemService : ServiceNested<LineItem>,
+    public class PaymentLinkLineItemService : Service,
         INestedListable<LineItem, PaymentLinkLineItemListOptions>
     {
         public PaymentLinkLineItemService()

--- a/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
+++ b/src/Stripe.net/Services/PaymentLinks/PaymentLinkService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class PaymentLinkService : Service<PaymentLink>,
+    public partial class PaymentLinkService : Service,
         ICreatable<PaymentLink, PaymentLinkCreateOptions>,
         IListable<PaymentLink, PaymentLinkListOptions>,
         IRetrievable<PaymentLink, PaymentLinkGetOptions>,

--- a/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
+++ b/src/Stripe.net/Services/PaymentMethodConfigurations/PaymentMethodConfigurationService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentMethodConfigurationService : Service<PaymentMethodConfiguration>,
+    public class PaymentMethodConfigurationService : Service,
         ICreatable<PaymentMethodConfiguration, PaymentMethodConfigurationCreateOptions>,
         IListable<PaymentMethodConfiguration, PaymentMethodConfigurationListOptions>,
         IRetrievable<PaymentMethodConfiguration, PaymentMethodConfigurationGetOptions>,

--- a/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
+++ b/src/Stripe.net/Services/PaymentMethodDomains/PaymentMethodDomainService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentMethodDomainService : Service<PaymentMethodDomain>,
+    public class PaymentMethodDomainService : Service,
         ICreatable<PaymentMethodDomain, PaymentMethodDomainCreateOptions>,
         IListable<PaymentMethodDomain, PaymentMethodDomainListOptions>,
         IRetrievable<PaymentMethodDomain, PaymentMethodDomainGetOptions>,

--- a/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
+++ b/src/Stripe.net/Services/PaymentMethods/PaymentMethodService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentMethodService : Service<PaymentMethod>,
+    public class PaymentMethodService : Service,
         ICreatable<PaymentMethod, PaymentMethodCreateOptions>,
         IListable<PaymentMethod, PaymentMethodListOptions>,
         IRetrievable<PaymentMethod, PaymentMethodGetOptions>,

--- a/src/Stripe.net/Services/Payouts/PayoutService.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PayoutService : Service<Payout>,
+    public class PayoutService : Service,
         ICreatable<Payout, PayoutCreateOptions>,
         IListable<Payout, PayoutListOptions>,
         IRetrievable<Payout, PayoutGetOptions>,

--- a/src/Stripe.net/Services/Plans/PlanService.cs
+++ b/src/Stripe.net/Services/Plans/PlanService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PlanService : Service<Plan>,
+    public class PlanService : Service,
         ICreatable<Plan, PlanCreateOptions>,
         IDeletable<Plan, PlanDeleteOptions>,
         IListable<Plan, PlanListOptions>,

--- a/src/Stripe.net/Services/Prices/PriceService.cs
+++ b/src/Stripe.net/Services/Prices/PriceService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PriceService : Service<Price>,
+    public class PriceService : Service,
         ICreatable<Price, PriceCreateOptions>,
         IListable<Price, PriceListOptions>,
         IRetrievable<Price, PriceGetOptions>,

--- a/src/Stripe.net/Services/ProductFeatures/ProductFeatureService.cs
+++ b/src/Stripe.net/Services/ProductFeatures/ProductFeatureService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ProductFeatureService : ServiceNested<ProductFeature>,
+    public class ProductFeatureService : Service,
         INestedCreatable<ProductFeature, ProductFeatureCreateOptions>,
         INestedDeletable<ProductFeature, ProductFeatureDeleteOptions>,
         INestedListable<ProductFeature, ProductFeatureListOptions>,

--- a/src/Stripe.net/Services/Products/ProductService.cs
+++ b/src/Stripe.net/Services/Products/ProductService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ProductService : Service<Product>,
+    public class ProductService : Service,
         ICreatable<Product, ProductCreateOptions>,
         IDeletable<Product, ProductDeleteOptions>,
         IListable<Product, ProductListOptions>,

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PromotionCodeService : Service<PromotionCode>,
+    public class PromotionCodeService : Service,
         ICreatable<PromotionCode, PromotionCodeCreateOptions>,
         IListable<PromotionCode, PromotionCodeListOptions>,
         IRetrievable<PromotionCode, PromotionCodeGetOptions>,

--- a/src/Stripe.net/Services/QuoteComputedUpfrontLineItems/QuoteComputedUpfrontLineItemsService.cs
+++ b/src/Stripe.net/Services/QuoteComputedUpfrontLineItems/QuoteComputedUpfrontLineItemsService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class QuoteComputedUpfrontLineItemsService : ServiceNested<LineItem>,
+    public class QuoteComputedUpfrontLineItemsService : Service,
         INestedListable<LineItem, QuoteComputedUpfrontLineItemsListOptions>
     {
         public QuoteComputedUpfrontLineItemsService()

--- a/src/Stripe.net/Services/QuoteLineItems/QuoteLineItemService.cs
+++ b/src/Stripe.net/Services/QuoteLineItems/QuoteLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class QuoteLineItemService : ServiceNested<LineItem>,
+    public class QuoteLineItemService : Service,
         INestedListable<LineItem, QuoteLineItemListOptions>
     {
         public QuoteLineItemService()

--- a/src/Stripe.net/Services/Quotes/QuoteService.cs
+++ b/src/Stripe.net/Services/Quotes/QuoteService.cs
@@ -9,7 +9,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class QuoteService : Service<Quote>,
+    public partial class QuoteService : Service,
         ICreatable<Quote, QuoteCreateOptions>,
         IListable<Quote, QuoteListOptions>,
         IRetrievable<Quote, QuoteGetOptions>,

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Radar
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class EarlyFraudWarningService : Service<EarlyFraudWarning>,
+    public class EarlyFraudWarningService : Service,
         IListable<EarlyFraudWarning, EarlyFraudWarningListOptions>,
         IRetrievable<EarlyFraudWarning, EarlyFraudWarningGetOptions>
     {

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Radar
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ValueListItemService : Service<ValueListItem>,
+    public class ValueListItemService : Service,
         ICreatable<ValueListItem, ValueListItemCreateOptions>,
         IDeletable<ValueListItem, ValueListItemDeleteOptions>,
         IListable<ValueListItem, ValueListItemListOptions>,

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Radar
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ValueListService : Service<ValueList>,
+    public class ValueListService : Service,
         ICreatable<ValueList, ValueListCreateOptions>,
         IDeletable<ValueList, ValueListDeleteOptions>,
         IListable<ValueList, ValueListListOptions>,

--- a/src/Stripe.net/Services/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/Refunds/RefundService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class RefundService : Service<Refund>,
+    public class RefundService : Service,
         ICreatable<Refund, RefundCreateOptions>,
         IListable<Refund, RefundListOptions>,
         IRetrievable<Refund, RefundGetOptions>,

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Reporting
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReportRunService : Service<ReportRun>,
+    public class ReportRunService : Service,
         ICreatable<ReportRun, ReportRunCreateOptions>,
         IListable<ReportRun, ReportRunListOptions>,
         IRetrievable<ReportRun, ReportRunGetOptions>

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Reporting
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReportTypeService : Service<ReportType>,
+    public class ReportTypeService : Service,
         IListable<ReportType, ReportTypeListOptions>,
         IRetrievable<ReportType, ReportTypeGetOptions>
     {

--- a/src/Stripe.net/Services/Reviews/ReviewService.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReviewService : Service<Review>,
+    public class ReviewService : Service,
         IListable<Review, ReviewListOptions>,
         IRetrievable<Review, ReviewGetOptions>
     {

--- a/src/Stripe.net/Services/SetupAttempts/SetupAttemptService.cs
+++ b/src/Stripe.net/Services/SetupAttempts/SetupAttemptService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SetupAttemptService : Service<SetupAttempt>,
+    public class SetupAttemptService : Service,
         IListable<SetupAttempt, SetupAttemptListOptions>
     {
         public SetupAttemptService()

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SetupIntentService : Service<SetupIntent>,
+    public class SetupIntentService : Service,
         ICreatable<SetupIntent, SetupIntentCreateOptions>,
         IListable<SetupIntent, SetupIntentListOptions>,
         IRetrievable<SetupIntent, SetupIntentGetOptions>,

--- a/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
+++ b/src/Stripe.net/Services/ShippingRates/ShippingRateService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ShippingRateService : Service<ShippingRate>,
+    public class ShippingRateService : Service,
         ICreatable<ShippingRate, ShippingRateCreateOptions>,
         IListable<ShippingRate, ShippingRateListOptions>,
         IRetrievable<ShippingRate, ShippingRateGetOptions>,

--- a/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
+++ b/src/Stripe.net/Services/Sigma/ScheduledQueryRuns/ScheduledQueryRunService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Sigma
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ScheduledQueryRunService : Service<ScheduledQueryRun>,
+    public class ScheduledQueryRunService : Service,
         IListable<ScheduledQueryRun, ScheduledQueryRunListOptions>,
         IRetrievable<ScheduledQueryRun, ScheduledQueryRunGetOptions>
     {

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class SourceTransactionService : ServiceNested<SourceTransaction>,
+    public partial class SourceTransactionService : Service,
         INestedListable<SourceTransaction, SourceTransactionListOptions>
     {
         public SourceTransactionService()

--- a/src/Stripe.net/Services/Sources/SourceService.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class SourceService : Service<Source>,
+    public partial class SourceService : Service,
         ICreatable<Source, SourceCreateOptions>,
         IRetrievable<Source, SourceGetOptions>,
         IUpdatable<Source, SourceUpdateOptions>,

--- a/src/Stripe.net/Services/Sources/SourceService.partial.cs
+++ b/src/Stripe.net/Services/Sources/SourceService.partial.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class SourceService : Service<Source>,
+    public partial class SourceService : Service,
         ICreatable<Source, SourceCreateOptions>,
         IRetrievable<Source, SourceGetOptions>,
         IUpdatable<Source, SourceUpdateOptions>,

--- a/src/Stripe.net/Services/SubscriptionItemUsageRecordSummaries/SubscriptionItemUsageRecordSummaryService.cs
+++ b/src/Stripe.net/Services/SubscriptionItemUsageRecordSummaries/SubscriptionItemUsageRecordSummaryService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SubscriptionItemUsageRecordSummaryService : ServiceNested<UsageRecordSummary>,
+    public class SubscriptionItemUsageRecordSummaryService : Service,
         INestedListable<UsageRecordSummary, SubscriptionItemUsageRecordSummaryListOptions>
     {
         public SubscriptionItemUsageRecordSummaryService()

--- a/src/Stripe.net/Services/SubscriptionItemUsageRecords/SubscriptionItemUsageRecordService.cs
+++ b/src/Stripe.net/Services/SubscriptionItemUsageRecords/SubscriptionItemUsageRecordService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SubscriptionItemUsageRecordService : ServiceNested<UsageRecord>,
+    public class SubscriptionItemUsageRecordService : Service,
         INestedCreatable<UsageRecord, SubscriptionItemUsageRecordCreateOptions>
     {
         public SubscriptionItemUsageRecordService()

--- a/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
+++ b/src/Stripe.net/Services/SubscriptionItems/SubscriptionItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SubscriptionItemService : Service<SubscriptionItem>,
+    public class SubscriptionItemService : Service,
         ICreatable<SubscriptionItem, SubscriptionItemCreateOptions>,
         IDeletable<SubscriptionItem, SubscriptionItemDeleteOptions>,
         IListable<SubscriptionItem, SubscriptionItemListOptions>,

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SubscriptionScheduleService : Service<SubscriptionSchedule>,
+    public class SubscriptionScheduleService : Service,
         ICreatable<SubscriptionSchedule, SubscriptionScheduleCreateOptions>,
         IListable<SubscriptionSchedule, SubscriptionScheduleListOptions>,
         IRetrievable<SubscriptionSchedule, SubscriptionScheduleGetOptions>,

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SubscriptionService : Service<Subscription>,
+    public class SubscriptionService : Service,
         ICreatable<Subscription, SubscriptionCreateOptions>,
         IListable<Subscription, SubscriptionListOptions>,
         IRetrievable<Subscription, SubscriptionGetOptions>,

--- a/src/Stripe.net/Services/Tax/CalculationLineItems/CalculationLineItemService.cs
+++ b/src/Stripe.net/Services/Tax/CalculationLineItems/CalculationLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CalculationLineItemService : ServiceNested<CalculationLineItem>,
+    public class CalculationLineItemService : Service,
         INestedListable<CalculationLineItem, CalculationLineItemListOptions>
     {
         public CalculationLineItemService()

--- a/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
+++ b/src/Stripe.net/Services/Tax/Calculations/CalculationService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class CalculationService : Service<Calculation>,
+    public partial class CalculationService : Service,
         ICreatable<Calculation, CalculationCreateOptions>,
         IRetrievable<Calculation, CalculationGetOptions>
     {

--- a/src/Stripe.net/Services/Tax/Registrations/RegistrationService.cs
+++ b/src/Stripe.net/Services/Tax/Registrations/RegistrationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class RegistrationService : Service<Registration>,
+    public class RegistrationService : Service,
         ICreatable<Registration, RegistrationCreateOptions>,
         IListable<Registration, RegistrationListOptions>,
         IRetrievable<Registration, RegistrationGetOptions>,

--- a/src/Stripe.net/Services/Tax/Settings/SettingsService.cs
+++ b/src/Stripe.net/Services/Tax/Settings/SettingsService.cs
@@ -6,8 +6,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SettingsService : Service<Settings>,
-        ISingletonRetrievable<Settings>
+    public class SettingsService : Service, ISingletonRetrievable<Settings>
     {
         public SettingsService()
         {

--- a/src/Stripe.net/Services/Tax/TransactionLineItems/TransactionLineItemService.cs
+++ b/src/Stripe.net/Services/Tax/TransactionLineItems/TransactionLineItemService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransactionLineItemService : ServiceNested<TransactionLineItem>,
+    public class TransactionLineItemService : Service,
         INestedListable<TransactionLineItem, TransactionLineItemListOptions>
     {
         public TransactionLineItemService()

--- a/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Tax/Transactions/TransactionService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Tax
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class TransactionService : Service<Transaction>,
+    public partial class TransactionService : Service,
         IRetrievable<Transaction, TransactionGetOptions>
     {
         private TransactionLineItemService lineItems;

--- a/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
+++ b/src/Stripe.net/Services/TaxCodes/TaxCodeService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TaxCodeService : Service<TaxCode>,
+    public class TaxCodeService : Service,
         IListable<TaxCode, TaxCodeListOptions>,
         IRetrievable<TaxCode, TaxCodeGetOptions>
     {

--- a/src/Stripe.net/Services/TaxIds/TaxIdService.cs
+++ b/src/Stripe.net/Services/TaxIds/TaxIdService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class TaxIdService : Service<TaxId>,
+    public partial class TaxIdService : Service,
         ICreatable<TaxId, TaxIdCreateOptions>,
         IDeletable<TaxId, TaxIdDeleteOptions>,
         IListable<TaxId, TaxIdListOptions>,

--- a/src/Stripe.net/Services/TaxRates/TaxRateService.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TaxRateService : Service<TaxRate>,
+    public class TaxRateService : Service,
         ICreatable<TaxRate, TaxRateCreateOptions>,
         IListable<TaxRate, TaxRateListOptions>,
         IRetrievable<TaxRate, TaxRateGetOptions>,

--- a/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
+++ b/src/Stripe.net/Services/Terminal/Configurations/ConfigurationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Terminal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ConfigurationService : Service<Configuration>,
+    public class ConfigurationService : Service,
         ICreatable<Configuration, ConfigurationCreateOptions>,
         IDeletable<Configuration, ConfigurationDeleteOptions>,
         IListable<Configuration, ConfigurationListOptions>,

--- a/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
+++ b/src/Stripe.net/Services/Terminal/ConnectionTokens/ConnectionTokenService.cs
@@ -6,7 +6,7 @@ namespace Stripe.Terminal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ConnectionTokenService : Service<ConnectionToken>,
+    public class ConnectionTokenService : Service,
         ICreatable<ConnectionToken, ConnectionTokenCreateOptions>
     {
         public ConnectionTokenService()

--- a/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
+++ b/src/Stripe.net/Services/Terminal/Locations/LocationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Terminal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class LocationService : Service<Location>,
+    public class LocationService : Service,
         ICreatable<Location, LocationCreateOptions>,
         IDeletable<Location, LocationDeleteOptions>,
         IListable<Location, LocationListOptions>,

--- a/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/Terminal/Readers/ReaderService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Terminal
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReaderService : Service<Reader>,
+    public class ReaderService : Service,
         ICreatable<Reader, ReaderCreateOptions>,
         IDeletable<Reader, ReaderDeleteOptions>,
         IListable<Reader, ReaderListOptions>,

--- a/src/Stripe.net/Services/TestHelpers/ConfirmationTokens/ConfirmationTokenService.cs
+++ b/src/Stripe.net/Services/TestHelpers/ConfirmationTokens/ConfirmationTokenService.cs
@@ -6,7 +6,7 @@ namespace Stripe.TestHelpers
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ConfirmationTokenService : Service<ConfirmationToken>
+    public class ConfirmationTokenService : Service
     {
         public ConfirmationTokenService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Customers/CustomerService.cs
@@ -7,7 +7,7 @@ namespace Stripe.TestHelpers
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomerService : Service<Customer>
+    public class CustomerService : Service
     {
         public CustomerService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Authorizations/AuthorizationService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Issuing
     using System.Threading.Tasks;
     using Stripe.Issuing;
 
-    public class AuthorizationService : Service<Stripe.Issuing.Authorization>
+    public class AuthorizationService : Service
     {
         public AuthorizationService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Issuing
     using System.Threading.Tasks;
     using Stripe.Issuing;
 
-    public class CardService : Service<Stripe.Issuing.Card>
+    public class CardService : Service
     {
         public CardService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/PersonalizationDesigns/PersonalizationDesignService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Issuing
     using System.Threading.Tasks;
     using Stripe.Issuing;
 
-    public class PersonalizationDesignService : Service<Stripe.Issuing.PersonalizationDesign>
+    public class PersonalizationDesignService : Service
     {
         public PersonalizationDesignService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Issuing/Transactions/TransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Issuing
     using System.Threading.Tasks;
     using Stripe.Issuing;
 
-    public class TransactionService : Service<Stripe.Issuing.Transaction>
+    public class TransactionService : Service
     {
         public TransactionService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Refunds/RefundService.cs
@@ -7,7 +7,7 @@ namespace Stripe.TestHelpers
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class RefundService : Service<Refund>
+    public class RefundService : Service
     {
         public RefundService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Terminal/Readers/ReaderService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Terminal
     using System.Threading.Tasks;
     using Stripe.Terminal;
 
-    public class ReaderService : Service<Stripe.Terminal.Reader>
+    public class ReaderService : Service
     {
         public ReaderService()
         {

--- a/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
+++ b/src/Stripe.net/Services/TestHelpers/TestClocks/TestClockService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TestClockService : Service<TestClock>,
+    public class TestClockService : Service,
         ICreatable<TestClock, TestClockCreateOptions>,
         IDeletable<TestClock, TestClockDeleteOptions>,
         IListable<TestClock, TestClockListOptions>,

--- a/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/InboundTransfers/InboundTransferService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Treasury
     using System.Threading.Tasks;
     using Stripe.Treasury;
 
-    public class InboundTransferService : Service<Stripe.Treasury.InboundTransfer>
+    public class InboundTransferService : Service
     {
         public InboundTransferService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Treasury
     using System.Threading.Tasks;
     using Stripe.Treasury;
 
-    public class OutboundPaymentService : Service<Stripe.Treasury.OutboundPayment>
+    public class OutboundPaymentService : Service
     {
         public OutboundPaymentService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -8,7 +8,7 @@ namespace Stripe.TestHelpers.Treasury
     using System.Threading.Tasks;
     using Stripe.Treasury;
 
-    public class OutboundTransferService : Service<Stripe.Treasury.OutboundTransfer>
+    public class OutboundTransferService : Service
     {
         public OutboundTransferService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -7,7 +7,7 @@ namespace Stripe.TestHelpers.Treasury
     using System.Threading.Tasks;
     using Stripe.Treasury;
 
-    public class ReceivedCreditService : Service<Stripe.Treasury.ReceivedCredit>
+    public class ReceivedCreditService : Service
     {
         public ReceivedCreditService()
         {

--- a/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/TestHelpers/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -7,7 +7,7 @@ namespace Stripe.TestHelpers.Treasury
     using System.Threading.Tasks;
     using Stripe.Treasury;
 
-    public class ReceivedDebitService : Service<Stripe.Treasury.ReceivedDebit>
+    public class ReceivedDebitService : Service
     {
         public ReceivedDebitService()
         {

--- a/src/Stripe.net/Services/Tokens/TokenService.cs
+++ b/src/Stripe.net/Services/Tokens/TokenService.cs
@@ -7,7 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TokenService : Service<Token>,
+    public class TokenService : Service,
         ICreatable<Token, TokenCreateOptions>,
         IRetrievable<Token, TokenGetOptions>
     {

--- a/src/Stripe.net/Services/Topups/TopupService.cs
+++ b/src/Stripe.net/Services/Topups/TopupService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TopupService : Service<Topup>,
+    public class TopupService : Service,
         ICreatable<Topup, TopupCreateOptions>,
         IListable<Topup, TopupListOptions>,
         IRetrievable<Topup, TopupGetOptions>,

--- a/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
+++ b/src/Stripe.net/Services/TransferReversals/TransferReversalService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransferReversalService : ServiceNested<TransferReversal>,
+    public class TransferReversalService : Service,
         INestedCreatable<TransferReversal, TransferReversalCreateOptions>,
         INestedListable<TransferReversal, TransferReversalListOptions>,
         INestedRetrievable<TransferReversal, TransferReversalGetOptions>,

--- a/src/Stripe.net/Services/Transfers/TransferService.cs
+++ b/src/Stripe.net/Services/Transfers/TransferService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransferService : Service<Transfer>,
+    public class TransferService : Service,
         ICreatable<Transfer, TransferCreateOptions>,
         IListable<Transfer, TransferListOptions>,
         IRetrievable<Transfer, TransferGetOptions>,

--- a/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/CreditReversals/CreditReversalService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CreditReversalService : Service<CreditReversal>,
+    public class CreditReversalService : Service,
         ICreatable<CreditReversal, CreditReversalCreateOptions>,
         IListable<CreditReversal, CreditReversalListOptions>,
         IRetrievable<CreditReversal, CreditReversalGetOptions>

--- a/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
+++ b/src/Stripe.net/Services/Treasury/DebitReversals/DebitReversalService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class DebitReversalService : Service<DebitReversal>,
+    public class DebitReversalService : Service,
         ICreatable<DebitReversal, DebitReversalCreateOptions>,
         IListable<DebitReversal, DebitReversalListOptions>,
         IRetrievable<DebitReversal, DebitReversalGetOptions>

--- a/src/Stripe.net/Services/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesService.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccountFeatures/FinancialAccountFeaturesService.cs
@@ -7,7 +7,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class FinancialAccountFeaturesService : ServiceNested<FinancialAccountFeatures>
+    public class FinancialAccountFeaturesService : Service
     {
         public FinancialAccountFeaturesService()
         {

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public partial class FinancialAccountService : Service<FinancialAccount>,
+    public partial class FinancialAccountService : Service,
         ICreatable<FinancialAccount, FinancialAccountCreateOptions>,
         IListable<FinancialAccount, FinancialAccountListOptions>,
         IRetrievable<FinancialAccount, FinancialAccountGetOptions>,

--- a/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/InboundTransfers/InboundTransferService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class InboundTransferService : Service<InboundTransfer>,
+    public class InboundTransferService : Service,
         ICreatable<InboundTransfer, InboundTransferCreateOptions>,
         IListable<InboundTransfer, InboundTransferListOptions>,
         IRetrievable<InboundTransfer, InboundTransferGetOptions>

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class OutboundPaymentService : Service<OutboundPayment>,
+    public class OutboundPaymentService : Service,
         ICreatable<OutboundPayment, OutboundPaymentCreateOptions>,
         IListable<OutboundPayment, OutboundPaymentListOptions>,
         IRetrievable<OutboundPayment, OutboundPaymentGetOptions>

--- a/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundTransfers/OutboundTransferService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class OutboundTransferService : Service<OutboundTransfer>,
+    public class OutboundTransferService : Service,
         ICreatable<OutboundTransfer, OutboundTransferCreateOptions>,
         IListable<OutboundTransfer, OutboundTransferListOptions>,
         IRetrievable<OutboundTransfer, OutboundTransferGetOptions>

--- a/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedCredits/ReceivedCreditService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReceivedCreditService : Service<ReceivedCredit>,
+    public class ReceivedCreditService : Service,
         IListable<ReceivedCredit, ReceivedCreditListOptions>,
         IRetrievable<ReceivedCredit, ReceivedCreditGetOptions>
     {

--- a/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
+++ b/src/Stripe.net/Services/Treasury/ReceivedDebits/ReceivedDebitService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class ReceivedDebitService : Service<ReceivedDebit>,
+    public class ReceivedDebitService : Service,
         IListable<ReceivedDebit, ReceivedDebitListOptions>,
         IRetrievable<ReceivedDebit, ReceivedDebitGetOptions>
     {

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransactionEntryService : Service<TransactionEntry>,
+    public class TransactionEntryService : Service,
         IListable<TransactionEntry, TransactionEntryListOptions>,
         IRetrievable<TransactionEntry, TransactionEntryGetOptions>
     {

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionService.cs
@@ -8,7 +8,7 @@ namespace Stripe.Treasury
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class TransactionService : Service<Transaction>,
+    public class TransactionService : Service,
         IListable<Transaction, TransactionListOptions>,
         IRetrievable<Transaction, TransactionGetOptions>
     {

--- a/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
+++ b/src/Stripe.net/Services/WebhookEndpoints/WebhookEndpointService.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class WebhookEndpointService : Service<WebhookEndpoint>,
+    public class WebhookEndpointService : Service,
         ICreatable<WebhookEndpoint, WebhookEndpointCreateOptions>,
         IDeletable<WebhookEndpoint, WebhookEndpointDeleteOptions>,
         IListable<WebhookEndpoint, WebhookEndpointListOptions>,

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -2,7 +2,7 @@ namespace Stripe
 {
     using System;
 
-    [Obsolete("This class is deprecated and will be removed in a future release.  Derive service classes directly from Stripe.Service.")]
+    [Obsolete("This class is deprecated and will be removed in a future release.  Use StripeClient#RequestAsync or StripeClient#RawRequest instead.")]
     public abstract class ServiceNested<TEntityReturned> : Service<TEntityReturned>
         where TEntityReturned : IStripeEntity
     {

--- a/src/Stripe.net/Services/_base/ServiceNested.cs
+++ b/src/Stripe.net/Services/_base/ServiceNested.cs
@@ -1,5 +1,8 @@
 namespace Stripe
 {
+    using System;
+
+    [Obsolete("This class is deprecated and will be removed in a future release.  Derive service classes directly from Stripe.Service.")]
     public abstract class ServiceNested<TEntityReturned> : Service<TEntityReturned>
         where TEntityReturned : IStripeEntity
     {

--- a/src/Stripe.net/Services/_base/Service{TEntityReturned}.cs
+++ b/src/Stripe.net/Services/_base/Service{TEntityReturned}.cs
@@ -1,9 +1,12 @@
 namespace Stripe
 {
+    using System;
+
     /// <summary>Abstract base class for all services.</summary>
     /// <typeparam name="TEntityReturned">
     /// The type of <see cref="IStripeEntity"/> that this service returns.
     /// </typeparam>
+    [Obsolete("This class is deprecated and will be removed in a future release.  Use StripeClient#RequestAsync or StripeClient#RawRequest instead.")]
     public abstract class Service<TEntityReturned> : Service
         where TEntityReturned : IStripeEntity
     {


### PR DESCRIPTION
### Why?
The ServiceNested used to contain methods that mirrored functionality from the Service base class but for nested services. These methods have been removed and ServiceNested is now effectively empty. This PR marks it for future deletion.

When working on this issue, I discovered Service<T> is no longer needed as well, as all Service type parameters in use are defined at the method level.

### What?
- added Obsolete tag and message to ServiceNested class and Service<T> class

## Changelog
- Deprecates `ServiceNested` and `Service<T>` classes.  To implement custom services, use the request methods defined on `StripeClient`