### PR TITLE
Pull in V2 FinancialAccount changes for June release

### DIFF
--- a/src/Stripe.net/Entities/V2/Core/Accounts/Account.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/Account.cs
@@ -37,7 +37,7 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Filter only accounts that have all of the configurations specified. If omitted, returns
         /// all accounts regardless of which configurations they have.
-        /// One of: <c>customer</c>, <c>merchant</c>, or <c>recipient</c>.
+        /// One of: <c>customer</c>, <c>merchant</c>, <c>recipient</c>, or <c>storer</c>.
         /// </summary>
         [JsonProperty("applied_configurations")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfiguration.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfiguration.cs
@@ -36,5 +36,15 @@ namespace Stripe.V2.Core
         [STJS.JsonPropertyName("recipient")]
 #endif
         public AccountConfigurationRecipient Recipient { get; set; }
+
+        /// <summary>
+        /// The Storer Configuration allows the Account to store and move funds using stored-value
+        /// FinancialAccounts.
+        /// </summary>
+        [JsonProperty("storer")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("storer")]
+#endif
+        public AccountConfigurationStorer Storer { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorer.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorer.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorer : StripeEntity<AccountConfigurationStorer>
+    {
+        /// <summary>
+        /// Capabilities that have been requested on the Storer Configuration.
+        /// </summary>
+        [JsonProperty("capabilities")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("capabilities")]
+#endif
+        public AccountConfigurationStorerCapabilities Capabilities { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilities.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilities.cs
@@ -1,0 +1,56 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilities : StripeEntity<AccountConfigurationStorerCapabilities>
+    {
+        /// <summary>
+        /// Can provision a financial address to credit/debit a FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_addresses")]
+#endif
+        public AccountConfigurationStorerCapabilitiesFinancialAddresses FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Can hold storage-type funds on Stripe.
+        /// </summary>
+        [JsonProperty("holds_currencies")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("holds_currencies")]
+#endif
+        public AccountConfigurationStorerCapabilitiesHoldsCurrencies HoldsCurrencies { get; set; }
+
+        /// <summary>
+        /// Can pull funds from an external source, owned by yourself, to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("inbound_transfers")]
+#endif
+        public AccountConfigurationStorerCapabilitiesInboundTransfers InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by someone else.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_payments")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundPayments OutboundPayments { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by yourself.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_transfers")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundTransfers OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddresses.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddresses.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesFinancialAddresses : StripeEntity<AccountConfigurationStorerCapabilitiesFinancialAddresses>
+    {
+        /// <summary>
+        /// Can provision a bank-account like financial address (VBAN) to credit/debit a
+        /// FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccounts BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesFinancialAddressesBankAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrencies.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrencies.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesHoldsCurrencies : StripeEntity<AccountConfigurationStorerCapabilitiesHoldsCurrencies>
+    {
+        /// <summary>
+        /// Can hold storage-type funds on Stripe in GBP.
+        /// </summary>
+        [JsonProperty("gbp")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("gbp")]
+#endif
+        public AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbp Gbp { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbp.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbp.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbp : StripeEntity<AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbp>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbpStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbpStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbpStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbpStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesHoldsCurrenciesGbpStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfers.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfers.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesInboundTransfers : StripeEntity<AccountConfigurationStorerCapabilitiesInboundTransfers>
+    {
+        /// <summary>
+        /// Can pull funds from an external bank account, owned by yourself, to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesInboundTransfersBankAccounts BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfersBankAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfersBankAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesInboundTransfersBankAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesInboundTransfersBankAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesInboundTransfersBankAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfersBankAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesInboundTransfersBankAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesInboundTransfersBankAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesInboundTransfersBankAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPayments.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPayments.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPayments : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPayments>
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a bank account, owned by someone else.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccounts BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a debit card, owned by someone else.
+        /// </summary>
+        [JsonProperty("cards")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("cards")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundPaymentsCards Cards { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount, owned by someone
+        /// else.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccounts FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsCards.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsCards.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsCards : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsCards>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesOutboundPaymentsCardsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsCardsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsCardsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsCardsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsCardsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfers.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfers.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundTransfers : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundTransfers>
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount, to a bank account, owned by yourself.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccounts BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount, owned by yourself.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccounts FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundTransfersBankAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccounts.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccounts.cs
@@ -1,0 +1,41 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccounts : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccounts>
+    {
+        /// <summary>
+        /// Whether the Capability has been requested.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool Requested { get; set; }
+
+        /// <summary>
+        /// The status of the Capability.
+        /// One of: <c>active</c>, <c>pending</c>, <c>restricted</c>, or <c>unsupported</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional details regarding the status of the Capability. <c>status_details</c> will be
+        /// empty if the Capability's status is <c>active</c>.
+        /// </summary>
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public List<AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsStatusDetail> StatusDetails { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsStatusDetail.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsStatusDetail.cs
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsStatusDetail : StripeEntity<AccountConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsStatusDetail>
+    {
+        /// <summary>
+        /// Machine-readable code explaining the reason for the Capability to be in its current
+        /// status.
+        /// One of: <c>determining_status</c>, <c>requirements_past_due</c>,
+        /// <c>requirements_pending_verification</c>, <c>restricted_other</c>,
+        /// <c>unsupported_business</c>, <c>unsupported_country</c>, or
+        /// <c>unsupported_entity_type</c>.
+        /// </summary>
+        [JsonProperty("code")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("code")]
+#endif
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Machine-readable code explaining how to make the Capability active.
+        /// One of: <c>contact_stripe</c>, <c>no_resolution</c>, or <c>provide_info</c>.
+        /// </summary>
+        [JsonProperty("resolution")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("resolution")]
+#endif
+        public string Resolution { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Accounts/AccountRequirementsEntryImpactRestrictsCapability.cs
+++ b/src/Stripe.net/Entities/V2/Core/Accounts/AccountRequirementsEntryImpactRestrictsCapability.cs
@@ -16,14 +16,18 @@ namespace Stripe.V2.Core
         /// <c>bacs_debit_payments</c>, <c>bancontact_payments</c>, <c>bank_accounts.local</c>,
         /// <c>bank_accounts.wire</c>, <c>blik_payments</c>, <c>boleto_payments</c>, <c>cards</c>,
         /// <c>card_payments</c>, <c>cartes_bancaires_payments</c>, <c>cashapp_payments</c>,
-        /// <c>eps_payments</c>, <c>fpx_payments</c>, <c>gb_bank_transfer_payments</c>,
-        /// <c>grabpay_payments</c>, <c>ideal_payments</c>, <c>jcb_payments</c>,
+        /// <c>eps_payments</c>, <c>financial_addresses.bank_accounts</c>, <c>fpx_payments</c>,
+        /// <c>gb_bank_transfer_payments</c>, <c>grabpay_payments</c>, <c>holds_currencies.gbp</c>,
+        /// <c>ideal_payments</c>, <c>inbound_transfers.financial_accounts</c>, <c>jcb_payments</c>,
         /// <c>jp_bank_transfer_payments</c>, <c>kakao_pay_payments</c>, <c>klarna_payments</c>,
         /// <c>konbini_payments</c>, <c>kr_card_payments</c>, <c>link_payments</c>,
         /// <c>mobilepay_payments</c>, <c>multibanco_payments</c>, <c>mx_bank_transfer_payments</c>,
-        /// <c>naver_pay_payments</c>, <c>oxxo_payments</c>, <c>p24_payments</c>,
-        /// <c>payco_payments</c>, <c>paynow_payments</c>, <c>pay_by_bank_payments</c>,
-        /// <c>promptpay_payments</c>, <c>revolut_pay_payments</c>, <c>samsung_pay_payments</c>,
+        /// <c>naver_pay_payments</c>, <c>outbound_payments.bank_accounts</c>,
+        /// <c>outbound_payments.cards</c>, <c>outbound_payments.financial_accounts</c>,
+        /// <c>outbound_transfers.bank_accounts</c>, <c>outbound_transfers.financial_accounts</c>,
+        /// <c>oxxo_payments</c>, <c>p24_payments</c>, <c>payco_payments</c>,
+        /// <c>paynow_payments</c>, <c>pay_by_bank_payments</c>, <c>promptpay_payments</c>,
+        /// <c>revolut_pay_payments</c>, <c>samsung_pay_payments</c>,
         /// <c>sepa_bank_transfer_payments</c>, <c>sepa_debit_payments</c>,
         /// <c>stripe_balance.payouts</c>, <c>stripe_balance.stripe_transfers</c>,
         /// <c>swish_payments</c>, <c>twint_payments</c>, <c>us_bank_transfer_payments</c>, or
@@ -37,7 +41,7 @@ namespace Stripe.V2.Core
 
         /// <summary>
         /// The configuration which specifies the Capability which will be restricted.
-        /// One of: <c>customer</c>, <c>merchant</c>, or <c>recipient</c>.
+        /// One of: <c>customer</c>, <c>merchant</c>, <c>recipient</c>, or <c>storer</c>.
         /// </summary>
         [JsonProperty("configuration")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccount.cs
+++ b/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccount.cs
@@ -135,6 +135,12 @@ namespace Stripe.V2.MoneyManagement
 #endif
         public string Status { get; set; }
 
+        [JsonProperty("status_details")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status_details")]
+#endif
+        public FinancialAccountStatusDetails StatusDetails { get; set; }
+
         /// <summary>
         /// If this is a <c>storage</c> FinancialAccount, this hash includes details specific to
         /// <c>storage</c> FinancialAccounts.

--- a/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetails.cs
+++ b/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetails.cs
@@ -1,0 +1,17 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountStatusDetails : StripeEntity<FinancialAccountStatusDetails>
+    {
+        [JsonProperty("closed")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("closed")]
+#endif
+        public FinancialAccountStatusDetailsClosed Closed { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetailsClosed.cs
+++ b/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetailsClosed.cs
@@ -1,0 +1,26 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountStatusDetailsClosed : StripeEntity<FinancialAccountStatusDetailsClosed>
+    {
+        [JsonProperty("forwarding_settings")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("forwarding_settings")]
+#endif
+        public FinancialAccountStatusDetailsClosedForwardingSettings ForwardingSettings { get; set; }
+
+        /// <summary>
+        /// One of: <c>account_closed</c>, <c>closed_by_platform</c>, or <c>other</c>.
+        /// </summary>
+        [JsonProperty("reason")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("reason")]
+#endif
+        public string Reason { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetailsClosedForwardingSettings.cs
+++ b/src/Stripe.net/Entities/V2/MoneyManagement/FinancialAccounts/FinancialAccountStatusDetailsClosedForwardingSettings.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountStatusDetailsClosedForwardingSettings : StripeEntity<FinancialAccountStatusDetailsClosedForwardingSettings>
+    {
+        /// <summary>
+        /// The address to send forwarded payments to.
+        /// </summary>
+        [JsonProperty("payment_method")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("payment_method")]
+#endif
+        public string PaymentMethod { get; set; }
+
+        /// <summary>
+        /// The address to send forwarded payouts to.
+        /// </summary>
+        [JsonProperty("payout_method")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("payout_method")]
+#endif
+        public string PayoutMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent.cs
+++ b/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent.cs
@@ -1,0 +1,52 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Events
+{
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    /// <summary>
+    /// Occurs when the status of an Account's storer configuration capability is updated.
+    /// </summary>
+    public class V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent : V2.Event
+    {
+        /// <summary>
+        /// Data for the v2.core.account[configuration.storer].capability_status_updated event.
+        /// </summary>
+        [JsonProperty("data")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("data")]
+#endif
+
+        public V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEventData Data { get; set; }
+
+        /// <summary>
+        /// Object containing the reference to API resource relevant to the event.
+        /// </summary>
+        [JsonProperty("related_object")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("related_object")]
+#endif
+
+        public V2.EventRelatedObject RelatedObject { get; set; }
+
+        /// <summary>
+        /// Asynchronously retrieves the related object from the API. Make an API request on every
+        /// call.
+        /// </summary>
+        public Task<V2.Core.Account> FetchRelatedObjectAsync()
+        {
+            return this.FetchRelatedObjectAsync<V2.Core.Account>(this.RelatedObject);
+        }
+
+        /// <summary>
+        /// Retrieves the related object from the API. Make an API request on every call.
+        /// </summary>
+        public V2.Core.Account FetchRelatedObject()
+        {
+            return this.FetchRelatedObject<V2.Core.Account>(this.RelatedObject);
+        }
+    }
+}

--- a/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEventData.cs
+++ b/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEventData.cs
@@ -1,0 +1,27 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Events
+{
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEventData : StripeEntity<V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEventData>
+    {
+        /// <summary>
+        /// Open Enum. The capability which had its status updated.
+        /// One of: <c>financial_addressses.bank_accounts</c>, <c>holds_currencies.eur</c>,
+        /// <c>holds_currencies.gbp</c>, <c>holds_currencies.usd</c>,
+        /// <c>inbound_transfers.bank_accounts</c>, <c>outbound_payments.bank_accounts</c>,
+        /// <c>outbound_payments.cards</c>, <c>outbound_payments.financial_accounts</c>,
+        /// <c>outbound_transfers.bank_accounts</c>, or
+        /// <c>outbound_transfers.financial_accounts</c>.
+        /// </summary>
+        [JsonProperty("updated_capability")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("updated_capability")]
+#endif
+        public string UpdatedCapability { get; set; }
+    }
+}

--- a/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerUpdatedEvent.cs
+++ b/src/Stripe.net/Events/V2CoreAccountIncludingConfigurationStorerUpdatedEvent.cs
@@ -1,0 +1,42 @@
+// File generated from our OpenAPI spec
+namespace Stripe.Events
+{
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    /// <summary>
+    /// Occurs when a Storer's configuration is updated.
+    /// </summary>
+    public class V2CoreAccountIncludingConfigurationStorerUpdatedEvent : V2.Event
+    {
+        /// <summary>
+        /// Object containing the reference to API resource relevant to the event.
+        /// </summary>
+        [JsonProperty("related_object")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("related_object")]
+#endif
+
+        public V2.EventRelatedObject RelatedObject { get; set; }
+
+        /// <summary>
+        /// Asynchronously retrieves the related object from the API. Make an API request on every
+        /// call.
+        /// </summary>
+        public Task<V2.Core.Account> FetchRelatedObjectAsync()
+        {
+            return this.FetchRelatedObjectAsync<V2.Core.Account>(this.RelatedObject);
+        }
+
+        /// <summary>
+        /// Retrieves the related object from the API. Make an API request on every call.
+        /// </summary>
+        public V2.Core.Account FetchRelatedObject()
+        {
+            return this.FetchRelatedObject<V2.Core.Account>(this.RelatedObject);
+        }
+    }
+}

--- a/src/Stripe.net/Exceptions/V2/AlreadyExistsException.cs
+++ b/src/Stripe.net/Exceptions/V2/AlreadyExistsException.cs
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2
+{
+    using System.Net;
+    using Newtonsoft.Json.Linq;
+
+    public class AlreadyExistsException : StripeException
+    {
+        private AlreadyExistsException(
+            HttpStatusCode httpStatusCode,
+            StripeError stripeError,
+            string message)
+            : base(httpStatusCode, stripeError)
+        {
+        }
+
+        internal static AlreadyExistsException Parse(
+            HttpStatusCode httpStatusCode,
+            JToken body)
+        {
+            var stripeError = StripeError.FromJson<StripeError>(body);
+            return new AlreadyExistsException(httpStatusCode, stripeError, stripeError.Message);
+        }
+    }
+}

--- a/src/Stripe.net/Exceptions/V2/NonZeroBalanceException.cs
+++ b/src/Stripe.net/Exceptions/V2/NonZeroBalanceException.cs
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2
+{
+    using System.Net;
+    using Newtonsoft.Json.Linq;
+
+    public class NonZeroBalanceException : StripeException
+    {
+        private NonZeroBalanceException(
+            HttpStatusCode httpStatusCode,
+            StripeError stripeError,
+            string message)
+            : base(httpStatusCode, stripeError)
+        {
+        }
+
+        internal static NonZeroBalanceException Parse(
+            HttpStatusCode httpStatusCode,
+            JToken body)
+        {
+            var stripeError = StripeError.FromJson<StripeError>(body);
+            return new NonZeroBalanceException(httpStatusCode, stripeError, stripeError.Message);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeException.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeException.cs
@@ -51,12 +51,20 @@ namespace Stripe
                     ret = Stripe.V2.TemporarySessionExpiredException.Parse(httpStatusCode, body);
                     break;
 
-                case "financial_account_not_open":
-                    ret = Stripe.V2.FinancialAccountNotOpenException.Parse(httpStatusCode, body);
+                case "non_zero_balance":
+                    ret = Stripe.V2.NonZeroBalanceException.Parse(httpStatusCode, body);
+                    break;
+
+                case "already_exists":
+                    ret = Stripe.V2.AlreadyExistsException.Parse(httpStatusCode, body);
                     break;
 
                 case "feature_not_enabled":
                     ret = Stripe.V2.FeatureNotEnabledException.Parse(httpStatusCode, body);
+                    break;
+
+                case "financial_account_not_open":
+                    ret = Stripe.V2.FinancialAccountNotOpenException.Parse(httpStatusCode, body);
                     break;
 
                 case "blocked_by_stripe":

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -350,6 +350,14 @@ namespace Stripe
                     Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEvent)
                 },
                 {
+                    "v2.core.account[configuration.storer].capability_status_updated", typeof(
+                    Events.V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent)
+                },
+                {
+                    "v2.core.account[configuration.storer].updated", typeof(
+                    Events.V2CoreAccountIncludingConfigurationStorerUpdatedEvent)
+                },
+                {
                     "v2.money_management.adjustment.created", typeof(
                     Events.V2MoneyManagementAdjustmentCreatedEvent)
                 },

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCloseOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCloseOptions.cs
@@ -12,7 +12,7 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Configurations on the Account to be closed. All configurations on the Account must be
         /// passed in for this request to succeed.
-        /// One of: <c>customer</c>, <c>merchant</c>, or <c>recipient</c>.
+        /// One of: <c>customer</c>, <c>merchant</c>, <c>recipient</c>, or <c>storer</c>.
         /// </summary>
         [JsonProperty("applied_configurations")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationOptions.cs
@@ -36,5 +36,15 @@ namespace Stripe.V2.Core
         [STJS.JsonPropertyName("recipient")]
 #endif
         public AccountCreateConfigurationRecipientOptions Recipient { get; set; }
+
+        /// <summary>
+        /// The Storer Configuration allows the Account to store and move funds using stored-value
+        /// FinancialAccounts.
+        /// </summary>
+        [JsonProperty("storer")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("storer")]
+#endif
+        public AccountCreateConfigurationStorerOptions Storer { get; set; }
     }
 }

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesFinancialAddressesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesFinancialAddressesOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesFinancialAddressesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can provision a bank-account-like financial address (VBAN) to credit/debit a
+        /// FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can hold storage-type funds on Stripe in GBP.
+        /// </summary>
+        [JsonProperty("gbp")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("gbp")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions Gbp { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesInboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesInboundTransfersOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesInboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOptions.cs
@@ -1,0 +1,56 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can provision a financial address to credit/debit a FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_addresses")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesFinancialAddressesOptions FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Can hold storage-type funds on Stripe.
+        /// </summary>
+        [JsonProperty("holds_currencies")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("holds_currencies")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesHoldsCurrenciesOptions HoldsCurrencies { get; set; }
+
+        /// <summary>
+        /// Can pull funds from an external source, owned by yourself, to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("inbound_transfers")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesInboundTransfersOptions InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by someone else.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_payments")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsOptions OutboundPayments { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by yourself.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_transfers")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundTransfersOptions OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a bank account owned by someone else.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a debit card owned by someone else.
+        /// </summary>
+        [JsonProperty("cards")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("cards")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions Cards { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+        /// else.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerCapabilitiesOutboundTransfersOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerCapabilitiesOutboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a bank account owned by yourself.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateConfigurationStorerOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountCreateConfigurationStorerOptions : INestedOptions
+    {
+        /// <summary>
+        /// Capabilities to request on the Storer Configuration.
+        /// </summary>
+        [JsonProperty("capabilities")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("capabilities")]
+#endif
+        public AccountCreateConfigurationStorerCapabilitiesOptions Capabilities { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountCreateOptions.cs
@@ -71,8 +71,8 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Additional fields to include in the response.
         /// One of: <c>configuration.customer</c>, <c>configuration.merchant</c>,
-        /// <c>configuration.recipient</c>, <c>defaults</c>, <c>identity</c>, or
-        /// <c>requirements</c>.
+        /// <c>configuration.recipient</c>, <c>configuration.storer</c>, <c>defaults</c>,
+        /// <c>identity</c>, or <c>requirements</c>.
         /// </summary>
         [JsonProperty("include")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountGetOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountGetOptions.cs
@@ -12,8 +12,8 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Additional fields to include in the response.
         /// One of: <c>configuration.customer</c>, <c>configuration.merchant</c>,
-        /// <c>configuration.recipient</c>, <c>defaults</c>, <c>identity</c>, or
-        /// <c>requirements</c>.
+        /// <c>configuration.recipient</c>, <c>configuration.storer</c>, <c>defaults</c>,
+        /// <c>identity</c>, or <c>requirements</c>.
         /// </summary>
         [JsonProperty("include")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationOptions.cs
@@ -36,5 +36,15 @@ namespace Stripe.V2.Core
         [STJS.JsonPropertyName("recipient")]
 #endif
         public AccountUpdateConfigurationRecipientOptions Recipient { get; set; }
+
+        /// <summary>
+        /// The Storer Configuration allows the Account to store and move funds using stored-value
+        /// FinancialAccounts.
+        /// </summary>
+        [JsonProperty("storer")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("storer")]
+#endif
+        public AccountUpdateConfigurationStorerOptions Storer { get; set; }
     }
 }

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can provision a bank-account-like financial address (VBAN) to credit/debit a
+        /// FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesBankAccountsOptions BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can hold storage-type funds on Stripe in GBP.
+        /// </summary>
+        [JsonProperty("gbp")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("gbp")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesGbpOptions Gbp { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesInboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesInboundTransfersOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesInboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesInboundTransfersBankAccountsOptions BankAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOptions.cs
@@ -1,0 +1,56 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can provision a financial address to credit/debit a FinancialAccount.
+        /// </summary>
+        [JsonProperty("financial_addresses")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_addresses")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesFinancialAddressesOptions FinancialAddresses { get; set; }
+
+        /// <summary>
+        /// Can hold storage-type funds on Stripe.
+        /// </summary>
+        [JsonProperty("holds_currencies")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("holds_currencies")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesHoldsCurrenciesOptions HoldsCurrencies { get; set; }
+
+        /// <summary>
+        /// Can pull funds from an external source, owned by yourself, to a FinancialAccount.
+        /// </summary>
+        [JsonProperty("inbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("inbound_transfers")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesInboundTransfersOptions InboundTransfers { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by someone else.
+        /// </summary>
+        [JsonProperty("outbound_payments")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_payments")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsOptions OutboundPayments { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a destination owned by yourself.
+        /// </summary>
+        [JsonProperty("outbound_transfers")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("outbound_transfers")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersOptions OutboundTransfers { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a bank account owned by someone else.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsBankAccountsOptions BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a debit card owned by someone else.
+        /// </summary>
+        [JsonProperty("cards")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("cards")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsCardsOptions Cards { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+        /// else.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundPaymentsFinancialAccountsOptions FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions.cs
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions : INestedOptions
+    {
+        /// <summary>
+        /// To request a new Capability for an account, pass true. There can be a delay before the
+        /// requested Capability becomes active.
+        /// </summary>
+        [JsonProperty("requested")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("requested")]
+#endif
+        public bool? Requested { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersOptions : INestedOptions
+    {
+        /// <summary>
+        /// Can send funds from a FinancialAccount to a bank account owned by yourself.
+        /// </summary>
+        [JsonProperty("bank_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("bank_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersBankAccountsOptions BankAccounts { get; set; }
+
+        /// <summary>
+        /// Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+        /// </summary>
+        [JsonProperty("financial_accounts")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("financial_accounts")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOutboundTransfersFinancialAccountsOptions FinancialAccounts { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateConfigurationStorerOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class AccountUpdateConfigurationStorerOptions : INestedOptions
+    {
+        /// <summary>
+        /// Capabilities to request on the Storer Configuration.
+        /// </summary>
+        [JsonProperty("capabilities")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("capabilities")]
+#endif
+        public AccountUpdateConfigurationStorerCapabilitiesOptions Capabilities { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateOptions.cs
+++ b/src/Stripe.net/Services/V2/Core/Accounts/AccountUpdateOptions.cs
@@ -71,8 +71,8 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Additional fields to include in the response.
         /// One of: <c>configuration.customer</c>, <c>configuration.merchant</c>,
-        /// <c>configuration.recipient</c>, <c>defaults</c>, <c>identity</c>, or
-        /// <c>requirements</c>.
+        /// <c>configuration.recipient</c>, <c>configuration.storer</c>, <c>defaults</c>,
+        /// <c>identity</c>, or <c>requirements</c>.
         /// </summary>
         [JsonProperty("include")]
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCloseForwardingSettingsOptions.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCloseForwardingSettingsOptions.cs
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountCloseForwardingSettingsOptions : INestedOptions
+    {
+        /// <summary>
+        /// The address to send forwarded payments to.
+        /// </summary>
+        [JsonProperty("payment_method")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("payment_method")]
+#endif
+        public string PaymentMethod { get; set; }
+
+        /// <summary>
+        /// The address to send forwarded payouts to.
+        /// </summary>
+        [JsonProperty("payout_method")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("payout_method")]
+#endif
+        public string PayoutMethod { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCloseOptions.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCloseOptions.cs
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountCloseOptions : BaseOptions
+    {
+        /// <summary>
+        /// The addresses to forward any incoming transactions to.
+        /// </summary>
+        [JsonProperty("forwarding_settings")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("forwarding_settings")]
+#endif
+        public FinancialAccountCloseForwardingSettingsOptions ForwardingSettings { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCreateOptions.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCreateOptions.cs
@@ -1,0 +1,39 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountCreateOptions : BaseOptions, IHasMetadata
+    {
+        /// <summary>
+        /// Metadata associated with the FinancialAccount.
+        /// </summary>
+        [JsonProperty("metadata")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("metadata")]
+#endif
+        public Dictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        /// Parameters specific to creating <c>storage</c> type FinancialAccounts.
+        /// </summary>
+        [JsonProperty("storage")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("storage")]
+#endif
+        public FinancialAccountCreateStorageOptions Storage { get; set; }
+
+        /// <summary>
+        /// The type of FinancialAccount to create.
+        /// </summary>
+        [JsonProperty("type")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("type")]
+#endif
+        public string Type { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCreateStorageOptions.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountCreateStorageOptions.cs
@@ -1,0 +1,47 @@
+// File generated from our OpenAPI spec
+namespace Stripe.V2.MoneyManagement
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    public class FinancialAccountCreateStorageOptions : INestedOptions
+    {
+        /// <summary>
+        /// The currencies that this FinancialAccount can hold.
+        /// One of: <c>aed</c>, <c>afn</c>, <c>all</c>, <c>amd</c>, <c>ang</c>, <c>aoa</c>,
+        /// <c>ars</c>, <c>aud</c>, <c>awg</c>, <c>azn</c>, <c>bam</c>, <c>bbd</c>, <c>bdt</c>,
+        /// <c>bgn</c>, <c>bhd</c>, <c>bif</c>, <c>bmd</c>, <c>bnd</c>, <c>bob</c>, <c>bov</c>,
+        /// <c>brl</c>, <c>bsd</c>, <c>btn</c>, <c>bwp</c>, <c>byn</c>, <c>byr</c>, <c>bzd</c>,
+        /// <c>cad</c>, <c>cdf</c>, <c>che</c>, <c>chf</c>, <c>chw</c>, <c>clf</c>, <c>clp</c>,
+        /// <c>cny</c>, <c>cop</c>, <c>cou</c>, <c>crc</c>, <c>cuc</c>, <c>cup</c>, <c>cve</c>,
+        /// <c>czk</c>, <c>djf</c>, <c>dkk</c>, <c>dop</c>, <c>dzd</c>, <c>eek</c>, <c>egp</c>,
+        /// <c>ern</c>, <c>etb</c>, <c>eur</c>, <c>fjd</c>, <c>fkp</c>, <c>gbp</c>, <c>gel</c>,
+        /// <c>ghc</c>, <c>ghs</c>, <c>gip</c>, <c>gmd</c>, <c>gnf</c>, <c>gtq</c>, <c>gyd</c>,
+        /// <c>hkd</c>, <c>hnl</c>, <c>hrk</c>, <c>htg</c>, <c>huf</c>, <c>idr</c>, <c>ils</c>,
+        /// <c>inr</c>, <c>iqd</c>, <c>irr</c>, <c>isk</c>, <c>jmd</c>, <c>jod</c>, <c>jpy</c>,
+        /// <c>kes</c>, <c>kgs</c>, <c>khr</c>, <c>kmf</c>, <c>kpw</c>, <c>krw</c>, <c>kwd</c>,
+        /// <c>kyd</c>, <c>kzt</c>, <c>lak</c>, <c>lbp</c>, <c>lkr</c>, <c>lrd</c>, <c>lsl</c>,
+        /// <c>ltl</c>, <c>lvl</c>, <c>lyd</c>, <c>mad</c>, <c>mdl</c>, <c>mga</c>, <c>mkd</c>,
+        /// <c>mmk</c>, <c>mnt</c>, <c>mop</c>, <c>mro</c>, <c>mru</c>, <c>mur</c>, <c>mvr</c>,
+        /// <c>mwk</c>, <c>mxn</c>, <c>mxv</c>, <c>myr</c>, <c>mzn</c>, <c>nad</c>, <c>ngn</c>,
+        /// <c>nio</c>, <c>nok</c>, <c>npr</c>, <c>nzd</c>, <c>omr</c>, <c>pab</c>, <c>pen</c>,
+        /// <c>pgk</c>, <c>php</c>, <c>pkr</c>, <c>pln</c>, <c>pyg</c>, <c>qar</c>, <c>ron</c>,
+        /// <c>rsd</c>, <c>rub</c>, <c>rwf</c>, <c>sar</c>, <c>sbd</c>, <c>scr</c>, <c>sdg</c>,
+        /// <c>sek</c>, <c>sgd</c>, <c>shp</c>, <c>sle</c>, <c>sll</c>, <c>sos</c>, <c>srd</c>,
+        /// <c>ssp</c>, <c>std</c>, <c>stn</c>, <c>svc</c>, <c>syp</c>, <c>szl</c>, <c>thb</c>,
+        /// <c>tjs</c>, <c>tmt</c>, <c>tnd</c>, <c>top</c>, <c>try</c>, <c>ttd</c>, <c>twd</c>,
+        /// <c>tzs</c>, <c>uah</c>, <c>ugx</c>, <c>usd</c>, <c>usdb</c>, <c>usdc</c>, <c>usn</c>,
+        /// <c>uyi</c>, <c>uyu</c>, <c>uzs</c>, <c>vef</c>, <c>ves</c>, <c>vnd</c>, <c>vuv</c>,
+        /// <c>wst</c>, <c>xaf</c>, <c>xcd</c>, <c>xcg</c>, <c>xof</c>, <c>xpf</c>, <c>yer</c>,
+        /// <c>zar</c>, <c>zmk</c>, <c>zmw</c>, <c>zwd</c>, <c>zwg</c>, or <c>zwl</c>.
+        /// </summary>
+        [JsonProperty("holds_currencies")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("holds_currencies")]
+#endif
+        public List<string> HoldsCurrencies { get; set; }
+    }
+}

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountListOptions.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountListOptions.cs
@@ -1,7 +1,22 @@
 // File generated from our OpenAPI spec
 namespace Stripe.V2.MoneyManagement
 {
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
     public class FinancialAccountListOptions : V2.ListOptions
     {
+        /// <summary>
+        /// The status of the FinancialAccount to filter by. By default, closed FinancialAccounts
+        /// are not returned.
+        /// One of: <c>closed</c>, <c>open</c>, or <c>pending</c>.
+        /// </summary>
+        [JsonProperty("status")]
+#if NET6_0_OR_GREATER
+        [STJS.JsonPropertyName("status")]
+#endif
+        public string Status { get; set; }
     }
 }

--- a/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountService.cs
+++ b/src/Stripe.net/Services/V2/MoneyManagement/FinancialAccounts/FinancialAccountService.cs
@@ -21,6 +21,38 @@ namespace Stripe.V2.MoneyManagement
         }
 
         /// <summary>
+        /// Closes a FinancialAccount with or without forwarding settings.
+        /// </summary>
+        public virtual FinancialAccount Close(string id, FinancialAccountCloseOptions options = null, RequestOptions requestOptions = null)
+        {
+            return this.Request<FinancialAccount>(BaseAddress.Api, HttpMethod.Post, $"/v2/money_management/financial_accounts/{WebUtility.UrlEncode(id)}/close", options, requestOptions);
+        }
+
+        /// <summary>
+        /// Closes a FinancialAccount with or without forwarding settings.
+        /// </summary>
+        public virtual Task<FinancialAccount> CloseAsync(string id, FinancialAccountCloseOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<FinancialAccount>(BaseAddress.Api, HttpMethod.Post, $"/v2/money_management/financial_accounts/{WebUtility.UrlEncode(id)}/close", options, requestOptions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new FinancialAccount.
+        /// </summary>
+        public virtual FinancialAccount Create(FinancialAccountCreateOptions options, RequestOptions requestOptions = null)
+        {
+            return this.Request<FinancialAccount>(BaseAddress.Api, HttpMethod.Post, $"/v2/money_management/financial_accounts", options, requestOptions);
+        }
+
+        /// <summary>
+        /// Creates a new FinancialAccount.
+        /// </summary>
+        public virtual Task<FinancialAccount> CreateAsync(FinancialAccountCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            return this.RequestAsync<FinancialAccount>(BaseAddress.Api, HttpMethod.Post, $"/v2/money_management/financial_accounts", options, requestOptions, cancellationToken);
+        }
+
+        /// <summary>
         /// Retrieves the details of an existing FinancialAccount.
         /// </summary>
         public virtual FinancialAccount Get(string id, FinancialAccountGetOptions options = null, RequestOptions requestOptions = null)

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -6311,7 +6311,7 @@ namespace StripeTests
                 HttpMethod.Get,
                 "/v2/core/accounts",
                 (HttpStatusCode)200,
-                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}],\"next_page_url\":null,\"previous_page_url\":null}");
+                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}],\"next_page_url\":null,\"previous_page_url\":null}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Accounts;
             Stripe.V2.StripeList<Stripe.V2.Core.Account> accounts = service
@@ -6326,7 +6326,7 @@ namespace StripeTests
                 HttpMethod.Post,
                 "/v2/core/accounts",
                 (HttpStatusCode)200,
-                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
+                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
             var options = new Stripe.V2.Core.AccountCreateOptions();
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Accounts;
@@ -6341,7 +6341,7 @@ namespace StripeTests
                 HttpMethod.Get,
                 "/v2/core/accounts/id_123",
                 (HttpStatusCode)200,
-                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
+                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Accounts;
             Stripe.V2.Core.Account account = service.Get("id_123");
@@ -6355,7 +6355,7 @@ namespace StripeTests
                 HttpMethod.Post,
                 "/v2/core/accounts/id_123",
                 (HttpStatusCode)200,
-                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
+                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
             var options = new Stripe.V2.Core.AccountUpdateOptions();
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Accounts;
@@ -6370,7 +6370,7 @@ namespace StripeTests
                 HttpMethod.Post,
                 "/v2/core/accounts/id_123/close",
                 (HttpStatusCode)200,
-                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
+                "{\"id\":\"obj_123\",\"object\":\"v2.core.account\",\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"identity\":null,\"livemode\":true,\"metadata\":null,\"requirements\":null}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Accounts;
             Stripe.V2.Core.Account account = service.Close("id_123");
@@ -6851,7 +6851,7 @@ namespace StripeTests
                 HttpMethod.Get,
                 "/v2/money_management/financial_accounts",
                 (HttpStatusCode)200,
-                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"storage\":null,\"type\":\"other\"}],\"next_page_url\":null,\"previous_page_url\":null}");
+                "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\"}],\"next_page_url\":null,\"previous_page_url\":null}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.MoneyManagement.FinancialAccounts;
             Stripe.V2.StripeList<Stripe.V2.MoneyManagement.FinancialAccount> financialAccounts = service
@@ -6862,13 +6862,34 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestV2MoneyManagementFinancialAccountPost()
+        {
+            this.StubRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts",
+                (HttpStatusCode)200,
+                "{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\"}");
+            var options = new Stripe.V2.MoneyManagement.FinancialAccountCreateOptions
+            {
+                Type = "storage",
+            };
+            var client = new StripeClient(this.Requestor);
+            var service = client.V2.MoneyManagement.FinancialAccounts;
+            Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
+                .Create(options);
+            this.AssertRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts");
+        }
+
+        [Fact]
         public void TestV2MoneyManagementFinancialAccountGet2()
         {
             this.StubRequest(
                 HttpMethod.Get,
                 "/v2/money_management/financial_accounts/id_123",
                 (HttpStatusCode)200,
-                "{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"storage\":null,\"type\":\"other\"}");
+                "{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.MoneyManagement.FinancialAccounts;
             Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
@@ -6876,6 +6897,23 @@ namespace StripeTests
             this.AssertRequest(
                 HttpMethod.Get,
                 "/v2/money_management/financial_accounts/id_123");
+        }
+
+        [Fact]
+        public void TestV2MoneyManagementFinancialAccountPost2()
+        {
+            this.StubRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts/id_123/close",
+                (HttpStatusCode)200,
+                "{\"id\":\"obj_123\",\"object\":\"v2.money_management.financial_account\",\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"metadata\":null,\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\"}");
+            var client = new StripeClient(this.Requestor);
+            var service = client.V2.MoneyManagement.FinancialAccounts;
+            Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
+                .Close("id_123");
+            this.AssertRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts/id_123/close");
         }
 
         [Fact]
@@ -7677,6 +7715,77 @@ namespace StripeTests
         }
 
         [Fact]
+        public void TestNonZeroBalanceError()
+        {
+            this.StubRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts/id_123/close",
+                (HttpStatusCode)400,
+                "{\"error\":{\"type\":\"non_zero_balance\",\"code\":\"closing_financial_account_with_non_zero_balances\"}}");
+            var exception = Assert.Throws<Stripe.V2.NonZeroBalanceException>(
+            () =>
+            {
+            var client = new StripeClient(this.Requestor);
+            var service = client.V2.MoneyManagement.FinancialAccounts;
+            Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
+                .Close("id_123");
+            });
+            this.AssertRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts/id_123/close");
+        }
+
+        [Fact]
+        public void TestAlreadyExistsError()
+        {
+            this.StubRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts",
+                (HttpStatusCode)400,
+                "{\"error\":{\"type\":\"already_exists\",\"code\":\"already_exists\"}}");
+            var exception = Assert.Throws<Stripe.V2.AlreadyExistsException>(
+            () =>
+            {
+            var options = new Stripe.V2.MoneyManagement.FinancialAccountCreateOptions
+            {
+                Type = "storage",
+            };
+            var client = new StripeClient(this.Requestor);
+            var service = client.V2.MoneyManagement.FinancialAccounts;
+            Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
+                .Create(options);
+            });
+            this.AssertRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts");
+        }
+
+        [Fact]
+        public void TestFeatureNotEnabledError()
+        {
+            this.StubRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts",
+                (HttpStatusCode)400,
+                "{\"error\":{\"type\":\"feature_not_enabled\",\"code\":\"storer_capability_missing\"}}");
+            var exception = Assert.Throws<Stripe.V2.FeatureNotEnabledException>(
+            () =>
+            {
+            var options = new Stripe.V2.MoneyManagement.FinancialAccountCreateOptions
+            {
+                Type = "storage",
+            };
+            var client = new StripeClient(this.Requestor);
+            var service = client.V2.MoneyManagement.FinancialAccounts;
+            Stripe.V2.MoneyManagement.FinancialAccount financialAccount = service
+                .Create(options);
+            });
+            this.AssertRequest(
+                HttpMethod.Post,
+                "/v2/money_management/financial_accounts");
+        }
+
+        [Fact]
         public void TestFinancialAccountNotOpenError()
         {
             this.StubRequest(
@@ -7685,32 +7794,6 @@ namespace StripeTests
                 (HttpStatusCode)400,
                 "{\"error\":{\"type\":\"financial_account_not_open\",\"code\":\"financial_account_not_in_open_status\"}}");
             var exception = Assert.Throws<Stripe.V2.FinancialAccountNotOpenException>(
-            () =>
-            {
-            var options = new Stripe.V2.MoneyManagement.FinancialAddressCreateOptions
-            {
-                Currency = "stn",
-                FinancialAccount = "financial_account",
-            };
-            var client = new StripeClient(this.Requestor);
-            var service = client.V2.MoneyManagement.FinancialAddresses;
-            Stripe.V2.MoneyManagement.FinancialAddress financialAddress = service
-                .Create(options);
-            });
-            this.AssertRequest(
-                HttpMethod.Post,
-                "/v2/money_management/financial_addresses");
-        }
-
-        [Fact]
-        public void TestFeatureNotEnabledError()
-        {
-            this.StubRequest(
-                HttpMethod.Post,
-                "/v2/money_management/financial_addresses",
-                (HttpStatusCode)400,
-                "{\"error\":{\"type\":\"feature_not_enabled\",\"code\":\"storer_capability_missing\"}}");
-            var exception = Assert.Throws<Stripe.V2.FeatureNotEnabledException>(
             () =>
             {
             var options = new Stripe.V2.MoneyManagement.FinancialAddressCreateOptions


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Changes were done to V2 FinancialAccount API in the June release which did not make it to the SDKs. Pulling those changes in now and making another SDK release for the 2025-06-30.preview API version

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

* Pull protos in codegen for 2025-06-30.preview
* Generate the SDK

## Changelog
* Add support for `Close` and `Create` methods on resource `V2.MoneyManagement.FinancialAccount`
* Add support for `Storer` on `V2.Core.Account.Configuration` and `V2CoreAccountConfigurationOptions`
* Add support for `StatusDetails` on `V2.MoneyManagement.FinancialAccount`
* Add support for `Status` on `V2.MoneyManagement.FinancialAccountListOptions`
* Add support for thin events `V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent` and `V2CoreAccountIncludingConfigurationStorerUpdatedEvent` with related object `V2.Core.Account`
* Add support for error types `AlreadyExistsException` and `NonZeroBalanceException`