### PR TITLE
Fixes STJDefaultConverter to safely ignore unknown properties

### DIFF
--- a/src/Stripe.net/Infrastructure/JsonConverters/STJDefaultConverter.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJDefaultConverter.cs
@@ -47,22 +47,21 @@ namespace Stripe.Infrastructure
 
                 string propertyName = reader.GetString();
 
-                foreach (var property in allProperties)
-                {
-                    if (property.JsonPropertyName == propertyName)
-                    {
-                        var valueType = property.PropertyInfo.PropertyType;
-                        var valueConverter = property.GetConverter(options);
+                // Advance the reader to the value token
+                reader.Read();
 
-                        // Get the value.
-                        reader.Read();
+                var property = allProperties.Find(p => p.JsonPropertyName == propertyName);
+                if (property != null)
+                {
+                    var valueType = property.PropertyInfo.PropertyType;
+                    var valueConverter = property.GetConverter(options);
+
+                    // Get the value.
 #pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
-                        object value = valueConverter.Read(ref reader, valueType, options)!;
+                    object value = valueConverter.Read(ref reader, valueType, options)!;
 #pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
 
-                        property.Set(newInstance, value);
-                        break;
-                    }
+                    property.Set(newInstance, value);
                 }
             }
 


### PR DESCRIPTION
### Why?
There is a bug in STJDefaultConverter where extra properties in the JSON could cause an exception when it is being deserialized.  We currently do not support capturing extra properties into a separate object with STJ (like we do with Newtonsoft Json.NET) so for now we can safely discard these properties.

### What?
- fixes STJDefaultConverter to advance the reader even if the property is not present in the type being deserialized
- changes loop to find the target property to a Filter call, for readability

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Fixes a bug when using System.Text.Json to deserialize JSON that has properties not present in the target object.
