### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,56 +42,9 @@ jobs:
           test_matrix=`just print_test_matrix_json`
           echo "test_matrix=$test_matrix" >> $GITHUB_OUTPUT
 
-  fetch-openapi:
-    name: Fetch OpenAPI spec
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - name: Determine OpenAPI versions and download specs
-        run: |
-          set -e -o pipefail
-
-          CURL_OPTS=(--retry 3 \
-            --retry-all-errors \
-            --fail \
-            --verbose \
-            --no-progress-meter \
-            --show-error)
-
-          LATEST_OPENAPI_VERSION=$(curl https://api.github.com/repos/stripe/openapi/releases/latest -s | jq .name -r)
-          CURRENT_OPENAPI_VERSION=$(cat OPENAPI_VERSION)
-          if [[ "$PR_BODY" == *"TEST USING LATEST OPENAPI"* ]]; then
-            OPENAPI_VERSION=$LATEST_OPENAPI_VERSION
-          else
-            OPENAPI_VERSION=$CURRENT_OPENAPI_VERSION
-          fi
-
-          SPEC_NAME="spec3.sdk.yaml"
-          FIXTURES_NAME="fixtures3.json"
-          if [[ "$GITHUB_BASE" == *"b"* ]]; then
-            SPEC_NAME="spec3.beta.sdk.yaml"
-            FIXTURES_NAME="fixtures3.beta.json"
-          fi
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/$OPENAPI_VERSION/openapi/${SPEC_NAME%.yaml}.json -o latest.json
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/$OPENAPI_VERSION/openapi/$FIXTURES_NAME -o fixtures.json
-
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          GITHUB_BASE: ${{ github.base_ref || github.ref_name }}
-
-      - name: Upload OpenAPI spec
-        uses: actions/upload-artifact@v4
-        with:
-          name: openapi-spec
-          path: |
-            latest.json
-            fixtures.json
-
   test:
-    name: Test (${{ matrix.framework }})
-    needs: [prepare-dotnet-versions, fetch-openapi]
+    name: Test (${{ matrix.framework }}, ubuntu)
+    needs: [prepare-dotnet-versions]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -126,23 +79,14 @@ jobs:
           echo "Building ${{ matrix.framework }} using dotnet v$(dotnet --version)"
           dotnet build src/StripeTests/StripeTests.csproj -c Release -f ${{ matrix.framework }} /p:ContinuousIntegrationBuild=true
 
-      - name: Download OpenAPI spec
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi-spec
-
       - uses: stripe/openapi/actions/stripe-mock@master
-        with:
-          base: ${{ github.base_ref || github.ref_name }}
-          fixtures: "/workspace/fixtures.json"
-          spec_path: "/workspace/latest.json"
 
       - name: Run tests
         run: dotnet test --no-build -f ${{ matrix.framework }} src/StripeTests/StripeTests.csproj -c Release
 
   test-net462:
-    name: Test (net462)
-    needs: [prepare-dotnet-versions, fetch-openapi]
+    name: Test (net462, windows)
+    needs: [prepare-dotnet-versions]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -163,27 +107,7 @@ jobs:
           echo "Building net462 using dotnet v$(dotnet --version)"
           dotnet build src/StripeTests/StripeTests.csproj -c Release -f net462 /p:ContinuousIntegrationBuild=true
 
-      - name: Download OpenAPI spec
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi-spec
-
-      - name: Start stripe-mock
-        shell: bash
-        run: |
-          MOCK_VERSION=$(curl -s https://api.github.com/repos/stripe/stripe-mock/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-          curl -L "https://github.com/stripe/stripe-mock/releases/download/v${MOCK_VERSION}/stripe-mock_${MOCK_VERSION}_windows_amd64.zip" -o stripe-mock.zip
-          unzip stripe-mock.zip -d stripe-mock
-
-          BETA_ARG=""
-          if [[ "${{ github.base_ref || github.ref_name }}" == *"b"* ]]; then
-            BETA_ARG="-beta"
-          fi
-
-          ./stripe-mock/stripe-mock.exe $BETA_ARG \
-            -fixtures "${{ github.workspace }}/fixtures.json" \
-            -spec "${{ github.workspace }}/latest.json" &
-          sleep 5
+      - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run tests
         run: dotnet test --no-build --configuration Release --framework net462 src/StripeTests/StripeTests.csproj

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![NuGet](https://img.shields.io/nuget/v/stripe.net.svg)](https://www.nuget.org/packages/Stripe.net/)
 [![Build Status](https://github.com/stripe/stripe-dotnet/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-dotnet/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-dotnet/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-dotnet?branch=master)
 
 > [!TIP]
 > Want to chat live with Stripe engineers? Join us on our [Discord server](https://stripe.com/go/discord/dotnet).

--- a/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/SystemNetHttpClient.cs
@@ -8,8 +8,6 @@ namespace Stripe
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Security.Cryptography;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
@@ -135,9 +133,6 @@ namespace Stripe
         /// </summary>
         public static TimeSpan MinNetworkRetriesDelay => TimeSpan.FromMilliseconds(500);
 
-        /// <summary>Gets or sets the cached source hash.</summary>
-        internal static string SourceHash { get; set; } = ComputeSourceHash();
-
         /// <summary>
         /// Gets whether telemetry was enabled for this client.
         /// </summary>
@@ -227,35 +222,6 @@ namespace Stripe
             return string.Empty;
         }
 
-        internal static string ComputeSourceHash()
-        {
-            try
-            {
-                var parts = new System.Collections.Generic.List<string>
-                {
-                    System.Runtime.InteropServices.RuntimeInformation.OSDescription,
-                };
-                try
-                {
-                    parts.Add(Environment.MachineName);
-                }
-                catch
-                {
-                }
-
-                var inputBytes = Encoding.UTF8.GetBytes(string.Join(" ", parts));
-                using (var md5 = MD5.Create())
-                {
-                    var hashBytes = md5.ComputeHash(inputBytes);
-                    return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
-                }
-            }
-            catch
-            {
-                return string.Empty;
-            }
-        }
-
         private async Task<(HttpResponseMessage responseMessage, int retries)> SendHttpRequest(
             StripeRequest request,
             CancellationToken cancellationToken)
@@ -331,9 +297,13 @@ namespace Stripe
                 { "lang", ".net" },
                 { "stripe_net_target_framework", StripeNetTargetFramework },
             };
-            if (!string.IsNullOrEmpty(SourceHash))
+            if (this.EnableTelemetry)
             {
-                values["source"] = SourceHash;
+                var telemetryId = TelemetryId.Get();
+                if (!string.IsNullOrEmpty(telemetryId))
+                {
+                    values["telemetry_id"] = telemetryId;
+                }
             }
 
             // The following values are in try/catch blocks on the off chance that the

--- a/src/Stripe.net/Infrastructure/TelemetryId.cs
+++ b/src/Stripe.net/Infrastructure/TelemetryId.cs
@@ -11,6 +11,9 @@ namespace Stripe.Infrastructure
         private static string cachedId;
         private static bool loaded;
 
+        // For testing: overrides GetConfigDir() when set.
+        internal static string ConfigDirOverride { get; set; }
+
         public static string Get()
         {
             if (loaded)
@@ -64,7 +67,7 @@ namespace Stripe.Infrastructure
 
         private static string Resolve()
         {
-            var configDir = GetConfigDir();
+            var configDir = ConfigDirOverride ?? GetConfigDir();
             if (configDir == null)
             {
                 return null;
@@ -122,6 +125,7 @@ namespace Stripe.Infrastructure
             {
                 cachedId = null;
                 loaded = false;
+                ConfigDirOverride = null;
             }
         }
     }

--- a/src/Stripe.net/Infrastructure/TelemetryId.cs
+++ b/src/Stripe.net/Infrastructure/TelemetryId.cs
@@ -1,0 +1,128 @@
+namespace Stripe.Infrastructure
+{
+    using System;
+    using System.IO;
+    using System.Security.Cryptography;
+
+    internal static class TelemetryId
+    {
+        private static readonly object LockObj = new object();
+
+        private static string cachedId;
+        private static bool loaded;
+
+        public static string Get()
+        {
+            if (loaded)
+            {
+                return cachedId;
+            }
+
+            lock (LockObj)
+            {
+                if (loaded)
+                {
+                    return cachedId;
+                }
+
+                cachedId = Resolve();
+                loaded = true;
+            }
+
+            return cachedId;
+        }
+
+        internal static string GetConfigDir()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                var appData = Environment.GetFolderPath(
+                    Environment.SpecialFolder.ApplicationData);
+                if (string.IsNullOrEmpty(appData))
+                {
+                    return null;
+                }
+
+                return Path.Combine(appData, "Stripe");
+            }
+
+            var xdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            if (!string.IsNullOrEmpty(xdg))
+            {
+                return Path.Combine(xdg, "stripe");
+            }
+
+            var home = Environment.GetFolderPath(
+                Environment.SpecialFolder.UserProfile);
+            if (string.IsNullOrEmpty(home))
+            {
+                return null;
+            }
+
+            return Path.Combine(home, ".config", "stripe");
+        }
+
+        private static string Resolve()
+        {
+            var configDir = GetConfigDir();
+            if (configDir == null)
+            {
+                return null;
+            }
+
+            var filePath = Path.Combine(configDir, "telemetry_id");
+
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    var content = File.ReadAllText(filePath).Trim();
+                    if (!string.IsNullOrEmpty(content))
+                    {
+                        return content;
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            var newId = GenerateId();
+            try
+            {
+                Directory.CreateDirectory(configDir);
+                File.WriteAllText(filePath, newId);
+            }
+            catch
+            {
+                return null;
+            }
+
+            return newId;
+        }
+
+        private static string GenerateId()
+        {
+            var bytes = new byte[16];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(bytes);
+            }
+
+            return BitConverter.ToString(bytes)
+                .Replace("-", string.Empty)
+                .ToLowerInvariant();
+        }
+
+        // For testing
+        internal static void Reset()
+        {
+            lock (LockObj)
+            {
+                cachedId = null;
+                loaded = false;
+            }
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
+++ b/src/StripeTests/Infrastructure/Public/SystemNetHttpClientTest.cs
@@ -135,27 +135,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void SourceHashIsHexString()
-        {
-            var hash = SystemNetHttpClient.ComputeSourceHash();
-
-            // MD5 produces 16 bytes → 32 hex characters
-            Assert.NotNull(hash);
-            Assert.Equal(32, hash.Length);
-            Assert.Matches("^[0-9a-f]{32}$", hash);
-        }
-
-        [Fact]
-        public void SourceHashIsDeterministic()
-        {
-            var hash1 = SystemNetHttpClient.ComputeSourceHash();
-            var hash2 = SystemNetHttpClient.ComputeSourceHash();
-
-            Assert.Equal(hash1, hash2);
-        }
-
-        [Fact]
-        public async Task SourceHashIncludedInUserAgentHeader()
+        public async Task TelemetryIdIncludedInUserAgentHeader()
         {
             var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
             responseMessage.Content = new StringContent("Hello world!");
@@ -167,7 +147,8 @@ namespace StripeTests
                 .Returns(Task.FromResult(responseMessage));
 
             var client = new SystemNetHttpClient(
-                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
+                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object),
+                enableTelemetry: true);
             var request = new StripeRequest(
                 this.StripeClient,
                 HttpMethod.Post,
@@ -180,48 +161,39 @@ namespace StripeTests
                 .Verify(
                     "SendAsync",
                     Times.Once(),
-                    ItExpr.Is<HttpRequestMessage>(m => this.VerifySourceHeader(m.Headers)),
+                    ItExpr.Is<HttpRequestMessage>(m => this.VerifyTelemetryIdHeader(m.Headers)),
                     ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
-        public async Task SourceHashAbsentFromUserAgentWhenEmpty()
+        public async Task TelemetryIdAbsentFromUserAgentWhenTelemetryDisabled()
         {
-            var savedHash = SystemNetHttpClient.SourceHash;
-            try
-            {
-                SystemNetHttpClient.SourceHash = string.Empty;
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Content = new StringContent("Hello world!");
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(responseMessage));
 
-                var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-                responseMessage.Content = new StringContent("Hello world!");
-                this.MockHttpClientFixture.MockHandler.Protected()
-                    .Setup<Task<HttpResponseMessage>>(
-                        "SendAsync",
-                        ItExpr.IsAny<HttpRequestMessage>(),
-                        ItExpr.IsAny<CancellationToken>())
-                    .Returns(Task.FromResult(responseMessage));
+            var client = new SystemNetHttpClient(
+                httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object),
+                enableTelemetry: false);
+            var request = new StripeRequest(
+                this.StripeClient,
+                HttpMethod.Post,
+                "/foo",
+                null,
+                null);
+            await client.MakeRequestAsync(request);
 
-                var client = new SystemNetHttpClient(
-                    httpClient: new HttpClient(this.MockHttpClientFixture.MockHandler.Object));
-                var request = new StripeRequest(
-                    this.StripeClient,
-                    HttpMethod.Post,
-                    "/foo",
-                    null,
-                    null);
-                await client.MakeRequestAsync(request);
-
-                this.MockHttpClientFixture.MockHandler.Protected()
-                    .Verify(
-                        "SendAsync",
-                        Times.Once(),
-                        ItExpr.Is<HttpRequestMessage>(m => this.VerifyNoSourceHeader(m.Headers)),
-                        ItExpr.IsAny<CancellationToken>());
-            }
-            finally
-            {
-                SystemNetHttpClient.SourceHash = savedHash;
-            }
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m => this.VerifyNoTelemetryIdHeader(m.Headers)),
+                    ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
@@ -363,22 +335,22 @@ namespace StripeTests
             return true;
         }
 
-        private bool VerifySourceHeader(HttpRequestHeaders headers)
+        private bool VerifyTelemetryIdHeader(HttpRequestHeaders headers)
         {
             var userAgentJson = JObject.Parse(headers.GetValues("X-Stripe-Client-User-Agent").First());
-            var source = userAgentJson.Value<string>("source");
+            var telemetryId = userAgentJson.Value<string>("telemetry_id");
 
-            Assert.NotNull(source);
-            Assert.Matches("^[0-9a-f]{32}$", source);
+            Assert.NotNull(telemetryId);
+            Assert.Matches("^[0-9a-f]{32}$", telemetryId);
 
             return true;
         }
 
-        private bool VerifyNoSourceHeader(HttpRequestHeaders headers)
+        private bool VerifyNoTelemetryIdHeader(HttpRequestHeaders headers)
         {
             var userAgentJson = JObject.Parse(headers.GetValues("X-Stripe-Client-User-Agent").First());
 
-            Assert.Null(userAgentJson["source"]);
+            Assert.Null(userAgentJson["telemetry_id"]);
 
             return true;
         }

--- a/src/StripeTests/Infrastructure/TelemetryIdTest.cs
+++ b/src/StripeTests/Infrastructure/TelemetryIdTest.cs
@@ -112,6 +112,92 @@ namespace StripeTests
         }
 
         [Fact]
+        public void GetReturnsNullWhenWriteFails()
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                // Create a regular file where the config directory would need to be.
+                // Pointing ConfigDirOverride to a path inside that file makes
+                // Directory.CreateDirectory throw, causing Get() to return null.
+                Directory.CreateDirectory(tmpDir);
+                var blockingFile = Path.Combine(tmpDir, "not-a-dir");
+                File.WriteAllText(blockingFile, "I am a file, not a directory");
+
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = Path.Combine(blockingFile, "stripe");
+
+                var id = TelemetryId.Get();
+
+                Assert.Null(id);
+            }
+            finally
+            {
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetCreatesParentDirectoriesIfMissing()
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var nestedDir = Path.Combine(tmpDir, "nested", "config");
+            try
+            {
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = nestedDir;
+
+                var id = TelemetryId.Get();
+
+                Assert.NotNull(id);
+                Assert.Matches("^[0-9a-f]{32}$", id);
+                Assert.True(Directory.Exists(nestedDir));
+            }
+            finally
+            {
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetReadsPersistedValueAfterReset()
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
+
+                var id1 = TelemetryId.Get();
+
+                // Reset clears the in-memory cache; the next Get() must read from disk.
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
+
+                var id2 = TelemetryId.Get();
+
+                Assert.NotNull(id1);
+                Assert.Equal(id1, id2);
+            }
+            finally
+            {
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
         public void GetConfigDir_UnixUsesXdgConfigHomeWhenSet()
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)

--- a/src/StripeTests/Infrastructure/TelemetryIdTest.cs
+++ b/src/StripeTests/Infrastructure/TelemetryIdTest.cs
@@ -1,0 +1,137 @@
+namespace StripeTests
+{
+    using System;
+    using System.IO;
+    using Stripe.Infrastructure;
+    using Xunit;
+
+    public class TelemetryIdTest : BaseStripeTest
+    {
+        [Fact]
+        public void GetReturns32CharHexString()
+        {
+            TelemetryId.Reset();
+            var id = TelemetryId.Get();
+
+            Assert.NotNull(id);
+            Assert.Matches("^[0-9a-f]{32}$", id);
+        }
+
+        [Fact]
+        public void GetIsDeterministic()
+        {
+            TelemetryId.Reset();
+            var id1 = TelemetryId.Get();
+            var id2 = TelemetryId.Get();
+
+            Assert.Equal(id1, id2);
+        }
+
+        [Fact]
+        public void GetReadsExistingIdFromFile()
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            // XDG_CONFIG_HOME is used as a base, GetConfigDir appends "stripe"
+            var stripeConfigDir = Path.Combine(tmpDir, "stripe");
+            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            try
+            {
+                Directory.CreateDirectory(stripeConfigDir);
+                var filePath = Path.Combine(stripeConfigDir, "telemetry_id");
+                var existingId = "aabbccddeeff00112233445566778899";
+                File.WriteAllText(filePath, existingId);
+
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", tmpDir);
+                TelemetryId.Reset();
+
+                var id = TelemetryId.Get();
+                Assert.Equal(existingId, id);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetGeneratesAndPersistsNewIdWhenFileAbsent()
+        {
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", tmpDir);
+                TelemetryId.Reset();
+
+                var id = TelemetryId.Get();
+
+                Assert.NotNull(id);
+                Assert.Matches("^[0-9a-f]{32}$", id);
+
+                // The ID should have been written to disk
+                var filePath = Path.Combine(tmpDir, "stripe", "telemetry_id");
+                Assert.True(File.Exists(filePath));
+                Assert.Equal(id, File.ReadAllText(filePath).Trim());
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetConfigDir_UnixUsesXdgConfigHomeWhenSet()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", "/custom/config");
+                var dir = TelemetryId.GetConfigDir();
+                Assert.Equal("/custom/config/stripe", dir);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
+            }
+        }
+
+        [Fact]
+        public void GetConfigDir_UnixFallsBackToHomeConfig()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            try
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", null);
+                var dir = TelemetryId.GetConfigDir();
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+                Assert.Equal(Path.Combine(home, ".config", "stripe"), dir);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
+            }
+        }
+    }
+}

--- a/src/StripeTests/Infrastructure/TelemetryIdTest.cs
+++ b/src/StripeTests/Infrastructure/TelemetryIdTest.cs
@@ -10,47 +10,70 @@ namespace StripeTests
         [Fact]
         public void GetReturns32CharHexString()
         {
-            TelemetryId.Reset();
-            var id = TelemetryId.Get();
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
 
-            Assert.NotNull(id);
-            Assert.Matches("^[0-9a-f]{32}$", id);
+                var id = TelemetryId.Get();
+
+                Assert.NotNull(id);
+                Assert.Matches("^[0-9a-f]{32}$", id);
+            }
+            finally
+            {
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
         }
 
         [Fact]
         public void GetIsDeterministic()
         {
-            TelemetryId.Reset();
-            var id1 = TelemetryId.Get();
-            var id2 = TelemetryId.Get();
+            var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
 
-            Assert.Equal(id1, id2);
+                var id1 = TelemetryId.Get();
+                var id2 = TelemetryId.Get();
+
+                Assert.Equal(id1, id2);
+            }
+            finally
+            {
+                TelemetryId.Reset();
+                if (Directory.Exists(tmpDir))
+                {
+                    Directory.Delete(tmpDir, recursive: true);
+                }
+            }
         }
 
         [Fact]
         public void GetReadsExistingIdFromFile()
         {
             var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
-            // XDG_CONFIG_HOME is used as a base, GetConfigDir appends "stripe"
-            var stripeConfigDir = Path.Combine(tmpDir, "stripe");
-            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
             try
             {
-                Directory.CreateDirectory(stripeConfigDir);
-                var filePath = Path.Combine(stripeConfigDir, "telemetry_id");
+                Directory.CreateDirectory(tmpDir);
+                var filePath = Path.Combine(tmpDir, "telemetry_id");
                 var existingId = "aabbccddeeff00112233445566778899";
                 File.WriteAllText(filePath, existingId);
 
-                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", tmpDir);
                 TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
 
                 var id = TelemetryId.Get();
                 Assert.Equal(existingId, id);
             }
             finally
             {
-                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
                 TelemetryId.Reset();
                 if (Directory.Exists(tmpDir))
                 {
@@ -63,11 +86,10 @@ namespace StripeTests
         public void GetGeneratesAndPersistsNewIdWhenFileAbsent()
         {
             var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            var savedXdg = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
             try
             {
-                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", tmpDir);
                 TelemetryId.Reset();
+                TelemetryId.ConfigDirOverride = tmpDir;
 
                 var id = TelemetryId.Get();
 
@@ -75,13 +97,12 @@ namespace StripeTests
                 Assert.Matches("^[0-9a-f]{32}$", id);
 
                 // The ID should have been written to disk
-                var filePath = Path.Combine(tmpDir, "stripe", "telemetry_id");
+                var filePath = Path.Combine(tmpDir, "telemetry_id");
                 Assert.True(File.Exists(filePath));
                 Assert.Equal(id, File.ReadAllText(filePath).Trim());
             }
             finally
             {
-                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", savedXdg);
                 TelemetryId.Reset();
                 if (Directory.Exists(tmpDir))
                 {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly
- (unrelated) remove unused coverage badge from readme

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
