### PR TITLE
Update CHANGELOG.md to include note on pinned API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 49.1.0 - 2025-10-29
 
-This release changes the pinned API version to 2025-10-29.clover.
+This release changes the pinned API version to `2025-10-29.clover`.
 
 * [#3236](https://github.com/stripe/stripe-dotnet/pull/3236) Update generated code
   * Improve docs for PaymentIntent related endpoints


### PR DESCRIPTION
### Why?
Missed adding this line when releasing the latest version

### What?
Added `This release changes the pinned API version to 2025-10-29.clover.`

### See Also
<!-- Include any links or additional information that help explain this change. -->
