### PR TITLE
Use a specified spec version for stripe-mock tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: Build and test
 
-    # TODO: this step is not compatible with ubuntu 24 LTS, so we pin the version here instead of using ubuntu-latest 
+    # TODO: this step is not compatible with ubuntu 24 LTS, so we pin the version here instead of using ubuntu-latest
     runs-on: ubuntu-22.04
 
     steps:
@@ -46,7 +46,48 @@ jobs:
       - name: Build Release
         run: dotnet build src -c Release /p:ContinuousIntegrationBuild=true
 
+      - name: Determine OpenAPI versions and extract specs
+        run: |
+          set -e -o pipefail
+
+          CURL_OPTS=(--retry 3 \
+            --retry-all-errors \
+            --fail \
+            --verbose \
+            --no-progress-meter \
+            --show-error)
+
+          LATEST_OPENAPI_VERSION=$(curl https://api.github.com/repos/stripe/openapi/releases/latest -s | jq .name -r)
+          CURRENT_OPENAPI_VERSION=$(cat OPENAPI_VERSION)
+          if [[ "$PR_BODY" == *"TEST USING LATEST OPENAPI"* ]]; then
+            OPENAPI_VERSION=$LATEST_OPENAPI_VERSION
+          else
+            OPENAPI_VERSION=$CURRENT_OPENAPI_VERSION
+          fi
+
+          CURRENT_OPENAPI_SPEC=$(realpath latest.yaml)
+          CURRENT_OPENAPI_SPEC_JSON=${CURRENT_OPENAPI_SPEC%.yaml}.json
+          CURRENT_FIXTURES_JSON=${CURRENT_OPENAPI_SPEC%/*}/fixtures.json
+
+          SPEC_NAME="spec3.sdk.yaml"
+          FIXTURES_NAME="fixtures3.json"
+          if [[ "$GITHUB_BASE" == *"b"* ]]; then
+            SPEC_NAME="spec3.beta.sdk.yaml"
+            FIXTURES_NAME="fixtures3.beta.json"
+          fi
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/$OPENAPI_VERSION/openapi/${SPEC_NAME%.yaml}.json -o $CURRENT_OPENAPI_SPEC_JSON
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/$OPENAPI_VERSION/openapi/$FIXTURES_NAME -o $CURRENT_FIXTURES_JSON
+
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_BASE: ${{ github.base_ref || github.ref_name }}
+
       - uses: stripe/openapi/actions/stripe-mock@master
+        with:
+          # Used to determine if stripe-mock runs in beta mode
+          base: ${{ github.base_ref || github.ref_name }}
+          fixtures: "/workspace/fixtures.json"
+          spec_path: "/workspace/latest.json"
 
       - name: Run test suite
         run: just ci-test


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We modified stripe-mock to allow spec/fixtures version, and due to some mismatches between codegen/spec in the last major, we were having issues. Let's update to pull spec/fixture version here.

TEST USING LATEST OPENAPI

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Adds a step to manually pull the relevant spec/fixtures for testing.

Tested in CI in this branch https://github.com/stripe/stripe-dotnet/pull/3117

### See Also
<!-- Include any links or additional information that help explain this change. -->
