### PR TITLE
Link to the /changelog page instead of /upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 48.2.0 - 2025-05-29
  This release changes the pinned API version to `2025-05-28.basil`.
 
-* [#3128](https://github.com/stripe/stripe-dotnet/pull/3128) Update generated code. 
+* [#3128](https://github.com/stripe/stripe-dotnet/pull/3128) Update generated code.
   * Add support for `AttachPayment` method on resource `Invoice`
   * Add support for `CollectInputs` method on resource `Terminal.Reader`
   * Add support for `SucceedInputCollection` and `TimeoutInputCollection` test helper methods on resource `Terminal.Reader`
@@ -57,11 +57,11 @@
 * [#3074](https://github.com/stripe/stripe-dotnet/pull/3074) System.Text.Json Serialization Support release to GA
   * Add System.Text.Json support for serializing Stripe.net entities and objects for applications running on .NET 6 and above. Now you can pass a Stripe.net object or collection of objects to the System.Text.Json serializer and it will produce the correct JSON string.
 * [#3056](https://github.com/stripe/stripe-dotnet/pull/3056) Support for APIs in the new API version 2025-03-31.basil
-  
+
   This release changes the pinned API version to `2025-03-31.basil`.
-  
+
   ### ⚠️ Breaking changes  due to changes in the Stripe API
-  
+
   Please review details for the breaking changes and alternatives in the [Stripe API changelog](https://docs.stripe.com/changelog/basil) before upgrading.
 
   * Remove support for resources `SubscriptionItemUsageRecordSummary` and `SubscriptionItemUsageRecord`
@@ -89,9 +89,9 @@
   * Remove support for `AggregateUsage` on `PlanCreateOptions`, `Plan`, `PriceRecurringOptions`, and `PriceRecurring`
   * Remove support for `CurrentPeriodEnd` and `CurrentPeriodStart` on `Subscription`
   * Remove support for Page on `V2.EventDestinationListOptions` and `V2.EventListOptions`
-  
+
   ### Additions
-  
+
   * Add support for new resource `InvoicePayment`
   * Add support for `Get` and `List` methods on resource `InvoicePayment`
   * Add support for `BilliePayments`, `NzBankAccountBecsDebitPayments`, and `SatispayPayments` on `AccountCapabilitiesOptions` and `AccountCapabilities`
@@ -117,7 +117,7 @@
   * Add support for `NzBankTransfer` on `RefundDestinationDetails`
   * Add support for `CurrentPeriodEnd` and `CurrentPeriodStart` on `SubscriptionItem`
   * Add support for `Wifi` on `Terminal.ConfigurationCreateOptions`, `Terminal.ConfigurationUpdateOptions`, and `TerminalConfiguration`
-  
+
   ### ⚠️ Other Breaking changes in the SDK
 * [#3065](https://github.com/stripe/stripe-dotnet/pull/3065) Merge breaking changes from sdk-release/next-major branch to master
   * Adds `StripeAccount` and `StripeContext` to `StripeClientOptions`, so you can specify the Stripe-Account or Stripe-Context header at the client (instead of the individual request) level. See [PR #3058](https://github.com/stripe/stripe-dotnet/pull/3058)
@@ -128,7 +128,7 @@
   * Remove `ListOptionsWithCreated` base class. The classes that use to extend it now extend `ListOptions` and have the the `created` field defined explicitly.
   * Classes`ReportTypeService` and `AccountCapabilityService` no longer implement the `IListable` interface, and the `ListAutoPaging` and `ListAutoPagingAsync` methods are removed. This is because the list APIs here are not pageable. See #2227 for more details.
      * As a consequence, the classes `ReportTypeOptions` and `AccountCapabilityOptions` no longer extend `ListOptions` as well
-  
+
 
 ## 47.4.0 - 2025-02-24
 * [#3050](https://github.com/stripe/stripe-dotnet/pull/3050) Update generated code
@@ -242,7 +242,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   - fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.
 * [#3007](https://github.com/stripe/stripe-dotnet/pull/3007) Fixes ApiRequestorAdapter requests with BaseAddress other than Api
   - fixes bug where OAuthTokenService created without an explicit StripeClient accesses the wrong base url
-  
+
 * [#3003](https://github.com/stripe/stripe-dotnet/pull/3003) Cleaned up examples and added documentation
 
 ## 46.2.0 - 2024-10-09
@@ -258,19 +258,19 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
 ## 46.0.0 - 2024-10-01
 
 * [#2980](https://github.com/stripe/stripe-dotnet/pull/2980) Support for APIs in the new API version 2024-09-30.acacia
-  
-  This release changes the pinned API version to `2024-09-30.acacia`. Please read the [API Upgrade Guide](https://stripe.com/docs/upgrades#2024-09-30.acacia) and carefully review the API changes before upgrading.
-  
+
+  This release changes the pinned API version to `2024-09-30.acacia`. Please read the [API Changelog](https://docs.stripe.com/changelog/acacia#2024-09-30.acacia) and carefully review the API changes before upgrading.
+
   ### ⚠️ Breaking changes due to changes in the API
-  
+
   * Rename `UsageThresholdConfig` to `UsageThreshold` on `Billing.Alert` and `Billing.AlertCreateOptions`
   * Remove support for `Filter` on `Billing.Alert` and `BillingAlert.AlertCreateOptions `. Use the filters on the `UsageThreshold` instead
   * Remove support for `CustomerConsentCollected` on `Terminal.ReaderProcessSetupIntentOptions`
-  
+
   ### ⚠️ Other Breaking changes in the SDK
-  
+
   Refer to our [migration guide for v46](https://github.com/stripe/stripe-dotnet/wiki/Migration-guide-for-v46) for a list of backwards incompatible changes in this release.  Here is a summary of things to watch out for:
-  
+
   * [Remove obsolete properties and methods](https://github.com/stripe/stripe-dotnet/wiki/Migration-guide-for-v46#removals) from `Service` and `ServiceNested` base classes including `CreateEntity` and other `*Entity` and `*EntityAsync` methods, `BasePath`, and `BaseUrl`
   * [Rename `Stripe.Event` to `Stripe.EventTypes`](https://github.com/stripe/stripe-dotnet/wiki/Migration-guide-for-v46#renaming-stripeevents-to-stripeeventtypes). This class contains constants for event type strings.
   * For more predictable naming of child services and their corresponding Options classes:
@@ -280,7 +280,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   * `Newtonsoft.Json` dependency has been upgraded for all .NET target runtimes. This is potentially a breaking change if you also depend on `Newtonsoft.Json` directly from your application. To migrate, please upgrade the version of Newtonsoft.Json your application depends on.  If you have runtime conflicts with another library dependency, you can use `<bindingRedirect>` to specify which version .NET should load (see https://stackoverflow.com/a/51053646 and https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/bindingredirect-element)
 
   ### Additions
-  
+
   * Add support for `UsageThreshold` on `Billing.AlertCreateOptions` and `BillingAlert`
   * Add support for `CustomUnitAmount` on `ProductDefaultPriceDataOptions`
   * Add support for `AllowRedisplay` on `Terminal.ReaderProcessSetupIntentOptions` and `TerminalReaderProcessConfigOptions`
@@ -394,22 +394,22 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
 
 ## 45.0.0 - 2024-06-24
 * [#2929](https://github.com/stripe/stripe-dotnet/pull/2929) Update generated code
-  
-  This release changes the pinned API version to 2024-06-20. Please read the [API Upgrade Guide](https://stripe.com/docs/upgrades#2024-06-20) and carefully review the API changes before upgrading.
-  
+
+  This release changes the pinned API version to 2024-06-20. Please read the [API Changelog](https://docs.stripe.com/changelog/2024-06-20) and carefully review the API changes before upgrading.
+
   ### ⚠️ Breaking changes
-  
+
     * Remove the unused resource `PlatformTaxFee`
     * Rename `VolumeDecimal` to `QuantityDecimal` on `IssuingAuthorizationPurchaseDetailsFuelOptions`, `IssuingTransactionPurchaseDetailsFuelOptions`, and `IssuingTransactionPurchaseDetailsFuel`
-  
+
   ### Additions
-  
+
   * Add support for `FinalizeAmount` test helper method on resource `Issuing.Authorization`
-  * Add support for new values `platform_disabled`, `paused.inactivity` and `other` on enums `CapabilityRequirements.DisabledReason` and `CapabilityFutureRequirements.DisabledReason` 
+  * Add support for new values `platform_disabled`, `paused.inactivity` and `other` on enums `CapabilityRequirements.DisabledReason` and `CapabilityFutureRequirements.DisabledReason`
   * Add support for `Fleet` on `Issuing.TestHelpersAuthorizationCreateOptions`, `IssuingAuthorizationPurchaseDetailsOptions`, `IssuingAuthorization`, `IssuingTransactionPurchaseDetailsOptions`, and `IssuingTransactionPurchaseDetails`
   * Add support for `Fuel` on `Issuing.TestHelpersAuthorizationCreateOptions` and `IssuingAuthorization`
   * Add support for `IndustryProductCode` and `QuantityDecimal` on `IssuingAuthorizationPurchaseDetailsFuelOptions`, `IssuingTransactionPurchaseDetailsFuelOptions`, and `IssuingTransactionPurchaseDetailsFuel`
-  
+
 
 ## 44.13.0 - 2024-06-17
 * [#2927](https://github.com/stripe/stripe-dotnet/pull/2927) Update generated code
@@ -455,7 +455,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
 ## 44.7.0 - 2024-05-09
 * [#2907](https://github.com/stripe/stripe-dotnet/pull/2907) Update generated code
   * Remove support for `PendingInvoiceItemsBehavior` on `SubscriptionCreateOptions` that was prematurely added in the previous release on the same day
-  
+
 
 ## 44.6.0 - 2024-05-09
 * [#2906](https://github.com/stripe/stripe-dotnet/pull/2906) Update generated code
@@ -511,26 +511,26 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   * Add support for `NextRefreshAvailableAt` on `FinancialConnectionsAccountOwnershipRefresh`
 
 ## 44.0.0 - 2024-04-10
-* [#2884](https://github.com/stripe/stripe-dotnet/pull/2884) 
-  
-  * This release changes the pinned API version to `2024-04-10`. Please read the [API Upgrade Guide](https://stripe.com/docs/upgrades#2024-04-10) and carefully review the API changes before upgrading.
-  
+* [#2884](https://github.com/stripe/stripe-dotnet/pull/2884)
+
+  * This release changes the pinned API version to `2024-04-10`. Please read the [API Changelog](https://docs.stripe.com/changelog/2024-04-10) and carefully review the API changes before upgrading.
+
   ### ⚠️ Breaking changes
-  
+
   * Change the property `Amount` on `SourceTransaction` to not be nullable
   * Remove the below unused classes
       * `InvoiceLineItemAutomaticTaxOptions`
       * `InvoiceLineItemCustomerDetailsOptions`
       * `InvoiceLineItemCustomerDetailsTaxIdOptions`
       * `InvoiceLineItemCustomerDetailsTaxOptions`
-  * Change the type of the below date fields from `long` to `DateTime` 
+  * Change the type of the below date fields from `long` to `DateTime`
       * `AccountSettingsCardIssuingTosAcceptance.Date`
       * `AccountSettingsTreasuryTosAcceptance.Date`
       * `PaymentIntentNextActionPixDisplayQrCode.ExpiresAt`
       * `PaymentIntentPaymentMethodOptionsPix.ExpiresAt`
       * `CalculationCreateOptions.TaxDate`
   * Rename `Features` to `MarketingFeatures` on `ProductCreateOptions`, `ProductUpdateOptions`, and `Product`.
-  
+
   #### ⚠️ Removal of enum values, properties and events that are no longer part of the publicly documented Stripe API
    * Remove `BillingPortal.ConfigurationFeatures.SubscriptionPause` and `BillingPortal.ConfigurationFeaturesOptions.SubscriptionPause` as the feature to pause subscription on the portal has been deprecated.
    * Remove the below deprecated events from `Event.Type`, `WebhookEndpointCreateOptions.EnabledEvents`, `WebhookEndpointUpdateOptions.EnabledEvents` and the constants in `Events`
@@ -547,7 +547,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
       * `obligation_payout`
       * `obligation_payout_failure`
       * `obligation_reversal_outbound`
-   * Remove the support for `various` in `Climate.Supplier.RemovalPathway` 
+   * Remove the support for `various` in `Climate.Supplier.RemovalPathway`
    * Remove support for `id_bank_transfer`, `multibanco`, `netbanking`, `pay_by_bank`, and `upi` on `PaymentMethodConfiguration` by removing the below classes
      * `PaymentMethodConfigurationIdBankTransfer`
      * `PaymentMethodConfigurationMultibanco`
@@ -563,20 +563,20 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
    * Remove the support for deprecated value `obligation` on `ReportRunParameterOptions.ReportingCategory`
    * Remove the legacy field `RenderingOptions` in `Invoice`, `InvoiceCreateOptions` and `InvoiceUpdateOptions`.
    * Rename the type of field `Rendering` in `InvoiceCreateOptions` and `InvoiceUpdateOptions` from `InvoiceRenderingOptionsOptions` to `InvoiceRenderingOptions`
-  
-   
-  
-   
-  
-  
-   
-   
-  
-  
-  
-  
-   
-   
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 ## 43.23.0 - 2024-04-09
 * [#2887](https://github.com/stripe/stripe-dotnet/pull/2887) Update generated code
@@ -805,7 +805,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
 * [#2789](https://github.com/stripe/stripe-dotnet/pull/2789) Add list enum comments and autogenerate more options
 
 ## 43.0.0 - 2023-10-16
-* This release changes the pinned API version to `2023-10-16`. Please read the [API Upgrade Guide](https://stripe.com/docs/upgrades#2023-10-16) and carefully review the API changes before upgrading `Stripe.net`.
+* This release changes the pinned API version to `2023-10-16`. Please read the [API Changelog](https://docs.stripe.com/changelog/2023-10-16) and carefully review the API changes before upgrading `Stripe.net`.
 * [#2781](https://github.com/stripe/stripe-dotnet/pull/2781) Update generated code
   * Add support for `LegalGuardian` on `AccountRelationshipOptions` and `TokenPersonRelationshipOptions`
   * Add support for `AdditionalTosAcceptances` on `TokenPersonOptions`
@@ -890,7 +890,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   * Add support for `FlatAmount` on `Tax.TransactionCreateReversalOptions`
 
 ## 42.0.0 - 2023-08-16
-* This release changes the pinned API version to `2023-08-16`. Please read the [API Upgrade Guide](https://stripe.com/docs/upgrades#2023-08-16) and carefully review the API changes before upgrading `stripe-dotnet`.
+* This release changes the pinned API version to `2023-08-16`. Please read the [API Changelog](https://docs.stripe.com/changelog/2023-08-16) and carefully review the API changes before upgrading `stripe-dotnet`.
 * More information is available in the [stripe-dotnet v42 migration guide](https://github.com/stripe/stripe-dotnet/wiki/Migration-guide-for-v42)
 * [#2750](https://github.com/stripe/stripe-dotnet/pull/2750) Update generated code
   "⚠️" symbol highlights breaking changes.
@@ -919,7 +919,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   `SubscriptionSchedulePhaseOptions.TrialEnd`. These fields are dates or numbers that also support special signifier strings like "now". They have been changed to use `AnyOf<...>`.
 * [#2746](http://github.com/stripe/stripe-dotnet/pull/2746) Type changes
   * ⚠️ Change type of `AccountSettingsPayoutsScheduleOptions.MonthlyAnchor` from string to long.
-* [#2751](https://github.com/stripe/stripe-dotnet/pull/2751) 
+* [#2751](https://github.com/stripe/stripe-dotnet/pull/2751)
   * ⚠️ Remove several deprecated constants from `Event`
   * ⚠️ Make `Discount.Start` non-nullable
   * ⚠️ Reflect that `Discount.Subscription` is not expandable
@@ -1055,7 +1055,7 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
   * Add support for `Country` on `ChargePaymentMethodDetailsLink`
   * Add support for `PreferredLocale` on `PaymentIntentPaymentMethodOptionsAffirmOptions` and `PaymentIntentPaymentMethodOptionsAffirm`
   * Add support for `CashappHandleRedirectOrDisplayQrCode` on `PaymentIntentNextAction` and `SetupIntentNextAction`
-  
+
 * [#2657](https://github.com/stripe/stripe-dotnet/pull/2657) Update generated code (new)
   * Add support for `CashappPayments` on `AccountCapabilitiesOptions` and `AccountCapabilities`
   * Add support for `Cashapp` on `ChargePaymentMethodDetails`, `Checkout.SessionPaymentMethodOptionsOptions`, `Checkout.SessionPaymentMethodOptions`, `MandatePaymentMethodDetails`, `PaymentIntentPaymentMethodDataOptions`, `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodOptions`, `PaymentMethodCreateOptions`, `PaymentMethodUpdateOptions`, `PaymentMethod`, `SetupAttemptPaymentMethodDetails`, and `SetupIntentPaymentMethodDataOptions`
@@ -1126,11 +1126,11 @@ However, [a bug](https://github.com/stripe/stripe-dotnet/pull/3010) in the `46.x
 * [#2609](https://github.com/stripe/stripe-dotnet/pull/2609) API Updates
   * Add support for `CustomText` on `Checkout.SessionCreateOptions`, `Checkout.Session`, `PaymentLinkCreateOptions`, `PaymentLinkUpdateOptions`, and `PaymentLink`
   * Add support for `HostedInstructionsUrl` on `PaymentIntentNextActionPaynowDisplayQrCode`
-  
+
 
 ## 41.0.0 - 2022-11-16
 
-Breaking changes that arose during code generation of the library that we postponed for the next major version. For changes to the Stripe products, read more at https://stripe.com/docs/upgrades#2022-11-15.
+Breaking changes that arose during code generation of the library that we postponed for the next major version. For changes to the Stripe products, read more at https://docs.stripe.com/changelog/2022-11-15.
 
 "⚠️" symbol highlights breaking changes.
 
@@ -1183,7 +1183,7 @@ Breaking changes that arose during code generation of the library that we postpo
   * Add support for `TermsOfService` on `Checkout.SessionConsentCollectionOptions`, `Checkout.SessionConsentCollection`, `Checkout.SessionConsent`, `PaymentLinkConsentCollectionOptions`, and `PaymentLinkConsentCollection`
   * ⚠️  Remove support for `Plan` on `Checkout.SessionPaymentMethodOptionsCardInstallmentsOptions`. The property was mistakenly released and never worked.
   * Add support for `StatementDescriptor` on `PaymentIntentIncrementAuthorizationOptions`
-  
+
 
 ## 40.9.0 - 2022-09-15
 * [#2577](https://github.com/stripe/stripe-dotnet/pull/2577) API Updates
@@ -1219,7 +1219,7 @@ Breaking changes that arose during code generation of the library that we postpo
 * [#2562](https://github.com/stripe/stripe-dotnet/pull/2562) Add beta README.md section
 * [#2564](https://github.com/stripe/stripe-dotnet/pull/2564) API Updates
   * Change the return type of `CustomerService.FundCashBalance` test helper from `CustomerBalanceTransaction` to `CustomerCashBalanceTransaction`.
-    * This would generally be considered a breaking change, but we've worked with all existing users to migrate and are comfortable releasing this as a minor as it is solely a test helper method. This was essentially broken prior to this change. 
+    * This would generally be considered a breaking change, but we've worked with all existing users to migrate and are comfortable releasing this as a minor as it is solely a test helper method. This was essentially broken prior to this change.
 
 ## 40.3.0 - 2022-08-19
 * [#2560](https://github.com/stripe/stripe-dotnet/pull/2560) API Updates
@@ -1232,7 +1232,7 @@ Breaking changes that arose during code generation of the library that we postpo
 ## 40.2.0 - 2022-08-11
 * [#2556](https://github.com/stripe/stripe-dotnet/pull/2556) API Updates
   * Add support for `PaymentMethodCollection` on `Checkout.SessionCreateOptions`, `Checkout.Session`, `PaymentLinkCreateOptions`, `PaymentLinkUpdateOptions`, and `PaymentLink`
-  
+
 * [#2555](https://github.com/stripe/stripe-dotnet/pull/2555) Set MaxDepth for serialization and deserialization
 * [#2554](https://github.com/stripe/stripe-dotnet/pull/2554) Add test for FileCreation from base64 in memory
 
@@ -1246,7 +1246,7 @@ Breaking changes that arose during code generation of the library that we postpo
 
 This release includes breaking changes resulting from:
 
-* Moving to use the new API version "2022-08-01". To learn more about these changes to Stripe products, see https://stripe.com/docs/upgrades#2022-08-01
+* Moving to use the new API version "2022-08-01". To learn more about these changes to Stripe products, see https://docs.stripe.com/changelog/2022-08-01
 * Cleaning up the SDK to remove deprecated/unused APIs and rename classes/methods/properties to sync with product APIs. Read more detailed description at https://github.com/stripe/stripe-dotnet/wiki/Migration-guide-for-v40.
 
 "⚠️" symbol highlights breaking changes.
@@ -1297,12 +1297,12 @@ This release includes breaking changes resulting from:
 
 ## 39.125.0 - 2022-07-25
 * [#2543](https://github.com/stripe/stripe-dotnet/pull/2543) API Updates
-  * Add support for `Installments` on `Checkout.SessionPaymentMethodOptionsCardOptions`, `Checkout.SessionPaymentMethodOptionsCard`, `InvoicePaymentSettingsPaymentMethodOptionsCardOptions`, and `InvoicePaymentSettingsPaymentMethodOptionsCard` 
+  * Add support for `Installments` on `Checkout.SessionPaymentMethodOptionsCardOptions`, `Checkout.SessionPaymentMethodOptionsCard`, `InvoicePaymentSettingsPaymentMethodOptionsCardOptions`, and `InvoicePaymentSettingsPaymentMethodOptionsCard`
   * Add support for `DefaultCurrency` and `InvoiceCreditBalance` on `Customer`
   * Add support for `Currency` on `InvoiceCreateOptions`
   * Add support for `DefaultMandate` on `InvoicePaymentSettingsOptions` and `InvoicePaymentSettings`
   * Add support for `Mandate` on `InvoicePayOptions`
-  
+
 
 ## 39.124.0 - 2022-07-18
 * [#2534](https://github.com/stripe/stripe-dotnet/pull/2534) API Updates
@@ -1390,7 +1390,7 @@ This release includes breaking changes resulting from:
   * Add support for `HostedInstructionsUrl` on `PaymentIntentNextActionDisplayBankTransferInstructions`
   * Add support for `IdNumberSecondaryProvided` on `Person`
   * Add support for `CardIssuing` on `Treasury.FinancialAccountFeaturesOptions` and `Treasury.FinancialAccountUpdateFeaturesOptions`
-  
+
 
 ## 39.114.0 - 2022-05-23
 * [#2492](https://github.com/stripe/stripe-dotnet/pull/2492) API Updates
@@ -1432,23 +1432,23 @@ This release includes breaking changes resulting from:
   * Add support for `Metadata` on `SubscriptionSchedulePhasesOptions` and `SubscriptionSchedulePhases`
 * [#2478](https://github.com/stripe/stripe-dotnet/pull/2478) Make dotnet formatting faster
 * [#2479](https://github.com/stripe/stripe-dotnet/pull/2479) API Updates
-  
+
   * Add support for `AmountDiscount`, `AmountTax`, and `Product` on `LineItem`
-  
+
 
 ## 39.110.0 - 2022-05-05
 * [#2475](https://github.com/stripe/stripe-dotnet/pull/2475) API Updates
   * Add support for `DefaultPriceData` on `ProductCreateOptions`
   * Add support for `DefaultPrice` on `ProductUpdateOptions` and `Product`
   * Add support for `InstructionsEmail` on `RefundCreateOptions` and `Refund`
-  
+
 
 ## 39.109.0 - 2022-05-05
 * [#2474](https://github.com/stripe/stripe-dotnet/pull/2474) API Updates
   * Add support for new resources `FinancialConnections.AccountOwner`, `FinancialConnections.AccountOwnership`, `FinancialConnections.Account`, and `FinancialConnections.Session`
   * Add support for `FinancialConnections` on `Checkout.SessionPaymentMethodOptionsUsBankAccountOptions`, `Checkout.SessionPaymentMethodOptionsUsBankAccount`, `InvoicePaymentSettingsPaymentMethodOptionsUsBankAccountOptions`, `InvoicePaymentSettingsPaymentMethodOptionsUsBankAccount`, `PaymentIntentPaymentMethodOptionsUsBankAccountOptions`, `PaymentIntentPaymentMethodOptionsUsBankAccount`, `SetupIntentPaymentMethodOptionsUsBankAccountOptions`, `SetupIntentPaymentMethodOptionsUsBankAccount`, `SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountOptions`, and `SubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccount`
   * Add support for `FinancialConnections.Account` on `PaymentIntentPaymentMethodDataUsBankAccountOptions`, `PaymentMethodUsBankAccountOptions`, `PaymentMethodUsBankAccount`, and `SetupIntentPaymentMethodDataUsBankAccountOptions`
-  
+
 * [#2473](https://github.com/stripe/stripe-dotnet/pull/2473) API Updates
   * Add support for `RegisteredAddress` on `AccountIndividualOptions`, `PersonCreateOptions`, `PersonUpdateOptions`, `Person`, `TokenAccountIndividualOptions`, and `TokenPersonOptions`
   * Change type of `PaymentIntentAmountDetailsTipAmount` from `nullable(integer)` to `integer`
@@ -1461,7 +1461,7 @@ This release includes breaking changes resulting from:
   * Add support for `Alipay` on `Checkout.SessionPaymentMethodOptionsOptions` and `Checkout.SessionPaymentMethodOptions`
   * Add support for `CashBalance` on `Customer`
   * Add support for `Application` on `Invoice`, `Quote`, `SubscriptionSchedule`, and `Subscription`
-  
+
 * [#2470](https://github.com/stripe/stripe-dotnet/pull/2470) Add missing payment links events
 * [#2468](https://github.com/stripe/stripe-dotnet/pull/2468) Harden ValidateSignature against invalid input
 * [#2467](https://github.com/stripe/stripe-dotnet/pull/2467) Cleanup .NET project files
@@ -1562,7 +1562,7 @@ This release includes breaking changes resulting from:
   * Add support for `MandateOptions` on `PaymentIntentPaymentMethodOptionsCardOptions`, `PaymentIntentPaymentMethodOptionsCard`, `SetupIntentPaymentMethodOptionsCardOptions`, and `SetupIntentPaymentMethodOptionsCard`
   * Add support for `CardAwaitNotification` on `PaymentIntentNextAction`
   * Add support for `CustomerNotification` on `PaymentIntentProcessingCard`
-  
+
 
 ## 39.96.0 - 2022-03-09
 * [#2435](https://github.com/stripe/stripe-dotnet/pull/2435) API Updates
@@ -1572,7 +1572,7 @@ This release includes breaking changes resulting from:
 * [#2432](https://github.com/stripe/stripe-dotnet/pull/2432) API Updates
   * Add support for new resources `InvoiceLineItemProrationDetails` and `InvoiceLineItemProrationDetailsCreditedItems`
   * Add support for `ProrationDetails` on `InvoiceLineItem`
-  
+
 
 ## 39.94.0 - 2022-03-01
 * [#2430](https://github.com/stripe/stripe-dotnet/pull/2430) [#2431](https://github.com/stripe/stripe-dotnet/pull/2431) API Updates
@@ -1583,7 +1583,7 @@ This release includes breaking changes resulting from:
   * Add support for `NextAction` on `Refund`
 
 ## 39.93.0 - 2022-02-25
-* [#2426](https://github.com/stripe/stripe-dotnet/pull/2426) API Updates 
+* [#2426](https://github.com/stripe/stripe-dotnet/pull/2426) API Updates
   * Add support for `KonbiniPayments` on `AccountCapabilitiesOptions`, `AccountCapabilitiesOptions`, and `AccountCapabilities`
   * Add support for `Konbini` on `ChargePaymentMethodDetails`, `Checkout.SessionPaymentMethodOptionsOptions`, `Checkout.SessionPaymentMethodOptions`, `InvoicePaymentSettingsPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodDataOptions`, `PaymentIntentPaymentMethodOptions`, `PaymentMethodCreateOptions`, `PaymentMethod`, `SubscriptionPaymentSettingsPaymentMethodOptionsOptions`, and `SubscriptionPaymentSettingsPaymentMethodOptions`
   * Add support for `KonbiniDisplayDetails` on `PaymentIntentNextAction`
@@ -1623,17 +1623,17 @@ This release includes breaking changes resulting from:
 * [#2412](https://github.com/stripe/stripe-dotnet/pull/2412) API Updates
   * Add support for `CustomerCreation` on `Checkout.SessionCreateOptions` and `Checkout.Session`
   * Add support for `Fpx` and `Grabpay` on `PaymentIntentPaymentMethodOptionsOptions`,  and `PaymentIntentPaymentMethodOptions`
-  
+
 * [#2408](https://github.com/stripe/stripe-dotnet/pull/2408) API Updates
   * Add support for `MandateOptions` on `SubscriptionPaymentSettingsPaymentMethodOptionsCardOptions`, `SubscriptionPaymentSettingsPaymentMethodOptionsCardOptions`, and `SubscriptionPaymentSettingsPaymentMethodOptionsCard`
 
 ## 39.84.0 - 2021-12-22
 * [#2406](https://github.com/stripe/stripe-dotnet/pull/2406) API Updates
   * Add support for `AuBecsDebit` on `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodOptionsOptions`, `PaymentIntentPaymentMethodOptionsOptions`, and `PaymentIntentPaymentMethodOptions`
-  
+
 * [#2405](https://github.com/stripe/stripe-dotnet/pull/2405) API Updates
   * Add support for `Boleto` on `SetupAttemptPaymentMethodDetails`
-  
+
 * [#2404](https://github.com/stripe/stripe-dotnet/pull/2404) API Updates
   * Add support for `Processing` on `PaymentIntent`
 
@@ -1683,7 +1683,7 @@ This release includes breaking changes resulting from:
 * [#2391](https://github.com/stripe/stripe-dotnet/pull/2391) API Updates
   * Remove support for `OwnershipDeclarationShownAndSigned` on `TokenAccountOptions`. This API was unused.
   * Add support for `OwnershipDeclarationShownAndSigned` on `TokenAccountCompanyOptions`
-  
+
 
 ## 39.75.0 - 2021-11-01
 * [#2388](https://github.com/stripe/stripe-dotnet/pull/2388) API Updates
@@ -1763,7 +1763,7 @@ This release includes breaking changes resulting from:
 ## 39.60.0 - 2021-07-20
 * [#2349](https://github.com/stripe/stripe-dotnet/pull/2349) API Updates
   * Add support for `Wallet` on `Issuing.Transaction`
-  * Add support for `Ideal` on `PaymentIntentPaymentMethodOptionsOptions` 
+  * Add support for `Ideal` on `PaymentIntentPaymentMethodOptionsOptions`
 
 * [#2348](https://github.com/stripe/stripe-dotnet/pull/2348) Remove unused API error types from docs.
 
@@ -2668,7 +2668,7 @@ Pull requests included in this release (cf. [#1694](https://github.com/stripe/st
   * This is technically a breaking change, but we're releasing as a patch version as the non-nullable type made it impossible to deserialize `credit_note` objects in most cases.
 
 ## 29.0.0 - 2019-09-10
-* [#1780](https://github.com/stripe/stripe-dotnet/pull/1780) Bump API version to [`2019-09-09`](https://stripe.com/docs/upgrades#2019-09-09)
+* [#1780](https://github.com/stripe/stripe-dotnet/pull/1780) Bump API version to [`2019-09-09`](https://docs.stripe.com/changelog/2019-09-09)
 
 ## 28.11.0 - 2019-09-09
 * [#1778](https://github.com/stripe/stripe-dotnet/pull/1778) Changes to `Account` and `Person` for identity verification
@@ -2710,7 +2710,7 @@ Pull requests included in this release (cf. [#1694](https://github.com/stripe/st
   * Add support for `Executive` on Person create, update and list
 
 ## 28.0.0 - 2019-08-14
-* [#1747](https://github.com/stripe/stripe-dotnet/pull/1747) Move to API version [`2019-08-14`](https://stripe.com/docs/upgrades#2019-08-14)
+* [#1747](https://github.com/stripe/stripe-dotnet/pull/1747) Move to API version [`2019-08-14`](https://docs.stripe.com/changelog/2019-08-14)
   * Rename `platform_payments` to `transfers` in `Account`
   * Introduce `executive` as a relationship on `Person`
 * [#1746](https://github.com/stripe/stripe-dotnet/pull/1746) Fix argument names in `SetupIntentService` methods
@@ -2979,7 +2979,7 @@ Pull requests included in this release (cf. [#1482](https://github.com/stripe/st
 * [#1557](https://github.com/stripe/stripe-dotnet/pull/1557) Add support for `person_token` on `Person` creation
 
 ## 25.0.0 - 2019-03-19
-* [#1552](https://github.com/stripe/stripe-dotnet/pull/1552) Add support for API version [2019-03-14](https://stripe.com/docs/upgrades#2019-03-14):
+* [#1552](https://github.com/stripe/stripe-dotnet/pull/1552) Add support for API version [2019-03-14](https://docs.stripe.com/changelog/2019-03-14):
   * The library is now pinned to API version `2019-03-14`.
   * Subscriptions are now created with `status: "incomplete"` if the first payment fails.
   * `PaymentIntentLastPaymentError` was removed in favour of `StripeError`.
@@ -3268,7 +3268,7 @@ Pull requests included in this release (cf. [#1293](https://github.com/stripe/st
 * Fix 19.0.0 release. The version that was pushed to NuGet did not include the changes from 19.0.0.
 
 ## 19.0.0 - 2018-08-27
-* [#1259](https://github.com/stripe/stripe-dotnet/pull/1259) Upgrade to API version [2018-08-23](https://stripe.com/docs/upgrades#2018-08-23)
+* [#1259](https://github.com/stripe/stripe-dotnet/pull/1259) Upgrade to API version [2018-08-23](https://docs.stripe.com/changelog/2018-08-23)
 
 List of backwards incompatible changes:
 * `BusinessVatId` on `StripeCustomer` / `StripeCustomerCreateOptions` / `StripeCustomerUpdateOptions` is replaced with `TaxInfo`


### PR DESCRIPTION
### Why?
The /upgrades page might eventually get removed in favor of the new /changelog page

### What?
Replace the links to the upgrades page with the one to the changelog page from the changelog file


