### PR TITLE
Fix STJ for Emptyable fields

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/STJEmptyableConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJEmptyableConverter.cs
@@ -1,0 +1,77 @@
+#if NET6_0_OR_GREATER
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Reflection;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Converts a <see cref="Emptyable{T}"/> to and from JSON.
+    /// </summary>
+    /// <typeparam name="T">Type of the field when expanded.</typeparam>
+    internal class STJEmptyableConverter<T> : JsonConverter<T>
+    {
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="options">The calling serializer's options.</param>
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            switch (value)
+            {
+                case null:
+                    break;
+
+                case Emptyable<T> emptyable:
+                    if (emptyable.Empty)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        JsonSerializer.Serialize(writer, emptyable.Value, options);
+                    }
+
+                    break;
+
+                default:
+                    throw new JsonException(string.Format(
+                        "Unexpected value when converting Emptyable. Expected Emptyable, got {0}.",
+                        value.GetType()));
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        ///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            if (!objectType.IsGenericType)
+            {
+                return false;
+            }
+
+            return typeof(Emptyable<>).GetTypeInfo().IsAssignableFrom(objectType.GetGenericTypeDefinition());
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
+        /// <param name="typeToConvert">Type of the object.</param>
+        /// <param name="options">The calling serializer's options.</param>
+        /// <returns>The object value.</returns>
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("Cannot deserialize Emptyable objects.");
+        }
+    }
+}
+#endif

--- a/src/Stripe.net/Infrastructure/JsonConverters/STJEmptyableConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJEmptyableConverter.cs
@@ -10,7 +10,7 @@ namespace Stripe.Infrastructure
     /// Converts a <see cref="Emptyable{T}"/> to and from JSON.
     /// </summary>
     /// <typeparam name="T">Type of the field when expanded.</typeparam>
-    internal class STJEmptyableConverter<T> : JsonConverter<T>
+    internal class STJEmptyableConverter<T> : JsonConverter<Emptyable<T>>
     {
         /// <summary>
         /// Writes the JSON representation of the object.
@@ -18,7 +18,7 @@ namespace Stripe.Infrastructure
         /// <param name="writer">The <see cref="Utf8JsonWriter"/> to write to.</param>
         /// <param name="value">The value.</param>
         /// <param name="options">The calling serializer's options.</param>
-        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, Emptyable<T> value, JsonSerializerOptions options)
         {
             switch (value)
             {
@@ -58,7 +58,7 @@ namespace Stripe.Infrastructure
                 return false;
             }
 
-            return typeof(Emptyable<>).GetTypeInfo().IsAssignableFrom(objectType.GetGenericTypeDefinition());
+            return typeof(IEmptyable).GetTypeInfo().IsAssignableFrom(objectType.GetGenericTypeDefinition());
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Stripe.Infrastructure
         /// <param name="typeToConvert">Type of the object.</param>
         /// <param name="options">The calling serializer's options.</param>
         /// <returns>The object value.</returns>
-        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override Emptyable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotSupportedException("Cannot deserialize Emptyable objects.");
         }

--- a/src/Stripe.net/Services/_common/Emptyable.cs
+++ b/src/Stripe.net/Services/_common/Emptyable.cs
@@ -1,8 +1,8 @@
 namespace Stripe
 {
-    /// <summary>Represents a generic expandable field.</summary>
-    /// <typeparam name="T">Type of the field when expanded.</typeparam>
-    internal class Emptyable<T>
+    /// <summary>Represents a field that might be emptyble.</summary>
+    /// <typeparam name="T">Type of the field when not empty.</typeparam>
+    internal class Emptyable<T> : IEmptyable<T>
     {
         private bool empty;
         private T value;
@@ -29,5 +29,9 @@ namespace Stripe
                 }
             }
         }
+
+        /// <summary>Gets or sets the expanded object.</summary>
+        /// <value>The expanded object.</value>
+        object IEmptyable.Value => this.Value;
     }
 }

--- a/src/Stripe.net/Services/_interfaces/IEmptyable.cs
+++ b/src/Stripe.net/Services/_interfaces/IEmptyable.cs
@@ -1,0 +1,25 @@
+namespace Stripe
+{
+    /// <summary>
+    /// Represents a value that may be of one of several different types.
+    /// </summary>
+    public interface IEmptyable
+    {
+        /// <summary>Gets whether or not the field is empty.</summary>
+        /// <returns>True if the value is empty; false if the value is set.</returns>
+        public bool Empty { get; }
+
+        /// <summary>Gets the value of the current <see cref="IEmptyable"/> object.</summary>
+        /// <returns>The value of the current <see cref="IEmptyable"/> object.</returns>
+        object Value { get; }
+    }
+
+    /// <summary>Represents a generic expandable field.</summary>
+    /// <typeparam name="T">Type of the field when expanded.</typeparam>
+    public interface IEmptyable<T> : IEmptyable
+    {
+        /// <summary>Gets the value of the current <see cref="IEmptyable"/> object.</summary>
+        /// <returns>The value of the current <see cref="IEmptyable"/> object.</returns>
+        new T Value { get; set; }
+    }
+}

--- a/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
+++ b/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
@@ -81,11 +81,6 @@ namespace StripeTests.Wholesome
                     continue;
                 }
 
-                if (stripeClass.Name.StartsWith("V1Billing"))
-                {
-                    Debugger.Break();
-                }
-
                 if (stripeClass.IsGenericType)
                 {
                     // Handle generic types (container types) separately, because

--- a/src/StripeTests/Wholesome/SystemTextJsonTestUtils.cs
+++ b/src/StripeTests/Wholesome/SystemTextJsonTestUtils.cs
@@ -115,6 +115,11 @@ namespace StripeTests.Wholesome
             {
                 expectedConverterType = typeof(STJUnixDateTimeConverter);
             }
+            else if (typeof(IEmptyable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            {
+                expectedConverterType = typeof(STJEmptyableConverter<>);
+                expectedGenericTypeArguments = type.GenericTypeArguments;
+            }
             else if (typeof(IAnyOf).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
             {
                 expectedConverterType = typeof(STJAnyOfConverter);


### PR DESCRIPTION
### Why?
Upcoming APIs use Emptyable fields which were not fully supported in our System.Text.Json implementation.  This PR fixes that.

### What?
- adds STJEmptyableConverter
- adds IEmptyable interface to make base type comparisons easier
- updates wholesome tests

### See Also
<!-- Include any links or additional information that help explain this change. -->
