### PR TITLE
Xavdid/merge dotnet beta & fix tests

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -230,6 +230,7 @@ namespace Stripe
                     new StripeObjectConverter(),
                 },
                 DateParseHandling = DateParseHandling.None,
+                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
                 MaxDepth = 128,
             };
         }

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -17,7 +17,7 @@ namespace Stripe
 
         public const int DefaultTimeTolerance = 300;
 
-        public static bool IsCompatibleApiVersion(string eventApiVersion)
+        public static bool IsCompatibleApiVersion(string sdkApiVersion, string eventApiVersion)
         {
             // If the event api version is from before we started adding
             // a release train, there's no way its compatible with this
@@ -28,9 +28,21 @@ namespace Stripe
             }
 
             // versions are yyyy-MM-dd.train
+            var currentReleaseTrain = sdkApiVersion.Split('.')[1];
+
+            // Beta SDKs should match event versions exactly when deserializing
+            if (currentReleaseTrain == "preview")
+            {
+                return eventApiVersion == sdkApiVersion;
+            }
+
             var eventReleaseTrain = eventApiVersion.Split('.')[1];
-            var currentReleaseTrain = ApiVersion.Current.Split('.')[1];
             return eventReleaseTrain == currentReleaseTrain;
+        }
+
+        public static bool IsCompatibleApiVersion(string eventApiVersion)
+        {
+            return IsCompatibleApiVersion(ApiVersion.Current, eventApiVersion);
         }
 
         /// <summary>

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -95,6 +95,14 @@ namespace StripeTests
         {
             var evt = Event.FromJson(this.json);
             var expectedReleaseTrain = ApiVersion.Current.Split('.')[1];
+
+            // this test only makes sense on GA versions- the exact version for preview versions doesn't
+            // work this way and we can't mock private methods from this test class.
+            if (expectedReleaseTrain == "preview")
+            {
+                return;
+            }
+
             evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
             var serialized = evt.ToJson();
 

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -144,5 +144,17 @@ namespace StripeTests
             Assert.Throws<StripeException>(() =>
                 EventUtility.ValidateSignature("{}", headerValue, string.Empty));
         }
+
+        [Theory]
+        [InlineData("2024-2-31.acacia", "1999-03-31", false)]
+        [InlineData("2024-2-31.acacia", "2025-03-31.basil", false)]
+        [InlineData("2024-04-31.basil", "2025-03-31.basil", true)]
+        [InlineData("2024-01-01.preview", "2025-03-31.basil", false)]
+        [InlineData("2024-01-01.preview", "2025-03-31.preview", false)]
+        [InlineData("2024-01-01.preview", "2024-01-01.preview", true)]
+        public void CompatibleAPIVersions(string sdkApiVersion, string eventApiVersion, bool expected)
+        {
+            Assert.Equal(EventUtility.IsCompatibleApiVersion(sdkApiVersion, eventApiVersion), expected);
+        }
     }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

This is fixing both a merge conflict and a failing test.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- `just merge dotnet-beta`
- add a skip in a test that doesn't work in beta SDKs anymore

### See Also
<!-- Include any links or additional information that help explain this change. -->
