### PR TITLE
Speed up just format in CI for private-preview branch

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ ci-test: (_test "--no-build" "" "Release")
 
 # ⭐ format all files
 format *args:
+    dotnet format whitespace --folder {{args}}
     # This sets TargetFramework because of a race condition in dotnet format when it tries to format to multiple targets at a time, which could lead to code with compiler errors after it completes
     TargetFramework=net5.0 dotnet format src/Stripe.net.sln --severity warn {{args}}
 


### PR DESCRIPTION
### Why?
Recently we noticed that the format stage of updating generated code for testing was taking > 30 min on the private preview build.  This PR updates the `just format` command to split out whitespace formatting in a more efficient manner, which also speeds up the regular formatting (run immediately after).

### What?
- separated formatting whitespace from other formatting, for performance

### See Also
<!-- Include any links or additional information that help explain this change. -->
