### PR TITLE
Make Error fields generated

### DIFF
--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -6,34 +6,43 @@ namespace Stripe
 
     public class StripeError : StripeEntity<StripeError>
     {
-        /*
-         * For regular API errors:
-         */
+        // errorFields: The beginning of the section generated from our OpenAPI spec
 
-        /// <summary>For card errors, the ID of the failed charge.</summary>
+        /// <summary>
+        /// For card errors resulting from a card issuer decline, a short string indicating <a
+        /// href="https://docs.stripe.com/declines#retrying-issuer-declines">how to proceed with an
+        /// error</a> if they provide one.
+        /// </summary>
+        [JsonProperty("advice_code")]
+        [STJS.JsonPropertyName("advice_code")]
+        public string AdviceCode { get; set; }
+
+        /// <summary>
+        /// For card errors, the ID of the failed charge.
+        /// </summary>
         [JsonProperty("charge")]
         [STJS.JsonPropertyName("charge")]
         public string Charge { get; set; }
 
         /// <summary>
-        /// For some errors that could be handled programmatically, a short string indicating the
-        /// <a href="https://stripe.com/docs/error-codes">error code</a> reported.
+        /// For some errors that could be handled programmatically, a short string indicating the <a
+        /// href="https://docs.stripe.com/error-codes">error code</a> reported.
         /// </summary>
         [JsonProperty("code")]
         [STJS.JsonPropertyName("code")]
         public string Code { get; set; }
 
         /// <summary>
-        /// For card errors resulting from a card issuer decline, a short string indicating the
-        /// <a href="https://stripe.com//docs/declines#issuer-declines">card issuer's reason for the
-        /// decline</a>.
+        /// For card errors resulting from a card issuer decline, a short string indicating the <a
+        /// href="https://docs.stripe.com/declines#issuer-declines">card issuer's reason for the
+        /// decline</a> if they provide one.
         /// </summary>
         [JsonProperty("decline_code")]
         [STJS.JsonPropertyName("decline_code")]
         public string DeclineCode { get; set; }
 
         /// <summary>
-        /// A URL to more information about the <a href="https://stripe.com/docs/error-codes">error
+        /// A URL to more information about the <a href="https://docs.stripe.com/error-codes">error
         /// code</a> reported.
         /// </summary>
         [JsonProperty("doc_url")]
@@ -49,24 +58,38 @@ namespace Stripe
         public string Message { get; set; }
 
         /// <summary>
-        /// If the error is parameter-specific, the parameter related to the error. For example,
-        /// you can use this to display a message near the correct form field.
+        /// For card errors resulting from a card issuer decline, a 2 digit code which indicates the
+        /// advice given to merchant by the card network on how to proceed with an error.
+        /// </summary>
+        [JsonProperty("network_advice_code")]
+        [STJS.JsonPropertyName("network_advice_code")]
+        public string NetworkAdviceCode { get; set; }
+
+        /// <summary>
+        /// For payments declined by the network, an alphanumeric code which indicates the reason
+        /// the payment failed.
+        /// </summary>
+        [JsonProperty("network_decline_code")]
+        [STJS.JsonPropertyName("network_decline_code")]
+        public string NetworkDeclineCode { get; set; }
+
+        /// <summary>
+        /// If the error is parameter-specific, the parameter related to the error. For example, you
+        /// can use this to display a message near the correct form field.
         /// </summary>
         [JsonProperty("param")]
         [STJS.JsonPropertyName("param")]
         public string Param { get; set; }
 
         /// <summary>
-        /// The <see cref="Stripe.PaymentIntent"/> object for errors returned on a request
-        /// involving a <see cref="Stripe.PaymentIntent"/>.
+        /// The PaymentIntent object for errors returned on a request involving a PaymentIntent.
         /// </summary>
         [JsonProperty("payment_intent")]
         [STJS.JsonPropertyName("payment_intent")]
         public PaymentIntent PaymentIntent { get; set; }
 
         /// <summary>
-        /// The <see cref="Stripe.PaymentMethod"/> object for errors returned on a request
-        /// involving a <see cref="Stripe.PaymentMethod"/>.
+        /// The PaymentMethod object for errors returned on a request involving a PaymentMethod.
         /// </summary>
         [JsonProperty("payment_method")]
         [STJS.JsonPropertyName("payment_method")]
@@ -88,15 +111,14 @@ namespace Stripe
         public string RequestLogUrl { get; set; }
 
         /// <summary>
-        /// The <see cref="Stripe.SetupIntent"/> object for errors returned on a request
-        /// involving a <see cref="Stripe.SetupIntent"/>.
+        /// The SetupIntent object for errors returned on a request involving a SetupIntent.
         /// </summary>
         [JsonProperty("setup_intent")]
         [STJS.JsonPropertyName("setup_intent")]
         public SetupIntent SetupIntent { get; set; }
 
         /// <summary>
-        /// The source object for errors returned on a request involving a source.
+        /// The PaymentSource object for errors returned on a request involving a PaymentSource.
         /// </summary>
         [JsonProperty("source")]
         [JsonConverter(typeof(StripeObjectConverter))]
@@ -110,6 +132,15 @@ namespace Stripe
         [JsonProperty("type")]
         [STJS.JsonPropertyName("type")]
         public string Type { get; set; }
+
+        /// <summary>
+        /// The user message associated with the error.
+        /// </summary>
+        [JsonProperty("user_message")]
+        [STJS.JsonPropertyName("user_message")]
+        public string UserMessage { get; set; }
+
+        // errorFields: The end of the section generated from our OpenAPI spec
 
         /*
          * For OAuth Errors:

--- a/src/Stripe.net/Entities/StripeError.cs
+++ b/src/Stripe.net/Entities/StripeError.cs
@@ -82,14 +82,16 @@ namespace Stripe
         public string Param { get; set; }
 
         /// <summary>
-        /// The PaymentIntent object for errors returned on a request involving a PaymentIntent.
+        /// The <see cref="Stripe.PaymentIntent"/> object for errors returned on a request involving
+        /// a <see cref="Stripe.PaymentIntent"/>.
         /// </summary>
         [JsonProperty("payment_intent")]
         [STJS.JsonPropertyName("payment_intent")]
         public PaymentIntent PaymentIntent { get; set; }
 
         /// <summary>
-        /// The PaymentMethod object for errors returned on a request involving a PaymentMethod.
+        /// The <see cref="Stripe.PaymentMethod"/> object for errors returned on a request involving
+        /// a <see cref="Stripe.PaymentMethod"/>.
         /// </summary>
         [JsonProperty("payment_method")]
         [STJS.JsonPropertyName("payment_method")]
@@ -111,7 +113,8 @@ namespace Stripe
         public string RequestLogUrl { get; set; }
 
         /// <summary>
-        /// The SetupIntent object for errors returned on a request involving a SetupIntent.
+        /// The <see cref="Stripe.SetupIntent"/> object for errors returned on a request involving a
+        /// <see cref="Stripe.SetupIntent"/>.
         /// </summary>
         [JsonProperty("setup_intent")]
         [STJS.JsonPropertyName("setup_intent")]

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -1,7 +1,7 @@
 namespace StripeTests
 {
+    using System.Text.Json;
     using System.Threading.Tasks;
-    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -32,7 +32,7 @@ namespace StripeTests
         public void DeserializesNetworkAdviceCode()
         {
             var json = "{\"type\": \"card_error\", \"network_advice_code\": \"02\"}";
-            var error = JsonConvert.DeserializeObject<StripeError>(json);
+            var error = JsonSerializer.Deserialize<StripeError>(json);
             Assert.Equal("02", error.NetworkAdviceCode);
         }
 
@@ -40,7 +40,7 @@ namespace StripeTests
         public void DeserializesPaymentIntent()
         {
             var json = "{\"type\": \"card_error\", \"payment_intent\": {\"id\": \"pi_123\", \"object\": \"payment_intent\", \"amount\": 1000}}";
-            var error = JsonConvert.DeserializeObject<StripeError>(json);
+            var error = JsonSerializer.Deserialize<StripeError>(json);
             Assert.NotNull(error.PaymentIntent);
             Assert.Equal("pi_123", error.PaymentIntent.Id);
             Assert.Equal(1000, error.PaymentIntent.Amount);

--- a/src/StripeTests/Infrastructure/StripeExceptionTest.cs
+++ b/src/StripeTests/Infrastructure/StripeExceptionTest.cs
@@ -1,6 +1,7 @@
 namespace StripeTests
 {
     using System.Threading.Tasks;
+    using Newtonsoft.Json;
     using Stripe;
     using Xunit;
 
@@ -25,6 +26,24 @@ namespace StripeTests
             Assert.NotNull(exception);
             Assert.NotNull(exception.StripeError);
             Assert.NotNull(exception.StripeError.StripeResponse);
+        }
+
+        [Fact]
+        public void DeserializesNetworkAdviceCode()
+        {
+            var json = "{\"type\": \"card_error\", \"network_advice_code\": \"02\"}";
+            var error = JsonConvert.DeserializeObject<StripeError>(json);
+            Assert.Equal("02", error.NetworkAdviceCode);
+        }
+
+        [Fact]
+        public void DeserializesPaymentIntent()
+        {
+            var json = "{\"type\": \"card_error\", \"payment_intent\": {\"id\": \"pi_123\", \"object\": \"payment_intent\", \"amount\": 1000}}";
+            var error = JsonConvert.DeserializeObject<StripeError>(json);
+            Assert.NotNull(error.PaymentIntent);
+            Assert.Equal("pi_123", error.PaymentIntent.Id);
+            Assert.Equal(1000, error.PaymentIntent.Amount);
         }
     }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our main API Error class has always been handwritten. As new fields have been added to `api_errors` in the spec over time (e.g. `advice_code`, `network_advice_code`, `network_decline_code`), we haven't picked them up in the SDKs.

This makes most of those properties generated so they stay in sync.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Makes the fields on the API error object generated from the OpenAPI spec
- Adds section markers so codegen can maintain these fields going forward
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2568](https://go/j/RUN_DEVSDK-2568)
- https://github.com/stripe/stripe-go/issues/2384
