### PR TITLE
Update param in deprecation docs link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          # see: https://docs.stripe.com/sdks/versioning?server=dotnet#stripe-sdk-language-version-support-policy
+          # see: https://docs.stripe.com/sdks/versioning?lang=dotnet#stripe-sdk-language-version-support-policy
           # even numbers are LTS
           # TODO: add 9.0.x; https://go/j/RUN_DEVSDK-1957
           dotnet-version: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
      - `Stripe.V2.EventReasonRequest` -> `Stripe.V2.Core.EventReasonRequest`
      - `Stripe.V2.EventRelatedObject` -> `Stripe.V2.Core.EventRelatedObject`
 * [#3206](https://github.com/stripe/stripe-dotnet/pull/3206) ⚠️ Drop support for .NET Core 3.1 & clarify policy
-  -  Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=dotnet#stripe-sdk-language-version-support-policy)
+  -  Read our new [language version support policy](https://docs.stripe.com/sdks/versioning?lang=dotnet#stripe-sdk-language-version-support-policy)
        - ⚠️ In this release, we drop support for .NET Core 3.1.
        - Support for .NET Core versions 5 & 7 are deprecated and will be removed in the next major version scheduled for March 2026
 * [#3197](https://github.com/stripe/stripe-dotnet/pull/3197) Remove unused obsolete classes SourceTransactionsListOptions and SourceTransactionsGetOptions

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ From within Visual Studio:
 
 ### Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=dotnet#stripe-sdk-language-version-support-policy), we currently support **.NET Standard 2.0+, .NET Core 5+, and .NET Framework 4.6.2+.**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=dotnet#stripe-sdk-language-version-support-policy), we currently support **.NET Standard 2.0+, .NET Core 5+, and .NET Framework 4.6.2+.**.
 
-Support for .NET Core versions 5 & 7 are deprecated and will be removed in the next major version. Support for version 6 will be removed in a future version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=dotnet#stripe-sdk-language-version-support-policy
+Support for .NET Core versions 5 & 7 are deprecated and will be removed in the next major version. Support for version 6 will be removed in a future version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=dotnet#stripe-sdk-language-version-support-policy
 
 ## Documentation
 


### PR DESCRIPTION
### Why?

We're using a different `pref` name in the docs for the version deprecation policy, so these links need to be updated.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- replace `?server=` with `?lang=` in links
