### PR TITLE
Separate the default StripeConfiguration.StripeClient from feature-full StripeClient class, and add telemetry string to StripeClient

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
+++ b/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
@@ -35,6 +35,11 @@ namespace Stripe
                 return stripeClient.Requestor;
             }
 
+            if (client is DefaultStripeClient defaultStripeClient)
+            {
+                return defaultStripeClient.Requestor;
+            }
+
             return new ApiRequestorAdapter(client);
         }
 

--- a/src/Stripe.net/Infrastructure/Public/DefaultStripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/DefaultStripeClient.cs
@@ -1,0 +1,80 @@
+namespace Stripe
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A default implementation of the <see cref="IStripeClient"/> interface.  This is used by
+    /// StripeConfiguration to provide a default client, which is used in conjuction with Service
+    /// instances when no client is provided.
+    /// </summary>
+    internal class DefaultStripeClient : IStripeClient
+    {
+        public DefaultStripeClient(string apiKey, string clientId, IHttpClient httpClient)
+        {
+            this.Requestor = new LiveApiRequestor(
+                new StripeClientOptions
+                {
+                    ApiKey = apiKey,
+                    ClientId = clientId,
+                    HttpClient = httpClient,
+                }, new List<string>());
+        }
+
+        /// <summary>Gets the base URL for Stripe's API.</summary>
+        /// <value>The base URL for Stripe's API.</value>
+        public string ApiBase => this.Requestor?.ApiBase;
+
+        /// <summary>Gets the API key used by the client to send requests.</summary>
+        /// <value>The API key used by the client to send requests.</value>
+        public string ApiKey => this.Requestor?.ApiKey;
+
+        /// <summary>Gets the client ID used by the client in OAuth requests.</summary>
+        /// <value>The client ID used by the client in OAuth requests.</value>
+        public string ClientId => this.Requestor?.ClientId;
+
+        /// <summary>Gets the base URL for Stripe's OAuth API.</summary>
+        /// <value>The base URL for Stripe's OAuth API.</value>
+        public string ConnectBase => this.Requestor?.ConnectBase;
+
+        /// <summary>Gets the base URL for Stripe's Files API.</summary>
+        /// <value>The base URL for Stripe's Files API.</value>
+        public string FilesBase => this.Requestor?.FilesBase;
+
+        /// <summary>Gets the base URL for Stripe's Meter Events API.</summary>
+        /// <value>The base URL for Stripe's Meter Events API.</value>
+        public string MeterEventsBase => this.Requestor?.MeterEventsBase;
+
+        /// <summary>Gets the <see cref="IHttpClient"/> used to send HTTP requests.</summary>
+        /// <value>The <see cref="IHttpClient"/> used to send HTTP requests.</value>
+        public IHttpClient HttpClient => this.Requestor?.HttpClient;
+
+        internal ApiRequestor Requestor { get; }
+
+        /// <inheritdoc/>
+        public async Task<T> RequestAsync<T>(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default)
+            where T : IStripeEntity
+        {
+            return await this.Requestor.RequestAsync<T>(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<Stream> RequestStreamingAsync(
+            HttpMethod method,
+            string path,
+            BaseOptions options,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken = default)
+        {
+            return await this.Requestor.RequestStreamingAsync(BaseAddress.Api, method, path, options, requestOptions, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -3,6 +3,7 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
@@ -17,8 +18,9 @@ namespace Stripe
         internal static readonly List<string> RawRequestUsage = new List<string> { "raw_request" };
         private JsonSerializerSettings jsonSerializerSettings;
         private StripeClientOptions clientOptions;
+        private List<string> defaultUsage;
 
-        public LiveApiRequestor(StripeClientOptions options)
+        public LiveApiRequestor(StripeClientOptions options, List<string> defaultUsage = null)
         {
             // Clone the object passed in, or use an empty option object if it is null
             options = options?.Clone() ?? new StripeClientOptions();
@@ -41,6 +43,7 @@ namespace Stripe
             this.ConnectBase = options.ConnectBase ?? DefaultConnectBase;
             this.FilesBase = options.FilesBase ?? DefaultFilesBase;
             this.MeterEventsBase = options.MeterEventsBase ?? DefaultMeterEventsBase;
+            this.defaultUsage = defaultUsage ?? new List<string>();
             this.jsonSerializerSettings = StripeConfiguration.DefaultSerializerSettings(this);
         }
 
@@ -216,6 +219,11 @@ namespace Stripe
             RequestOptions requestOptions,
             ApiMode apiMode)
         {
+            if (this.defaultUsage.Count > 0)
+            {
+                requestOptions = requestOptions.WithUsage(this.defaultUsage);
+            }
+
             var uri = StripeRequest.BuildUri(
                 requestOptions?.BaseUrl ?? this.GetBaseUrl(baseAddress),
                 method,
@@ -297,7 +305,7 @@ namespace Stripe
                 throw new InvalidOperationException("content is not allowed for non-POST requests.");
             }
 
-            requestOptions = requestOptions.WithUsage(RawRequestUsage);
+            requestOptions = requestOptions.WithUsage(this.defaultUsage.Concat(RawRequestUsage).ToList());
             var apiMode = ApiModeUtils.GetApiMode(path);
             var uri = StripeRequest.BuildUri(
                 requestOptions?.BaseUrl ?? this.GetBaseUrl(BaseAddress.Api),

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -221,7 +221,13 @@ namespace Stripe
         {
             if (this.defaultUsage.Count > 0)
             {
-                requestOptions = requestOptions.WithUsage(this.defaultUsage);
+                var usage = this.defaultUsage;
+                if (requestOptions?.Usage?.Count > 0)
+                {
+                    usage = usage.Concat(requestOptions.Usage).ToList();
+                }
+
+                requestOptions = requestOptions.WithUsage(usage);
             }
 
             var uri = StripeRequest.BuildUri(

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -1,6 +1,7 @@
 namespace Stripe
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Net.Http;
     using System.Threading;
@@ -13,6 +14,8 @@ namespace Stripe
     /// </summary>
     public class StripeClient : IStripeClient
     {
+        internal static readonly List<string> StripeClientUsage = new List<string> { "stripe_client" };
+
         private JsonSerializerSettings jsonSerializerSettings;
 
         // Fields: The beginning of the section generated from our OpenAPI spec
@@ -71,7 +74,7 @@ namespace Stripe
         }
 
         public StripeClient(StripeClientOptions options)
-            : this(new LiveApiRequestor(options))
+            : this(new LiveApiRequestor(options, StripeClientUsage))
         {
         }
 

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -3,7 +3,6 @@ namespace Stripe
     using System;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.Reflection;
     using System.Runtime.Serialization;
     using Newtonsoft.Json;
     using Stripe.Infrastructure;
@@ -243,7 +242,7 @@ namespace Stripe
             ApiKey = newApiKey;
         }
 
-        private static StripeClient BuildDefaultStripeClient()
+        private static IStripeClient BuildDefaultStripeClient()
         {
             if (ApiKey != null && ApiKey.Length == 0)
             {
@@ -268,7 +267,7 @@ namespace Stripe
                 maxNetworkRetries: MaxNetworkRetries,
                 appInfo: AppInfo,
                 enableTelemetry: EnableTelemetry);
-            return new StripeClient(ApiKey, ClientId, httpClient: httpClient);
+            return new DefaultStripeClient(ApiKey, ClientId, httpClient);
         }
     }
 }

--- a/src/StripeTests/BaseStripeTest.cs
+++ b/src/StripeTests/BaseStripeTest.cs
@@ -69,9 +69,10 @@ namespace StripeTests
             if ((this.StripeMockFixture != null) && (this.MockHttpClientFixture != null))
             {
                 // Set up StripeClient to use stripe-mock with the mock HTTP client
-                var requestor = this.StripeMockFixture.BuildApiRequestor(this.MockHttpClientFixture.MockHandler.Object);
-                this.StripeClient = new StripeClient(requestor);
-                this.Requestor = requestor;
+                var clientOptions = this.StripeMockFixture.BuildStripeClientOptions(this.MockHttpClientFixture.MockHandler.Object);
+                var client = new StripeClient(clientOptions);
+                this.StripeClient = client;
+                this.Requestor = client.Requestor;
 
                 // Reset the mock before each test
                 this.MockHttpClientFixture.Reset();
@@ -79,22 +80,24 @@ namespace StripeTests
             else if (this.StripeMockFixture != null)
             {
                 // Set up StripeClient to use stripe-mock
-                var requestor = this.StripeMockFixture.BuildApiRequestor();
-                this.StripeClient = new StripeClient(requestor);
-                this.Requestor = requestor;
+                var clientOptions = this.StripeMockFixture.BuildStripeClientOptions();
+                var client = new StripeClient(clientOptions);
+                this.StripeClient = client;
+                this.Requestor = client.Requestor;
             }
             else if (this.MockHttpClientFixture != null)
             {
                 // Set up StripeClient with the mock HTTP client
                 var httpClient = new SystemNetHttpClient(
                     new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                var requestor = new LiveApiRequestor(new StripeClientOptions
+                var clientOptions = new StripeClientOptions
                 {
                     ApiKey = "sk_test_123",
                     HttpClient = httpClient,
-                });
-                this.StripeClient = new StripeClient(requestor);
-                this.Requestor = requestor;
+                };
+                var client = new StripeClient(clientOptions);
+                this.StripeClient = client;
+                this.Requestor = client.Requestor;
 
                 // Reset the mock before each test
                 this.MockHttpClientFixture.Reset();
@@ -102,9 +105,10 @@ namespace StripeTests
             else
             {
                 // Use the default StripeClient
-                var requestor = new LiveApiRequestor(new StripeClientOptions { ApiKey = "sk_test_123" });
-                this.StripeClient = new StripeClient(requestor);
-                this.Requestor = requestor;
+                var clientOptions = new StripeClientOptions { ApiKey = "sk_test_123" };
+                var client = new StripeClient(clientOptions);
+                this.StripeClient = client;
+                this.Requestor = client.Requestor;
             }
         }
 

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -15,6 +15,8 @@ namespace StripeTests
     using Stripe;
     using Xunit;
 
+    using static TelemetryTestUtils;
+
     public class TelemetryTest : BaseStripeTest
     {
         public TelemetryTest(MockHttpClientFixture mockHttpClientFixture)
@@ -173,33 +175,6 @@ namespace StripeTests
                     ItExpr.Is<HttpRequestMessage>(m =>
                         !m.Headers.Contains("X-Stripe-Client-Telemetry")),
                     ItExpr.IsAny<CancellationToken>());
-        }
-
-        private static bool TelemetryHeaderMatcher(
-            HttpHeaders headers,
-            Func<string, bool> requestIdMatcher,
-            Func<long, bool> durationMatcher,
-            Func<List<string>, bool> usageMatcher)
-        {
-            if (!headers.Contains("X-Stripe-Client-Telemetry"))
-            {
-                return false;
-            }
-
-            var payload = headers.GetValues("X-Stripe-Client-Telemetry").First();
-
-            var deserialized = JToken.Parse(payload);
-            var requestId = (string)deserialized["last_request_metrics"]["request_id"];
-            var duration = (long)deserialized["last_request_metrics"]["request_duration_ms"];
-            var usageRaw = deserialized["last_request_metrics"]["usage"];
-
-            List<string> usage = null;
-            if (usageRaw != null)
-            {
-                usage = usageRaw.Select(x => (string)x).ToList();
-            }
-
-            return requestIdMatcher(requestId) && durationMatcher(duration) && usageMatcher(usage);
         }
 
         private class TestEntity : StripeEntity<TestEntity>

--- a/src/StripeTests/Functional/TelemetryTest.cs
+++ b/src/StripeTests/Functional/TelemetryTest.cs
@@ -97,7 +97,7 @@ namespace StripeTests
                             m.Headers,
                             (_) => true,
                             (_) => true,
-                            (t) => t != null && t.Count == 2 && t.Contains("llama") && t.Contains("bufo"))),
+                            (t) => t != null && t.Count >= 2 && t.Contains("llama") && t.Contains("bufo"))),
                     ItExpr.IsAny<CancellationToken>());
         }
 

--- a/src/StripeTests/Functional/TelemetryTestUtils.cs
+++ b/src/StripeTests/Functional/TelemetryTestUtils.cs
@@ -1,0 +1,47 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using Moq.Protected;
+    using Newtonsoft.Json.Linq;
+    using Stripe;
+    using Xunit;
+
+    internal class TelemetryTestUtils
+    {
+        public static bool TelemetryHeaderMatcher(
+            HttpHeaders headers,
+            Func<string, bool> requestIdMatcher,
+            Func<long, bool> durationMatcher,
+            Func<List<string>, bool> usageMatcher)
+        {
+            if (!headers.Contains("X-Stripe-Client-Telemetry"))
+            {
+                return false;
+            }
+
+            var payload = headers.GetValues("X-Stripe-Client-Telemetry").First();
+
+            var deserialized = JToken.Parse(payload);
+            var requestId = (string)deserialized["last_request_metrics"]["request_id"];
+            var duration = (long)deserialized["last_request_metrics"]["request_duration_ms"];
+            var usageRaw = deserialized["last_request_metrics"]["usage"];
+
+            List<string> usage = null;
+            if (usageRaw != null)
+            {
+                usage = usageRaw.Select(x => (string)x).ToList();
+            }
+
+            return requestIdMatcher(requestId) && durationMatcher(duration) && usageMatcher(usage);
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -167,23 +167,20 @@ namespace StripeTests
         [Fact]
         public async Task RawRequestAsyncIncludesCorrectUsage()
         {
-            // Stub a request as stripe-mock does not support v2
-            this.MockHttpClientFixture.StubRequest(
-                    HttpMethod.Post,
-                    "/v2/billing/meter_event_session",
-                    System.Net.HttpStatusCode.OK,
-                    "{\"id\": \"mes_123\",\"object\":\"v2.billing.meter_event_session\"}");
+            await this.stripeClient.RawRequestAsync(
+               HttpMethod.Get,
+               "/v1/customers/cus_123",
+               null,
+               new RawRequestOptions
+               {
+               });
 
-            var rawResponse = await this.stripeClient.RawRequestAsync(
-                HttpMethod.Post,
-                "/v2/billing/meter_event_session",
-                "{}",
+            await this.stripeClient.RawRequestAsync(
+                HttpMethod.Get,
+                "/v1/customers/cus_123",
+                null,
                 new RawRequestOptions
                 {
-                    AdditionalHeaders =
-                    {
-                        { "foo", "bar" },
-                    },
                 });
 
             this.MockHttpClientFixture.MockHandler.Protected()

--- a/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeClientTest.cs
@@ -1,15 +1,19 @@
 namespace StripeTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Moq;
     using Moq.Protected;
+    using Newtonsoft.Json.Linq;
     using Stripe;
-    using StripeTests.V2;
     using Xunit;
+
+    using static TelemetryTestUtils;
 
     public class StripeClientTest : BaseStripeTest
     {
@@ -71,6 +75,58 @@ namespace StripeTests
             options.ApiKey = "wrong_key_456";
             Assert.NotEqual(options.ApiKey, client.ApiKey);
             Assert.Equal(goodApiKey, client.ApiKey);
+        }
+
+        [Fact]
+        public void StripeClientRequestorIncludesCorrectUsage()
+        {
+            var client = this.StripeClient as StripeClient;
+            client.V1.Customers.Get("cus_123");
+            client.V1.Customers.Get("cus_123");
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        TelemetryHeaderMatcher(
+                            m.Headers,
+                            (_) => true,
+                            (_) => true,
+                            (t) => t != null && t.Count == 1 && t.Contains(Stripe.StripeClient.StripeClientUsage[0]))),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public void DefaultStripeClientRequestorDoesNotIncludeUsage()
+        {
+            var stripeClient = this.StripeClient as StripeClient;
+
+            // This mimics StripeConfiguration.BuildDefaultStripeClient, which is used
+            // by StripeConfiguration.StripeClient when a client is not set
+            StripeConfiguration.StripeClient = new DefaultStripeClient(
+                stripeClient.ApiKey, stripeClient.ClientId, stripeClient.HttpClient);
+
+            var customers = new CustomerService();
+            customers.Get("cus_123");
+            customers.Get("cus_123");
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        TelemetryHeaderMatcher(
+                            m.Headers,
+                            (_) => true,
+                            (_) => true,
+                            (t) => t != null && t.Count == 0)),
+                    ItExpr.IsAny<CancellationToken>());
+
+            // unfortunately we cannot check at the top of the test because
+            // StripeConfiguration.StripeClient always returns a value; but
+            // we should assume it was not set
+            StripeConfiguration.StripeClient = null;
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeConfigurationTest.cs
@@ -24,6 +24,7 @@ namespace StripeTests
 
                 var client = StripeConfiguration.StripeClient;
                 Assert.NotNull(client);
+                Assert.IsType<DefaultStripeClient>(client);
                 Assert.Equal(StripeConfiguration.ApiKey, client.ApiKey);
                 Assert.Equal(StripeConfiguration.ClientId, client.ClientId);
             }
@@ -46,6 +47,7 @@ namespace StripeTests
 
                 var client = StripeConfiguration.StripeClient;
                 Assert.NotNull(client);
+                Assert.IsType<DefaultStripeClient>(client);
                 Assert.Null(client.ApiKey);
             }
             finally

--- a/src/StripeTests/StripeMockFixture.cs
+++ b/src/StripeTests/StripeMockFixture.cs
@@ -43,14 +43,14 @@ namespace StripeTests
         /// created with default parameters.
         /// </param>
         /// <returns>The new <see cref="ApiRequestor"/> instance.</returns>
-        internal ApiRequestor BuildApiRequestor(HttpClientHandler innerHandler = null)
+        internal StripeClientOptions BuildStripeClientOptions(HttpClientHandler innerHandler = null)
         {
-            return new LiveApiRequestor(new StripeClientOptions
+            return new StripeClientOptions
             {
                 ApiKey = "sk_test_123",
                 ClientId = "ca_123",
                 HttpClient = new SystemNetHttpClient(new ForwardingHttpClient(innerHandler, this.port)),
-            });
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
### Why?
Stripe.NET supports two different service usage patterns: direct Service class construction, and accessing services via StripeClient.  We want to be able to differentiate these patterns in our client telemetry.

### What?
- adds defaultUsage construction parameter to LiveApiRequestor to let callers specify telemetry usage strings for each request
- adds telemetry usage strings to LiveApiRequestor constructor in StripeClient
- add DefaultStripeClient IStripeClient implementation (without a usage string)
- modifies StripeConfiguration.BuildDefaultStripeClient to create a DefaultStripeClient
- adds tests to verify correct telemetry usage strings

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Adds usage string to telemetry on API calls made through `StripeClient` service accessors
