### PR TITLE
Add test coverage for 2D list form encoding

### DIFF
--- a/src/StripeTests/Infrastructure/FormEncoding/ContentEncoderTest.cs
+++ b/src/StripeTests/Infrastructure/FormEncoding/ContentEncoderTest.cs
@@ -351,6 +351,20 @@ namespace StripeTests
                     Want = "list[0][foo]=bar&list[1][foo]=baz",
                 },
 
+                // Nested list (2D array)
+                new QueryStringTestCase
+                {
+                    Data = new TestOptions
+                    {
+                        List = new List<object>
+                        {
+                            new List<object> { 1, 2 },
+                            new List<object> { 3, 4 },
+                        },
+                    },
+                    Want = "list[0][0]=1&list[0][1]=2&list[1][0]=3&list[1][1]=4",
+                },
+
                 // Long
                 new QueryStringTestCase
                 {


### PR DESCRIPTION
### Why?

The content encoder correctly handles nested lists (`List<List<T>>`) via recursive dispatch through `FlattenParamsList`. However, there was no explicit test for this behavior, making it possible for a future refactor to break it silently.

### What?

- Add nested `List<object>` test case to `ContentEncoderTest.cs` verifying `list[0][0]=1&list[0][1]=2&list[1][0]=3&list[1][1]=4` encoding

### See Also

- https://jira.corp.stripe.com/browse/RUN_DEVSDK-2304
- Bug fix PRs in stripe-ruby, stripe-python, stripe-php
- Test-only PR in stripe-go