### PR TITLE
Mark StripeConfiguration as partial so we can add configuration in beta branch

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -10,7 +10,7 @@ namespace Stripe
     /// <summary>
     /// Global configuration class for Stripe.net settings.
     /// </summary>
-    public static class StripeConfiguration
+    public static partial class StripeConfiguration
     {
         private static string apiKey;
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Our beta branch includes additional configuration, and this set up leads to frequent merge conflicts when StripeConfiguration is changed in the master branch.  This PR marks StripeConfiguration as partial so we can keep beta-specific configuration in the StripeConfiguration class but define it in a separate physical file.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- marks StripeConfiguration to be partial so that we can have additional partial class in a separate file on the beta branch

### See Also
<!-- Include any links or additional information that help explain this change. -->
