### PR TITLE
Updated timeout for publishing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           dotnet-version: ${{ needs.prepare-dotnet-versions.outputs.latest-dotnet-version }}
       - name: Publish NuGet packages to NuGet
-        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org"
+        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org" --timeout 1200
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:


### PR DESCRIPTION
### Why?
Our .NET publishing was timing out. 

### What?
Bumped .NET nuget publishing timeout to 1200s(20 min).

### See Also
* https://stripe.slack.com/archives/C04TU6TEV0U/p1763495906114489
* https://github.com/stripe/stripe-dotnet/actions/runs/19479151697/job/55748386497
