### PR TITLE
Enhance beta version handling in ApiVersion

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -254,28 +254,28 @@ namespace Stripe
         {
             if (!System.Text.RegularExpressions.Regex.IsMatch(betaVersion, @"^v\d+$"))
             {
-            throw new Exception($"Invalid beta version format: {betaVersion}. Expected format is 'v' followed by a number (e.g., 'v3').");
+                throw new Exception($"Invalid beta version format: {betaVersion}. Expected format is 'v' followed by a number (e.g., 'v3').");
             }
 
             var existingBeta = $"; {betaName}=";
             if (ApiVersion.Contains(existingBeta))
             {
-            var startIndex = ApiVersion.IndexOf(existingBeta) + existingBeta.Length;
-            var endIndex = ApiVersion.IndexOf(';', startIndex);
-            endIndex = endIndex == -1 ? ApiVersion.Length : endIndex;
+                var startIndex = ApiVersion.IndexOf(existingBeta) + existingBeta.Length;
+                var endIndex = ApiVersion.IndexOf(';', startIndex);
+                endIndex = endIndex == -1 ? ApiVersion.Length : endIndex;
 
-            var currentVersion = ApiVersion.Substring(startIndex, endIndex - startIndex);
-            var currentVersionNumber = int.Parse(currentVersion.Substring(1));
-            var newVersionNumber = int.Parse(betaVersion.Substring(1));
+                var currentVersion = ApiVersion.Substring(startIndex, endIndex - startIndex);
+                var currentVersionNumber = int.Parse(currentVersion.Substring(1));
+                var newVersionNumber = int.Parse(betaVersion.Substring(1));
 
-            if (newVersionNumber > currentVersionNumber)
-            {
-                ApiVersion = ApiVersion.Replace($"{existingBeta}{currentVersion}", $"{existingBeta}{betaVersion}");
-            }
+                if (newVersionNumber > currentVersionNumber)
+                {
+                    ApiVersion = ApiVersion.Replace($"{existingBeta}{currentVersion}", $"{existingBeta}{betaVersion}");
+                }
             }
             else
             {
-            ApiVersion = $"{ApiVersion}; {betaName}={betaVersion}";
+                ApiVersion = $"{ApiVersion}; {betaName}={betaVersion}";
             }
         }
 

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -95,14 +95,23 @@ namespace StripeTests
         }
 
         [Fact]
-        public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedOnceOnly()
+        public void StripeClient_Getter_ShouldAllowBetaVersionsToBeAddedMultipleTimes()
         {
             StripeConfiguration.ClearBetaVersion();
             StripeConfiguration.AddBetaVersion("feature_beta", "v3");
             Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
 
-            var exception = Record.Exception(() => StripeConfiguration.AddBetaVersion("feature_beta", "v2"));
-            Assert.NotNull(exception);
+            // Same version is a no-op
+            StripeConfiguration.AddBetaVersion("feature_beta", "v3");
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v3", StripeConfiguration.ApiVersion);
+
+            // Higher version is used
+            StripeConfiguration.AddBetaVersion("feature_beta", "v5");
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v5", StripeConfiguration.ApiVersion);
+
+            // Lower version is a no-op
+            StripeConfiguration.AddBetaVersion("feature_beta", "v2");
+            Assert.Equal(ApiVersion.Current + "; feature_beta=v5", StripeConfiguration.ApiVersion);
         }
 
         [Fact]


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We decided to allow AddBetaVersion to overwrite an existing beta version

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Validates that betaVersion is of the form "v" + a number
- Allows overwriting existing `betaName`. The new behavior is that the higher `betaVersion` is accepted instead of throwing.

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
- `StripeConfiguation.AddBetaVersion` will use the highest version number used for a beta feature instead of throwing an `Exception` on a conflict as it had done previously.
