### PR TITLE
Fix STJUnixDateTimeConverter to handle null values for nullable DateTime properties

### DIFF
--- a/src/StripeTests/Infrastructure/JsonConverters/STJUnixDateTimeConverterTest.cs
+++ b/src/StripeTests/Infrastructure/JsonConverters/STJUnixDateTimeConverterTest.cs
@@ -1,0 +1,229 @@
+#if NET6_0_OR_GREATER
+namespace StripeTests
+{
+    using System;
+    using System.Text.Json;
+    using Stripe;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="Stripe.Infrastructure.STJUnixDateTimeConverter"/>.
+    /// These tests do NOT require stripe-mock as they test JSON deserialization directly.
+    /// </summary>
+    public class STJUnixDateTimeConverterTest
+    {
+        /// <summary>
+        /// Deserialization with valid Unix timestamp: Verifies the converter correctly
+        /// converts a valid Unix epoch timestamp to a DateTime value.
+        /// </summary>
+        [Fact]
+        public void Deserialize_WithValidUnixTimestamp_ReturnsCorrectDateTime()
+        {
+            // Unix timestamp: 1609459200 = 2021-01-01 00:00:00 UTC
+            var json = @"{""id"":""sub_123"",""object"":""subscription"",""canceled_at"":1609459200,""created"":1609459200}";
+
+            var subscription = JsonSerializer.Deserialize<Subscription>(json);
+
+            Assert.NotNull(subscription);
+            Assert.True(subscription.CanceledAt.HasValue);
+            Assert.Equal(new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc), subscription.CanceledAt.Value);
+        }
+
+        /// <summary>
+        /// Deserialization with null DateTime: Tests the fix for issue #3157.
+        /// A nullable DateTime? property should accept null values without throwing JsonException.
+        /// This test ensures the converter properly handles JsonTokenType.Null.
+        /// </summary>
+        [Fact]
+        public void Deserialize_WithNullDateTime_ShouldNotThrow()
+        {
+            // This is the bug from issue #3157
+            // canceled_at is a DateTime? property, so null should be valid
+            var json = @"{""id"":""sub_123"",""object"":""subscription"",""canceled_at"":null,""created"":1609459200}";
+
+            // This should NOT throw JsonException
+            var subscription = JsonSerializer.Deserialize<Subscription>(json);
+
+            Assert.NotNull(subscription);
+            Assert.Null(subscription.CanceledAt);
+        }
+
+        /// <summary>
+        /// Multiple nullable DateTime fields with null values: Verifies the converter can handle
+        /// multiple DateTime? properties all with null values in a single object.
+        /// This is common for entities that have optional date fields (canceled_at, trial_end, etc.).
+        /// </summary>
+        [Fact]
+        public void Deserialize_MultipleNullableDateTimeFields_ShouldWork()
+        {
+            // Testing multiple nullable DateTime fields with null values
+            var json = @"{
+                ""id"":""sub_123"",
+                ""object"":""subscription"",
+                ""canceled_at"":null,
+                ""trial_end"":null,
+                ""trial_start"":null,
+                ""cancel_at"":null,
+                ""ended_at"":null,
+                ""created"":1609459200,
+                ""current_period_end"":1612137600,
+                ""current_period_start"":1609459200
+            }";
+
+            var subscription = JsonSerializer.Deserialize<Subscription>(json);
+
+            Assert.NotNull(subscription);
+            Assert.Null(subscription.CanceledAt);
+            Assert.Null(subscription.TrialEnd);
+            Assert.Null(subscription.TrialStart);
+            Assert.Null(subscription.CancelAt);
+            Assert.Null(subscription.EndedAt);
+
+            // Created is non-nullable DateTime, so it should have a value
+            Assert.NotEqual(default(DateTime), subscription.Created);
+        }
+
+        /// <summary>
+        /// Mixed null and actual values: Verifies the converter correctly handles a mix of
+        /// null and non-null DateTime? fields in the same object.
+        /// </summary>
+        [Fact]
+        public void Deserialize_MixedNullAndValues_ShouldWork()
+        {
+            // Some DateTime? fields with null, others with values
+            var json = @"{
+                ""id"":""sub_123"",
+                ""object"":""subscription"",
+                ""canceled_at"":1612137600,
+                ""trial_end"":null,
+                ""trial_start"":1609459200,
+                ""created"":1609459200
+            }";
+
+            var subscription = JsonSerializer.Deserialize<Subscription>(json);
+
+            Assert.NotNull(subscription);
+            Assert.True(subscription.CanceledAt.HasValue);
+            Assert.Null(subscription.TrialEnd);
+            Assert.True(subscription.TrialStart.HasValue);
+        }
+
+        /// <summary>
+        /// Serialization with null DateTime: Verifies that when serializing an object with
+        /// a null DateTime? property, the converter outputs JSON null (not a number or empty value).
+        /// </summary>
+        [Fact]
+        public void Serialize_NullDateTime_WritesNull()
+        {
+            var subscription = new Subscription
+            {
+                Id = "sub_123",
+                CanceledAt = null,
+                Created = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            };
+
+            var json = JsonSerializer.Serialize(subscription);
+
+            Assert.Contains("\"canceled_at\":null", json);
+        }
+
+        /// <summary>
+        /// Serialization with DateTime value: Verifies that when serializing an object with
+        /// a non-null DateTime? property, the converter outputs the Unix epoch timestamp.
+        /// </summary>
+        [Fact]
+        public void Serialize_WithDateTime_WritesUnixTimestamp()
+        {
+            var subscription = new Subscription
+            {
+                Id = "sub_123",
+                CanceledAt = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Created = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            };
+
+            var json = JsonSerializer.Serialize(subscription);
+
+            // 1609459200 = 2021-01-01 00:00:00 UTC
+            Assert.Contains("\"canceled_at\":1609459200", json);
+        }
+
+        /// <summary>
+        /// Serialization then deserialization of null DateTime: Tests that the serialized null value
+        /// is correctly preserved through the serialization-deserialization cycle.
+        /// This test validates the converter produces correct JSON output for null values.
+        /// </summary>
+        [Fact]
+        public void RoundTrip_NullDateTime_SerializesCorrectly()
+        {
+            // First, deserialize a subscription with null canceled_at
+            var originalJson = @"{""id"":""sub_123"",""object"":""subscription"",""canceled_at"":null,""created"":1609459200}";
+            var subscription = JsonSerializer.Deserialize<Subscription>(originalJson);
+            Assert.NotNull(subscription);
+            Assert.Null(subscription.CanceledAt);
+
+            // Then serialize and verify the null is preserved in the output
+            var serializedJson = JsonSerializer.Serialize(subscription);
+            Assert.Contains("\"canceled_at\":null", serializedJson);
+        }
+
+        /// <summary>
+        /// Serialization then deserialization of DateTime value: Tests that the serialized timestamp
+        /// is correctly preserved through the serialization-deserialization cycle.
+        /// </summary>
+        [Fact]
+        public void RoundTrip_WithDateTime_SerializesCorrectly()
+        {
+            // First, deserialize a subscription with a valid canceled_at timestamp
+            var originalJson = @"{""id"":""sub_123"",""object"":""subscription"",""canceled_at"":1609459200,""created"":1609459200}";
+            var expectedDate = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            var subscription = JsonSerializer.Deserialize<Subscription>(originalJson);
+            Assert.NotNull(subscription);
+            Assert.Equal(expectedDate, subscription.CanceledAt);
+
+            // Then serialize and verify the timestamp is preserved in the output
+            var serializedJson = JsonSerializer.Serialize(subscription);
+            Assert.Contains("\"canceled_at\":1609459200", serializedJson);
+        }
+
+        /// <summary>
+        /// Full Event payload from issue #3157: Real-world scenario where a nested Subscription object
+        /// within an Event payload contains null DateTime fields. This represents the exact scenario
+        /// reported in issue #3157 with a customer.subscription.created event.
+        /// </summary>
+        [Fact]
+        public void Deserialize_FullEventPayload_WithNullCanceledAt_ShouldWork()
+        {
+            // Real-world scenario from issue #3157
+            var eventPayload = @"{
+                ""id"": ""evt_123"",
+                ""object"": ""event"",
+                ""type"": ""customer.subscription.created"",
+                ""created"": 1609459200,
+                ""data"": {
+                    ""object"": {
+                        ""id"": ""sub_123"",
+                        ""object"": ""subscription"",
+                        ""canceled_at"": null,
+                        ""created"": 1609459200,
+                        ""current_period_end"": 1612137600,
+                        ""current_period_start"": 1609459200
+                    }
+                }
+            }";
+
+            var evt = JsonSerializer.Deserialize<Event>(eventPayload);
+
+            Assert.NotNull(evt);
+            Assert.Equal("evt_123", evt.Id);
+
+            // The subscription should be deserialized correctly with null canceled_at
+            if (evt.Data?.Object is Subscription subscription)
+            {
+                Assert.Equal("sub_123", subscription.Id);
+                Assert.Null(subscription.CanceledAt);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# Pull Request: Fix STJUnixDateTimeConverter to handle null values for nullable DateTime properties

> ⚠️ **DISCLAIMER: Educational/Demonstration Purpose**
>
> This PR was created as a demonstration of how AI coding agents can assist developers in their first encounter with a new codebase. The entire process—from understanding the issue, analyzing the repository structure, investigating related work, reproducing the bug, creating tests, and implementing the fix—was conducted as a conversation with a coding agent (GitHub Copilot with Claude).
>
> While this kind of AI-assisted exploration of unfamiliar codebases might not be particularly impressive by January 2026 standards, it remains an interesting exercise in understanding how these tools can facilitate initial contact with complex projects.
>
> **I do not expect this PR to be merged**, primarily because there is already a more comprehensive solution in the `origin/prathmesh/stj-datetimeconvertor` branch that the team has been working on. Additionally, the team may have architectural considerations or release timing concerns that make merging this change inappropriate at this time.
>
> This PR exists purely as an educational artifact documenting the journey of understanding and fixing a bug with AI assistance.

---

## Why?

Fixes #3157

When deserializing a `Stripe.Event` payload using `System.Text.Json`, nullable `DateTime?` properties throw a `JsonException` when the JSON value is `null`. This affects common webhook scenarios where properties like `canceled_at`, `trial_end`, or `ended_at` are null.

**Error:**
```
System.Text.Json.JsonException: Unexpected token parsing date. Expected Integer or String, got Null.
   at Stripe.Infrastructure.STJUnixDateTimeConverter.Read(...)
```

## What?

This PR makes two changes:

### 1. Convert `STJUnixDateTimeConverter` to a `JsonConverterFactory`

The converter is now a factory that creates specialized converters for each type:
- `STJUnixDateTimeConverterImpl` for non-nullable `DateTime`
- `STJUnixNullableDateTimeConverter` for nullable `DateTime?`

The nullable converter properly handles `JsonTokenType.Null` and returns `null` instead of throwing an exception.

### 2. Add `JsonConverterFactory` support to `SerializablePropertyCache`

The `GetConverter` method now detects when a property-level `[JsonConverter]` attribute specifies a `JsonConverterFactory` type and handles it appropriately by calling `CreateConverter` with the property's actual type.

## Testing

Added comprehensive unit tests in `STJUnixDateTimeConverterTest.cs`:
- Deserialization with valid Unix timestamps
- Deserialization with null DateTime values (the core bug scenario)
- Deserialization with multiple nullable DateTime fields
- Deserialization with mixed null and non-null values
- Serialization with null DateTime
- Serialization with DateTime value
- Round-trip tests for both null and non-null values
- Full event payload scenario matching issue #3157

<details>
<summary>Test execution output (click to expand)</summary>

```
dotnet test StripeTests/StripeTests.csproj -f net8.0 --filter "FullyQualifiedName~STJUnixDateTimeConverterTest"
  Stripe.net net8.0 succeeded (7.2s) → Stripe.net\bin\Debug\net8.0\Stripe.net.dll
  StripeTests net8.0 succeeded (0.1s) → StripeTests\bin\Debug\net8.0\StripeTests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.3+1b45f5407b (64-bit .NET 8.0.20)
[xUnit.net 00:00:00.27]   Discovering: StripeTests (method display = ClassAndMethod, method display options = None)
[xUnit.net 00:00:00.34]   Discovered:  StripeTests (found 1654 test cases)
[xUnit.net 00:00:00.34]   Starting:    StripeTests (parallel test collections = on, max threads = 12)
[xUnit.net 00:00:00.39]   Finished:    StripeTests
  StripeTests test net8.0 succeeded (0.9s)

Test summary: total: 9, failed: 0, succeeded: 9, skipped: 0, duration: 0.8s
Build succeeded in 8.7s
```

</details>

_All 9 tests pass without requiring stripe-mock._

## Files Changed

- `src/Stripe.net/Infrastructure/JsonConverters/STJUnixDateTimeConverter.cs` - Converted to JsonConverterFactory pattern with specialized converters
- `src/Stripe.net/Infrastructure/JsonConverters/SerializablePropertyCache.cs` - Added support for JsonConverterFactory in property-level attributes
- `src/StripeTests/Infrastructure/JsonConverters/STJUnixDateTimeConverterTest.cs` - New comprehensive test suite

## Changelog

* Bug fix for #3157. `STJUnixDateTimeConverter` now properly handles null values for nullable `DateTime?` properties when deserializing JSON with `System.Text.Json`.

---

## Journey with AI Assistance

This fix was developed through an interactive conversation with a coding agent. Here's the chronology of how we arrived at this solution:

**TL;DR:** Claude Opus initially attempted a simple fix (just adding null handling). During the investigation, we discovered the `origin/prathmesh/stj-datetimeconvertor` branch that already contained a comprehensive solution. After running our tests, we realized the simple approach wasn't sufficient due to `JsonConverter<DateTime>` return type constraints, and we needed the `JsonConverterFactory` pattern—essentially arriving at the same solution already implemented in that branch.

### Phase 1: Issue Discovery & Analysis
- Read and understood issue #3157 and its symptoms
- Identified the root cause: `STJUnixDateTimeConverter.Read()` doesn't handle `JsonTokenType.Null`
- Compared with the Newtonsoft version (`UnixDateTimeConverter`) which correctly handles null

### Phase 2: Differentiating Related Issues
- Analyzed PR #3254 (milliseconds vs seconds handling) and confirmed it's a separate bug
- Understood that issue #3157 is specifically about null handling, not timestamp format

### Phase 3: Reproduction & Test Creation
- Created a reproduction console app demonstrating the bug
- Created comprehensive unit tests that don't require stripe-mock
- Verified tests fail with the original code and pass with the fix

### Phase 4: Investigation of Existing Work
- Discovered the `origin/prathmesh/stj-datetimeconvertor` branch with a more comprehensive solution
- Understood that the team has been working on this with a `JsonConverterFactory` approach
- Recognized that `SerializablePropertyCache` needed modification to support factories

### Phase 5: Implementation
- Initially tried a simpler fix (just adding null check) but discovered it doesn't work due to `JsonConverter<DateTime>` return type constraints
- Understood why `JsonConverterFactory` is necessary for proper null handling with `DateTime?`
- Implemented the factory pattern similar to the approach in prathmesh's branch
- Added factory support to `SerializablePropertyCache`

### Phase 6: Validation
- All 9 new tests pass
- All 16 Wholesome tests pass (converter validation)
- No regressions in the codebase

---

## Acknowledgments

Thanks to @sebastiencrevier for the detailed bug report with reproduction steps, and to @prathmesh-stripe and @jar-stripe for their work and collaboration in addressing this issue.