### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,13 @@ on:
       - sdk-release/**
       - feature/**
 
+permissions: {}
+
 jobs:
   prepare-dotnet-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       supported-dotnet-versions: ${{ steps.supported-dotnet-versions.outputs.dotnet_versions }}
       latest-dotnet-version: ${{ steps.latest-dotnet-version.outputs.latest_dotnet_version }}
@@ -43,6 +47,8 @@ jobs:
     needs: prepare-dotnet-versions
     # TODO: this step is not compatible with ubuntu 24 LTS, so we pin the version here instead of using ubuntu-latest
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
       - uses: extractions/setup-just@v2
@@ -122,6 +128,8 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: prepare-dotnet-versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@master
       - name: Setup .NET
@@ -136,6 +144,8 @@ jobs:
     if: (((github.event_name == 'push') || (github.event_name == 'workflow_dispatch')) && startsWith(github.ref, 'refs/tags/v') && endsWith(github.actor, '-stripe'))
     needs: [build, prepare-dotnet-versions]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,6 +7,8 @@ on:
     types:
       - auto_merge_enabled
 
+permissions: {}
+
 jobs:
   require_merge_commit_on_merge_script_pr:
     name: Merge script PRs must create merge commits


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- The `rules` workflow gets empty permissions as it only runs shell scripts

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)