### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -2,10 +2,12 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
@@ -225,6 +227,18 @@ namespace Stripe
             }
         }
 
+        private static void MaybeEmitStripeNotice(HttpResponseHeaders headers)
+        {
+            if (headers != null && headers.Contains("Stripe-Notice"))
+            {
+                var notice = headers.GetValues("Stripe-Notice").FirstOrDefault();
+                if (notice != null)
+                {
+                    Trace.TraceWarning(notice);
+                }
+            }
+        }
+
         // Note: BaseOptions options really means query params here
         private StripeRequest MakeStripeRequest(
             BaseAddress baseAddress,
@@ -273,6 +287,8 @@ namespace Stripe
 
                 throw BuildStripeException(response);
             }
+
+            MaybeEmitStripeNotice(response.Headers);
 
             T obj;
             try
@@ -361,6 +377,8 @@ namespace Stripe
             {
                 throw BuildStripeException(response);
             }
+
+            MaybeEmitStripeNotice(response.Headers);
 
             return response;
         }

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -2,7 +2,6 @@ namespace Stripe
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -232,9 +231,9 @@ namespace Stripe
             if (headers != null && headers.Contains("Stripe-Notice"))
             {
                 var notice = headers.GetValues("Stripe-Notice").FirstOrDefault();
-                if (notice != null)
+                if (!string.IsNullOrEmpty(notice))
                 {
-                    Trace.TraceWarning(notice);
+                    Console.Error.WriteLine(notice);
                 }
             }
         }

--- a/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
+++ b/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
@@ -2,7 +2,6 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -714,14 +713,14 @@ namespace StripeTests
         }
 
         [Fact]
-        public async Task RequestAsync_EmitsTraceWarning_WhenStripeNoticeHeaderPresent()
+        public async Task RequestAsync_WritesToStderr_WhenStripeNoticeHeaderPresent()
         {
             var headers = BuildHeaders("Stripe-Notice", "test notice message");
             var response = new StripeResponse(HttpStatusCode.OK, headers, "{\"id\": \"ch_123\"}");
             this.httpClient.Response = response;
 
-            var listener = new CapturingTraceListener();
-            Trace.Listeners.Add(listener);
+            var stderr = new StringWriter();
+            Console.SetError(stderr);
             try
             {
                 await this.apiRequestor.RequestAsync<Charge>(
@@ -731,22 +730,22 @@ namespace StripeTests
                     this.options,
                     this.requestOptions);
 
-                Assert.Contains("test notice message", listener.Warnings);
+                Assert.Contains("test notice message", stderr.ToString());
             }
             finally
             {
-                Trace.Listeners.Remove(listener);
+                Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
             }
         }
 
         [Fact]
-        public async Task RequestAsync_NoTraceWarning_WhenStripeNoticeHeaderAbsent()
+        public async Task RequestAsync_NoStderrWrite_WhenStripeNoticeHeaderAbsent()
         {
             var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
             this.httpClient.Response = response;
 
-            var listener = new CapturingTraceListener();
-            Trace.Listeners.Add(listener);
+            var stderr = new StringWriter();
+            Console.SetError(stderr);
             try
             {
                 await this.apiRequestor.RequestAsync<Charge>(
@@ -756,23 +755,49 @@ namespace StripeTests
                     this.options,
                     this.requestOptions);
 
-                Assert.Empty(listener.Warnings);
+                Assert.Empty(stderr.ToString());
             }
             finally
             {
-                Trace.Listeners.Remove(listener);
+                Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
             }
         }
 
         [Fact]
-        public async Task RawRequestAsync_EmitsTraceWarning_WhenStripeNoticeHeaderPresent()
+        public async Task RequestAsync_NoStderrWrite_WhenStripeNoticeHeaderEmpty()
+        {
+            var headers = BuildHeaders("Stripe-Notice", string.Empty);
+            var response = new StripeResponse(HttpStatusCode.OK, headers, "{\"id\": \"ch_123\"}");
+            this.httpClient.Response = response;
+
+            var stderr = new StringWriter();
+            Console.SetError(stderr);
+            try
+            {
+                await this.apiRequestor.RequestAsync<Charge>(
+                    BaseAddress.Api,
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions);
+
+                Assert.Empty(stderr.ToString());
+            }
+            finally
+            {
+                Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+            }
+        }
+
+        [Fact]
+        public async Task RawRequestAsync_WritesToStderr_WhenStripeNoticeHeaderPresent()
         {
             var headers = BuildHeaders("Stripe-Notice", "raw notice message");
             var response = new StripeResponse(HttpStatusCode.OK, headers, "{\"id\": \"ch_123\"}");
             this.httpClient.Response = response;
 
-            var listener = new CapturingTraceListener();
-            Trace.Listeners.Add(listener);
+            var stderr = new StringWriter();
+            Console.SetError(stderr);
             try
             {
                 await this.apiRequestor.RawRequestAsync(
@@ -780,22 +805,22 @@ namespace StripeTests
                     "/v1/charges",
                     "foo=bar");
 
-                Assert.Contains("raw notice message", listener.Warnings);
+                Assert.Contains("raw notice message", stderr.ToString());
             }
             finally
             {
-                Trace.Listeners.Remove(listener);
+                Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
             }
         }
 
         [Fact]
-        public async Task RawRequestAsync_NoTraceWarning_WhenStripeNoticeHeaderAbsent()
+        public async Task RawRequestAsync_NoStderrWrite_WhenStripeNoticeHeaderAbsent()
         {
             var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
             this.httpClient.Response = response;
 
-            var listener = new CapturingTraceListener();
-            Trace.Listeners.Add(listener);
+            var stderr = new StringWriter();
+            Console.SetError(stderr);
             try
             {
                 await this.apiRequestor.RawRequestAsync(
@@ -803,11 +828,11 @@ namespace StripeTests
                     "/v1/charges",
                     "foo=bar");
 
-                Assert.Empty(listener.Warnings);
+                Assert.Empty(stderr.ToString());
             }
             finally
             {
-                Trace.Listeners.Remove(listener);
+                Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
             }
         }
 
@@ -816,32 +841,6 @@ namespace StripeTests
             var message = new HttpResponseMessage();
             message.Headers.Add(name, value);
             return message.Headers;
-        }
-
-        private class CapturingTraceListener : TraceListener
-        {
-            public List<string> Warnings { get; } = new List<string>();
-
-            public override void TraceEvent(
-                TraceEventCache eventCache,
-                string source,
-                TraceEventType eventType,
-                int id,
-                string message)
-            {
-                if (eventType == TraceEventType.Warning)
-                {
-                    this.Warnings.Add(message);
-                }
-            }
-
-            public override void Write(string message)
-            {
-            }
-
-            public override void WriteLine(string message)
-            {
-            }
         }
 
         private class Foo : StripeEntity<Foo>

--- a/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
+++ b/src/StripeTests/Infrastructure/Public/LiveApiRequestorTest.cs
@@ -2,10 +2,12 @@ namespace StripeTests
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -709,6 +711,137 @@ namespace StripeTests
             await service.CreateAsync(new CustomerCreateOptions() { }, new RequestOptions { StripeAccount = "acct_2345" });
             lastRequest = this.httpClient.LastRequest;
             Assert.Equal("acct_2345", lastRequest.StripeHeaders["Stripe-Account"]);
+        }
+
+        [Fact]
+        public async Task RequestAsync_EmitsTraceWarning_WhenStripeNoticeHeaderPresent()
+        {
+            var headers = BuildHeaders("Stripe-Notice", "test notice message");
+            var response = new StripeResponse(HttpStatusCode.OK, headers, "{\"id\": \"ch_123\"}");
+            this.httpClient.Response = response;
+
+            var listener = new CapturingTraceListener();
+            Trace.Listeners.Add(listener);
+            try
+            {
+                await this.apiRequestor.RequestAsync<Charge>(
+                    BaseAddress.Api,
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions);
+
+                Assert.Contains("test notice message", listener.Warnings);
+            }
+            finally
+            {
+                Trace.Listeners.Remove(listener);
+            }
+        }
+
+        [Fact]
+        public async Task RequestAsync_NoTraceWarning_WhenStripeNoticeHeaderAbsent()
+        {
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            this.httpClient.Response = response;
+
+            var listener = new CapturingTraceListener();
+            Trace.Listeners.Add(listener);
+            try
+            {
+                await this.apiRequestor.RequestAsync<Charge>(
+                    BaseAddress.Api,
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    this.options,
+                    this.requestOptions);
+
+                Assert.Empty(listener.Warnings);
+            }
+            finally
+            {
+                Trace.Listeners.Remove(listener);
+            }
+        }
+
+        [Fact]
+        public async Task RawRequestAsync_EmitsTraceWarning_WhenStripeNoticeHeaderPresent()
+        {
+            var headers = BuildHeaders("Stripe-Notice", "raw notice message");
+            var response = new StripeResponse(HttpStatusCode.OK, headers, "{\"id\": \"ch_123\"}");
+            this.httpClient.Response = response;
+
+            var listener = new CapturingTraceListener();
+            Trace.Listeners.Add(listener);
+            try
+            {
+                await this.apiRequestor.RawRequestAsync(
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    "foo=bar");
+
+                Assert.Contains("raw notice message", listener.Warnings);
+            }
+            finally
+            {
+                Trace.Listeners.Remove(listener);
+            }
+        }
+
+        [Fact]
+        public async Task RawRequestAsync_NoTraceWarning_WhenStripeNoticeHeaderAbsent()
+        {
+            var response = new StripeResponse(HttpStatusCode.OK, null, "{\"id\": \"ch_123\"}");
+            this.httpClient.Response = response;
+
+            var listener = new CapturingTraceListener();
+            Trace.Listeners.Add(listener);
+            try
+            {
+                await this.apiRequestor.RawRequestAsync(
+                    HttpMethod.Post,
+                    "/v1/charges",
+                    "foo=bar");
+
+                Assert.Empty(listener.Warnings);
+            }
+            finally
+            {
+                Trace.Listeners.Remove(listener);
+            }
+        }
+
+        private static HttpResponseHeaders BuildHeaders(string name, string value)
+        {
+            var message = new HttpResponseMessage();
+            message.Headers.Add(name, value);
+            return message.Headers;
+        }
+
+        private class CapturingTraceListener : TraceListener
+        {
+            public List<string> Warnings { get; } = new List<string>();
+
+            public override void TraceEvent(
+                TraceEventCache eventCache,
+                string source,
+                TraceEventType eventType,
+                int id,
+                string message)
+            {
+                if (eventType == TraceEventType.Warning)
+                {
+                    this.Warnings.Add(message);
+                }
+            }
+
+            public override void Write(string message)
+            {
+            }
+
+            public override void WriteLine(string message)
+            {
+            }
         }
 
         private class Foo : StripeEntity<Foo>


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response. **Note** this is the first warning we're emitting in this SDK, so make sure it's the correct way to do that!
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
