### PR TITLE
Add `StripeContext` object

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/StripeContextConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/StripeContextConverter.cs
@@ -1,0 +1,73 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Converts a <see cref="StripeContext"/> to and from JSON.
+    /// </summary>
+    internal class StripeContextConverter : JsonConverter
+    {
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.
+        /// </value>
+        public override bool CanWrite => true;
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is StripeContext context)
+            {
+                writer.WriteValue(context.ToString());
+            }
+            else
+            {
+                writer.WriteNull();
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        ///     <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(StripeContext) || objectType == typeof(StripeContext?);
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                var contextString = (string)reader.Value;
+                return StripeContext.Parse(contextString);
+            }
+
+            throw new JsonSerializationException($"Unexpected token type {reader.TokenType} when deserializing StripeContext.");
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeClientOptions.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClientOptions.cs
@@ -42,6 +42,23 @@ namespace Stripe
         /// <summary>Gets and sets the Stripe-Context header value for requests made from this client.</summary>
         public string StripeContext { get; set; }
 
+        /// <summary>
+        /// Sets the Stripe-Context header from a StripeContext object.
+        /// </summary>
+        /// <param name="context">The StripeContext to set.</param>
+        public void SetStripeContext(StripeContext context)
+        {
+            if (context != null)
+            {
+                var contextValue = context.ToString();
+                this.StripeContext = !string.IsNullOrEmpty(contextValue) ? contextValue : null;
+            }
+            else
+            {
+                this.StripeContext = null;
+            }
+        }
+
         internal StripeClientOptions Clone()
         {
             return (StripeClientOptions)this.MemberwiseClone();

--- a/src/Stripe.net/Infrastructure/Public/StripeContext.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeContext.cs
@@ -1,0 +1,89 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using Newtonsoft.Json;
+#if NET6_0_OR_GREATER
+    using STJS = System.Text.Json.Serialization;
+#endif
+
+    /// <summary>
+    /// Represents a path-like context for Stripe API operations, allowing for
+    /// hierarchical organization of API calls. The context is externally immutable,
+    /// meaning all operations return new instances rather than modifying existing ones.
+    /// </summary>
+    public class StripeContext
+    {
+        private readonly ReadOnlyCollection<string> segments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeContext"/> class.
+        /// </summary>
+        public StripeContext()
+            : this(new List<string>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeContext"/> class.
+        /// </summary>
+        /// <param name="segments">The segments that make up the context.</param>
+        public StripeContext(IEnumerable<string> segments)
+        {
+            this.segments = new ReadOnlyCollection<string>(segments?.ToList() ?? new List<string>());
+        }
+
+        /// <summary>
+        /// Parses a context string into a StripeContext instance.
+        /// </summary>
+        /// <param name="contextString">The context string to parse.</param>
+        /// <returns>A new StripeContext instance.</returns>
+        public static StripeContext Parse(string contextString)
+        {
+            if (string.IsNullOrEmpty(contextString))
+            {
+                return new StripeContext();
+            }
+
+            return new StripeContext(contextString.Split('/'));
+        }
+
+        /// <summary>
+        /// Returns the parent context by removing the last segment.
+        /// Throws an exception if the context is empty.
+        /// </summary>
+        /// <returns>A new StripeContext instance representing the parent.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the context is empty.</exception>
+        public StripeContext Parent()
+        {
+            if (this.segments.Count == 0)
+            {
+                throw new InvalidOperationException("Cannot get parent of empty context");
+            }
+
+            return new StripeContext(this.segments.Take(this.segments.Count - 1));
+        }
+
+        /// <summary>
+        /// Returns a new context with the given segment appended.
+        /// </summary>
+        /// <param name="segment">The segment to append.</param>
+        /// <returns>A new StripeContext instance with the segment appended.</returns>
+        public StripeContext Child(string segment)
+        {
+            var newSegments = new List<string>(this.segments) { segment };
+            return new StripeContext(newSegments);
+        }
+
+        /// <summary>
+        /// Returns the string representation of the context.
+        /// </summary>
+        /// <returns>The context as a forward-slash separated string.</returns>
+        public override string ToString()
+        {
+            return string.Join("/", this.segments);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
+++ b/src/Stripe.net/Infrastructure/Public/ThinEvent.cs
@@ -64,10 +64,11 @@ namespace Stripe
         /// [Optional] Authentication context needed to fetch the event or related object.
         /// </summary>
         [JsonProperty("context")]
+        [JsonConverter(typeof(Infrastructure.StripeContextConverter))]
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("context")]
 #endif
-        public string? Context { get; internal set; }
+        public StripeContext? Context { get; internal set; }
 
         /// <summary>
         /// [Optional] Object containing the reference to API resource relevant to the event.

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -27,6 +27,23 @@ namespace Stripe
         /// <summary>Gets or sets the value or Stripe-Context request header.</summary>
         public string StripeContext { get; set; }
 
+        /// <summary>
+        /// Sets the Stripe-Context header from a StripeContext object.
+        /// </summary>
+        /// <param name="context">The StripeContext to set.</param>
+        public void SetStripeContext(StripeContext context)
+        {
+            if (context != null)
+            {
+                var contextValue = context.ToString();
+                this.StripeContext = !string.IsNullOrEmpty(contextValue) ? contextValue : null;
+            }
+            else
+            {
+                this.StripeContext = null;
+            }
+        }
+
         /// <summary>Gets the base URL for the request.</summary>
         /// <remarks>
         /// This is an internal property. It is set by services or individual request methods when

--- a/src/StripeTests/Infrastructure/Public/StripeContextTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeContextTest.cs
@@ -1,0 +1,264 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Stripe;
+    using Xunit;
+
+    public class StripeContextTest : BaseStripeTest
+    {
+        [Fact]
+        public void EmptyContext()
+        {
+            var context = new StripeContext();
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void ContextWithSegments()
+        {
+            var context = new StripeContext(new[] { "a", "b", "c" });
+            Assert.Equal("a/b/c", context.ToString());
+        }
+
+        [Fact]
+        public void ParseEmptyString()
+        {
+            var context = StripeContext.Parse(string.Empty);
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void ParseNullString()
+        {
+            var context = StripeContext.Parse(null);
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void ParseSingleSegment()
+        {
+            var context = StripeContext.Parse("a");
+            Assert.Equal("a", context.ToString());
+        }
+
+        [Fact]
+        public void ParseMultipleSegments()
+        {
+            var context = StripeContext.Parse("a/b/c");
+            Assert.Equal("a/b/c", context.ToString());
+        }
+
+        [Fact]
+        public void ParentReturnsNewInstance()
+        {
+            var context = StripeContext.Parse("a/b/c");
+            var parent = context.Parent();
+
+            // Original unchanged
+            Assert.Equal("a/b/c", context.ToString());
+            // New instance with removed segment
+            Assert.Equal("a/b", parent.ToString());
+        }
+
+        [Fact]
+        public void ParentOfSingleSegment()
+        {
+            var context = StripeContext.Parse("a");
+            var parent = context.Parent();
+            Assert.Equal(string.Empty, parent.ToString());
+        }
+
+        [Fact]
+        public void ParentOfEmptyContextThrowsException()
+        {
+            var context = new StripeContext();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => context.Parent());
+            Assert.Equal("Cannot get parent of empty context", ex.Message);
+        }
+
+        [Fact]
+        public void ChildReturnsNewInstance()
+        {
+            var context = StripeContext.Parse("a/b");
+            var child = context.Child("c");
+
+            // Original unchanged
+            Assert.Equal("a/b", context.ToString());
+            // New instance with added segment
+            Assert.Equal("a/b/c", child.ToString());
+        }
+
+        [Fact]
+        public void ChildOnEmptyContext()
+        {
+            var context = new StripeContext();
+            var child = context.Child("a");
+            Assert.Equal("a", child.ToString());
+        }
+
+        [Fact]
+        public void MethodChaining()
+        {
+            var context = StripeContext.Parse("a");
+            var result = context.Child("b").Child("c").Parent();
+            Assert.Equal("a/b", result.ToString());
+        }
+
+        [Fact]
+        public void InitWithNullSegments()
+        {
+            var context = new StripeContext(null);
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void InitWithEmptyList()
+        {
+            var context = new StripeContext(new List<string>());
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void RequestOptionsSetStripeContext()
+        {
+            var context = StripeContext.Parse("org_123/proj_456");
+            var options = new RequestOptions();
+
+            options.SetStripeContext(context);
+
+            Assert.Equal("org_123/proj_456", options.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptionsSetStripeContextWithNull()
+        {
+            var options = new RequestOptions();
+            options.SetStripeContext(null);
+
+            Assert.Null(options.StripeContext);
+        }
+
+        [Fact]
+        public void StripeClientOptionsSetStripeContext()
+        {
+            var context = StripeContext.Parse("org_123/proj_456");
+            var clientOptions = new StripeClientOptions();
+
+            clientOptions.SetStripeContext(context);
+
+            Assert.Equal("org_123/proj_456", clientOptions.StripeContext);
+        }
+
+        [Fact]
+        public void StripeClientOptionsSetStripeContextWithNull()
+        {
+            var clientOptions = new StripeClientOptions();
+            clientOptions.SetStripeContext(null);
+
+            Assert.Null(clientOptions.StripeContext);
+        }
+
+        [Fact]
+        public void JsonSerializationWithContext()
+        {
+            var thinEvent = new ThinEvent
+            {
+                Context = StripeContext.Parse("org_123/proj_456")
+            };
+
+            var json = JsonConvert.SerializeObject(thinEvent);
+            var deserializedEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.NotNull(deserializedEvent.Context);
+            Assert.Equal("org_123/proj_456", deserializedEvent.Context.ToString());
+        }
+
+        [Fact]
+        public void JsonSerializationWithEmptyContext()
+        {
+            var thinEvent = new ThinEvent
+            {
+                Context = new StripeContext()
+            };
+
+            var json = JsonConvert.SerializeObject(thinEvent);
+            var deserializedEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.NotNull(deserializedEvent.Context);
+            Assert.Equal(string.Empty, deserializedEvent.Context.ToString());
+        }
+
+        [Fact]
+        public void JsonSerializationWithNullContext()
+        {
+            var thinEvent = new ThinEvent
+            {
+                Context = null
+            };
+
+            var json = JsonConvert.SerializeObject(thinEvent);
+            var deserializedEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.Null(deserializedEvent.Context);
+        }
+
+        [Fact]
+        public void JsonDeserializationFromString()
+        {
+            var json = @"{""context"":""org_123/proj_456""}";
+
+            var thinEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.NotNull(thinEvent.Context);
+            Assert.Equal("org_123/proj_456", thinEvent.Context.ToString());
+        }
+
+        [Fact]
+        public void JsonDeserializationFromEmptyString()
+        {
+            var json = @"{""context"":""""}";
+
+            var thinEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.NotNull(thinEvent.Context);
+            Assert.Equal(string.Empty, thinEvent.Context.ToString());
+        }
+
+        [Fact]
+        public void JsonDeserializationFromNull()
+        {
+            var json = @"{""context"":null}";
+
+            var thinEvent = JsonConvert.DeserializeObject<ThinEvent>(json);
+
+            Assert.Null(thinEvent.Context);
+        }
+
+        [Fact]
+        public void EmptyContextDoesNotSetHeader()
+        {
+            var emptyContext = new StripeContext();
+            var options = new RequestOptions();
+
+            options.SetStripeContext(emptyContext);
+
+            // Empty context should result in null StripeContext
+            Assert.Null(options.StripeContext);
+        }
+
+        [Fact]
+        public void NonEmptyContextSetsHeader()
+        {
+            var context = StripeContext.Parse("org_123/proj_456");
+            var options = new RequestOptions();
+
+            options.SetStripeContext(context);
+
+            // Non-empty context should set the header
+            Assert.Equal("org_123/proj_456", options.StripeContext);
+        }
+    }
+}

--- a/src/StripeTests/Services/_common/RequestOptionsTest.cs
+++ b/src/StripeTests/Services/_common/RequestOptionsTest.cs
@@ -64,5 +64,36 @@ namespace StripeTests
             newOptions = options.WithClientOptions(clientOptions);
             Assert.Equal(options.StripeAccount, newOptions.StripeAccount);
         }
+
+        [Fact]
+        public void SetStripeContextWithStripeContextObject()
+        {
+            var context = StripeContext.Parse("org_123/proj_456");
+            var options = new RequestOptions();
+
+            options.SetStripeContext(context);
+
+            Assert.Equal("org_123/proj_456", options.StripeContext);
+        }
+
+        [Fact]
+        public void SetStripeContextWithNull()
+        {
+            var options = new RequestOptions();
+            options.SetStripeContext(null);
+
+            Assert.Null(options.StripeContext);
+        }
+
+        [Fact]
+        public void SetStripeContextWithEmptyContext()
+        {
+            var context = new StripeContext();
+            var options = new RequestOptions();
+
+            options.SetStripeContext(context);
+
+            Assert.Equal(string.Empty, options.StripeContext);
+        }
     }
 }


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
