### PR TITLE
Adds public BaseUrl to RawRequestOptions

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
+++ b/src/Stripe.net/Infrastructure/Public/ApiRequestorAdapter.cs
@@ -54,7 +54,7 @@ namespace Stripe
             if (baseAddress != BaseAddress.Api)
             {
                 requestOptions ??= new RequestOptions();
-                requestOptions.BaseUrl = this.GetBaseUrl(baseAddress);
+                requestOptions.InternalBaseUrl = this.GetBaseUrl(baseAddress);
             }
 
             return this.client.RequestAsync<T>(method, path, options, requestOptions, cancellationToken);

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -231,7 +231,7 @@ namespace Stripe
             }
 
             var uri = StripeRequest.BuildUri(
-                requestOptions?.BaseUrl ?? this.GetBaseUrl(baseAddress),
+                requestOptions?.InternalBaseUrl ?? this.GetBaseUrl(baseAddress),
                 method,
                 path,
                 options,

--- a/src/Stripe.net/Services/_common/RawRequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RawRequestOptions.cs
@@ -4,6 +4,13 @@ namespace Stripe
 
     public class RawRequestOptions : RequestOptions
     {
+        /// <summary>Gets or sets the base URL for the raw request.</summary>
+        /// <remarks>
+        /// Use this to send API calls to e.g. files.stripe.com or
+        /// a proxy address.
+        /// </remarks>
+        public string BaseUrl { get => this.InternalBaseUrl; set => this.InternalBaseUrl = value; }
+
         /// <summary>Gets or sets additional headers for the request.</summary>
         public Dictionary<string, string> AdditionalHeaders { get; set; } = new Dictionary<string, string>();
 

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -27,13 +27,13 @@ namespace Stripe
         /// <summary>Gets or sets the value or Stripe-Context request header.</summary>
         public string StripeContext { get; set; }
 
-        /// <summary>Gets or sets the base URL for the request.</summary>
+        /// <summary>Gets the base URL for the request.</summary>
         /// <remarks>
         /// This is an internal property. It is set by services or individual request methods when
         /// they need to send a request to a non-standard destination, e.g. <c>files.stripe.com</c>
         /// for file creation requests or <c>connect.stripe.com</c> for OAuth requests.
         /// </remarks>
-        internal string BaseUrl { get; set; }
+        internal string InternalBaseUrl { get; set; }
 
         /// <summary>Gets or sets the API version for the request.</summary>
         /// <remarks>


### PR DESCRIPTION

### Why?
[RawRequest](https://github.com/stripe/stripe-dotnet?tab=readme-ov-file#custom-requests) can be used to make custom requests to Stripe APIs not yet supported by the SDK, but it was limited to APIs exposed via api.stripe.com.  This limits the ability to call some of our APs.

### What?
- renames internal `BaseUrl` in RequestOptions to `InternalBaseUrl`
- adds public BaseUrl to RawRequestOptions which delegates to InternalBaseUrl for safety
- adds test

### See Also
<!-- Include any links or additional information that help explain this change. -->
