### PR TITLE
Fixed encoding of boolean query params

### DIFF
--- a/src/Stripe.net/Infrastructure/FormEncoding/ContentEncoder.cs
+++ b/src/Stripe.net/Infrastructure/FormEncoding/ContentEncoder.cs
@@ -163,6 +163,12 @@ namespace Stripe.Infrastructure.FormEncoding
                     flatParams = SingleParam(keyPrefix, JsonUtils.SerializeObject(e).Trim('"'));
                     break;
 
+                case bool b:
+                    flatParams = SingleParam(
+                        keyPrefix,
+                        b ? "true" : "false");
+                    break;
+
                 default:
                     flatParams = SingleParam(
                         keyPrefix,

--- a/src/StripeTests/Infrastructure/FormEncoding/ContentEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/ContentEncoderTest.cs
@@ -205,7 +205,7 @@ namespace StripeTests
                     {
                         Bool = false,
                     },
-                    Want = "bool=False",
+                    Want = "bool=false",
                 },
                 new QueryStringTestCase
                 {
@@ -213,7 +213,7 @@ namespace StripeTests
                     {
                         Bool = true,
                     },
-                    Want = "bool=True",
+                    Want = "bool=true",
                 },
 
                 // DateRangeOptions

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentConfirmOptionsTest.cs
@@ -14,7 +14,7 @@ namespace StripeTests
                 OffSession = true,
             };
 
-            Assert.Equal("off_session=True", ContentEncoder.CreateQueryString(options_bool));
+            Assert.Equal("off_session=true", ContentEncoder.CreateQueryString(options_bool));
         }
     }
 }

--- a/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
+++ b/src/StripeTests/Services/PaymentIntents/PaymentIntentCreateOptionsTest.cs
@@ -14,7 +14,7 @@ namespace StripeTests
                 OffSession = true,
             };
 
-            Assert.Equal("off_session=True", ContentEncoder.CreateQueryString(options_bool));
+            Assert.Equal("off_session=true", ContentEncoder.CreateQueryString(options_bool));
         }
     }
 }


### PR DESCRIPTION
### Why?
The `ContentEncoder` class does not have a special case for encoding boolean query params, and .NET's bool ToString method outputs capitalized True or False.  v1 apis would accept these or the lowercase versions true or false, but but v2 strictly requires the lowercase true or false.  This PR updates ContentEncoder to correctly encode booleans for both API versions.

### What?
- changed ContentEncoder to emit lowercase true/false for boolean params
- updated tests

### See Also
<!-- Include any links or additional information that help explain this change. -->
