### PR TITLE
⚠️ Make `tax_rate.tax_details` expandable

### DIFF
--- a/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItemTaxTaxRateDetails.cs
+++ b/src/Stripe.net/Entities/CreditNoteLineItems/CreditNoteLineItemTaxTaxRateDetails.cs
@@ -8,11 +8,39 @@ namespace Stripe
     [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
     public class CreditNoteLineItemTaxTaxRateDetails : StripeEntity<CreditNoteLineItemTaxTaxRateDetails>
     {
+        #region Expandable TaxRate
+
         /// <summary>
+        /// (ID of the TaxRate)
         /// ID of the tax rate.
         /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the tax rate.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
+        }
+
         [JsonProperty("tax_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
         [STJS.JsonPropertyName("tax_rate")]
-        public string TaxRate { get; set; }
+        [STJS.JsonConverter(typeof(STJExpandableFieldConverter<TaxRate>))]
+        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
+        #endregion
     }
 }

--- a/src/Stripe.net/Entities/CreditNotes/CreditNoteTotalTaxTaxRateDetails.cs
+++ b/src/Stripe.net/Entities/CreditNotes/CreditNoteTotalTaxTaxRateDetails.cs
@@ -8,11 +8,39 @@ namespace Stripe
     [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
     public class CreditNoteTotalTaxTaxRateDetails : StripeEntity<CreditNoteTotalTaxTaxRateDetails>
     {
+        #region Expandable TaxRate
+
         /// <summary>
+        /// (ID of the TaxRate)
         /// ID of the tax rate.
         /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the tax rate.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
+        }
+
         [JsonProperty("tax_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
         [STJS.JsonPropertyName("tax_rate")]
-        public string TaxRate { get; set; }
+        [STJS.JsonConverter(typeof(STJExpandableFieldConverter<TaxRate>))]
+        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
+        #endregion
     }
 }

--- a/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemTaxTaxRateDetails.cs
+++ b/src/Stripe.net/Entities/InvoiceLineItems/InvoiceLineItemTaxTaxRateDetails.cs
@@ -8,11 +8,39 @@ namespace Stripe
     [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
     public class InvoiceLineItemTaxTaxRateDetails : StripeEntity<InvoiceLineItemTaxTaxRateDetails>
     {
+        #region Expandable TaxRate
+
         /// <summary>
+        /// (ID of the TaxRate)
         /// ID of the tax rate.
         /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the tax rate.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
+        }
+
         [JsonProperty("tax_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
         [STJS.JsonPropertyName("tax_rate")]
-        public string TaxRate { get; set; }
+        [STJS.JsonConverter(typeof(STJExpandableFieldConverter<TaxRate>))]
+        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
+        #endregion
     }
 }

--- a/src/Stripe.net/Entities/Invoices/InvoiceTotalTaxTaxRateDetails.cs
+++ b/src/Stripe.net/Entities/Invoices/InvoiceTotalTaxTaxRateDetails.cs
@@ -8,11 +8,39 @@ namespace Stripe
     [STJS.JsonConverter(typeof(STJStripeEntityConverter))]
     public class InvoiceTotalTaxTaxRateDetails : StripeEntity<InvoiceTotalTaxTaxRateDetails>
     {
+        #region Expandable TaxRate
+
         /// <summary>
+        /// (ID of the TaxRate)
         /// ID of the tax rate.
         /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public string TaxRateId
+        {
+            get => this.InternalTaxRate?.Id;
+            set => this.InternalTaxRate = SetExpandableFieldId(value, this.InternalTaxRate);
+        }
+
+        /// <summary>
+        /// (Expanded)
+        /// ID of the tax rate.
+        ///
+        /// For more information, see the <a href="https://stripe.com/docs/expand">expand documentation</a>.
+        /// </summary>
+        [JsonIgnore]
+        [STJS.JsonIgnore]
+        public TaxRate TaxRate
+        {
+            get => this.InternalTaxRate?.ExpandedObject;
+            set => this.InternalTaxRate = SetExpandableFieldObject(value, this.InternalTaxRate);
+        }
+
         [JsonProperty("tax_rate")]
+        [JsonConverter(typeof(ExpandableFieldConverter<TaxRate>))]
         [STJS.JsonPropertyName("tax_rate")]
-        public string TaxRate { get; set; }
+        [STJS.JsonConverter(typeof(STJExpandableFieldConverter<TaxRate>))]
+        internal ExpandableField<TaxRate> InternalTaxRate { get; set; }
+        #endregion
     }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In the recent `2026-04-22.dahlia` API version, we made `tax_details` [expandable wherever they appear](https://docs.stripe.com/changelog/dahlia/2026-04-22/adds-expandable-tax-rate-property-to-tax-rate-details). Changing the type of a field is a breaking change in the SDKs, so the team made the decision to hold that field change out of the SDKs until our next major version in September (which is a fairly common pattern for us).

We figured that by keeping the field as as string, existing users wouldn't have to navigate a breaking change, but users who wanted to could expand and use as needed (after doing some manual type casting). This _is_ true for our interpreted SDKs, but isn't in the compiled ones. In compiled SDKs, expanding `tax_details` fails at runtime because we try to deserialize an object into a string.

The feature needs to work, so we're biting the bullet and doing an out-of-band major in our compiled languages.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- regenerate SDK, which converts 4 usages of `tax_rate.tax_details` into expandable fields

### See Also

<!-- Include any links or additional information that help explain this change. -->
