### PR TITLE
Move `V2.Event` API resources to `V2.Core.Events`

### DIFF
--- a/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestination.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestination.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using System;
     using System.Collections.Generic;

--- a/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationAmazonEventbridge.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationAmazonEventbridge.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationStatusDetails.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationStatusDetails.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationStatusDetailsDisabled.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationStatusDetailsDisabled.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationWebhookEndpoint.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventDestinations/EventDestinationWebhookEndpoint.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/EventNotification.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotification.cs
@@ -1,4 +1,4 @@
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using System;
     using System.Collections.Generic;
@@ -96,13 +96,13 @@ namespace Stripe.V2
         }
 
         protected internal T FetchEvent<T>()
-        where T : V2.Event
+        where T : V2.Core.Event
         {
             return this.FetchEventAsync<T>().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         protected async Task<T> FetchEventAsync<T>(CancellationToken cancellationToken = default)
-        where T : V2.Event
+        where T : V2.Core.Event
         {
             if (this.Client == null)
             {

--- a/src/Stripe.net/Entities/V2/Core/EventNotificationReason.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotificationReason.cs
@@ -1,12 +1,14 @@
-// File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    public class EventReason : StripeEntity<EventReason>
+    /// <summary>
+    ///  The non-StripeEntity version of a Reason.
+    /// </summary>
+    public class EventNotificationReason
     {
         /// <summary>
         /// Event reason type.
@@ -24,6 +26,6 @@ namespace Stripe.V2
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("request")]
 #endif
-        public EventReasonRequest Request { get; set; }
+        public EventNotificationReasonRequest Request { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/V2/Core/EventNotificationReasonRequest.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotificationReasonRequest.cs
@@ -1,4 +1,4 @@
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/EventNotificationRelatedObject.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotificationRelatedObject.cs
@@ -1,6 +1,6 @@
 #nullable disable
 
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/Events/Event.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/Event.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using System;
     using Newtonsoft.Json;
@@ -8,7 +8,7 @@ namespace Stripe.V2
 #endif
 
     /// <summary>
-    /// Code generated portion of Thin Event.
+    /// Code generated portion of V2 Event resource.
     /// </summary>
     public partial class Event : StripeEntity<Event>, IHasId, IHasObject
     {

--- a/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
@@ -1,4 +1,4 @@
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using System;
     using System.Net.Http;

--- a/src/Stripe.net/Entities/V2/Core/Events/EventReason.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/EventReason.cs
@@ -1,14 +1,12 @@
-namespace Stripe.V2
+// File generated from our OpenAPI spec
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
 
-    /// <summary>
-    ///  The non-StripeEntity version of a Reason.
-    /// </summary>
-    public class EventNotificationReason
+    public class EventReason : StripeEntity<EventReason>
     {
         /// <summary>
         /// Event reason type.
@@ -26,6 +24,6 @@ namespace Stripe.V2
 #if NET6_0_OR_GREATER
         [STJS.JsonPropertyName("request")]
 #endif
-        public EventNotificationReasonRequest Request { get; set; }
+        public EventReasonRequest Request { get; set; }
     }
 }

--- a/src/Stripe.net/Entities/V2/Core/Events/EventReasonRequest.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/EventReasonRequest.cs
@@ -1,5 +1,5 @@
 // File generated from our OpenAPI spec
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Entities/V2/Core/Events/EventRelatedObject.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/EventRelatedObject.cs
@@ -1,4 +1,4 @@
-namespace Stripe.V2
+namespace Stripe.V2.Core
 {
     using Newtonsoft.Json;
 #if NET6_0_OR_GREATER

--- a/src/Stripe.net/Events/UnknownEventNotification.cs
+++ b/src/Stripe.net/Events/UnknownEventNotification.cs
@@ -1,10 +1,11 @@
-namespace Stripe.V2
+namespace Stripe.Events
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
+    using Stripe.V2.Core;
 #if NET6_0_OR_GREATER
     using STJS = System.Text.Json.Serialization;
 #endif
@@ -12,7 +13,7 @@ namespace Stripe.V2
     /// <summary>
     /// Represents an EventNotification that is valid, but that the SDK doesn't have types for. May have a RelatedObject and can be used to fetch the corresponding full event.
     /// </summary>
-    public class UnknownEventNotification : EventNotification
+    public class UnknownEventNotification : V2.Core.EventNotification
     {
 #nullable enable
         /// <summary>
@@ -24,14 +25,14 @@ namespace Stripe.V2
 #endif
         public EventNotificationRelatedObject? RelatedObject { get; internal set; }
 
-        public V2.Event FetchEvent()
+        public V2.Core.Event FetchEvent()
         {
-            return this.FetchEvent<V2.Event>();
+            return this.FetchEvent<V2.Core.Event>();
         }
 
-        public Task<V2.Event> FetchEventAsync(CancellationToken cancellationToken = default)
+        public Task<V2.Core.Event> FetchEventAsync(CancellationToken cancellationToken = default)
         {
-            return this.FetchEventAsync<V2.Event>(cancellationToken);
+            return this.FetchEventAsync<V2.Core.Event>(cancellationToken);
         }
 
         public StripeEntity FetchRelatedObject()

--- a/src/Stripe.net/Events/V1BillingMeterErrorReportTriggeredEvent.cs
+++ b/src/Stripe.net/Events/V1BillingMeterErrorReportTriggeredEvent.cs
@@ -10,7 +10,7 @@ namespace Stripe.Events
     /// <summary>
     /// Occurs when a Meter has invalid async usage events.
     /// </summary>
-    public class V1BillingMeterErrorReportTriggeredEvent : V2.Event
+    public class V1BillingMeterErrorReportTriggeredEvent : V2.Core.Event
     {
         /// <summary>
         /// Data for the v1.billing.meter.error_report_triggered event.
@@ -30,7 +30,7 @@ namespace Stripe.Events
         [STJS.JsonPropertyName("related_object")]
 #endif
 
-        public V2.EventRelatedObject RelatedObject { get; set; }
+        public V2.Core.EventRelatedObject RelatedObject { get; set; }
 
         /// <summary>
         /// Asynchronously retrieves the related object from the API. Make an API request on every

--- a/src/Stripe.net/Events/V1BillingMeterErrorReportTriggeredEventNotification.cs
+++ b/src/Stripe.net/Events/V1BillingMeterErrorReportTriggeredEventNotification.cs
@@ -11,7 +11,7 @@ namespace Stripe.Events
     /// <summary>
     /// Occurs when a Meter has invalid async usage events.
     /// </summary>
-    public class V1BillingMeterErrorReportTriggeredEventNotification : V2.EventNotification
+    public class V1BillingMeterErrorReportTriggeredEventNotification : V2.Core.EventNotification
     {
         /// <summary>
         /// Object containing the reference to API resource relevant to the event.
@@ -21,7 +21,7 @@ namespace Stripe.Events
         [STJS.JsonPropertyName("related_object")]
 #endif
 
-        public V2.EventNotificationRelatedObject RelatedObject { get; set; }
+        public V2.Core.EventNotificationRelatedObject RelatedObject { get; set; }
 
         /// <summary>
         /// Asynchronously retrieves the related object from the API. Make an API request on every

--- a/src/Stripe.net/Events/V1BillingMeterNoMeterFoundEvent.cs
+++ b/src/Stripe.net/Events/V1BillingMeterNoMeterFoundEvent.cs
@@ -10,7 +10,7 @@ namespace Stripe.Events
     /// <summary>
     /// Occurs when a Meter's id is missing or invalid in async usage events.
     /// </summary>
-    public class V1BillingMeterNoMeterFoundEvent : V2.Event
+    public class V1BillingMeterNoMeterFoundEvent : V2.Core.Event
     {
         /// <summary>
         /// Data for the v1.billing.meter.no_meter_found event.

--- a/src/Stripe.net/Events/V1BillingMeterNoMeterFoundEventNotification.cs
+++ b/src/Stripe.net/Events/V1BillingMeterNoMeterFoundEventNotification.cs
@@ -7,7 +7,7 @@ namespace Stripe.Events
     /// <summary>
     /// Occurs when a Meter's id is missing or invalid in async usage events.
     /// </summary>
-    public class V1BillingMeterNoMeterFoundEventNotification : V2.EventNotification
+    public class V1BillingMeterNoMeterFoundEventNotification : V2.Core.EventNotification
     {
         public V1BillingMeterNoMeterFoundEvent FetchEvent()
         {

--- a/src/Stripe.net/Events/V2CoreEventDestinationPingEvent.cs
+++ b/src/Stripe.net/Events/V2CoreEventDestinationPingEvent.cs
@@ -10,7 +10,7 @@ namespace Stripe.Events
     /// <summary>
     /// A ping event used to test the connection to an EventDestination.
     /// </summary>
-    public class V2CoreEventDestinationPingEvent : V2.Event
+    public class V2CoreEventDestinationPingEvent : V2.Core.Event
     {
         /// <summary>
         /// Object containing the reference to API resource relevant to the event.
@@ -20,23 +20,23 @@ namespace Stripe.Events
         [STJS.JsonPropertyName("related_object")]
 #endif
 
-        public V2.EventRelatedObject RelatedObject { get; set; }
+        public V2.Core.EventRelatedObject RelatedObject { get; set; }
 
         /// <summary>
         /// Asynchronously retrieves the related object from the API. Make an API request on every
         /// call.
         /// </summary>
-        public Task<V2.EventDestination> FetchRelatedObjectAsync()
+        public Task<V2.Core.EventDestination> FetchRelatedObjectAsync()
         {
-            return this.FetchRelatedObjectAsync<V2.EventDestination>(this.RelatedObject);
+            return this.FetchRelatedObjectAsync<V2.Core.EventDestination>(this.RelatedObject);
         }
 
         /// <summary>
         /// Retrieves the related object from the API. Make an API request on every call.
         /// </summary>
-        public V2.EventDestination FetchRelatedObject()
+        public V2.Core.EventDestination FetchRelatedObject()
         {
-            return this.FetchRelatedObject<V2.EventDestination>(this.RelatedObject);
+            return this.FetchRelatedObject<V2.Core.EventDestination>(this.RelatedObject);
         }
     }
 }

--- a/src/Stripe.net/Events/V2CoreEventDestinationPingEventNotification.cs
+++ b/src/Stripe.net/Events/V2CoreEventDestinationPingEventNotification.cs
@@ -11,7 +11,7 @@ namespace Stripe.Events
     /// <summary>
     /// A ping event used to test the connection to an EventDestination.
     /// </summary>
-    public class V2CoreEventDestinationPingEventNotification : V2.EventNotification
+    public class V2CoreEventDestinationPingEventNotification : V2.Core.EventNotification
     {
         /// <summary>
         /// Object containing the reference to API resource relevant to the event.
@@ -21,23 +21,23 @@ namespace Stripe.Events
         [STJS.JsonPropertyName("related_object")]
 #endif
 
-        public V2.EventNotificationRelatedObject RelatedObject { get; set; }
+        public V2.Core.EventNotificationRelatedObject RelatedObject { get; set; }
 
         /// <summary>
         /// Asynchronously retrieves the related object from the API. Make an API request on every
         /// call.
         /// </summary>
-        public Task<V2.EventDestination> FetchRelatedObjectAsync()
+        public Task<V2.Core.EventDestination> FetchRelatedObjectAsync()
         {
-            return this.FetchRelatedObjectAsync<V2.EventDestination>(this.RelatedObject);
+            return this.FetchRelatedObjectAsync<V2.Core.EventDestination>(this.RelatedObject);
         }
 
         /// <summary>
         /// Retrieves the related object from the API. Make an API request on every call.
         /// </summary>
-        public V2.EventDestination FetchRelatedObject()
+        public V2.Core.EventDestination FetchRelatedObject()
         {
-            return this.FetchRelatedObject<V2.EventDestination>(this.RelatedObject);
+            return this.FetchRelatedObject<V2.Core.EventDestination>(this.RelatedObject);
         }
 
         public V2CoreEventDestinationPingEvent FetchEvent()

--- a/src/Stripe.net/Infrastructure/JsonConverters/STJStripeObjectConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJStripeObjectConverter.cs
@@ -28,7 +28,7 @@ namespace Stripe.Infrastructure
         {
             var typeInfo = objectType.GetTypeInfo();
             return (typeInfo.IsInterface && typeInfo.FullName.StartsWith("Stripe")) ||
-                    typeInfo.FullName.Equals("Stripe.V2.Event");
+                    typeInfo.FullName.Equals("Stripe.V2.Core.Event");
         }
 
         public override JsonConverter CreateConverter(

--- a/src/Stripe.net/Infrastructure/JsonConverters/STJV2EventConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJV2EventConverter.cs
@@ -8,10 +8,10 @@ namespace Stripe.Infrastructure
     using static Stripe.Infrastructure.SerializablePropertyCache;
 
     /// <summary>
-    /// Converts a <see cref="V2.Event"/> to JSON, including any fields
+    /// Converts a <see cref="V2.Core.Event"/> to JSON, including any fields
     /// in derived classes.
     /// </summary>
-    internal class STJV2EventConverter : STJDefaultConverter<V2.Event>
+    internal class STJV2EventConverter : STJDefaultConverter<V2.Core.Event>
     {
         /// <summary>
         /// Reads the JSON representation of the object.
@@ -20,7 +20,7 @@ namespace Stripe.Infrastructure
         /// <param name="typeToConvert">Type of the object.</param>
         /// <param name="options">The calling serializer's options.</param>
         /// <returns>The object value.</returns>
-        public override V2.Event Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override V2.Core.Event Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotSupportedException("STJV2EventConverter should only be used while serializing.");
         }
@@ -34,7 +34,7 @@ namespace Stripe.Infrastructure
         /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            return typeof(Stripe.V2.Event).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+            return typeof(Stripe.V2.Core.Event).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/JsonConverters/STJV2EventNotificationConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJV2EventNotificationConverter.cs
@@ -8,10 +8,10 @@ namespace Stripe.Infrastructure
     using static Stripe.Infrastructure.SerializablePropertyCache;
 
     /// <summary>
-    /// Converts a <see cref="V2.Event"/> to JSON, including any fields
+    /// Converts a <see cref="V2.Core.Event"/> to JSON, including any fields
     /// in derived classes.
     /// </summary>
-    internal class STJV2EventNotificationConverter : STJDefaultConverter<V2.EventNotification>
+    internal class STJV2EventNotificationConverter : STJDefaultConverter<V2.Core.EventNotification>
     {
         /// <summary>
         /// Reads the JSON representation of the object.
@@ -20,7 +20,7 @@ namespace Stripe.Infrastructure
         /// <param name="typeToConvert">Type of the object.</param>
         /// <param name="options">The calling serializer's options.</param>
         /// <returns>The object value.</returns>
-        public override V2.EventNotification Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override V2.Core.EventNotification Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotSupportedException("STJV2EventConverter should only be used while serializing.");
         }
@@ -34,7 +34,7 @@ namespace Stripe.Infrastructure
         /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            return typeof(Stripe.V2.EventNotification).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+            return typeof(Stripe.V2.Core.EventNotification).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/JsonConverters/V2EventConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/V2EventConverter.cs
@@ -35,12 +35,12 @@ namespace Stripe.Infrastructure
             if (concreteType == null)
             {
                 // If "type" is unknown by this SDK, default to the generic ThinEvent type.
-                concreteType = typeof(V2.Event);
+                concreteType = typeof(V2.Core.Event);
             }
 
             using (var subReader = jsonObject.CreateReader())
             {
-                var e = (V2.Event)Activator.CreateInstance(concreteType);
+                var e = (V2.Core.Event)Activator.CreateInstance(concreteType);
 
                 if (serializer.Context.Context is DeserializationContext context)
                 {
@@ -62,7 +62,7 @@ namespace Stripe.Infrastructure
         /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            return objectType.GetTypeInfo() == typeof(V2.Event);
+            return objectType.GetTypeInfo() == typeof(V2.Core.Event);
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/JsonConverters/V2EventNotificationConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/V2EventNotificationConverter.cs
@@ -25,7 +25,7 @@ namespace Stripe.Infrastructure
             // class to deserialize into.
             var typeValue = (string)jsonObject["type"];
 
-            Type concreteType = StripeTypeRegistry.GetConcreteV2EventNotificationType(typeValue) ?? typeof(V2.UnknownEventNotification);
+            Type concreteType = StripeTypeRegistry.GetConcreteV2EventNotificationType(typeValue) ?? typeof(Events.UnknownEventNotification);
 
             using var subReader = jsonObject.CreateReader();
             var e = Activator.CreateInstance(concreteType);
@@ -42,7 +42,7 @@ namespace Stripe.Infrastructure
         /// </returns>
         public override bool CanConvert(Type objectType)
         {
-            return objectType.GetTypeInfo() == typeof(V2.EventNotification);
+            return objectType.GetTypeInfo() == typeof(V2.Core.EventNotification);
         }
     }
 }

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -7,8 +7,7 @@ namespace Stripe
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
-    using Stripe.Infrastructure;
-    using Stripe.V2;
+    using Stripe.V2.Core;
 
     /// <summary>
     /// A Stripe client, used to issue requests to Stripe's API and deserialize responses.

--- a/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeTypeRegistry.cs
@@ -181,8 +181,8 @@ namespace Stripe
                 { "v2.billing.meter_event", typeof(V2.Billing.MeterEvent) },
                 { "v2.billing.meter_event_adjustment", typeof(V2.Billing.MeterEventAdjustment) },
                 { "v2.billing.meter_event_session", typeof(V2.Billing.MeterEventSession) },
-                { "v2.core.event", typeof(V2.Event) },
-                { "v2.core.event_destination", typeof(V2.EventDestination) },
+                { "v2.core.event", typeof(V2.Core.Event) },
+                { "v2.core.event_destination", typeof(V2.Core.EventDestination) },
 
                 // V2ObjectsToTypes: The end of the section generated from our OpenAPI spec
             });

--- a/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
+++ b/src/Stripe.net/Services/V2/Core/EventDestinations/EventDestinationService.cs
@@ -23,17 +23,17 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Create a new event destination.
         /// </summary>
-        public virtual V2.EventDestination Create(EventDestinationCreateOptions options, RequestOptions requestOptions = null)
+        public virtual EventDestination Create(EventDestinationCreateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations", options, requestOptions);
+            return this.Request<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations", options, requestOptions);
         }
 
         /// <summary>
         /// Create a new event destination.
         /// </summary>
-        public virtual Task<V2.EventDestination> CreateAsync(EventDestinationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<EventDestination> CreateAsync(EventDestinationCreateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -55,113 +55,113 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Disable an event destination.
         /// </summary>
-        public virtual V2.EventDestination Disable(string id, EventDestinationDisableOptions options = null, RequestOptions requestOptions = null)
+        public virtual EventDestination Disable(string id, EventDestinationDisableOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/disable", options, requestOptions);
+            return this.Request<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/disable", options, requestOptions);
         }
 
         /// <summary>
         /// Disable an event destination.
         /// </summary>
-        public virtual Task<V2.EventDestination> DisableAsync(string id, EventDestinationDisableOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<EventDestination> DisableAsync(string id, EventDestinationDisableOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/disable", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/disable", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Enable an event destination.
         /// </summary>
-        public virtual V2.EventDestination Enable(string id, EventDestinationEnableOptions options = null, RequestOptions requestOptions = null)
+        public virtual EventDestination Enable(string id, EventDestinationEnableOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/enable", options, requestOptions);
+            return this.Request<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/enable", options, requestOptions);
         }
 
         /// <summary>
         /// Enable an event destination.
         /// </summary>
-        public virtual Task<V2.EventDestination> EnableAsync(string id, EventDestinationEnableOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<EventDestination> EnableAsync(string id, EventDestinationEnableOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/enable", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/enable", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Retrieves the details of an event destination.
         /// </summary>
-        public virtual V2.EventDestination Get(string id, EventDestinationGetOptions options = null, RequestOptions requestOptions = null)
+        public virtual EventDestination Get(string id, EventDestinationGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.EventDestination>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions);
+            return this.Request<EventDestination>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
         /// Retrieves the details of an event destination.
         /// </summary>
-        public virtual Task<V2.EventDestination> GetAsync(string id, EventDestinationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<EventDestination> GetAsync(string id, EventDestinationGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.EventDestination>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EventDestination>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Lists all event destinations.
         /// </summary>
-        public virtual V2.StripeList<V2.EventDestination> List(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
+        public virtual V2.StripeList<EventDestination> List(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.StripeList<V2.EventDestination>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations", options, requestOptions);
+            return this.Request<V2.StripeList<EventDestination>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations", options, requestOptions);
         }
 
         /// <summary>
         /// Lists all event destinations.
         /// </summary>
-        public virtual Task<V2.StripeList<V2.EventDestination>> ListAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<V2.StripeList<EventDestination>> ListAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.StripeList<V2.EventDestination>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations", options, requestOptions, cancellationToken);
+            return this.RequestAsync<V2.StripeList<EventDestination>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/event_destinations", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Lists all event destinations.
         /// </summary>
-        public virtual IEnumerable<V2.EventDestination> ListAutoPaging(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
+        public virtual IEnumerable<EventDestination> ListAutoPaging(EventDestinationListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions);
+            return this.ListRequestAutoPaging<EventDestination>($"/v2/core/event_destinations", options, requestOptions);
         }
 
         /// <summary>
         /// Lists all event destinations.
         /// </summary>
-        public virtual IAsyncEnumerable<V2.EventDestination> ListAutoPagingAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual IAsyncEnumerable<EventDestination> ListAutoPagingAsync(EventDestinationListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<V2.EventDestination>($"/v2/core/event_destinations", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<EventDestination>($"/v2/core/event_destinations", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Send a <c>ping</c> event to an event destination.
         /// </summary>
-        public virtual V2.Event Ping(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null)
+        public virtual Event Ping(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.Event>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/ping", options, requestOptions);
+            return this.Request<Event>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/ping", options, requestOptions);
         }
 
         /// <summary>
         /// Send a <c>ping</c> event to an event destination.
         /// </summary>
-        public virtual Task<V2.Event> PingAsync(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Event> PingAsync(string id, EventDestinationPingOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.Event>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/ping", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Event>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}/ping", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// Update the details of an event destination.
         /// </summary>
-        public virtual V2.EventDestination Update(string id, EventDestinationUpdateOptions options, RequestOptions requestOptions = null)
+        public virtual EventDestination Update(string id, EventDestinationUpdateOptions options, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions);
+            return this.Request<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
         /// Update the details of an event destination.
         /// </summary>
-        public virtual Task<V2.EventDestination> UpdateAsync(string id, EventDestinationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<EventDestination> UpdateAsync(string id, EventDestinationUpdateOptions options, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<EventDestination>(BaseAddress.Api, HttpMethod.Post, $"/v2/core/event_destinations/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/Stripe.net/Services/V2/Core/Events/EventService.cs
+++ b/src/Stripe.net/Services/V2/Core/Events/EventService.cs
@@ -23,49 +23,49 @@ namespace Stripe.V2.Core
         /// <summary>
         /// Retrieves the details of an event.
         /// </summary>
-        public virtual V2.Event Get(string id, EventGetOptions options = null, RequestOptions requestOptions = null)
+        public virtual Event Get(string id, EventGetOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.Event>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events/{WebUtility.UrlEncode(id)}", options, requestOptions);
+            return this.Request<Event>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events/{WebUtility.UrlEncode(id)}", options, requestOptions);
         }
 
         /// <summary>
         /// Retrieves the details of an event.
         /// </summary>
-        public virtual Task<V2.Event> GetAsync(string id, EventGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<Event> GetAsync(string id, EventGetOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.Event>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
+            return this.RequestAsync<Event>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events/{WebUtility.UrlEncode(id)}", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// List events, going back up to 30 days.
         /// </summary>
-        public virtual V2.StripeList<V2.Event> List(EventListOptions options = null, RequestOptions requestOptions = null)
+        public virtual V2.StripeList<Event> List(EventListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.Request<V2.StripeList<V2.Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions);
+            return this.Request<V2.StripeList<Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions);
         }
 
         /// <summary>
         /// List events, going back up to 30 days.
         /// </summary>
-        public virtual Task<V2.StripeList<V2.Event>> ListAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual Task<V2.StripeList<Event>> ListAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.RequestAsync<V2.StripeList<V2.Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions, cancellationToken);
+            return this.RequestAsync<V2.StripeList<Event>>(BaseAddress.Api, HttpMethod.Get, $"/v2/core/events", options, requestOptions, cancellationToken);
         }
 
         /// <summary>
         /// List events, going back up to 30 days.
         /// </summary>
-        public virtual IEnumerable<V2.Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
+        public virtual IEnumerable<Event> ListAutoPaging(EventListOptions options = null, RequestOptions requestOptions = null)
         {
-            return this.ListRequestAutoPaging<V2.Event>($"/v2/core/events", options, requestOptions);
+            return this.ListRequestAutoPaging<Event>($"/v2/core/events", options, requestOptions);
         }
 
         /// <summary>
         /// List events, going back up to 30 days.
         /// </summary>
-        public virtual IAsyncEnumerable<V2.Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        public virtual IAsyncEnumerable<Event> ListAutoPagingAsync(EventListOptions options = null, RequestOptions requestOptions = null, CancellationToken cancellationToken = default)
         {
-            return this.ListRequestAutoPagingAsync<V2.Event>($"/v2/core/events", options, requestOptions, cancellationToken);
+            return this.ListRequestAutoPagingAsync<Event>($"/v2/core/events", options, requestOptions, cancellationToken);
         }
     }
 }

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -164,8 +164,8 @@ namespace StripeTests.V2
         /// parse a EventNotification and then uses the method to retrieve the full Event.
         /// </summary>
         /// <param name="payload">The json payload to parse.</param>
-        /// <returns>A V2.Event derived class.</returns>
-        private Stripe.V2.Event DoParseSignedEventAndFetch(string payload)
+        /// <returns>A V2.Core.Event derived class.</returns>
+        private Stripe.V2.Core.Event DoParseSignedEventAndFetch(string payload)
         {
             this.MockHttpClientFixture.MockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -180,7 +180,7 @@ namespace StripeTests.V2
             var bte = this.DoParseSignedEventNotification(payload);
 
             // fetch full event
-            return bte.FetchEvent<Stripe.V2.Event>();
+            return bte.FetchEvent<Stripe.V2.Core.Event>();
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace StripeTests.V2
         /// </summary>
         /// <param name="payload">The json payload to parse.</param>
         /// <returns>An EventNotification derived class.</returns>
-        private Stripe.V2.EventNotification DoParseSignedEventNotification(string payload)
+        private Stripe.V2.Core.EventNotification DoParseSignedEventNotification(string payload)
         {
             var notif = this.stripeClient.ParseEventNotification(payload, GenerateSigHeader(payload), WebhookSecret);
 
@@ -292,7 +292,7 @@ namespace StripeTests.V2
         [Fact]
         public void ParseUnknownEventDirectly()
         {
-            var stripeEvent = JsonUtils.DeserializeObject<Stripe.V2.Event>(v2UnknownEventPayload);
+            var stripeEvent = JsonUtils.DeserializeObject<Stripe.V2.Core.Event>(v2UnknownEventPayload);
             Assert.NotNull(stripeEvent);
             Assert.Equal("evt_234", stripeEvent.Id);
             Assert.Equal("event", stripeEvent.Object);

--- a/src/StripeTests/Services/GeneratedExamplesTest.cs
+++ b/src/StripeTests/Services/GeneratedExamplesTest.cs
@@ -726,7 +726,7 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event\",\"context\":\"context\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"reason\":{\"type\":\"request\",\"request\":{\"id\":\"obj_123\",\"idempotency_key\":\"idempotency_key\"}},\"type\":\"type\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Events;
-            Stripe.V2.Event result = service.Get("ll_123");
+            Stripe.V2.Core.Event result = service.Get("ll_123");
             this.AssertRequest(HttpMethod.Get, "/v2/core/events/ll_123");
         }
 
@@ -6254,7 +6254,7 @@ namespace StripeTests
             };
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Events;
-            Stripe.V2.StripeList<Stripe.V2.Event> events = service.List(
+            Stripe.V2.StripeList<Stripe.V2.Core.Event> events = service.List(
                 options);
             this.AssertRequest(
                 HttpMethod.Get,
@@ -6272,7 +6272,7 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"type\":\"type\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.Events;
-            Stripe.V2.Event result = service.Get("id_123");
+            Stripe.V2.Core.Event result = service.Get("id_123");
             this.AssertRequest(HttpMethod.Get, "/v2/core/events/id_123");
         }
 
@@ -6286,7 +6286,7 @@ namespace StripeTests
                 "{\"data\":[{\"id\":\"obj_123\",\"object\":\"v2.core.event_destination\",\"created\":\"1970-01-12T21:42:34.472Z\",\"description\":\"description\",\"enabled_events\":[\"enabled_events\"],\"event_payload\":\"thin\",\"livemode\":true,\"name\":\"name\",\"status\":\"disabled\",\"type\":\"amazon_eventbridge\",\"updated\":\"1970-01-03T17:07:10.277Z\"}],\"next_page_url\":null,\"previous_page_url\":null}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.StripeList<Stripe.V2.EventDestination> eventDestinations = service
+            Stripe.V2.StripeList<Stripe.V2.Core.EventDestination> eventDestinations = service
                 .List();
             this.AssertRequest(HttpMethod.Get, "/v2/core/event_destinations");
         }
@@ -6308,7 +6308,7 @@ namespace StripeTests
             };
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.EventDestination eventDestination = service.Create(
+            Stripe.V2.Core.EventDestination eventDestination = service.Create(
                 options);
             this.AssertRequest(HttpMethod.Post, "/v2/core/event_destinations");
         }
@@ -6339,7 +6339,8 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event_destination\",\"created\":\"1970-01-12T21:42:34.472Z\",\"description\":\"description\",\"enabled_events\":[\"enabled_events\"],\"event_payload\":\"thin\",\"livemode\":true,\"name\":\"name\",\"status\":\"disabled\",\"type\":\"amazon_eventbridge\",\"updated\":\"1970-01-03T17:07:10.277Z\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.EventDestination eventDestination = service.Get("id_123");
+            Stripe.V2.Core.EventDestination eventDestination = service.Get(
+                "id_123");
             this.AssertRequest(
                 HttpMethod.Get,
                 "/v2/core/event_destinations/id_123");
@@ -6356,7 +6357,7 @@ namespace StripeTests
             var options = new Stripe.V2.Core.EventDestinationUpdateOptions();
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.EventDestination eventDestination = service.Update(
+            Stripe.V2.Core.EventDestination eventDestination = service.Update(
                 "id_123",
                 options);
             this.AssertRequest(
@@ -6374,7 +6375,7 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event_destination\",\"created\":\"1970-01-12T21:42:34.472Z\",\"description\":\"description\",\"enabled_events\":[\"enabled_events\"],\"event_payload\":\"thin\",\"livemode\":true,\"name\":\"name\",\"status\":\"disabled\",\"type\":\"amazon_eventbridge\",\"updated\":\"1970-01-03T17:07:10.277Z\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.EventDestination eventDestination = service.Disable(
+            Stripe.V2.Core.EventDestination eventDestination = service.Disable(
                 "id_123");
             this.AssertRequest(
                 HttpMethod.Post,
@@ -6391,7 +6392,7 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event_destination\",\"created\":\"1970-01-12T21:42:34.472Z\",\"description\":\"description\",\"enabled_events\":[\"enabled_events\"],\"event_payload\":\"thin\",\"livemode\":true,\"name\":\"name\",\"status\":\"disabled\",\"type\":\"amazon_eventbridge\",\"updated\":\"1970-01-03T17:07:10.277Z\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.EventDestination eventDestination = service.Enable(
+            Stripe.V2.Core.EventDestination eventDestination = service.Enable(
                 "id_123");
             this.AssertRequest(
                 HttpMethod.Post,
@@ -6408,7 +6409,7 @@ namespace StripeTests
                 "{\"id\":\"obj_123\",\"object\":\"v2.core.event\",\"created\":\"1970-01-12T21:42:34.472Z\",\"livemode\":true,\"type\":\"type\"}");
             var client = new StripeClient(this.Requestor);
             var service = client.V2.Core.EventDestinations;
-            Stripe.V2.Event result = service.Ping("id_123");
+            Stripe.V2.Core.Event result = service.Ping("id_123");
             this.AssertRequest(
                 HttpMethod.Post,
                 "/v2/core/event_destinations/id_123/ping");

--- a/src/StripeTests/Wholesome/ClassesHaveAllNecessaryJsonAttributes.cs
+++ b/src/StripeTests/Wholesome/ClassesHaveAllNecessaryJsonAttributes.cs
@@ -62,8 +62,8 @@ namespace StripeTests.Wholesome
                     }
                 }
 
-                // Special case for Stripe.V2.Event
-                if (type == typeof(Stripe.V2.Event))
+                // Special case for Stripe.V2.Core.Event
+                if (type == typeof(Stripe.V2.Core.Event))
                 {
                     var converter = type.GetCustomAttribute(typeof(STJS.JsonConverterAttribute), false) as STJS.JsonConverterAttribute;
                     if (converter?.ConverterType != typeof(STJV2EventConverter))

--- a/src/StripeTests/Wholesome/DontForgetEntityType.cs
+++ b/src/StripeTests/Wholesome/DontForgetEntityType.cs
@@ -35,7 +35,7 @@ namespace StripeTests.Wholesome
                     continue;
                 }
 
-                if (baseType == typeof(Stripe.V2.Event))
+                if (baseType == typeof(Stripe.V2.Core.Event))
                 {
                     continue;
                 }

--- a/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
+++ b/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
@@ -349,11 +349,11 @@ namespace StripeTests.Wholesome
             var listType = list.GetType();
             genericTypes.RemoveAll(gt => listType.FullName.StartsWith(gt.FullName));
 
-            // This also tests polymorphic types like V2.Event within
+            // This also tests polymorphic types like V2.Core.Event within
             // the list
-            var v2List = new Stripe.V2.StripeList<Stripe.V2.Event>
+            var v2List = new Stripe.V2.StripeList<Stripe.V2.Core.Event>
             {
-                Data = new List<Stripe.V2.Event>
+                Data = new List<Stripe.V2.Core.Event>
                 {
                     this.PopulateWithReasonableDefaults(new V1BillingMeterErrorReportTriggeredEvent(), null, new Dictionary<Type, object>()),
                     this.PopulateWithReasonableDefaults(new V1BillingMeterErrorReportTriggeredEvent(), null, new Dictionary<Type, object>()),


### PR DESCRIPTION
### Why?

In `2024-09-30.acacia` ([docs](https://docs.stripe.com/changelog/acacia)), we released our new V2 Event system, found under the `/v2/core/events` API endpoint. When we put them in our in SDKs, for presentation reasons, we put these new resources in the `Stripe.V2.Event` namespace.

We've realized that dropping `Core` from the SDK namespace adds more confusion than good, so we're putting the v2 `Event` resource into the `Stripe.V2.Core` namespace, where you'd expect to find it in the first place.

There's no change to specific event classes, like `V1BillingMeterErrorReportTriggeredEvent`. Those are, and will continue to be, under `Stripe.Events`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- moved all resources from `V2.Events` to `V2.Core.Events`
- updated tests

## Changelog

- ⚠️ Move all V2 Event-related resources (`Event`, `RelatedObject`, etc) into the to `Stripe.V2.Core` namespace. They now correctly match their API path and are in line with all other resources.
  - To update your code, replace instances of `Stripe.V2.Event` with `Stripe.V2.Core.Event`
- Existing event types (like `V1BillingMeterErrorReportTriggeredEvent` haven't moved).
