### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -8,6 +8,8 @@ namespace Stripe
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Security.Cryptography;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
@@ -133,6 +135,9 @@ namespace Stripe
         /// </summary>
         public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
 
+        /// <summary>Gets or sets the cached source hash. Internal for testing.</summary>
+        internal static string SourceHash { get; set; } = ComputeSourceHash();
+
         /// <summary>
         /// Gets whether telemetry was enabled for this client.
         /// </summary>
@@ -222,6 +227,35 @@ namespace Stripe
             return string.Empty;
         }
 
+        internal static string ComputeSourceHash()
+        {
+            try
+            {
+                var parts = new System.Collections.Generic.List<string>
+                {
+                    System.Runtime.InteropServices.RuntimeInformation.OSDescription,
+                };
+                try
+                {
+                    parts.Add(Environment.MachineName);
+                }
+                catch
+                {
+                }
+
+                var inputBytes = Encoding.UTF8.GetBytes(string.Join(" ", parts));
+                using (var md5 = MD5.Create())
+                {
+                    var hashBytes = md5.ComputeHash(inputBytes);
+                    return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+                }
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
         private async Task<(HttpResponseMessage responseMessage, int retries)> SendHttpRequest(
             StripeRequest request,
             CancellationToken cancellationToken)
@@ -297,6 +331,10 @@ namespace Stripe
                 { "lang", ".net" },
                 { "stripe_net_target_framework", StripeNetTargetFramework },
             };
+            if (!string.IsNullOrEmpty(SourceHash))
+            {
+                values["source"] = SourceHash;
+            }
 
             // The following values are in try/catch blocks on the off chance that the
             // RuntimeInformation methods fail in an unexpected way. This should ~never happen, but

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -135,7 +135,7 @@ namespace Stripe
         /// </summary>
         public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
 
-        /// <summary>Gets or sets the cached source hash. Internal for testing.</summary>
+        /// <summary>Gets or sets the cached source hash.</summary>
         internal static string SourceHash { get; set; } = ComputeSourceHash();
 
         /// <summary>

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -135,6 +135,96 @@ namespace StripeTests
         }
 
         [Fact]
+        public void SourceHashIsHexString()
+        {
+            var hash = SystemNetHttpClient.ComputeSourceHash();
+
+            // MD5 produces 16 bytes → 32 hex characters
+            Assert.NotNull(hash);
+            Assert.Equal(32, hash.Length);
+            Assert.Matches("^[0-9a-f]{32}$", hash);
+        }
+
+        [Fact]
+        public void SourceHashIsDeterministic()
+        {
+            var hash1 = SystemNetHttpClient.ComputeSourceHash();
+            var hash2 = SystemNetHttpClient.ComputeSourceHash();
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Fact]
+        public async Task SourceHashIncludedInUserAgentHeader()
+        {
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Content = new StringContent("Hello world!");
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(responseMessage));
+
+            var client = new SystemNetHttpClient(
+                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
+            var request = new StripeRequest(
+                this.StripeClient,
+                HttpMethod.Post,
+                "/foo",
+                null,
+                null);
+            await client.MakeRequestAsync(request);
+
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m => this.VerifySourceHeader(m.Headers)),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task SourceHashAbsentFromUserAgentWhenEmpty()
+        {
+            var savedHash = SystemNetHttpClient.SourceHash;
+            try
+            {
+                SystemNetHttpClient.SourceHash = string.Empty;
+
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                responseMessage.Content = new StringContent("Hello world!");
+                this.MockHttpClientFixture.MockHandler.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>())
+                    .Returns(Task.FromResult(responseMessage));
+
+                var client = new SystemNetHttpClient(
+                    httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
+                var request = new StripeRequest(
+                    this.StripeClient,
+                    HttpMethod.Post,
+                    "/foo",
+                    null,
+                    null);
+                await client.MakeRequestAsync(request);
+
+                this.MockHttpClientFixture.MockHandler.Protected()
+                    .Verify(
+                        "SendAsync",
+                        Times.Once(),
+                        ItExpr.Is<HttpRequestMessage>(m => this.VerifyNoSourceHeader(m.Headers)),
+                        ItExpr.IsAny<CancellationToken>());
+            }
+            finally
+            {
+                SystemNetHttpClient.SourceHash = savedHash;
+            }
+        }
+
+        [Fact]
         public void TestDetectAIAgent()
         {
             var result = SystemNetHttpClient.DetectAIAgent(
@@ -269,6 +359,26 @@ namespace StripeTests
 
             Assert.Contains("AIAgent/claude_code", userAgent);
             Assert.Equal("claude_code", userAgentJson.Value<string>("ai_agent"));
+
+            return true;
+        }
+
+        private bool VerifySourceHeader(HttpRequestHeaders headers)
+        {
+            var userAgentJson = JObject.Parse(headers.GetValues("X-Stripe-Client-User-Agent").First());
+            var source = userAgentJson.Value<string>("source");
+
+            Assert.NotNull(source);
+            Assert.Matches("^[0-9a-f]{32}$", source);
+
+            return true;
+        }
+
+        private bool VerifyNoSourceHeader(HttpRequestHeaders headers)
+        {
+            var userAgentJson = JObject.Parse(headers.GetValues("X-Stripe-Client-User-Agent").First());
+
+            Assert.Null(userAgentJson["source"]);
 
             return true;
         }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
