### PR TITLE
Clean up ListOptions

### DIFF
--- a/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityListOptions.cs
+++ b/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityListOptions.cs
@@ -1,7 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    public class AccountCapabilityListOptions : ListOptions
+    public class AccountCapabilityListOptions : BaseOptions
     {
     }
 }

--- a/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityService.cs
+++ b/src/Stripe.net/Services/AccountCapabilities/AccountCapabilityService.cs
@@ -9,7 +9,6 @@ namespace Stripe
     using System.Threading.Tasks;
 
     public class AccountCapabilityService : Service,
-        INestedListable<Capability, AccountCapabilityListOptions>,
         INestedRetrievable<Capability, AccountCapabilityGetOptions>,
         INestedUpdatable<Capability, AccountCapabilityUpdateOptions>
     {
@@ -59,24 +58,6 @@ namespace Stripe
         public virtual Task<StripeList<Capability>> ListAsync(string parentId, AccountCapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync<StripeList<Capability>>(BaseAddress.Api, HttpMethod.Get, $"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions, cancellationToken);
-        }
-
-        /// <summary>
-        /// <p>Returns a list of capabilities associated with the account. The capabilities are
-        /// returned sorted by creation date, with the most recent capability appearing first.</p>.
-        /// </summary>
-        public virtual IEnumerable<Capability> ListAutoPaging(string parentId, AccountCapabilityListOptions options = null, RequestOptions requestOptions = null)
-        {
-            return this.ListRequestAutoPaging<Capability>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions);
-        }
-
-        /// <summary>
-        /// <p>Returns a list of capabilities associated with the account. The capabilities are
-        /// returned sorted by creation date, with the most recent capability appearing first.</p>.
-        /// </summary>
-        public virtual IAsyncEnumerable<Capability> ListAutoPagingAsync(string parentId, AccountCapabilityListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
-        {
-            return this.ListRequestAutoPagingAsync<Capability>($"/v1/accounts/{WebUtility.UrlEncode(parentId)}/capabilities", options, requestOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Stripe.net/Services/Accounts/AccountListOptions.cs
+++ b/src/Stripe.net/Services/Accounts/AccountListOptions.cs
@@ -1,7 +1,24 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    public class AccountListOptions : ListOptionsWithCreated
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return connected accounts that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/ApplicationFees/ApplicationFeeListOptions.cs
+++ b/src/Stripe.net/Services/ApplicationFees/ApplicationFeeListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ApplicationFeeListOptions : ListOptionsWithCreated
+    public class ApplicationFeeListOptions : ListOptions
     {
         /// <summary>
         /// Only return application fees for the charge specified by this charge ID.
@@ -16,5 +18,16 @@ namespace Stripe
         [STJS.JsonPropertyName("charge")]
 #endif
         public string Charge { get; set; }
+
+        /// <summary>
+        /// Only return applications fees that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionListOptions.cs
+++ b/src/Stripe.net/Services/BalanceTransactions/BalanceTransactionListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class BalanceTransactionListOptions : ListOptionsWithCreated
+    public class BalanceTransactionListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return transactions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return transactions in a certain currency. Three-letter <a
         /// href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in

--- a/src/Stripe.net/Services/Charges/ChargeListOptions.cs
+++ b/src/Stripe.net/Services/Charges/ChargeListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ChargeListOptions : ListOptionsWithCreated
+    public class ChargeListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return charges that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return charges for the customer specified by this customer ID.
         /// </summary>

--- a/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
+++ b/src/Stripe.net/Services/Checkout/Sessions/SessionListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Checkout
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class SessionListOptions : ListOptionsWithCreated
+    public class SessionListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return Checkout Sessions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return the Checkout Sessions for the Customer specified.
         /// </summary>

--- a/src/Stripe.net/Services/Coupons/CouponListOptions.cs
+++ b/src/Stripe.net/Services/Coupons/CouponListOptions.cs
@@ -1,7 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    public class CouponListOptions : ListOptionsWithCreated
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class CouponListOptions : ListOptions
     {
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/CreditNotes/CreditNoteListOptions.cs
+++ b/src/Stripe.net/Services/CreditNotes/CreditNoteListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class CreditNoteListOptions : ListOptionsWithCreated
+    public class CreditNoteListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return credit notes that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return credit notes for the customer specified by this customer ID.
         /// </summary>

--- a/src/Stripe.net/Services/Customers/CustomerListOptions.cs
+++ b/src/Stripe.net/Services/Customers/CustomerListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class CustomerListOptions : ListOptionsWithCreated
+    public class CustomerListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return customers that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// A case-sensitive filter on the list based on the customer's <c>email</c> field. The
         /// value must be a string.

--- a/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
+++ b/src/Stripe.net/Services/Disputes/DisputeListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class DisputeListOptions : ListOptionsWithCreated
+    public class DisputeListOptions : ListOptions
     {
         /// <summary>
         /// Only return disputes associated to the charge specified by this charge ID.
@@ -16,6 +18,17 @@ namespace Stripe
         [STJS.JsonPropertyName("charge")]
 #endif
         public string Charge { get; set; }
+
+        /// <summary>
+        /// Only return disputes that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return disputes associated to the PaymentIntent specified by this PaymentIntent ID.

--- a/src/Stripe.net/Services/Events/EventListOptions.cs
+++ b/src/Stripe.net/Services/Events/EventListOptions.cs
@@ -1,14 +1,27 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class EventListOptions : ListOptionsWithCreated
+    public class EventListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return events that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Filter events by whether all webhooks were successfully delivered. If false, events
         /// which are still pending or have failed all delivery attempts to a webhook endpoint will

--- a/src/Stripe.net/Services/FileLinks/FileLinkListOptions.cs
+++ b/src/Stripe.net/Services/FileLinks/FileLinkListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class FileLinkListOptions : ListOptionsWithCreated
+    public class FileLinkListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return links that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Filter links by their expiration status. By default, Stripe returns all links.
         /// </summary>

--- a/src/Stripe.net/Services/Files/FileListOptions.cs
+++ b/src/Stripe.net/Services/Files/FileListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class FileListOptions : ListOptionsWithCreated
+    public class FileListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return files that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Filter queries by the file purpose. If you don't provide a purpose, the queries return
         /// unfiltered files.

--- a/src/Stripe.net/Services/Forwarding/Requests/RequestCreatedOptions.cs
+++ b/src/Stripe.net/Services/Forwarding/Requests/RequestCreatedOptions.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Forwarding
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class RequestCreatedOptions : INestedOptions
+    {
+        /// <summary>
+        /// Return results where the <c>created</c> field is greater than this value.
+        /// </summary>
+        [JsonProperty("gt")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("gt")]
+#endif
+        public long? Gt { get; set; }
+
+        /// <summary>
+        /// Return results where the <c>created</c> field is greater than or equal to this value.
+        /// </summary>
+        [JsonProperty("gte")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("gte")]
+#endif
+        public long? Gte { get; set; }
+
+        /// <summary>
+        /// Return results where the <c>created</c> field is less than this value.
+        /// </summary>
+        [JsonProperty("lt")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("lt")]
+#endif
+        public long? Lt { get; set; }
+
+        /// <summary>
+        /// Return results where the <c>created</c> field is less than or equal to this value.
+        /// </summary>
+        [JsonProperty("lte")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("lte")]
+#endif
+        public long? Lte { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/Forwarding/Requests/RequestListOptions.cs
+++ b/src/Stripe.net/Services/Forwarding/Requests/RequestListOptions.cs
@@ -1,7 +1,21 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Forwarding
 {
-    public class RequestListOptions : ListOptionsWithCreated
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class RequestListOptions : ListOptions
     {
+        /// <summary>
+        /// Similar to other List endpoints, filters results based on created timestamp. You can
+        /// pass gt, gte, lt, and lte timestamp values.
+        /// </summary>
+        [JsonProperty("created")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+#endif
+        public RequestCreatedOptions Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportListOptions.cs
+++ b/src/Stripe.net/Services/Identity/VerificationReports/VerificationReportListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Identity
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class VerificationReportListOptions : ListOptionsWithCreated
+    public class VerificationReportListOptions : ListOptions
     {
         /// <summary>
         /// A string to reference this user. This can be a customer ID, a session ID, or similar,
@@ -17,6 +19,17 @@ namespace Stripe.Identity
         [STJS.JsonPropertyName("client_reference_id")]
 #endif
         public string ClientReferenceId { get; set; }
+
+        /// <summary>
+        /// Only return VerificationReports that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return VerificationReports of this type.

--- a/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionListOptions.cs
+++ b/src/Stripe.net/Services/Identity/VerificationSessions/VerificationSessionListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Identity
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class VerificationSessionListOptions : ListOptionsWithCreated
+    public class VerificationSessionListOptions : ListOptions
     {
         /// <summary>
         /// A string to reference this user. This can be a customer ID, a session ID, or similar,
@@ -17,6 +19,17 @@ namespace Stripe.Identity
         [STJS.JsonPropertyName("client_reference_id")]
 #endif
         public string ClientReferenceId { get; set; }
+
+        /// <summary>
+        /// Only return VerificationSessions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         [JsonProperty("related_customer")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/InvoiceItems/InvoiceItemListOptions.cs
+++ b/src/Stripe.net/Services/InvoiceItems/InvoiceItemListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class InvoiceItemListOptions : ListOptionsWithCreated
+    public class InvoiceItemListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return invoice items that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// The identifier of the customer whose invoice items to return. If none is provided, all
         /// invoice items will be returned.

--- a/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListOptions.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class InvoiceListOptions : ListOptionsWithCreated
+    public class InvoiceListOptions : ListOptions
     {
         /// <summary>
         /// The collection method of the invoice to retrieve. Either <c>charge_automatically</c> or
@@ -20,6 +20,17 @@ namespace Stripe
         [STJS.JsonPropertyName("collection_method")]
 #endif
         public string CollectionMethod { get; set; }
+
+        /// <summary>
+        /// Only return invoices that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return invoices for the customer specified by this customer ID.

--- a/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Authorizations/AuthorizationListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class AuthorizationListOptions : ListOptionsWithCreated
+    public class AuthorizationListOptions : ListOptions
     {
         /// <summary>
         /// Only return authorizations that belong to the given card.
@@ -25,6 +27,17 @@ namespace Stripe.Issuing
         [STJS.JsonPropertyName("cardholder")]
 #endif
         public string Cardholder { get; set; }
+
+        /// <summary>
+        /// Only return authorizations that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return authorizations with the given status. One of <c>pending</c>, <c>closed</c>,

--- a/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cardholders/CardholderListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class CardholderListOptions : ListOptionsWithCreated
+    public class CardholderListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return cardholders that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return cardholders that have the given email address.
         /// </summary>

--- a/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Cards/CardListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class CardListOptions : ListOptionsWithCreated
+    public class CardListOptions : ListOptions
     {
         /// <summary>
         /// Only return cards belonging to the Cardholder with the provided ID.
@@ -16,6 +18,17 @@ namespace Stripe.Issuing
         [STJS.JsonPropertyName("cardholder")]
 #endif
         public string Cardholder { get; set; }
+
+        /// <summary>
+        /// Only return cards that were issued during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return cards that have the given expiration month.

--- a/src/Stripe.net/Services/Issuing/Disputes/DisputeListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Disputes/DisputeListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class DisputeListOptions : ListOptionsWithCreated
+    public class DisputeListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return Issuing disputes that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Select Issuing disputes with the given status.
         /// One of: <c>expired</c>, <c>lost</c>, <c>submitted</c>, <c>unsubmitted</c>, or

--- a/src/Stripe.net/Services/Issuing/Tokens/TokenListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Tokens/TokenListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TokenListOptions : ListOptionsWithCreated
+    public class TokenListOptions : ListOptions
     {
         /// <summary>
         /// The Issuing card identifier to list tokens for.
@@ -16,6 +18,17 @@ namespace Stripe.Issuing
         [STJS.JsonPropertyName("card")]
 #endif
         public string Card { get; set; }
+
+        /// <summary>
+        /// Only return Issuing tokens that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Select Issuing tokens with the given status.

--- a/src/Stripe.net/Services/Issuing/Transactions/TransactionListOptions.cs
+++ b/src/Stripe.net/Services/Issuing/Transactions/TransactionListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Issuing
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TransactionListOptions : ListOptionsWithCreated
+    public class TransactionListOptions : ListOptions
     {
         /// <summary>
         /// Only return transactions that belong to the given card.
@@ -25,6 +27,17 @@ namespace Stripe.Issuing
         [STJS.JsonPropertyName("cardholder")]
 #endif
         public string Cardholder { get; set; }
+
+        /// <summary>
+        /// Only return transactions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return transactions that have the given type. One of <c>capture</c> or

--- a/src/Stripe.net/Services/PaymentIntents/PaymentIntentListOptions.cs
+++ b/src/Stripe.net/Services/PaymentIntents/PaymentIntentListOptions.cs
@@ -1,13 +1,28 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class PaymentIntentListOptions : ListOptionsWithCreated
+    public class PaymentIntentListOptions : ListOptions
     {
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp or a dictionary with a number of different query
+        /// options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return PaymentIntents for the customer that this customer ID specifies.
         /// </summary>

--- a/src/Stripe.net/Services/Payouts/PayoutListOptions.cs
+++ b/src/Stripe.net/Services/Payouts/PayoutListOptions.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class PayoutListOptions : ListOptionsWithCreated
+    public class PayoutListOptions : ListOptions
     {
         /// <summary>
         /// Only return payouts that are expected to arrive during the given date interval.
@@ -20,6 +20,17 @@ namespace Stripe
         [STJS.JsonConverter(typeof(STJAnyOfConverter))]
 #endif
         public AnyOf<DateTime?, DateRangeOptions> ArrivalDate { get; set; }
+
+        /// <summary>
+        /// Only return payouts that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// The ID of an external account - only return payouts sent to this external account.

--- a/src/Stripe.net/Services/Plans/PlanListOptions.cs
+++ b/src/Stripe.net/Services/Plans/PlanListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class PlanListOptions : ListOptionsWithCreated
+    public class PlanListOptions : ListOptions
     {
         /// <summary>
         /// Only return plans that are active or inactive (e.g., pass <c>false</c> to list all
@@ -17,6 +19,19 @@ namespace Stripe
         [STJS.JsonPropertyName("active")]
 #endif
         public bool? Active { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return plans for the given product.

--- a/src/Stripe.net/Services/Prices/PriceListOptions.cs
+++ b/src/Stripe.net/Services/Prices/PriceListOptions.cs
@@ -1,13 +1,15 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class PriceListOptions : ListOptionsWithCreated
+    public class PriceListOptions : ListOptions
     {
         /// <summary>
         /// Only return prices that are active or inactive (e.g., pass <c>false</c> to list all
@@ -18,6 +20,19 @@ namespace Stripe
         [STJS.JsonPropertyName("active")]
 #endif
         public bool? Active { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return prices for the given currency.

--- a/src/Stripe.net/Services/Products/ProductListOptions.cs
+++ b/src/Stripe.net/Services/Products/ProductListOptions.cs
@@ -1,13 +1,15 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ProductListOptions : ListOptionsWithCreated
+    public class ProductListOptions : ListOptions
     {
         /// <summary>
         /// Only return products that are active or inactive (e.g., pass <c>false</c> to list all
@@ -18,6 +20,17 @@ namespace Stripe
         [STJS.JsonPropertyName("active")]
 #endif
         public bool? Active { get; set; }
+
+        /// <summary>
+        /// Only return products that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return products with the given IDs. Cannot be used with <a

--- a/src/Stripe.net/Services/PromotionCodes/PromotionCodeListOptions.cs
+++ b/src/Stripe.net/Services/PromotionCodes/PromotionCodeListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class PromotionCodeListOptions : ListOptionsWithCreated
+    public class PromotionCodeListOptions : ListOptions
     {
         /// <summary>
         /// Filter promotion codes by whether they are active.
@@ -34,6 +36,19 @@ namespace Stripe
         [STJS.JsonPropertyName("coupon")]
 #endif
         public string Coupon { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return promotion codes that are restricted to this customer.

--- a/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningListOptions.cs
+++ b/src/Stripe.net/Services/Radar/EarlyFraudWarnings/EarlyFraudWarningListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Radar
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class EarlyFraudWarningListOptions : ListOptionsWithCreated
+    public class EarlyFraudWarningListOptions : ListOptions
     {
         /// <summary>
         /// Only return early fraud warnings for the charge specified by this charge ID.
@@ -16,6 +18,17 @@ namespace Stripe.Radar
         [STJS.JsonPropertyName("charge")]
 #endif
         public string Charge { get; set; }
+
+        /// <summary>
+        /// Only return early fraud warnings that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return early fraud warnings for charges that were created by the PaymentIntent

--- a/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemListOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueListItems/ValueListItemListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Radar
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ValueListItemListOptions : ListOptionsWithCreated
+    public class ValueListItemListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return items that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Return items belonging to the parent list whose value matches the specified value (using
         /// an "is like" match).

--- a/src/Stripe.net/Services/Radar/ValueLists/ValueListListOptions.cs
+++ b/src/Stripe.net/Services/Radar/ValueLists/ValueListListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Radar
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ValueListListOptions : ListOptionsWithCreated
+    public class ValueListListOptions : ListOptions
     {
         /// <summary>
         /// The alias used to reference the value list when writing rules.
@@ -25,5 +27,16 @@ namespace Stripe.Radar
         [STJS.JsonPropertyName("contains")]
 #endif
         public string Contains { get; set; }
+
+        /// <summary>
+        /// Only return value lists that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Refunds/RefundListOptions.cs
+++ b/src/Stripe.net/Services/Refunds/RefundListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class RefundListOptions : ListOptionsWithCreated
+    public class RefundListOptions : ListOptions
     {
         /// <summary>
         /// Only return refunds for the charge specified by this charge ID.
@@ -16,6 +18,17 @@ namespace Stripe
         [STJS.JsonPropertyName("charge")]
 #endif
         public string Charge { get; set; }
+
+        /// <summary>
+        /// Only return refunds that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return refunds for the PaymentIntent specified by this ID.

--- a/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunListOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportRuns/ReportRunListOptions.cs
@@ -1,7 +1,24 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Reporting
 {
-    public class ReportRunListOptions : ListOptionsWithCreated
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class ReportRunListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return Report Runs that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeListOptions.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeListOptions.cs
@@ -1,7 +1,7 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Reporting
 {
-    public class ReportTypeListOptions : ListOptions
+    public class ReportTypeListOptions : BaseOptions
     {
     }
 }

--- a/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
+++ b/src/Stripe.net/Services/Reporting/ReportTypes/ReportTypeService.cs
@@ -9,7 +9,6 @@ namespace Stripe.Reporting
     using System.Threading.Tasks;
 
     public class ReportTypeService : Service,
-        IListable<ReportType, ReportTypeListOptions>,
         IRetrievable<ReportType, ReportTypeGetOptions>
     {
         public ReportTypeService()
@@ -58,22 +57,6 @@ namespace Stripe.Reporting
         public virtual Task<StripeList<ReportType>> ListAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
             return this.RequestAsync<StripeList<ReportType>>(BaseAddress.Api, HttpMethod.Get, $"/v1/reporting/report_types", options, requestOptions, cancellationToken);
-        }
-
-        /// <summary>
-        /// <p>Returns a full list of Report Types.</p>.
-        /// </summary>
-        public virtual IEnumerable<ReportType> ListAutoPaging(ReportTypeListOptions options = null, RequestOptions requestOptions = null)
-        {
-            return this.ListRequestAutoPaging<ReportType>($"/v1/reporting/report_types", options, requestOptions);
-        }
-
-        /// <summary>
-        /// <p>Returns a full list of Report Types.</p>.
-        /// </summary>
-        public virtual IAsyncEnumerable<ReportType> ListAutoPagingAsync(ReportTypeListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
-        {
-            return this.ListRequestAutoPagingAsync<ReportType>($"/v1/reporting/report_types", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/Reviews/ReviewListOptions.cs
+++ b/src/Stripe.net/Services/Reviews/ReviewListOptions.cs
@@ -1,7 +1,24 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
-    public class ReviewListOptions : ListOptionsWithCreated
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class ReviewListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return reviews that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/SetupAttempts/SetupAttemptListOptions.cs
+++ b/src/Stripe.net/Services/SetupAttempts/SetupAttemptListOptions.cs
@@ -1,13 +1,28 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class SetupAttemptListOptions : ListOptionsWithCreated
+    public class SetupAttemptListOptions : ListOptions
     {
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp or a dictionary with a number of different query
+        /// options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return SetupAttempts created by the SetupIntent specified by this ID.
         /// </summary>

--- a/src/Stripe.net/Services/SetupIntents/SetupIntentListOptions.cs
+++ b/src/Stripe.net/Services/SetupIntents/SetupIntentListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class SetupIntentListOptions : ListOptionsWithCreated
+    public class SetupIntentListOptions : ListOptions
     {
         /// <summary>
         /// If present, the SetupIntent's payment method will be attached to the in-context Stripe
@@ -22,6 +24,19 @@ namespace Stripe
         [STJS.JsonPropertyName("attach_to_self")]
 #endif
         public bool? AttachToSelf { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return SetupIntents for the customer specified by this customer ID.

--- a/src/Stripe.net/Services/ShippingRates/ShippingRateListOptions.cs
+++ b/src/Stripe.net/Services/ShippingRates/ShippingRateListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class ShippingRateListOptions : ListOptionsWithCreated
+    public class ShippingRateListOptions : ListOptions
     {
         /// <summary>
         /// Only return shipping rates that are active or inactive.
@@ -16,6 +18,19 @@ namespace Stripe
         [STJS.JsonPropertyName("active")]
 #endif
         public bool? Active { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return shipping rates for the given currency.

--- a/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
+++ b/src/Stripe.net/Services/SubscriptionSchedules/SubscriptionScheduleListOptions.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class SubscriptionScheduleListOptions : ListOptionsWithCreated
+    public class SubscriptionScheduleListOptions : ListOptions
     {
         /// <summary>
         /// Only return subscription schedules that were created canceled the given date interval.
@@ -31,6 +31,17 @@ namespace Stripe
         [STJS.JsonConverter(typeof(STJAnyOfConverter))]
 #endif
         public AnyOf<DateTime?, DateRangeOptions> CompletedAt { get; set; }
+
+        /// <summary>
+        /// Only return subscription schedules that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return subscription schedules for the given customer.

--- a/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
+++ b/src/Stripe.net/Services/Subscriptions/SubscriptionListOptions.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class SubscriptionListOptions : ListOptionsWithCreated
+    public class SubscriptionListOptions : ListOptions
     {
         /// <summary>
         /// Filter subscriptions by their automatic tax settings.
@@ -29,6 +29,17 @@ namespace Stripe
         [STJS.JsonPropertyName("collection_method")]
 #endif
         public string CollectionMethod { get; set; }
+
+        /// <summary>
+        /// Only return subscriptions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return subscriptions whose current_period_end falls within the given date interval.

--- a/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
+++ b/src/Stripe.net/Services/TaxRates/TaxRateListOptions.cs
@@ -1,12 +1,14 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TaxRateListOptions : ListOptionsWithCreated
+    public class TaxRateListOptions : ListOptions
     {
         /// <summary>
         /// Optional flag to filter by tax rates that are either active or inactive (archived).
@@ -16,6 +18,17 @@ namespace Stripe
         [STJS.JsonPropertyName("active")]
 #endif
         public bool? Active { get; set; }
+
+        /// <summary>
+        /// Optional range for filtering created date.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Optional flag to filter by tax rates that are inclusive (or those that are not

--- a/src/Stripe.net/Services/Topups/TopupListOptions.cs
+++ b/src/Stripe.net/Services/Topups/TopupListOptions.cs
@@ -8,7 +8,7 @@ namespace Stripe
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TopupListOptions : ListOptionsWithCreated
+    public class TopupListOptions : ListOptions
     {
         /// <summary>
         /// A positive integer representing how much to transfer.
@@ -20,6 +20,19 @@ namespace Stripe
         [STJS.JsonConverter(typeof(STJAnyOfConverter))]
 #endif
         public AnyOf<DateTime?, DateRangeOptions> Amount { get; set; }
+
+        /// <summary>
+        /// A filter on the list, based on the object <c>created</c> field. The value can be a
+        /// string with an integer Unix timestamp, or it can be a dictionary with a number of
+        /// different query options.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
 
         /// <summary>
         /// Only return top-ups that have the given status. One of <c>canceled</c>, <c>failed</c>,

--- a/src/Stripe.net/Services/Transfers/TransferListOptions.cs
+++ b/src/Stripe.net/Services/Transfers/TransferListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TransferListOptions : ListOptionsWithCreated
+    public class TransferListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return transfers that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return transfers for the destination specified by this account ID.
         /// </summary>

--- a/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/FinancialAccounts/FinancialAccountListOptions.cs
@@ -1,7 +1,24 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Treasury
 {
-    public class FinancialAccountListOptions : ListOptionsWithCreated
+    using System;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return FinancialAccounts that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
     }
 }

--- a/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/OutboundPayments/OutboundPaymentListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Treasury
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class OutboundPaymentListOptions : ListOptionsWithCreated
+    public class OutboundPaymentListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return OutboundPayments that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Only return OutboundPayments sent to this customer.
         /// </summary>

--- a/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/TransactionEntries/TransactionEntryListOptions.cs
@@ -8,8 +8,19 @@ namespace Stripe.Treasury
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TransactionEntryListOptions : ListOptionsWithCreated
+    public class TransactionEntryListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return TransactionEntries that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         [JsonProperty("effective_at")]
         [JsonConverter(typeof(AnyOfConverter))]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/Treasury/Transactions/TransactionListOptions.cs
+++ b/src/Stripe.net/Services/Treasury/Transactions/TransactionListOptions.cs
@@ -1,13 +1,26 @@
 // File generated from our OpenAPI spec
 namespace Stripe.Treasury
 {
+    using System;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class TransactionListOptions : ListOptionsWithCreated
+    public class TransactionListOptions : ListOptions
     {
+        /// <summary>
+        /// Only return Transactions that were created during the given date interval.
+        /// </summary>
+        [JsonProperty("created")]
+        [JsonConverter(typeof(AnyOfConverter))]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("created")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
+#endif
+        public AnyOf<DateTime?, DateRangeOptions> Created { get; set; }
+
         /// <summary>
         /// Returns objects associated with this FinancialAccount.
         /// </summary>

--- a/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
+++ b/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
@@ -117,22 +117,6 @@ namespace Stripe.V2.Core
         }
 
         /// <summary>
-        /// Lists all event destinations.
-        /// </summary>
-        public virtual IEnumerable<V2.EventDestination> ListAutoPaging(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
-        {
-            return this.ListRequestAutoPaging<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions);
-        }
-
-        /// <summary>
-        /// Lists all event destinations.
-        /// </summary>
-        public virtual IAsyncEnumerable<V2.EventDestination> ListAutoPagingAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
-        {
-            return this.ListRequestAutoPagingAsync<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions, cancellationToken);
-        }
-
-        /// <summary>
         /// Send a <c>ping</c> event to an event destination.
         /// </summary>
         public virtual V2.Event Ping(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
+++ b/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
@@ -117,6 +117,22 @@ namespace Stripe.V2.Core
         }
 
         /// <summary>
+        /// Lists all event destinations.
+        /// </summary>
+        public virtual IEnumerable<V2.EventDestination> ListAutoPaging(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions);
+        }
+
+        /// <summary>
+        /// Lists all event destinations.
+        /// </summary>
+        public virtual IAsyncEnumerable<V2.EventDestination> ListAutoPagingAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions, cancellationToken);
+        }
+
+        /// <summary>
         /// Send a <c>ping</c> event to an event destination.
         /// </summary>
         public virtual V2.Event Ping(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null)

--- a/src/Stripe.net/Services/V2/Core/Events/EventListOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Events/EventListOptions.cs
@@ -1,7 +1,6 @@
 // File generated from our OpenAPI spec
 namespace Stripe.V2.Core
 {
-    using System;
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
@@ -9,53 +8,6 @@ namespace Stripe.V2.Core
 
     public class EventListOptions : V2.ListOptions
     {
-        /// <summary>
-        /// Filter for events created after the specified timestamp.
-        /// </summary>
-        [JsonProperty("created_gt")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("created_gt")]
-#endif
-        public DateTime? CreatedGt { get; set; }
-
-        /// <summary>
-        /// Filter for events created at or after the specified timestamp.
-        /// </summary>
-        [JsonProperty("created_gte")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("created_gte")]
-#endif
-        public DateTime? CreatedGte { get; set; }
-
-        /// <summary>
-        /// Filter for events created before the specified timestamp.
-        /// </summary>
-        [JsonProperty("created_lt")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("created_lt")]
-#endif
-        public DateTime? CreatedLt { get; set; }
-
-        /// <summary>
-        /// Filter for events created at or before the specified timestamp.
-        /// </summary>
-        [JsonProperty("created_lte")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("created_lte")]
-#endif
-        public DateTime? CreatedLte { get; set; }
-
-        /// <summary>
-        /// Filter events based on whether they were successfully delivered to all subscribed event
-        /// destinations. If false, events which are still pending or have failed all delivery
-        /// attempts to a event destination will be returned.
-        /// </summary>
-        [JsonProperty("delivery_success")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("delivery_success")]
-#endif
-        public bool? DeliverySuccess { get; set; }
-
         /// <summary>
         /// Primary object ID used to retrieve related events.
         /// </summary>

--- a/src/Stripe.net/Services/V2/Core/Events/EventService.cs
+++ b/src/Stripe.net/Services/V2/Core/Events/EventService.cs
@@ -51,5 +51,21 @@ namespace Stripe.V2.Core
         {
             return this.RequestAsync<V2.StripeList<V2.Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions, cancellationToken);
         }
+
+        /// <summary>
+        /// List events, going back up to 30 days.
+        /// </summary>
+        public virtual IEnumerable<V2.Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.ListRequestAutoPaging<V2.Event>($"/v2/core/events", options, requestOptions);
+        }
+
+        /// <summary>
+        /// List events, going back up to 30 days.
+        /// </summary>
+        public virtual IAsyncEnumerable<V2.Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.ListRequestAutoPagingAsync<V2.Event>($"/v2/core/events", options, requestOptions, cancellationToken);
+        }
     }
 }

--- a/src/Stripe.net/Services/V2/Core/Events/EventService.cs
+++ b/src/Stripe.net/Services/V2/Core/Events/EventService.cs
@@ -51,21 +51,5 @@ namespace Stripe.V2.Core
         {
             return this.RequestAsync<V2.StripeList<V2.Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions, cancellationToken);
         }
-
-        /// <summary>
-        /// List events, going back up to 30 days.
-        /// </summary>
-        public virtual IEnumerable<V2.Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
-        {
-            return this.ListRequestAutoPaging<V2.Event>($"/v2/core/events", options, requestOptions);
-        }
-
-        /// <summary>
-        /// List events, going back up to 30 days.
-        /// </summary>
-        public virtual IAsyncEnumerable<V2.Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
-        {
-            return this.ListRequestAutoPagingAsync<V2.Event>($"/v2/core/events", options, requestOptions, cancellationToken);
-        }
     }
 }

--- a/src/StripeTests/Services/Capabilities/AccountCapabilityServiceTest.cs
+++ b/src/StripeTests/Services/Capabilities/AccountCapabilityServiceTest.cs
@@ -74,22 +74,6 @@ namespace StripeTests
         }
 
         [Fact]
-        public void ListAutoPaging()
-        {
-            var capabilitie = this.service.ListAutoPaging(AccountId, this.listOptions).First();
-            Assert.NotNull(capabilitie);
-            Assert.Equal("capability", capabilitie.Object);
-        }
-
-        [Fact]
-        public async Task ListAutoPagingAsync()
-        {
-            var capabilitie = await this.service.ListAutoPagingAsync(AccountId, this.listOptions).FirstAsync();
-            Assert.NotNull(capabilitie);
-            Assert.Equal("capability", capabilitie.Object);
-        }
-
-        [Fact]
         public void Update()
         {
             var capability = this.service.Update(AccountId, CapabilityId, this.updateOptions);

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -6180,11 +6180,20 @@ namespace StripeTests
                 HttpMethod.Get,
                 "/v2/core/events",
                 (HttpStatusCode)200,
-                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.core.event\",\"context\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"reason\":null,\"type\":\"type\"}],\"next_page_url\":null,\"previous_page_url\":null}");
+                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.core.event\",\"context\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"reason\":null,\"type\":\"type\"}],\"next_page_url\":null,\"previous_page_url\":null}",
+                "object_id=object_id");
+            var options = new Stripe.V2.Core.EventListOptions
+            {
+                ObjectId = "object_id",
+            };
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Events;
-            Stripe.V2.StripeList<Stripe.V2.Event> events = service.List();
-            this.AssertRequest(HttpMethod.Get, "/v2/core/events");
+            Stripe.V2.StripeList<Stripe.V2.Event> events = service.List(
+                options);
+            this.AssertRequest(
+                HttpMethod.Get,
+                "/v2/core/events",
+                "object_id=object_id");
         }
 
         [Fact]

--- a/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
+++ b/src/StripeTests/Services/Reporting/ReportTypes/ReportTypeServiceTest.cs
@@ -57,19 +57,5 @@ namespace StripeTests.Reporting
             this.AssertRequest(HttpMethod.Get, "/v1/reporting/report_types");
             Assert.NotNull(reportTypes);
         }
-
-        [Fact]
-        public void ListAutoPaging()
-        {
-            var reportType = this.service.ListAutoPaging(this.listOptions).First();
-            Assert.NotNull(reportType);
-        }
-
-        [Fact]
-        public async Task ListAutoPagingAsync()
-        {
-            var reportType = await this.service.ListAutoPagingAsync(this.listOptions).FirstAsync();
-            Assert.NotNull(reportType);
-        }
     }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `ListOptionsWithCreated` base class is superfluous, so we are removing it. There are also a couple of List methods, namely `ReportType` and `AccountCapability` that do not actually auto-paginate, so those services should not implement `IListable`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Removes `ListOptionsWithCreated` base class and pushes the `created` field into the children.
- `ReportTypeOptions` and `AccountCapabilityOptions` no longer extend `ListOptions`
- `ReportTypeService` and `AccountCapabilityService` no longer implement the `IListable` interface, and the `ListAutoPaging` and `ListAutoPagingAsync` methods are removed

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://github.com/stripe/stripe-dotnet/issues/2227

## Changelog
- Remove `ListOptionsWithCreated` base class and pushes the `created` field into the children.
- Classes `ReportTypeOptions` and `AccountCapabilityOptions` no longer extend `ListOptions`
- Classes`ReportTypeService` and `AccountCapabilityService` no longer implement the `IListable` interface, and the `ListAutoPaging` and `ListAutoPagingAsync` methods are removed
