### PR TITLE
Add `stripe.major_api_version` constant

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -34,7 +34,10 @@ namespace Stripe
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion => Stripe.ApiVersion.Current;
 
-        /// <summary>Major API version used by Stripe.net.</summary>
+        /// <summary>
+        /// The major API version that this SDK uses. Objects retrieved using the same major version
+        /// are compatible. Is an empty string in preview versions of the SDK.
+        /// </summary>
         public static string MajorApiVersion => Stripe.ApiVersion.CurrentMajor;
 
         /// <summary>Gets or sets the API key.</summary>

--- a/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeConfiguration.cs
@@ -34,6 +34,9 @@ namespace Stripe
         /// <summary>API version used by Stripe.net.</summary>
         public static string ApiVersion => Stripe.ApiVersion.Current;
 
+        /// <summary>Major API version used by Stripe.net.</summary>
+        public static string MajorApiVersion => Stripe.ApiVersion.CurrentMajor;
+
         /// <summary>Gets or sets the API key.</summary>
         /// <remarks>
         /// You can also set the API key using the <c>StripeApiKey</c> key in


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been generating information about the current API version into the SDKs for a while (codegen PR `2555`), but accidentally didn't make those constants user-facing.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- adds a user-facing `major_api_version` constant set to the generated value (currently `"dahlia"`)

### See Also

<!-- Include any links or additional information that help explain this change. -->

- (originally from https://github.com/stripe/stripe-java/issues/2001)
