### PR TITLE
copy fixed test from beta

### DIFF
--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -94,6 +94,14 @@ namespace StripeTests
         {
             var evt = Event.FromJson(this.json);
             var expectedReleaseTrain = StripeConfiguration.ApiVersion.Split('.')[1];
+
+            // this test only makes sense on GA versions- the exact version for preview versions doesn't
+            // work this way and we can't mock private methods from this test class.
+            if (expectedReleaseTrain == "preview")
+            {
+                return;
+            }
+
             evt.ApiVersion = "2999-10-10." + expectedReleaseTrain;
             var serialized = evt.ToJson();
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Backports a fix from https://github.com/stripe/stripe-dotnet/pull/3091

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- skips a test when it's a preview SDK (which won't happen in GA, but it's nice for the code to be consistent)

### See Also
<!-- Include any links or additional information that help explain this change. -->
