### PR TITLE
Surface `object` property on `EventNotification`

### DIFF
--- a/src/Stripe.net/Entities/V2/Core/EventNotification.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotification.cs
@@ -24,6 +24,13 @@ namespace Stripe.V2.Core
         public string Id { get; internal set; }
 
         /// <summary>
+        /// String representing the object's type. Objects of the same type share the same value.
+        /// </summary>
+        [JsonProperty("object")]
+        [STJS.JsonPropertyName("object")]
+        public string Object { get; internal set; }
+
+        /// <summary>
         /// The type of the event.
         /// </summary>
         [JsonProperty("type")]

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -217,6 +217,7 @@ namespace StripeTests.V2
             var eventNotif = this.stripeClient.ParseEventNotification(v2KnownEventNoRelatedObjectPayload, GenerateSigHeader(v2KnownEventNoRelatedObjectPayload), WebhookSecret);
             Assert.NotNull(eventNotif);
             Assert.Equal("evt_234", eventNotif.Id);
+            Assert.Equal("v2.core.event", eventNotif.Object);
             Assert.Equal("v1.billing.meter.no_meter_found", eventNotif.Type);
             Assert.Equal(new DateTime(2022, 2, 15, 0, 27, 45, 330, DateTimeKind.Utc), eventNotif.Created);
             Assert.True(eventNotif.Livemode);


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`object` is present in the original payload, but we didn't surface it on the `EventNotification` class. Because ``v2.core.event"` is the only value that will ever be present, It didn't seem worth adding it to the interface.

I also wanted to better differentiate `EventNotification`s from all other `StripeObject`s (since they _do_ behave differently).

But, that also means interacting with it along with other objects is unnecessarily complicated. From the [original ruby issue](https://github.com/stripe/stripe-ruby/issues/1860):

```rb
def v1?(event)
  (event.try(:object) || event.try(:dig, "object")) == "event"
end

def v2?(event)
  event.is_a?(::Stripe::V2::Core::EventNotification) || # thin event notification
    (event.try(:object) || event.try(:dig, "object")) == "v2.core.event"
end
```

Because the value is present in the original response, it doesn't make sense to eat it.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add public `object` property to `EventNotification`
- add test

### See Also

<!-- Include any links or additional information that help explain this change. -->

- originally brought up in [stripe/stripe-ruby#1860](https://github.com/stripe/stripe-ruby/issues/1860)
- [DEVSDK-3101](https://go/j/DEVSDK-3101)
