### PR TITLE
Handle external_account field

### DIFF
--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardOptions.cs
@@ -1,0 +1,101 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class ExternalAccountCardOptions : INestedOptions, IHasMetadata, IHasObject
+    {
+        [JsonProperty("object")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("object")]
+#endif
+        public string Object { get; set; } = "card";
+
+        [JsonProperty("address_city")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_city")]
+#endif
+        public string AddressCity { get; set; }
+
+        [JsonProperty("address_country")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_country")]
+#endif
+        public string AddressCountry { get; set; }
+
+        [JsonProperty("address_line1")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_line1")]
+#endif
+        public string AddressLine1 { get; set; }
+
+        [JsonProperty("address_line2")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_line2")]
+#endif
+        public string AddressLine2 { get; set; }
+
+        [JsonProperty("address_state")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_state")]
+#endif
+        public string AddressState { get; set; }
+
+        [JsonProperty("address_zip")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("address_zip")]
+#endif
+        public string AddressZip { get; set; }
+
+        [JsonProperty("currency")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("currency")]
+#endif
+        public string Currency { get; set; }
+
+        [JsonProperty("cvc")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("cvc")]
+#endif
+        public string Cvc { get; set; }
+
+        [JsonProperty("exp_month")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("exp_month")]
+#endif
+        public long? ExpMonth { get; set; }
+
+        [JsonProperty("exp_year")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("exp_year")]
+#endif
+        public long? ExpYear { get; set; }
+
+        [JsonProperty("name")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("name")]
+#endif
+        public string Name { get; set; }
+
+        [JsonProperty("number")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("number")]
+#endif
+        public string Number { get; set; }
+
+        /// <summary>
+        /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can
+        /// attach to an object. This can be useful for storing additional information about the
+        /// object in a structured format.
+        /// </summary>
+        [JsonProperty("metadata")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("metadata")]
+#endif
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardTokenOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCardTokenOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class ExternalAccountCardTokenOptions : INestedOptions, IHasObject
+    {
+        [JsonProperty("object")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("object")]
+#endif
+        public string Object { get; set; } = "card";
+
+        [JsonProperty("currency")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("currency")]
+#endif
+        public string Currency { get; set; }
+
+        [JsonProperty("token")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("token")]
+#endif
+        public string Token { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/ExternalAccounts/ExternalAccountCreateOptions.cs
@@ -3,6 +3,7 @@ namespace Stripe
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Stripe.Infrastructure;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
@@ -25,10 +26,12 @@ namespace Stripe
         /// external account details (with the options shown below).
         /// </summary>
         [JsonProperty("external_account")]
+        [JsonConverter(typeof(AnyOfConverter))]
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("external_account")]
+        [STJS.JsonConverter(typeof(STJAnyOfConverter))]
 #endif
-        public string ExternalAccount { get; set; }
+        public AnyOf<string, ExternalAccountCardOptions, AccountBankAccountOptions, ExternalAccountCardTokenOptions> ExternalAccount { get; set; }
 
         /// <summary>
         /// Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `external_account` should be a union type, not a `string`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Changes `externalAccount` field in `externalAccounts.create` from a `string` to a union type.


## Changelog
- Changes `externalAccount` field in `externalAccounts.create` from a `string` to a union type.