### PR TITLE
Add `StripeContext` object

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/EventNotification.cs
+++ b/src/Stripe.net/Infrastructure/Public/EventNotification.cs
@@ -73,7 +73,7 @@ namespace Stripe.V2
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("context")]
 #endif
-        public string? Context { get; internal set; }
+        public StripeContext? Context { get; internal set; }
 
         protected StripeClient? Client { get; set; }
 

--- a/src/Stripe.net/Infrastructure/Public/StripeContext.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeContext.cs
@@ -1,0 +1,177 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// The StripeContext class provides an immutable container and convenience methods for
+    /// interacting with the <c>Stripe-Context</c> header. All methods return a new instance of StripeContext.
+    ///
+    /// You can use it whenever you're initializing a <c>StripeClient</c> or sending <c>StripeContext</c> with a request.
+    /// It's also found in the <c>EventNotification.context</c> property.
+    /// </summary>
+    public sealed class StripeContext : IEquatable<StripeContext>
+    {
+        private readonly IReadOnlyList<string> segments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeContext"/> class with no segments.
+        /// </summary>
+        public StripeContext()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeContext"/> class with the given segments.
+        /// </summary>
+        /// <param name="segments">Array of context segments (can be null or empty).</param>
+        public StripeContext(IEnumerable<string> segments)
+        {
+            this.segments = (segments ?? Enumerable.Empty<string>()).ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Gets the segments of this context.
+        /// </summary>
+        public IReadOnlyList<string> Segments => this.segments;
+
+        /// <summary>
+        /// Implicitly converts a string to a StripeContext.
+        /// </summary>
+        /// <param name="contextStr">The string to convert.</param>
+        /// <returns>A new StripeContext instance.</returns>
+        public static implicit operator StripeContext(string contextStr)
+        {
+            if (string.IsNullOrEmpty(contextStr))
+            {
+                return null;
+            }
+
+            return Parse(contextStr);
+        }
+
+        /// <summary>
+        /// Implicitly converts a StripeContext to a string.
+        /// </summary>
+        /// <param name="context">The StripeContext to convert.</param>
+        /// <returns>The string representation of the context.</returns>
+        public static implicit operator string(StripeContext context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+
+            if (context.segments.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return context.ToString();
+        }
+
+        /// <summary>
+        /// Parses a context string into a StripeContext instance.
+        /// </summary>
+        /// <param name="contextStr">String to parse (can be null or empty).</param>
+        /// <returns>A new StripeContext instance.</returns>
+        public static StripeContext Parse(string contextStr)
+        {
+            if (string.IsNullOrEmpty(contextStr))
+            {
+                return new StripeContext();
+            }
+
+            return new StripeContext(contextStr.Split('/'));
+        }
+
+        /// <summary>
+        /// Creates a new StripeContext with an additional segment appended.
+        /// </summary>
+        /// <param name="segment">The segment to append.</param>
+        /// <returns>A new StripeContext instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when segment is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when segment is empty or whitespace.</exception>
+        public StripeContext Push(string segment)
+        {
+            if (segment == null)
+            {
+                throw new ArgumentNullException(nameof(segment));
+            }
+
+            if (string.IsNullOrWhiteSpace(segment))
+            {
+                throw new ArgumentException("Segment cannot be empty or whitespace.", nameof(segment));
+            }
+
+            var newSegments = new List<string>(this.segments) { segment };
+            return new StripeContext(newSegments);
+        }
+
+        /// <summary>
+        /// Creates a new StripeContext with the last segment removed.
+        /// If there are no segments, returns a new empty StripeContext.
+        /// </summary>
+        /// <returns>A new StripeContext instance.</returns>
+        public StripeContext Pop()
+        {
+            if (this.segments.Count == 0)
+            {
+                throw new InvalidOperationException("Cannot pop from an empty StripeContext.");
+            }
+
+            var newSegments = this.segments.Take(this.segments.Count - 1);
+            return new StripeContext(newSegments);
+        }
+
+        /// <summary>
+        /// Converts this context to its string representation.
+        /// </summary>
+        /// <returns>String representation using '/' as separator.</returns>
+        public override string ToString()
+        {
+            return string.Join("/", this.segments);
+        }
+
+        /// <summary>
+        /// Checks equality with another StripeContext.
+        /// </summary>
+        /// <param name="other">The other context to compare with.</param>
+        /// <returns>true if contexts are equal, false otherwise.</returns>
+        public bool Equals(StripeContext other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (this.segments.Count != other.segments.Count)
+            {
+                return false;
+            }
+
+            return this.segments.SequenceEqual(other.segments);
+        }
+
+        /// <summary>
+        /// Checks equality with another object.
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>true if objects are equal, false otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as StripeContext);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this context.
+        /// </summary>
+        /// <returns>A hash code based on the string representation.</returns>
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+    }
+}

--- a/src/Stripe.net/Services/_common/RequestOptions.cs
+++ b/src/Stripe.net/Services/_common/RequestOptions.cs
@@ -71,10 +71,8 @@ namespace Stripe
                 clone.ApiKey = clientOptions.ApiKey;
             }
 
-            if (string.IsNullOrEmpty(clone.StripeContext))
-            {
-                clone.StripeContext = clientOptions.StripeContext;
-            }
+            // an empty string in the clone means we should _not_ overwrite here
+            clone.StripeContext ??= clientOptions.StripeContext;
 
             if (string.IsNullOrEmpty(clone.StripeAccount))
             {

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -362,6 +362,8 @@ namespace StripeTests.V2
             var notif = this.DoParseSignedEventNotification(v2KnownEventPayload);
             var evt = this.AssertAndCast<V1BillingMeterErrorReportTriggeredEventNotification>(notif);
 
+            Assert.IsType<StripeContext>(evt.Context);
+
             var relatedObjectPayload = @"
             {
                 ""id"": ""meter_123"",

--- a/src/StripeTests/Infrastructure/Public/StripeContextIntegrationTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeContextIntegrationTest.cs
@@ -1,0 +1,231 @@
+namespace StripeTests.Infrastructure.Public
+{
+    using System;
+    using Stripe;
+    using Stripe.V2;
+    using Xunit;
+
+    public class StripeContextIntegrationTest
+    {
+        [Fact]
+        public void RequestOptions_StripeContextObject_GetAndSet()
+        {
+            var context = new StripeContext(new[] { "workspace", "123" });
+            var options = new RequestOptions
+            {
+                StripeContext = context,
+            };
+
+            Assert.Equal("workspace/123", options.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptions_StripeContextConversion()
+        {
+            var options = new RequestOptions
+            {
+                StripeContext = "a/b/c",
+            };
+
+            Assert.Equal("a/b/c", options.StripeContext);
+            StripeContext ctx = options.StripeContext;
+            Assert.Equal(new[] { "a", "b", "c" }, ctx.Segments);
+        }
+
+        [Fact]
+        public void RequestOptions_StripeContextNull_ReturnsNullObject()
+        {
+            var options = new RequestOptions
+            {
+                StripeContext = null,
+            };
+
+            Assert.Null(options.StripeContext);
+        }
+
+        [Fact]
+        public void StripeClientOptions_StripeContextObject_GetAndSet()
+        {
+            var context = new StripeContext(new[] { "workspace", "123" });
+            var options = new StripeClientOptions()
+            {
+                StripeContext = context,
+            };
+
+            Assert.Equal("workspace/123", options.StripeContext);
+        }
+
+        [Fact]
+        public void StripeClientOptions_StripeContextString_ReturnsContextObject()
+        {
+            var options = new StripeClientOptions
+            {
+                StripeContext = "a/b/c",
+            };
+
+            Assert.Equal("a/b/c", options.StripeContext);
+            StripeContext ctx = options.StripeContext;
+            Assert.Equal(new[] { "a", "b", "c" }, ctx.Segments);
+        }
+
+        [Fact]
+        public void EventNotification_ContextString_ReturnsStripeContextObject()
+        {
+            var eventNotification = new EventNotification
+            {
+                Id = "evt_123",
+                Type = "test.event",
+                Created = DateTime.UtcNow,
+                Livemode = false,
+                Context = "a/b/c",
+            };
+
+            Assert.Equal("a/b/c", eventNotification.Context);
+        }
+
+        [Fact]
+        public void EventNotification_NullContext_ReturnsNullStripeContext()
+        {
+            var eventNotification = new EventNotification
+            {
+                Id = "evt_123",
+                Type = "test.event",
+                Created = DateTime.UtcNow,
+                Livemode = false,
+                Context = null,
+            };
+
+            Assert.Null(eventNotification.Context);
+        }
+
+        [Fact]
+        public void EventNotification_EmptyContext_ReturnsEmptyStripeContext()
+        {
+            var eventNotification = new EventNotification
+            {
+                Id = "evt_123",
+                Type = "test.event",
+                Created = DateTime.UtcNow,
+                Livemode = false,
+                Context = string.Empty,
+            };
+
+            Assert.Null(eventNotification.Context);
+        }
+
+        [Fact]
+        public void ContextBuilderPattern_WorksWithRequestOptions()
+        {
+            var baseContext = StripeContext.Parse("workspace_123");
+            var options = new RequestOptions
+            {
+                StripeContext = baseContext.Push("account_456"),
+            };
+            Assert.Equal("workspace_123/account_456", options.StripeContext);
+        }
+
+        [Fact]
+        public void ContextCompatibility_StringAndObjectEquivalent()
+        {
+            var stringOptions = new RequestOptions
+            {
+                StripeContext = "a/b/c",
+            };
+            var context = new StripeContext(new[] { "a", "b", "c" });
+            var contextOptions = new RequestOptions
+            {
+                StripeContext = context,
+            };
+
+            // Both should represent the same logical context
+            Assert.Equal(stringOptions.StripeContext, contextOptions.StripeContext);
+        }
+
+        [Fact]
+        public void ImplicitConversion_WorksInRequestOptions()
+        {
+            var options = new RequestOptions();
+
+            // Can assign string to StripeContext due to implicit conversion
+            options.StripeContext = "workspace/123";
+            Assert.Equal("workspace/123", options.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptionsExtensions_WithClientOptions_PreservesStripeContext()
+        {
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "client_context",
+            };
+
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = "request_context",
+            };
+
+            var merged = requestOptions.WithClientOptions(clientOptions);
+
+            // Request context should take precedence
+            Assert.Equal("request_context", merged.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptionsExtensions_WithClientOptions_FallsBackToClientContext()
+        {
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "client_context",
+            };
+
+            var requestOptions = new RequestOptions();
+
+            var merged = requestOptions.WithClientOptions(clientOptions);
+
+            // Should use client context when request has none
+            Assert.Equal("client_context", merged.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptionsExtensions_WithClientOptions_RequestOverwritesWithEmptyContext()
+        {
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "client_context",
+            };
+
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = new StripeContext(),
+            };
+
+            var merged = requestOptions.WithClientOptions(clientOptions);
+
+            // Should use client context when request has none
+            Assert.Equal(string.Empty, merged.StripeContext);
+        }
+
+        [Fact]
+        public void RequestOptionsExtensions_WithClientOptions_RequestOverwritesEmptyClientContext()
+        {
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = new StripeContext(),
+            };
+
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = "acct_123",
+            };
+
+            var merged = requestOptions.WithClientOptions(clientOptions);
+
+            // Should use client context when request has none
+            Assert.Equal("acct_123", merged.StripeContext);
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeContextTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeContextTest.cs
@@ -1,0 +1,247 @@
+namespace StripeTests.Infrastructure.Public
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Stripe;
+    using Xunit;
+
+    public class StripeContextTest
+    {
+        [Fact]
+        public void Constructor_WithNoSegments_CreatesEmptyContext()
+        {
+            var context = new StripeContext();
+            Assert.Empty(context.Segments);
+        }
+
+        [Fact]
+        public void Constructor_WithSegments_CreatesContextWithSegments()
+        {
+            var segments = new[] { "a", "b", "c" };
+            var context = new StripeContext(segments);
+            Assert.Equal(segments, context.Segments);
+        }
+
+        [Fact]
+        public void Constructor_WithNullSegments_CreatesEmptyContext()
+        {
+            var context = new StripeContext(null);
+            Assert.Empty(context.Segments);
+        }
+
+        [Fact]
+        public void Segments_IsReadOnly()
+        {
+            var context = new StripeContext(new[] { "a", "b" });
+            Assert.IsAssignableFrom<IReadOnlyList<string>>(context.Segments);
+        }
+
+        [Fact]
+        public void Push_WithValidSegment_ReturnsNewContextWithAddedSegment()
+        {
+            var context = new StripeContext(new[] { "a", "b" });
+            var newContext = context.Push("c");
+
+            // Original context unchanged
+            Assert.Equal(new[] { "a", "b" }, context.Segments);
+
+            // New context has added segment
+            Assert.Equal(new[] { "a", "b", "c" }, newContext.Segments);
+
+            // Different objects
+            Assert.NotSame(context, newContext);
+        }
+
+        [Fact]
+        public void Push_WithNullSegment_ThrowsArgumentNullException()
+        {
+            var context = new StripeContext();
+            Assert.Throws<ArgumentNullException>(() => context.Push(null));
+        }
+
+        [Fact]
+        public void Push_WithEmptySegment_ThrowsArgumentException()
+        {
+            var context = new StripeContext();
+            Assert.Throws<ArgumentException>(() => context.Push(string.Empty));
+        }
+
+        [Fact]
+        public void Push_WithWhitespaceSegment_ThrowsArgumentException()
+        {
+            var context = new StripeContext();
+            Assert.Throws<ArgumentException>(() => context.Push("   "));
+        }
+
+        [Fact]
+        public void Pop_WithSegments_ReturnsNewContextWithLastSegmentRemoved()
+        {
+            var context = new StripeContext(new[] { "a", "b", "c" });
+            var newContext = context.Pop();
+
+            // Original context unchanged
+            Assert.Equal(new[] { "a", "b", "c" }, context.Segments);
+
+            // New context has removed last segment
+            Assert.Equal(new[] { "a", "b" }, newContext.Segments);
+
+            // Different objects
+            Assert.NotSame(context, newContext);
+        }
+
+        [Fact]
+        public void Pop_WithEmptyContext_ReturnsNewEmptyContext()
+        {
+            var context = new StripeContext();
+            Assert.Throws<InvalidOperationException>(() => context.Pop());
+        }
+
+        [Fact]
+        public void ToString_WithEmptyContext_ReturnsEmptyString()
+        {
+            var context = new StripeContext();
+            Assert.Equal(string.Empty, context.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithSingleSegment_ReturnsSegment()
+        {
+            var context = new StripeContext(new[] { "a" });
+            Assert.Equal("a", context.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithMultipleSegments_ReturnsSlashSeparatedSegments()
+        {
+            var context = new StripeContext(new[] { "a", "b", "c" });
+            Assert.Equal("a/b/c", context.ToString());
+        }
+
+        [Fact]
+        public void Parse_WithNullString_ReturnsEmptyContext()
+        {
+            var context = StripeContext.Parse(null);
+            Assert.Empty(context.Segments);
+        }
+
+        [Fact]
+        public void Parse_WithEmptyString_ReturnsEmptyContext()
+        {
+            var context = StripeContext.Parse(string.Empty);
+            Assert.Empty(context.Segments);
+        }
+
+        [Fact]
+        public void Parse_WithSingleSegment_ReturnsContextWithSingleSegment()
+        {
+            var context = StripeContext.Parse("a");
+            Assert.Equal(new[] { "a" }, context.Segments);
+        }
+
+        [Fact]
+        public void Parse_WithMultipleSegments_ReturnsContextWithMultipleSegments()
+        {
+            var context = StripeContext.Parse("a/b/c");
+            Assert.Equal(new[] { "a", "b", "c" }, context.Segments);
+        }
+
+        [Fact]
+        public void Equals_WithSameSegments_ReturnsTrue()
+        {
+            var context1 = new StripeContext(new[] { "a", "b" });
+            var context2 = new StripeContext(new[] { "a", "b" });
+
+            Assert.True(context1.Equals(context2));
+        }
+
+        [Fact]
+        public void Equals_WithDifferentSegments_ReturnsFalse()
+        {
+            var context1 = new StripeContext(new[] { "a", "b" });
+            var context2 = new StripeContext(new[] { "a", "c" });
+
+            Assert.False(context1.Equals(context2));
+            Assert.True(context1 != context2);
+        }
+
+        [Fact]
+        public void Equals_WithNull_ReturnsFalse()
+        {
+            var context = new StripeContext(new[] { "a", "b" });
+
+            Assert.False(context.Equals(null));
+            Assert.False(context.Equals((object)null));
+        }
+
+        [Fact]
+        public void GetHashCode_WithEqualContexts_ReturnsSameHashCode()
+        {
+            var context1 = new StripeContext(new[] { "a", "b" });
+            var context2 = new StripeContext(new[] { "a", "b" });
+
+            Assert.Equal(context1.GetHashCode(), context2.GetHashCode());
+        }
+
+        [Fact]
+        public void ImplicitConversion_FromString_CreatesStripeContext()
+        {
+            StripeContext context = "a/b/c";
+            Assert.Equal(new[] { "a", "b", "c" }, context.Segments);
+        }
+
+        [Fact]
+        public void ImplicitConversion_ToString_ReturnsStringRepresentation()
+        {
+            var context = new StripeContext(new[] { "a", "b", "c" });
+            string contextStr = context;
+            Assert.Equal("a/b/c", contextStr);
+        }
+
+        [Fact]
+        public void ImplicitConversion_NullContext_ReturnsNull()
+        {
+            StripeContext context = null;
+            string contextStr = context;
+            Assert.Null(contextStr);
+        }
+
+        [Fact]
+        public void Immutability_OperationsDoNotModifyOriginalContext()
+        {
+            var original = new StripeContext(new[] { "a", "b" });
+            var pushed = original.Push("c");
+            var popped = original.Pop();
+
+            // Original remains unchanged
+            Assert.Equal(new[] { "a", "b" }, original.Segments);
+            Assert.Equal(new[] { "a", "b", "c" }, pushed.Segments);
+            Assert.Equal(new[] { "a" }, popped.Segments);
+
+            // All are different objects
+            Assert.NotSame(original, pushed);
+            Assert.NotSame(original, popped);
+            Assert.NotSame(pushed, popped);
+        }
+
+        [Fact]
+        public void UsagePattern_ContextHierarchyBuilding()
+        {
+            // Common usage: start with base context, add child contexts
+            var baseContext = StripeContext.Parse("workspace_123");
+            var child = baseContext.Push("account_456");
+            var grandchild = child.Push("customer_789");
+
+            Assert.Equal("workspace_123", baseContext.ToString());
+            Assert.Equal("workspace_123/account_456", child.ToString());
+            Assert.Equal("workspace_123/account_456/customer_789", grandchild.ToString());
+
+            // Go back up the hierarchy
+            var backToChild = grandchild.Pop();
+            var backToBase = backToChild.Pop();
+
+            Assert.Equal("workspace_123/account_456", backToChild.ToString());
+            Assert.Equal("workspace_123", backToBase.ToString());
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -202,6 +202,74 @@ namespace StripeTests
         }
 
         [Fact]
+        public void Ctor_HandlesStringStripeContext()
+        {
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = "ctx_123",
+            };
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                null,
+                requestOptions);
+
+            Assert.Equal("ctx_123", request.StripeHeaders["Stripe-Context"]);
+        }
+
+        [Fact]
+        public void Ctor_HandlesObjStripeContext()
+        {
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = StripeContext.Parse("ctx_123"),
+            };
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                null,
+                requestOptions);
+
+            Assert.Equal("ctx_123", request.StripeHeaders["Stripe-Context"]);
+        }
+
+        [Fact]
+        public void Ctor_HandlesDoesntSetEmptyString()
+        {
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = string.Empty,
+            };
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                null,
+                requestOptions);
+
+            Assert.DoesNotContain("Stripe-Context", request.StripeHeaders);
+        }
+
+        [Fact]
+        public void Ctor_HandlesDoesntSetEmptyContext()
+        {
+            var requestOptions = new RequestOptions
+            {
+                StripeContext = new StripeContext(),
+            };
+            var request = new StripeRequest(
+                this.stripeClient,
+                HttpMethod.Get,
+                "/get",
+                null,
+                requestOptions);
+
+            Assert.DoesNotContain("Stripe-Context", request.StripeHeaders);
+        }
+
+        [Fact]
         public void Ctor_ThrowsIfApiKeyIsNull()
         {
             var client = new StripeClient(apiKey: null);


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
