### PR TITLE
Standardize version variable for EventUtility

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/EventConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/EventConverter.cs
@@ -8,7 +8,7 @@ namespace Stripe.Infrastructure
     /// <summary>
     /// This converter is used to deserialize event objects regardless of which API version they're
     /// formatted with. In the general case, Stripe.net uses a specific API version
-    /// (<see cref="StripeConfiguration.ApiVersion"/>), but events are a special case: when
+    /// (<see cref="ApiVersion.Current"/>), but events are a special case: when
     /// receiving an event object via a webhook notification, the object will be formatted with
     /// the Stripe account's default API version which may be different than Stripe.net's API
     /// version.

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -52,7 +52,7 @@ namespace Stripe
         /// <param name="throwOnApiVersionMismatch">
         /// If <c>true</c> (default), the method will throw a <see cref="StripeException"/> if the
         /// API version of the event doesn't match Stripe.net's default API version (see
-        /// <see cref="StripeConfiguration.ApiVersion"/>).
+        /// <see cref="ApiVersion.Current"/>).
         /// </param>
         /// <returns>The deserialized <see cref="Event"/>.</returns>
         /// <exception cref="StripeException">
@@ -75,7 +75,7 @@ namespace Stripe
                 throw new StripeException(
                     $"Received event with API version {stripeEvent.ApiVersion}, but Stripe.net "
                     + $"{StripeConfiguration.StripeNetVersion} expects API version "
-                    + $"{StripeConfiguration.ApiVersion}. We recommend that you create a "
+                    + $"{ApiVersion.Current}. We recommend that you create a "
                     + "WebhookEndpoint with this API version. Otherwise, you can disable this "
                     + "exception by passing `throwOnApiVersionMismatch: false` to "
                     + "`Stripe.EventUtility.ParseEvent` or `Stripe.EventUtility.ConstructEvent`, "
@@ -99,7 +99,7 @@ namespace Stripe
         /// <param name="throwOnApiVersionMismatch">
         /// If <c>true</c> (default), the method will throw a <see cref="StripeException"/> if the
         /// API version of the event doesn't match Stripe.net's default API version (see
-        /// <see cref="StripeConfiguration.ApiVersion"/>).
+        /// <see cref="ApiVersion.Current"/>).
         /// </param>
         /// <returns>The deserialized <see cref="Event"/>.</returns>
         /// <exception cref="StripeException">
@@ -137,7 +137,7 @@ namespace Stripe
         /// <param name="throwOnApiVersionMismatch">
         /// If <c>true</c> (default), the method will throw a <see cref="StripeException"/> if the
         /// API version of the event doesn't match Stripe.net's default API version (see
-        /// <see cref="StripeConfiguration.ApiVersion"/>).
+        /// <see cref="ApiVersion.Current"/>).
         /// </param>
         /// <returns>The deserialized <see cref="Event"/>.</returns>
         /// <exception cref="StripeException">

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -82,18 +82,18 @@ namespace StripeTests
         public void AcceptsExpectedApiVersion()
         {
             var evt = Event.FromJson(this.json);
-            evt.ApiVersion = StripeConfiguration.ApiVersion;
+            evt.ApiVersion = ApiVersion.Current
             var serialized = evt.ToJson();
 
             evt = EventUtility.ParseEvent(serialized);
-            Assert.Equal(StripeConfiguration.ApiVersion, evt.ApiVersion);
+            Assert.Equal(ApiVersion.Current, evt.ApiVersion);
         }
 
         [Fact]
         public void AcceptsNewApiVersionInExpectedReleaseTrain()
         {
             var evt = Event.FromJson(this.json);
-            var expectedReleaseTrain = StripeConfiguration.ApiVersion.Split('.')[1];
+            var expectedReleaseTrain = ApiVersion.Current.Split('.')[1];
 
             // this test only makes sense on GA versions- the exact version for preview versions doesn't
             // work this way and we can't mock private methods from this test class.


### PR DESCRIPTION
### Why?
Api versions work a bit differently between GA and beta; the beta SDK supports beta headers that can be sent with API calls to enable beta features.  Event parsing and validating, however, is performed against the base pinned version `ApiVersion.Current` in both SDKs.  This PR updates the code to use `ApiVersion.Current` directly in these cases in order to avoid merge conflicts when merging code between beta and GA.

### What?
- updated event code and docs to use ApiVersion.Current instead of StripeConfiguration.ApiVersion

### See Also
<!-- Include any links or additional information that help explain this change. -->
