### PR TITLE
Add Ref<T> type for typed v2 object references

### DIFF
--- a/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
@@ -13,15 +13,20 @@ namespace Stripe.V2.Core
     /// </summary>
     [JsonConverter(typeof(V2EventConverter))]
     [STJS.JsonConverter(typeof(STJV2EventConverter))]
-    public partial class Event : StripeEntity<Event>, IHasId, IHasObject
+    public partial class Event : StripeEntity<Event>, IHasId, IHasObject, IHasRequestor
     {
         /// <summary>
         /// Used for .FetchObject and .FetchData helpers.
         /// </summary>
         [JsonIgnore]
         [STJS.JsonIgnore]
-
         internal ApiRequestor Requestor { get; set; }
+
+        ApiRequestor IHasRequestor.Requestor
+        {
+            get => this.Requestor;
+            set => this.Requestor = value;
+        }
 
         /// <summary>
         /// Makes an API request to fetch the object associated with this event.

--- a/src/Stripe.net/Entities/V2/IHasRequestor.cs
+++ b/src/Stripe.net/Entities/V2/IHasRequestor.cs
@@ -1,0 +1,11 @@
+namespace Stripe.V2
+{
+    /// <summary>
+    /// Implemented by V2 entities that need a reference to the <see cref="ApiRequestor"/>
+    /// after deserialization, e.g. so they can make follow-up API calls.
+    /// </summary>
+    internal interface IHasRequestor
+    {
+        ApiRequestor Requestor { get; set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Ref.cs
+++ b/src/Stripe.net/Entities/V2/Ref.cs
@@ -15,7 +15,7 @@ namespace Stripe.V2
     /// </summary>
     /// <typeparam name="T">The type of the referenced Stripe entity.</typeparam>
     [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
-    public class Ref<T> : StripeEntity<Ref<T>>, IHasId
+    public class Ref<T> : StripeEntity<Ref<T>>, IHasId, IHasRequestor
         where T : IStripeEntity
     {
         /// <summary>
@@ -39,13 +39,15 @@ namespace Stripe.V2
         [STJS.JsonPropertyName("url")]
         public string Url { get; set; }
 
-        internal StripeClient Client { get; set; }
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        ApiRequestor IHasRequestor.Requestor { get; set; }
 
         /// <summary>
         /// Fetches the full object this reference points to.
         /// </summary>
         /// <returns>The fully populated object.</returns>
-        /// <exception cref="Exception">Thrown when no client has been set on this instance.</exception>
+        /// <exception cref="Exception">Thrown when no requestor has been set on this instance.</exception>
         public T Fetch()
         {
             return this.FetchAsync().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -56,25 +58,23 @@ namespace Stripe.V2
         /// </summary>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
         /// <returns>A task that represents the asynchronous operation. The task result is the fully populated object.</returns>
-        /// <exception cref="Exception">Thrown when no client has been set on this instance.</exception>
+        /// <exception cref="Exception">Thrown when no requestor has been set on this instance.</exception>
         public async Task<T> FetchAsync(CancellationToken cancellationToken = default)
         {
-            if (this.Client == null)
+            var requestor = ((IHasRequestor)this).Requestor;
+            if (requestor == null)
             {
-                throw new Exception("Ref<T> is trying to make a request with no client.");
+                throw new Exception("Ref<T> is trying to make a request with no requestor.");
             }
 
-            var res = await this.Client.RawRequestAsync(
+            return await requestor.RequestAsync<T>(
+                BaseAddress.Api,
                 HttpMethod.Get,
                 this.Url,
-                requestOptions: new RawRequestOptions
-                {
-                    Usage = new List<string> { "ref_fetch" },
-                },
+                null,
+                new RequestOptions { Usage = new List<string> { "ref_fetch" } },
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
-
-            return this.Client.Deserialize<T>(res.Content);
         }
     }
 }

--- a/src/Stripe.net/Entities/V2/Ref.cs
+++ b/src/Stripe.net/Entities/V2/Ref.cs
@@ -1,0 +1,80 @@
+namespace Stripe.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    using Stripe.Infrastructure;
+    using STJS = System.Text.Json.Serialization;
+
+    /// <summary>
+    /// A typed reference to a Stripe V2 object. Holds the object's <c>id</c>, <c>type</c>, and
+    /// <c>url</c> and can fetch the full object on demand.
+    /// </summary>
+    /// <typeparam name="T">The type of the referenced Stripe entity.</typeparam>
+    [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
+    public class Ref<T> : StripeEntity<Ref<T>>, IHasId
+        where T : IStripeEntity
+    {
+        /// <summary>
+        /// Unique identifier for the referenced object.
+        /// </summary>
+        [JsonProperty("id")]
+        [STJS.JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The type of the referenced object.
+        /// </summary>
+        [JsonProperty("type")]
+        [STJS.JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The URL where the full object can be retrieved.
+        /// </summary>
+        [JsonProperty("url")]
+        [STJS.JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        internal StripeClient Client { get; set; }
+
+        /// <summary>
+        /// Fetches the full object this reference points to.
+        /// </summary>
+        /// <returns>The fully populated object.</returns>
+        /// <exception cref="Exception">Thrown when no client has been set on this instance.</exception>
+        public T Fetch()
+        {
+            return this.FetchAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Fetches the full object this reference points to as an asynchronous operation.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result is the fully populated object.</returns>
+        /// <exception cref="Exception">Thrown when no client has been set on this instance.</exception>
+        public async Task<T> FetchAsync(CancellationToken cancellationToken = default)
+        {
+            if (this.Client == null)
+            {
+                throw new Exception("Ref<T> is trying to make a request with no client.");
+            }
+
+            var res = await this.Client.RawRequestAsync(
+                HttpMethod.Get,
+                this.Url,
+                requestOptions: new RawRequestOptions
+                {
+                    Usage = new List<string> { "ref_fetch" },
+                },
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+            return this.Client.Deserialize<T>(res.Content);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/JsonConverters/STJRequestorInjectionConverterFactory.cs
+++ b/src/Stripe.net/Infrastructure/JsonConverters/STJRequestorInjectionConverterFactory.cs
@@ -1,0 +1,89 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using Stripe.V2;
+
+    /// <summary>
+    /// A <see cref="JsonConverterFactory"/> that, during deserialization, injects an
+    /// <see cref="ApiRequestor"/> into any entity that implements <see cref="IHasRequestor"/>.
+    /// Add an instance of this factory (with the desired requestor) to a cloned
+    /// <see cref="JsonSerializerOptions"/> before calling <c>JsonSerializer.Deserialize</c>.
+    /// </summary>
+#pragma warning disable SA1649 // File name should match first type name
+    internal class STJRequestorInjectionConverterFactory : JsonConverterFactory
+#pragma warning restore SA1649 // File name should match first type name
+    {
+        private static readonly Type IHasRequestorType = typeof(IHasRequestor);
+
+        private readonly ApiRequestor requestor;
+
+        public STJRequestorInjectionConverterFactory(ApiRequestor requestor)
+        {
+            this.requestor = requestor;
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return IHasRequestorType.GetTypeInfo().IsAssignableFrom(typeToConvert.GetTypeInfo());
+        }
+
+        public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
+        {
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
+            JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+                typeof(STJRequestorInjectionConverter<>).MakeGenericType(type),
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                args: new object[] { this.requestor, this },
+                culture: null)!;
+#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+
+            return converter;
+        }
+    }
+
+    /// <summary>
+    /// Deserializes a <typeparamref name="T"/> using options that exclude this factory (to avoid
+    /// infinite recursion), then injects the requestor.
+    /// </summary>
+    /// <typeparam name="T">An entity type that implements <see cref="IHasRequestor"/>.</typeparam>
+#pragma warning disable SA1402 // File may only contain a single type
+    internal class STJRequestorInjectionConverter<T> : JsonConverter<T>
+#pragma warning restore SA1402 // File may only contain a single type
+        where T : IHasRequestor
+    {
+        private readonly ApiRequestor requestor;
+        private readonly STJRequestorInjectionConverterFactory factory;
+
+        public STJRequestorInjectionConverter(ApiRequestor requestor, STJRequestorInjectionConverterFactory factory)
+        {
+            this.requestor = requestor;
+            this.factory = factory;
+        }
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Build inner options with this factory removed to prevent infinite recursion.
+            var innerOptions = new JsonSerializerOptions(options);
+            innerOptions.Converters.Remove(this.factory);
+
+            var result = (T)JsonSerializer.Deserialize(ref reader, typeToConvert, innerOptions);
+
+            if (result != null)
+            {
+                result.Requestor = this.requestor;
+            }
+
+            return result;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, typeof(T), options);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -277,8 +277,9 @@ namespace Stripe
             T obj;
             try
             {
-                obj = System.Text.Json.JsonSerializer.Deserialize<T>(
-                    response.Content, StripeConfiguration.SerializerOptions);
+                var opts = new System.Text.Json.JsonSerializerOptions(StripeConfiguration.SerializerOptions);
+                opts.Converters.Insert(0, new STJRequestorInjectionConverterFactory(this));
+                obj = System.Text.Json.JsonSerializer.Deserialize<T>(response.Content, opts);
             }
             catch (System.Text.Json.JsonException)
             {
@@ -292,16 +293,6 @@ namespace Stripe
             }
 
             obj.StripeResponse = response;
-
-            // Some deserialized types need a reference to the requestor (e.g. V2
-            // events use it to fetch related objects). Since STJ converters have no
-            // mechanism to pass ambient state during deserialization, we set it here
-            // after the fact. If a new type needs the requestor, add a check below
-            // and ensure the type exposes an internal Requestor property.
-            if (obj is V2.Core.Event v2Event)
-            {
-                v2Event.Requestor = this;
-            }
 
             return obj;
         }

--- a/src/StripeTests/Events/V2/RefTest.cs
+++ b/src/StripeTests/Events/V2/RefTest.cs
@@ -3,19 +3,18 @@ namespace StripeTests.V2
     using System;
     using System.Net;
     using System.Net.Http;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Stripe;
+    using Stripe.Infrastructure;
     using Stripe.V2;
     using Xunit;
 
     public class RefTest : BaseStripeTest
     {
-        private StripeClient stripeClient;
-
         public RefTest(MockHttpClientFixture mockHttpClientFixture)
             : base(mockHttpClientFixture)
         {
-            this.stripeClient = this.StripeClient as StripeClient;
         }
 
         [Fact]
@@ -36,7 +35,7 @@ namespace StripeTests.V2
         }
 
         [Fact]
-        public void FetchThrowsWithNoClient()
+        public void DeserializeViaRequestorInjectsRequestor()
         {
             var json = @"{
                 ""id"": ""fa_123"",
@@ -44,15 +43,20 @@ namespace StripeTests.V2
                 ""url"": ""/v2/financial_accounts/fa_123""
             }";
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
+            // Simulate how LiveApiRequestor.ProcessResponse deserializes: cloned options
+            // with the factory prepended.
+            var opts = new JsonSerializerOptions(StripeConfiguration.SerializerOptions);
+            opts.Converters.Insert(0, new STJRequestorInjectionConverterFactory(this.Requestor));
 
-            // Client is null — Fetch() should throw
-            var ex = Assert.Throws<Exception>(() => refObj.Fetch());
-            Assert.Contains("no client", ex.Message);
+            var refObj = JsonSerializer.Deserialize<Ref<Stripe.V2.Core.Account>>(json, opts);
+
+            Assert.NotNull(refObj);
+            Assert.Equal("fa_123", refObj.Id);
+            Assert.Same(this.Requestor, ((IHasRequestor)refObj).Requestor);
         }
 
         [Fact]
-        public async Task FetchAsyncThrowsWithNoClient()
+        public void FetchThrowsWithNoRequestor()
         {
             var json = @"{
                 ""id"": ""fa_123"",
@@ -62,9 +66,25 @@ namespace StripeTests.V2
 
             var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
 
-            // Client is null — FetchAsync() should throw
+            // Requestor is null — Fetch() should throw
+            var ex = Assert.Throws<Exception>(() => refObj.Fetch());
+            Assert.Contains("no requestor", ex.Message);
+        }
+
+        [Fact]
+        public async Task FetchAsyncThrowsWithNoRequestor()
+        {
+            var json = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
+
+            // Requestor is null — FetchAsync() should throw
             var ex = await Assert.ThrowsAsync<Exception>(() => refObj.FetchAsync());
-            Assert.Contains("no client", ex.Message);
+            Assert.Contains("no requestor", ex.Message);
         }
 
         [Fact]
@@ -89,7 +109,7 @@ namespace StripeTests.V2
                 responseJson);
 
             var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(refJson);
-            refObj.Client = this.stripeClient;
+            ((IHasRequestor)refObj).Requestor = this.Requestor;
 
             var result = await refObj.FetchAsync();
 
@@ -121,7 +141,7 @@ namespace StripeTests.V2
                 responseJson);
 
             var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(refJson);
-            refObj.Client = this.stripeClient;
+            ((IHasRequestor)refObj).Requestor = this.Requestor;
 
             var result = refObj.Fetch();
 

--- a/src/StripeTests/Events/V2/RefTest.cs
+++ b/src/StripeTests/Events/V2/RefTest.cs
@@ -4,10 +4,7 @@ namespace StripeTests.V2
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Moq;
-    using Moq.Protected;
     using Stripe;
-    using Stripe.Infrastructure;
     using Stripe.V2;
     using Xunit;
 
@@ -30,7 +27,7 @@ namespace StripeTests.V2
                 ""url"": ""/v2/financial_accounts/fa_123""
             }";
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
 
             Assert.NotNull(refObj);
             Assert.Equal("fa_123", refObj.Id);
@@ -47,7 +44,7 @@ namespace StripeTests.V2
                 ""url"": ""/v2/financial_accounts/fa_123""
             }";
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
 
             // Client is null — Fetch() should throw
             var ex = Assert.Throws<Exception>(() => refObj.Fetch());
@@ -63,7 +60,7 @@ namespace StripeTests.V2
                 ""url"": ""/v2/financial_accounts/fa_123""
             }";
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(json);
 
             // Client is null — FetchAsync() should throw
             var ex = await Assert.ThrowsAsync<Exception>(() => refObj.FetchAsync());
@@ -91,7 +88,7 @@ namespace StripeTests.V2
                 HttpStatusCode.OK,
                 responseJson);
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(refJson);
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(refJson);
             refObj.Client = this.stripeClient;
 
             var result = await refObj.FetchAsync();
@@ -123,7 +120,7 @@ namespace StripeTests.V2
                 HttpStatusCode.OK,
                 responseJson);
 
-            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(refJson);
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.Core.Account>>(refJson);
             refObj.Client = this.stripeClient;
 
             var result = refObj.Fetch();

--- a/src/StripeTests/Events/V2/RefTest.cs
+++ b/src/StripeTests/Events/V2/RefTest.cs
@@ -1,0 +1,137 @@
+namespace StripeTests.V2
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Moq;
+    using Moq.Protected;
+    using Stripe;
+    using Stripe.Infrastructure;
+    using Stripe.V2;
+    using Xunit;
+
+    public class RefTest : BaseStripeTest
+    {
+        private StripeClient stripeClient;
+
+        public RefTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.stripeClient = this.StripeClient as StripeClient;
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var json = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+
+            Assert.NotNull(refObj);
+            Assert.Equal("fa_123", refObj.Id);
+            Assert.Equal("financial_account", refObj.Type);
+            Assert.Equal("/v2/financial_accounts/fa_123", refObj.Url);
+        }
+
+        [Fact]
+        public void FetchThrowsWithNoClient()
+        {
+            var json = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+
+            // Client is null — Fetch() should throw
+            var ex = Assert.Throws<Exception>(() => refObj.Fetch());
+            Assert.Contains("no client", ex.Message);
+        }
+
+        [Fact]
+        public async Task FetchAsyncThrowsWithNoClient()
+        {
+            var json = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(json);
+
+            // Client is null — FetchAsync() should throw
+            var ex = await Assert.ThrowsAsync<Exception>(() => refObj.FetchAsync());
+            Assert.Contains("no client", ex.Message);
+        }
+
+        [Fact]
+        public async Task FetchAsyncGetsUrlAndDeserializes()
+        {
+            var refJson = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var responseJson = @"{
+                ""id"": ""fa_123"",
+                ""object"": ""financial_account"",
+                ""livemode"": false
+            }";
+
+            this.MockHttpClientFixture.StubRequest(
+                HttpMethod.Get,
+                "/v2/financial_accounts/fa_123",
+                HttpStatusCode.OK,
+                responseJson);
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(refJson);
+            refObj.Client = this.stripeClient;
+
+            var result = await refObj.FetchAsync();
+
+            Assert.NotNull(result);
+            Assert.Equal("fa_123", result.Id);
+
+            this.AssertRequest(HttpMethod.Get, "/v2/financial_accounts/fa_123");
+        }
+
+        [Fact]
+        public void FetchGetsUrlAndDeserializes()
+        {
+            var refJson = @"{
+                ""id"": ""fa_123"",
+                ""type"": ""financial_account"",
+                ""url"": ""/v2/financial_accounts/fa_123""
+            }";
+
+            var responseJson = @"{
+                ""id"": ""fa_123"",
+                ""object"": ""financial_account"",
+                ""livemode"": false
+            }";
+
+            this.MockHttpClientFixture.StubRequest(
+                HttpMethod.Get,
+                "/v2/financial_accounts/fa_123",
+                HttpStatusCode.OK,
+                responseJson);
+
+            var refObj = StripeEntity.FromJson<Ref<Stripe.V2.MoneyManagement.FinancialAccount>>(refJson);
+            refObj.Client = this.stripeClient;
+
+            var result = refObj.Fetch();
+
+            Assert.NotNull(result);
+            Assert.Equal("fa_123", result.Id);
+
+            this.AssertRequest(HttpMethod.Get, "/v2/financial_accounts/fa_123");
+        }
+    }
+}

--- a/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
+++ b/src/StripeTests/Wholesome/NewtonsoftAndSystemTextJsonOutputTheSameObject.cs
@@ -399,6 +399,17 @@ namespace StripeTests.Wholesome
             this.CheckOneStripeClass(searchResult, results);
             var searchResultType = searchResult.GetType();
             genericTypes.RemoveAll(gt => searchResultType.FullName.StartsWith(gt.FullName));
+
+            var refObj = new Stripe.V2.Ref<Stripe.V2.Core.Account>
+            {
+                Id = "fa_123",
+                Type = "financial_account",
+                Url = "/v2/financial_accounts/fa_123",
+            };
+
+            this.CheckOneStripeClass(refObj, results);
+            var refType = refObj.GetType();
+            genericTypes.RemoveAll(gt => refType.FullName.StartsWith(gt.FullName));
         }
     }
 }

--- a/src/StripeTests/Wholesome/WholesomeTest.cs
+++ b/src/StripeTests/Wholesome/WholesomeTest.cs
@@ -176,7 +176,12 @@ namespace StripeTests.Wholesome
             var nonpublicProperties = type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
             var allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-            return allProperties.Select(p => new ExtendedPropertyInfo(p, nonpublicProperties.Contains(p)));
+            // Explicit interface implementations have a '.' in their name (e.g.
+            // "Stripe.V2.IHasRequestor.Requestor"). They are not serialized fields and cannot
+            // carry Json attributes, so we exclude them from JSON attribute checks.
+            return allProperties
+                .Where(p => !p.Name.Contains('.'))
+                .Select(p => new ExtendedPropertyInfo(p, nonpublicProperties.Contains(p)));
         }
     }
 }


### PR DESCRIPTION
### Why?

Custom objects need typed references to other Stripe objects. A reference has the wire shape `{type, id, url}` and in the SDK becomes `Ref<T>` — a container that knows the target type and can fetch it.

### What?

- `Stripe.V2.Ref<T>` extending `StripeEntity<Ref<T>>` where `T : IStripeEntity`
- Implements `IHasRequestor` — requestor is auto-injected by `STJRequestorInjectionConverterFactory` during STJ deserialization
- `IHasRequestor` interface: any V2 entity that needs the requestor after deserialization (Ref and Event both implement it)
- `STJRequestorInjectionConverterFactory`: registered in `LiveApiRequestor.ProcessResponse` via cloned `JsonSerializerOptions`. Delegates to default STJ deserialization, then sets `Requestor` on any `IHasRequestor` result. Applies recursively to nested objects.
- `FetchAsync()` calls `Requestor.RequestAsync<T>(BaseAddress.Api, HttpMethod.Get, Url, ...)` — same pattern as `Event.FetchRelatedObjectAsync()`
- Replaces the per-type Event check in ProcessResponse with the generic `IHasRequestor` mechanism

### See Also

Generated with [Claude Code](https://claude.com/claude-code)