### PR TITLE
Fix V2 namespace singularization

### DIFF
--- a/src/Stripe.net/Services/V2/PaymentsService.cs
+++ b/src/Stripe.net/Services/V2/PaymentsService.cs
@@ -5,17 +5,17 @@ namespace Stripe.V2
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class PaymentService : Service
+    public class PaymentsService : Service
     {
         private V2.Payments.OffSessionPaymentService offSessionPayments;
         private V2.Payments.SettlementAllocationIntentService settlementAllocationIntents;
 
-        internal PaymentService(ApiRequestor requestor)
+        internal PaymentsService(ApiRequestor requestor)
             : base(requestor)
         {
         }
 
-        internal PaymentService(IStripeClient client)
+        internal PaymentsService(IStripeClient client)
             : base(client)
         {
         }

--- a/src/Stripe.net/Services/V2/SignalsService.cs
+++ b/src/Stripe.net/Services/V2/SignalsService.cs
@@ -5,16 +5,16 @@ namespace Stripe.V2
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class SignalService : Service
+    public class SignalsService : Service
     {
         private V2.Signals.AccountSignalService accountSignals;
 
-        internal SignalService(ApiRequestor requestor)
+        internal SignalsService(ApiRequestor requestor)
             : base(requestor)
         {
         }
 
-        internal SignalService(IStripeClient client)
+        internal SignalsService(IStripeClient client)
             : base(client)
         {
         }

--- a/src/Stripe.net/Services/V2Services.cs
+++ b/src/Stripe.net/Services/V2Services.cs
@@ -16,9 +16,9 @@ namespace Stripe
         private V2.MoneyManagementService moneyManagement;
         private V2.NetworkService network;
         private V2.OrchestratedCommerceService orchestratedCommerce;
-        private V2.PaymentService payments;
+        private V2.PaymentsService payments;
         private V2.ReportingService reporting;
-        private V2.SignalService signals;
+        private V2.SignalsService signals;
         private V2.TaxService tax;
         private V2.TestHelperService testHelpers;
 
@@ -59,13 +59,13 @@ namespace Stripe
         public virtual V2.OrchestratedCommerceService OrchestratedCommerce => this.orchestratedCommerce ??= new V2.OrchestratedCommerceService(
             this.Requestor);
 
-        public virtual V2.PaymentService Payments => this.payments ??= new V2.PaymentService(
+        public virtual V2.PaymentsService Payments => this.payments ??= new V2.PaymentsService(
             this.Requestor);
 
         public virtual V2.ReportingService Reporting => this.reporting ??= new V2.ReportingService(
             this.Requestor);
 
-        public virtual V2.SignalService Signals => this.signals ??= new V2.SignalService(
+        public virtual V2.SignalsService Signals => this.signals ??= new V2.SignalsService(
             this.Requestor);
 
         public virtual V2.TaxService Tax => this.tax ??= new V2.TaxService(


### PR DESCRIPTION
### Why?

The codegen incorrectly singularized V2 namespace-promoted service names (`PaymentService` instead of `PaymentsService`). This was a latent bug that only manifested when new V2 namespaces were added.

### What?

- Renames `V2.PaymentService` to `V2.PaymentsService`

### See Also

## Changelog

- ⚠️ Rename `V2.PaymentService` to `V2.PaymentsService` to more closely match our API naming