### PR TITLE
Remove unused obsolete classes SourceTransactionsListOptions and SourceTransactionsGetOptions

### DIFF
--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionsGetOptions.cs
@@ -1,9 +1,0 @@
-namespace Stripe
-{
-    using System;
-
-    [Obsolete]
-    public class SourceTransactionsGetOptions : BaseOptions
-    {
-    }
-}

--- a/src/Stripe.net/Services/SourceTransactions/SourceTransactionsListOptions.cs
+++ b/src/Stripe.net/Services/SourceTransactions/SourceTransactionsListOptions.cs
@@ -1,9 +1,0 @@
-namespace Stripe
-{
-    using System;
-
-    [Obsolete("Use SourceTransactionListOptions instead.")]
-    public class SourceTransactionsListOptions : ListOptions
-    {
-    }
-}


### PR DESCRIPTION
### Why?
* SourceTransactionsListOptions was renamed to SourceTransactionListOptions and the old name is no longer being used
* SourceTransactionsGetOptions has not been referenced in the SDK for some time

This was previously attempted in https://github.com/stripe/stripe-dotnet/pull/2987 but was reverted

### What?
- deleted classes SourceTransactionsGetOptions and SourceTransactionsListOptions

## Changelog
* Removed class `SourceTransactionsListOptions` in favor of `SourceTransactionListOptions`
* Removed unused class `SourceTransactionsGetOptions`