### PR TITLE
Remove tests for `Invoice.subscription` field being removed

### DIFF
--- a/src/StripeTests/Entities/Invoices/InvoiceTest.cs
+++ b/src/StripeTests/Entities/Invoices/InvoiceTest.cs
@@ -33,7 +33,6 @@ namespace StripeTests
               "customer",
               "default_payment_method",
               "payment_intent",
-              "subscription",
             };
 
             string json = this.GetFixture("/v1/invoices/in_123", expansions);
@@ -48,9 +47,6 @@ namespace StripeTests
 
             Assert.NotNull(invoice.DefaultPaymentMethod);
             Assert.Equal("payment_method", invoice.DefaultPaymentMethod.Object);
-
-            Assert.NotNull(invoice.Subscription);
-            Assert.Equal("subscription", invoice.Subscription.Object);
         }
 
         [Fact]


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`Invoice.subscription` is being removed, remove reference to it in test

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
