### PR TITLE
Upgrade CI runners from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
   build:
     name: Build
     needs: [test, test-net462, prepare-dotnet-versions]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -213,7 +213,7 @@ jobs:
     name: Pack NuGet
     if: (((github.event_name == 'push') || (github.event_name == 'workflow_dispatch')) && startsWith(github.ref, 'refs/tags/v'))
     needs: [build, prepare-dotnet-versions]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Why?
ubuntu-22.04 is EOL next year and our more powerful runners are already on ubuntu-24.04.  this upgrades stripe-dotnet to ubuntu-24.04 so we can stay ahead of the EOL and standardize on a single runner version

### What?
- `build` job: `ubuntu-22.04` → `ubuntu-24.04`
- `pack` job: `ubuntu-22.04` → `ubuntu-24.04`

### See Also
- DEVSDK-2337: https://go/j/DEVSDK-2337