### PR TITLE
Make EventUtility.ComputeSignature public

### DIFF
--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -218,7 +218,14 @@ namespace Stripe
             return signatures.Any(key => StringUtils.SecureEquals(key, signature));
         }
 
-        private static string ComputeSignature(string secret, string timestamp, string payload)
+        /// <summary>
+        /// Computes the signature for a given payload.
+        /// </summary>
+        /// <param name="secret">The webhook endpoint's signing secret.</param>
+        /// <param name="timestamp">The timestamp of the payload.</param>
+        /// <param name="payload">The payload to compute the signature for.</param>
+        /// <returns>The computed signature.</returns>
+        public static string ComputeSignature(string secret, string timestamp, string payload)
         {
             var secretBytes = SafeUTF8.GetBytes(secret);
             var payloadBytes = SafeUTF8.GetBytes($"{timestamp}.{payload}");


### PR DESCRIPTION
### Why?
User requested us to make our internal `ComputeSignature` method public so they can write better integration tests for testing webhooks: https://github.com/stripe/stripe-dotnet/issues/3255
We have similar public methods in other languages(e.g. stripe-node)

### What?
- Make existing `ComputeSignature` public for users.

### See Also
* https://jira.corp.stripe.com/browse/RUN_DEVSDK-2056
* https://github.com/stripe/stripe-dotnet/issues/3255