### PR TITLE
Remove RawRequestOptions#ApiMode 

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -298,7 +298,7 @@ namespace Stripe
             }
 
             requestOptions = requestOptions.WithUsage(RawRequestUsage);
-            var apiMode = requestOptions?.ApiMode ?? ApiMode.V1;
+            var apiMode = ApiModeUtils.GetApiMode(path);
             var uri = StripeRequest.BuildUri(
                 requestOptions?.BaseUrl ?? this.GetBaseUrl(BaseAddress.Api),
                 method,

--- a/src/Stripe.net/Services/_common/RawRequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RawRequestOptions.cs
@@ -1,10 +1,12 @@
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
 
     public class RawRequestOptions : RequestOptions
     {
         /// <summary>Gets or sets the API mode to use for the request.</summary>
+        [Obsolete("This property is no longer used and will be removed in a future release")]
         public ApiMode ApiMode { get; set; }
 
         /// <summary>Gets or sets additional headers for the request.</summary>

--- a/src/Stripe.net/Services/_common/RawRequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RawRequestOptions.cs
@@ -5,10 +5,6 @@ namespace Stripe
 
     public class RawRequestOptions : RequestOptions
     {
-        /// <summary>Gets or sets the API mode to use for the request.</summary>
-        [Obsolete("This property is no longer used and will be removed in a future release")]
-        public ApiMode ApiMode { get; set; }
-
         /// <summary>Gets or sets additional headers for the request.</summary>
         public Dictionary<string, string> AdditionalHeaders { get; set; } = new Dictionary<string, string>();
 

--- a/src/Stripe.net/Services/_common/RawRequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RawRequestOptions.cs
@@ -1,6 +1,5 @@
 namespace Stripe
 {
-    using System;
     using System.Collections.Generic;
 
     public class RawRequestOptions : RequestOptions

--- a/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
+++ b/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
@@ -476,7 +476,7 @@ namespace StripeTests
 
             var rawResponse = await this.apiRequestor.RawRequestAsync(
                 HttpMethod.Post,
-                "/v1/charges",
+                "/v2/charges",
                 "{\"foo\":\"bar\"}",
                 new RawRequestOptions
                 {
@@ -484,7 +484,6 @@ namespace StripeTests
                     {
                         { "foo", "bar" },
                     },
-                    ApiMode = ApiMode.V2,
                 });
 
             var lastRequest = this.httpClient.LastRequest;

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -157,7 +157,6 @@ namespace StripeTests
                     {
                         { "foo", "bar" },
                     },
-                    ApiMode = ApiMode.V1,
                 });
 
             this.MockHttpClientFixture.MockHandler.Protected()


### PR DESCRIPTION
### Why?
When we shipped RawRequest functionality in the 9/30 release, most LiveApiRequestor calls were implemented to determine the API mode from the path.  The exception to this was RawRequestAsync, which accepted ApiMode as an option.  This is not a configurable option (it is either V1 or V2 depending on the API) and inspecting the path is a reliable way to determine ApiMode; specifying the wrong ApiMode means that responses may be interpreted incorrectly.  Because of this, we are removing this option to avoid confusion and the potential for subtle errors.

### What?
- removed  RawRequestOptions@ApiMode argument
- changed LiveApiRequestor#RawRequestAsync to use GetApiMode to determine apiMode
- updated tests

## Changelog
* Removes `ApiMode` from `RawRequestOptions`.  ApiMode is automatically determined from the path passed to RawRequest.