### PR TITLE
Removes subscription_items from options

### DIFF
--- a/src/Stripe.net/Services/Invoices/InvoiceLineItemListOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceLineItemListOptions.cs
@@ -26,12 +26,6 @@ namespace Stripe
 #endif
         public string Subscription { get; set; }
 
-        [JsonProperty("subscription_items")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("subscription_items")]
-#endif
-        public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
-
         [JsonProperty("subscription_plan")]
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("subscription_plan")]

--- a/src/Stripe.net/Services/Invoices/InvoiceListLineItemsOptions.cs
+++ b/src/Stripe.net/Services/Invoices/InvoiceListLineItemsOptions.cs
@@ -28,12 +28,6 @@ namespace Stripe
 #endif
         public string Subscription { get; set; }
 
-        [JsonProperty("subscription_items")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("subscription_items")]
-#endif
-        public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
-
         [JsonProperty("subscription_plan")]
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("subscription_plan")]

--- a/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
+++ b/src/Stripe.net/Services/Invoices/UpcomingInvoiceOptions.cs
@@ -105,12 +105,6 @@ namespace Stripe
 #endif
         public List<string> SubscriptionDefaultTaxRates { get; set; }
 
-        [JsonProperty("subscription_items")]
-#if NET6_0_OR_GREATER
-        [STJS.JsonPropertyName("subscription_items")]
-#endif
-        public List<InvoiceSubscriptionItemOptions> SubscriptionItems { get; set; }
-
         [Obsolete("Use SubscriptionProrationBehavior instead.")]
         [JsonProperty("subscription_prorate")]
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
### Why?
SubscriptionItem was removed in the spec.  This PR updates manually maintained list options classes to also remove these fields.

### What?
- removed `SubscriptionItems` from `InvoiceLineItemListOptions`, `InvoiceListLineItemOptions`, and `UpcomingInvoiceOptions`

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* ⚠️ Removes `SubscriptionItems` from `InvoiceLineItemListOptions`, `InvoiceListLineItemOptions`, and `UpcomingInvoiceOptions`.  This field is no longer supported on these API methods.
