### PR TITLE
Disable Json.NET metadata special handling

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -225,6 +225,7 @@ namespace Stripe
                     new StripeObjectConverter(),
                 },
                 DateParseHandling = DateParseHandling.None,
+                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
                 MaxDepth = 128,
             };
         }

--- a/src/StripeTests/Entities/_base/StripeEntityTest.cs
+++ b/src/StripeTests/Entities/_base/StripeEntityTest.cs
@@ -94,11 +94,12 @@ namespace StripeTests
             {
                 Integer = 234,
                 String = "String!",
+                Metadata = new Dictionary<string, string>() { { "foo", "bar" } },
             };
 
             var json = o.ToJson().Replace("\r\n", "\n");
 
-            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\",\n  \"$ref\": null,\n  \"nested\": null\n}";
+            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\",\n  \"metadata\": {\n    \"foo\": \"bar\"\n  },\n  \"nested\": null\n}";
             Assert.Equal(expectedJson, json);
         }
 

--- a/src/StripeTests/Entities/_base/StripeEntityTest.cs
+++ b/src/StripeTests/Entities/_base/StripeEntityTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
 
     using Newtonsoft.Json;
@@ -73,6 +74,20 @@ namespace StripeTests
         }
 
         [Fact]
+        public void FromJsonDollarRefInMetadata()
+        {
+            var json = "{\"integer\": 234, \"string\": \"String!\", \"metadata\": { \"$ref\": \"1\", \"foo\": \"bar\" }}";
+
+            var o = StripeEntity.FromJson<TestEntity>(json);
+
+            Assert.NotNull(o);
+            Assert.Equal(234, o.Integer);
+            Assert.Equal("String!", o.String);
+            Assert.Equal("1", o.Metadata["$ref"]);
+            Assert.Equal("bar", o.Metadata["foo"]);
+        }
+
+        [Fact]
         public void ToJson()
         {
             var o = new TestEntity
@@ -83,7 +98,7 @@ namespace StripeTests
 
             var json = o.ToJson().Replace("\r\n", "\n");
 
-            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\",\n  \"nested\": null\n}";
+            var expectedJson = "{\n  \"integer\": 234,\n  \"string\": \"String!\",\n  \"$ref\": null,\n  \"nested\": null\n}";
             Assert.Equal(expectedJson, json);
         }
 
@@ -181,13 +196,16 @@ namespace StripeTests
                 subscription.RawJObject["items"]["data"][0]["id"]);
         }
 
-        private class TestEntity : StripeEntity<TestEntity>
+        private class TestEntity : StripeEntity<TestEntity>, IHasMetadata
         {
             [JsonProperty("integer")]
             public int Integer { get; set; }
 
             [JsonProperty("string")]
             public string String { get; set; }
+
+            [JsonProperty("metadata")]
+            public Dictionary<string, string> Metadata { get; set; }
 
             [JsonIgnore]
             public string NestedId


### PR DESCRIPTION
### Why?
https://github.com/stripe/stripe-dotnet/issues/3068 reported a persistent issue with parsing API responses in Stripe.net.  The example posted shows a "$ref" key in the metadata of the returned `payment_intent` object.  Newtonsoft Json.NET has support for [object references](https://www.newtonsoft.com/json/help/html/preserveobjectreferences.htm), in which case it interprets an JSON object string with only "$ref" key as a reference to an object defined elsewhere in the JSON.  Json.NET requires reference objects contain only the single "$ref" key; because the metadata object in the failure case had additional keys, Json.NET throws an exception.

Stripe.net does not write object references nor does it use Json.NET metadata to parse responses from Stripe's API, so this PR configures our Json deserialization to ignore handling metadata properties specially.

### What?
- added MetadataPropertyHandling = MetadataPropertyHandling.Ignore in DefaultSerializerSettings
- added test to confirm reference objects are ignored

### See Also
<!-- Include any links or additional information that help explain this change. -->
