### PR TITLE
Rename beta SDKs to public preview SDKs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ We would love for you to try these as we incrementally release new features and 
 The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
 
 ```
-dotnet add package Stripe.net --version <beta version>
+dotnet add package Stripe.net --version <replace-with-the-version-of-your-choice>
 ```
 
 > **Note**

--- a/README.md
+++ b/README.md
@@ -266,10 +266,10 @@ StripeConfiguration.EnableTelemetry = false;
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `45.1.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are different versions of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
+To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
 
 ```
 dotnet add package Stripe.net --version <replace-with-the-version-of-your-choice>
@@ -278,7 +278,7 @@ dotnet add package Stripe.net --version <replace-with-the-version-of-your-choice
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your project file. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-If your beta feature requires a `Stripe-Version` header to be sent, set the `StripeConfiguration.ApiVersion` property with the `StripeConfiguration.AddBetaVersion` function (available only in the public preview SDKs):
+Some preview features require a name and version to be set in the `Stripe-Version` header like `feature_beta=v3`. If your preview feature has this requirement, use the `StripeConfiguration.AddBetaVersion` function (available only in the public preview SDKs):
 
 ```csharp
 StripeConfiguration.AddBetaVersion("feature_beta", "v3");

--- a/README.md
+++ b/README.md
@@ -264,27 +264,21 @@ You can disable this behavior if you prefer:
 StripeConfiguration.EnableTelemetry = false;
 ```
 
-### Beta SDKs
+### Public Preview SDKs
 
-Stripe has features in the beta phase that can be accessed via the beta version of this package.
-We would love for you to try these and share feedback with us before these features reach the stable phase.
-To install a beta version of Stripe.net use the version parameter with `dotnet add package` command:
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+We would love for you to try these as we incrementally release new features and improve them based on your feedback.
+
+The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
 
 ```
 dotnet add package Stripe.net --version <beta version>
 ```
 
-Beta versions are appended with `-beta.X` such as `45.0.0-beta.1`. Make sure to choose the version that includes support for the beta you are interested in!
-
 > **Note**
-> There can be breaking changes between beta versions. Therefore we recommend pinning the package version to a specific beta version in your project file. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest beta version.
+> There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your project file. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-We highly recommend keeping an eye on when the beta feature you are interested in goes from beta to stable so that you can move from using a beta version of the SDK to the stable version.
-
-If your beta feature requires a `Stripe-Version` header to be sent, set the `StripeConfiguration.ApiVersion` property with the `StripeConfiguration.AddBetaVersion` function:
-
-> **Note**
-> The `ApiVersion` can only be set in beta versions of the library.
+If your beta feature requires a `Stripe-Version` header to be sent, set the `StripeConfiguration.ApiVersion` property with the `StripeConfiguration.AddBetaVersion` function (available only in the public preview SDKs):
 
 ```csharp
 StripeConfiguration.AddBetaVersion("feature_beta", "v3");

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ StripeConfiguration.EnableTelemetry = false;
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
+The public preview SDKs are different versions of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-dotnet/releases/) and then use it in the version parameter with `dotnet add package` command:
 
 ```
 dotnet add package Stripe.net --version <replace-with-the-version-of-your-choice>


### PR DESCRIPTION
### Why?
Beta SDKs are being re-branded as public preview SDKs

### What?
- Reword the beta SDKs section to use the term "public preview" unless talking about the actual version string
- Link to https://docs.stripe.com/release-phases and re-use verbiage from ther


