### PR TITLE
Use the right API version 2025-08-27.preview

### DIFF
--- a/src/Stripe.net/Constants/ApiVersion.cs
+++ b/src/Stripe.net/Constants/ApiVersion.cs
@@ -3,6 +3,6 @@ namespace Stripe
 {
     internal class ApiVersion
     {
-        public const string Current = "2025-08-04.private";
+        public const string Current = "2025-08-27.preview";
     }
 }


### PR DESCRIPTION
### Why?
The Open API spec used to generate the SDK was using an older API version. The spec with the fix for this cannot be used as it also contains changes meant for the next release. Therefore, manually making the API version change here

### What?
Update API version 2025-08-04.private to 2025-08-27.preview 


