### PR TITLE
Add new `EventNotificationHandler` class for better thin event management

### DIFF
--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);V2/*WebhookHandler.cs</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);V2/*HandlerEndpoint.cs</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -1,0 +1,74 @@
+namespace Examples.V2
+{
+#pragma warning disable SA1101 // Prefix local calls with this
+
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Stripe;
+    using Stripe.Events;
+
+    /// <summary>
+    /// receive and process event notifications (AKA thin events) like "v1.billing.meter.no_meter_found" using EventNotificationHandler.
+    ///
+    /// In this example, we:
+    ///     - write a fallback callback to handle unrecognized event notifications
+    ///     - create a StripeClient called client
+    ///     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+    ///     - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
+    ///     - use handler.handle() to process the received notification webhook body.
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EventNotificationHandlerEndpoint : ControllerBase
+    {
+        private readonly StripeClient client;
+        private readonly StripeEventNotificationHandler handler;
+
+        // Handles events delivered through a channel that has already authenticated them, such as
+        // AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+        // this handler skips verification. Callbacks are registered separately from the one above.
+        private readonly StripeEventNotificationHandlerWithoutVerification unverifiedHandler;
+
+        public EventNotificationHandlerEndpoint()
+        {
+            client = new StripeClient(Environment.GetEnvironmentVariable("STRIPE_API_KEY"));
+            handler = client.NotificationHandler(Environment.GetEnvironmentVariable("WEBHOOK_SECRET") ?? string.Empty, FallbackCallback);
+            unverifiedHandler = client.NotificationHandlerWithoutVerification(FallbackCallback);
+
+            // register handlers
+            handler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
+            unverifiedHandler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
+        }
+
+        private void HandleBillingMeterErrorReportTriggeredEventNotification(object sender, Stripe.StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification> e)
+        {
+            var meter = e.EventNotification.FetchRelatedObject();
+            Console.WriteLine($"Meter {meter.DisplayName} had an error");
+        }
+
+        private void FallbackCallback(object sender, Stripe.StripeUnhandledEventNotificationEventArgs e)
+        {
+            Console.WriteLine($"Received unhandled event notification type: {e.EventNotification.Type}");
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Index()
+        {
+            var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+            handler.Handle(json, Request.Headers["Stripe-Signature"]);
+            return Ok();
+        }
+
+        [HttpPost("from-cloud-provider")]
+        public async Task<IActionResult> FromCloudProvider()
+        {
+            var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+
+            // Handle takes only the body here; there's no signature to check
+            unverifiedHandler.Handle(json);
+            return Ok();
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
+++ b/src/Stripe.net/Infrastructure/Public/LiveApiRequestor.cs
@@ -90,6 +90,13 @@ namespace Stripe
         /// <value>The <see cref="IHttpClient"/> used to send HTTP requests.</value>
         public override IHttpClient HttpClient { get; }
 
+        /// <summary>Gets the current StripeContext for this requestor; Used in unit tests.</summary>
+        /// <value>The current StripeContext.</value>
+        internal StripeContext CurrentStripeContext
+        {
+            get => this.clientOptions.StripeContext;
+        }
+
         /// <summary>Sends a request to Stripe's API as an asynchronous operation.</summary>
         /// <typeparam name="T">Type of the Stripe entity returned by the API.</typeparam>
         /// <param name="baseAddress">The base address of the request.</param>

--- a/src/Stripe.net/Infrastructure/Public/StripeClient.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeClient.cs
@@ -275,6 +275,27 @@ namespace Stripe
             return EventNotification.FromJson(json ?? element.GetRawText(), this);
         }
 
+        /// <summary>
+        /// Create a new StripeEventNotificationHandler bound to this StripeClient.
+        /// </summary>
+        /// <param name="webhookSecret">The secret for this event destination, e.g. "wh_sec_...".</param>
+        /// <param name="fallbackCallback">The function to call when handing an event for whom there's no callback registered.</param>
+        /// <returns></returns>
+        public StripeEventNotificationHandler NotificationHandler(string webhookSecret, Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+        {
+            return new StripeEventNotificationHandler(this, webhookSecret, fallbackCallback);
+        }
+
+        /// <summary>
+        /// Creates a handler that processes events without webhook signature verification.
+        /// Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+        /// </summary>
+        /// <param name="fallbackCallback">The function to call when handing an event for whom there's no callback registered.</param>
+        public StripeEventNotificationHandlerWithoutVerification NotificationHandlerWithoutVerification(Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+        {
+            return StripeEventNotificationHandler.WithoutVerification(this, fallbackCallback);
+        }
+
         internal JsonSerializerSettings GetJsonSerializationSettings()
         {
             return this.jsonSerializerSettings;

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationEventArgs.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationEventArgs.cs
@@ -1,0 +1,45 @@
+namespace Stripe
+{
+    using System;
+
+    /// <summary>
+    /// EventArgs for Stripe webhook event notifications.
+    /// Contains the strongly-typed EventNotification and the StripeClient instance.
+    /// </summary>
+    /// <typeparam name="TEventNotification">The type of EventNotification.</typeparam>
+    public class StripeEventNotificationEventArgs<TEventNotification> : EventArgs
+        where TEventNotification : V2.Core.EventNotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeEventNotificationEventArgs{TEventNotification}"/> class.
+        /// </summary>
+        /// <param name="eventNotification">The event notification instance.</param>
+        /// <param name="client">The StripeClient instance.</param>
+        public StripeEventNotificationEventArgs(TEventNotification eventNotification, StripeClient client)
+        {
+            if (eventNotification == null)
+            {
+                throw new ArgumentNullException(nameof(eventNotification));
+            }
+
+            this.EventNotification = eventNotification;
+
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            this.Client = client;
+        }
+
+        /// <summary>
+        /// Gets the event notification instance.
+        /// </summary>
+        public TEventNotification EventNotification { get; }
+
+        /// <summary>
+        /// Gets the StripeClient instance that can be used to make API requests.
+        /// </summary>
+        public StripeClient Client { get; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandler.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandler.cs
@@ -1,0 +1,76 @@
+namespace Stripe
+{
+    using System;
+
+    /// <summary>
+    /// A handler for Stripe webhook events that uses the .NET event handler pattern.
+    /// Allows registration of strongly-typed event handlers for specific EventNotification types.
+    ///
+    /// Verifies incoming webhook signatures before dispatching. For events arriving through a
+    /// channel that has already authenticated them, see
+    /// <see cref="WithoutVerification(StripeClient, Action{object, StripeUnhandledEventNotificationEventArgs})"/>.
+    /// </summary>
+    public class StripeEventNotificationHandler : StripeEventNotificationHandlerBase
+    {
+        private readonly string webhookSecret;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeEventNotificationHandler"/> class.
+        /// </summary>
+        /// <param name="client">The StripeClient instance to use for parsing and API requests.</param>
+        /// <param name="webhookSecret">The webhook secret used for signature verification.</param>
+        /// <param name="fallbackCallback">The function to call when handing an event for whom there's no callback registered.</param>
+        public StripeEventNotificationHandler(StripeClient client, string webhookSecret, Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+            : base(client, fallbackCallback)
+        {
+            if (string.IsNullOrEmpty(webhookSecret))
+            {
+                throw new ArgumentNullException(nameof(webhookSecret));
+            }
+
+            this.webhookSecret = webhookSecret;
+        }
+
+        /// <summary>
+        /// Creates a handler that processes events without webhook signature verification.
+        /// Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+        /// </summary>
+        public static StripeEventNotificationHandlerWithoutVerification WithoutVerification(StripeClient client, Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+        {
+            return new StripeEventNotificationHandlerWithoutVerification(client, fallbackCallback);
+        }
+
+        /// <summary>
+        /// Handles an incoming webhook by parsing the payload, validating the signature,
+        /// and dispatching to the registered handler if one exists.
+        /// </summary>
+        /// <param name="json">The JSON payload from the webhook request body.</param>
+        /// <param name="stripeSignatureHeader">The Stripe-Signature header value.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any required parameter is null.</exception>
+        /// <exception cref="StripeException">Thrown if signature validation fails or parsing fails.</exception>
+        /// TODO: allow async?
+        public void Handle(
+            string json,
+            string stripeSignatureHeader)
+        {
+            if (json == null)
+            {
+                throw new ArgumentNullException(nameof(json));
+            }
+
+            if (stripeSignatureHeader == null)
+            {
+                throw new ArgumentNullException(nameof(stripeSignatureHeader));
+            }
+
+            // set after argument validation, so a bad call doesn't lock out registration
+            this.HasHandledEvent = true;
+
+            // Parse and validate the event notification
+            var eventNotification = this.client.ParseEventNotification(json, stripeSignatureHeader, this.webhookSecret);
+
+            // Dispatch to the registered handler with the event's context
+            this.DispatchEventWithContext(eventNotification);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -1,0 +1,447 @@
+namespace Stripe
+{
+    using System;
+    using System.Collections.Generic;
+    using Stripe.Events;
+
+    /// <summary>
+    /// Shared registration and dispatch machinery for <see cref="StripeEventNotificationHandler"/>
+    /// and <see cref="StripeEventNotificationHandlerWithoutVerification"/>.
+    ///
+    /// Deliberately declares no Handle method. C# resolves overloads by signature rather than
+    /// replacing them, so if either handler derived from the other it would inherit — and publicly
+    /// expose — the other's Handle. As siblings, each declares only its own.
+    ///
+    /// This type has to be public (CS0060 forbids a less-accessible base for a public class), but
+    /// its constructor is internal, so it cannot be derived from outside this assembly.
+    /// </summary>
+    public abstract class StripeEventNotificationHandlerBase
+    {
+#pragma warning disable SA1401 // Fields should be private
+        protected readonly StripeClient client;
+#pragma warning restore SA1401 // Fields should be private
+        private readonly HashSet<string> handledEventTypes = new HashSet<string>();
+#pragma warning disable SA1401 // Fields should be private
+        protected readonly StripeClientOptions clientOptions;
+#pragma warning restore SA1401 // Fields should be private
+
+        // A private EventHandler for each EventNotification. We'll route notifications to the correct handler.
+        // private-event-handlers: The beginning of the section generated from our OpenAPI spec
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification>> v1BillingMeterErrorReportTriggered;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterNoMeterFoundEventNotification>> v1BillingMeterNoMeterFound;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsFailedEventNotification>> v2CommerceProductCatalogImportsFailed;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsProcessingEventNotification>> v2CommerceProductCatalogImportsProcessing;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededEventNotification>> v2CommerceProductCatalogImportsSucceeded;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification>> v2CommerceProductCatalogImportsSucceededWithErrors;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountClosedEventNotification>> v2CoreAccountClosed;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountCreatedEventNotification>> v2CoreAccountCreated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountUpdatedEventNotification>> v2CoreAccountUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification>> v2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification>> v2CoreAccountIncludingConfigurationCustomerUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification>> v2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification>> v2CoreAccountIncludingConfigurationMerchantUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification>> v2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification>> v2CoreAccountIncludingConfigurationRecipientUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingDefaultsUpdatedEventNotification>> v2CoreAccountIncludingDefaultsUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification>> v2CoreAccountIncludingFutureRequirementsUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingIdentityUpdatedEventNotification>> v2CoreAccountIncludingIdentityUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingRequirementsUpdatedEventNotification>> v2CoreAccountIncludingRequirementsUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountLinkReturnedEventNotification>> v2CoreAccountLinkReturned;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonCreatedEventNotification>> v2CoreAccountPersonCreated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonDeletedEventNotification>> v2CoreAccountPersonDeleted;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonUpdatedEventNotification>> v2CoreAccountPersonUpdated;
+        private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreEventDestinationPingEventNotification>> v2CoreEventDestinationPing;
+
+        // private-event-handlers: The end of the section generated from our OpenAPI spec
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeEventNotificationHandlerBase"/> class.
+        /// </summary>
+        /// <param name="client">The StripeClient instance to use for parsing and API requests.</param>
+        /// <param name="fallbackCallback">The function to call when handing an event for whom there's no callback registered.</param>
+        internal StripeEventNotificationHandlerBase(StripeClient client, Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            this.client = client;
+
+            this.FallbackCallback += new EventHandler<StripeUnhandledEventNotificationEventArgs>(fallbackCallback);
+
+            // Capture the client options to reuse configuration when creating new clients
+            var requestor = client.Requestor as LiveApiRequestor;
+            if (requestor == null)
+            {
+                throw new InvalidOperationException("StripeEventNotificationHandler requires a StripeClient with a LiveApiRequestor.");
+            }
+
+            this.clientOptions = new StripeClientOptions
+            {
+                ApiKey = requestor.ApiKey,
+                ClientId = requestor.ClientId,
+                HttpClient = requestor.HttpClient,
+                ApiBase = requestor.ApiBase,
+                ConnectBase = requestor.ConnectBase,
+                FilesBase = requestor.FilesBase,
+                MeterEventsBase = requestor.MeterEventsBase,
+                StripeAccount = null, // Don't copy StripeAccount or StripeContext
+                StripeContext = null,
+            };
+        }
+
+        private event EventHandler<StripeUnhandledEventNotificationEventArgs> FallbackCallback;
+
+        // public facing EventHandler
+        // public-event-handlers: The beginning of the section generated from our OpenAPI spec
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification>> V1BillingMeterErrorReportTriggered
+        {
+            add { this.AddEventHandler(ref this.v1BillingMeterErrorReportTriggered, value, "v1.billing.meter.error_report_triggered"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterNoMeterFoundEventNotification>> V1BillingMeterNoMeterFound
+        {
+            add { this.AddEventHandler(ref this.v1BillingMeterNoMeterFound, value, "v1.billing.meter.no_meter_found"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsFailedEventNotification>> V2CommerceProductCatalogImportsFailed
+        {
+            add { this.AddEventHandler(ref this.v2CommerceProductCatalogImportsFailed, value, "v2.commerce.product_catalog.imports.failed"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsProcessingEventNotification>> V2CommerceProductCatalogImportsProcessing
+        {
+            add { this.AddEventHandler(ref this.v2CommerceProductCatalogImportsProcessing, value, "v2.commerce.product_catalog.imports.processing"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededEventNotification>> V2CommerceProductCatalogImportsSucceeded
+        {
+            add { this.AddEventHandler(ref this.v2CommerceProductCatalogImportsSucceeded, value, "v2.commerce.product_catalog.imports.succeeded"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification>> V2CommerceProductCatalogImportsSucceededWithErrors
+        {
+            add { this.AddEventHandler(ref this.v2CommerceProductCatalogImportsSucceededWithErrors, value, "v2.commerce.product_catalog.imports.succeeded_with_errors"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountClosedEventNotification>> V2CoreAccountClosed
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountClosed, value, "v2.core.account.closed"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountCreatedEventNotification>> V2CoreAccountCreated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountCreated, value, "v2.core.account.created"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountUpdatedEventNotification>> V2CoreAccountUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountUpdated, value, "v2.core.account.updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification>> V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated, value, "v2.core.account[configuration.customer].capability_status_updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification>> V2CoreAccountIncludingConfigurationCustomerUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationCustomerUpdated, value, "v2.core.account[configuration.customer].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification>> V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated, value, "v2.core.account[configuration.merchant].capability_status_updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification>> V2CoreAccountIncludingConfigurationMerchantUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationMerchantUpdated, value, "v2.core.account[configuration.merchant].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification>> V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated, value, "v2.core.account[configuration.recipient].capability_status_updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification>> V2CoreAccountIncludingConfigurationRecipientUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingConfigurationRecipientUpdated, value, "v2.core.account[configuration.recipient].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingDefaultsUpdatedEventNotification>> V2CoreAccountIncludingDefaultsUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingDefaultsUpdated, value, "v2.core.account[defaults].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification>> V2CoreAccountIncludingFutureRequirementsUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingFutureRequirementsUpdated, value, "v2.core.account[future_requirements].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingIdentityUpdatedEventNotification>> V2CoreAccountIncludingIdentityUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingIdentityUpdated, value, "v2.core.account[identity].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingRequirementsUpdatedEventNotification>> V2CoreAccountIncludingRequirementsUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountIncludingRequirementsUpdated, value, "v2.core.account[requirements].updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountLinkReturnedEventNotification>> V2CoreAccountLinkReturned
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountLinkReturned, value, "v2.core.account_link.returned"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonCreatedEventNotification>> V2CoreAccountPersonCreated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountPersonCreated, value, "v2.core.account_person.created"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonDeletedEventNotification>> V2CoreAccountPersonDeleted
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountPersonDeleted, value, "v2.core.account_person.deleted"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonUpdatedEventNotification>> V2CoreAccountPersonUpdated
+        {
+            add { this.AddEventHandler(ref this.v2CoreAccountPersonUpdated, value, "v2.core.account_person.updated"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        public event EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreEventDestinationPingEventNotification>> V2CoreEventDestinationPing
+        {
+            add { this.AddEventHandler(ref this.v2CoreEventDestinationPing, value, "v2.core.event_destination.ping"); }
+            remove { this.RemoveEventHandler(); }
+        }
+
+        // public-event-handlers: The end of the section generated from our OpenAPI spec
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this handler has already handled an event.
+        /// Registering a callback afterwards is refused, since callbacks are expected to be
+        /// registered once at startup; doing so later indicates a bug.
+        ///
+        /// Set naiively rather than with a lock: we expect registration to happen synchronously
+        /// at startup and handling to happen afterwards, so a race here is not a real concern.
+        /// </summary>
+        protected bool HasHandledEvent { get; set; }
+
+        /// <summary>
+        /// Returns a sorted list of event types that have registered handlers.
+        /// </summary>
+        /// <returns></returns>
+        public List<string> HandledEventTypes()
+        {
+            var events = new List<string>(this.handledEventTypes);
+            events.Sort();
+            return events;
+        }
+
+        /// <summary>
+        /// Dispatches the event with the event's StripeContext by creating a new client instance.
+        /// </summary>
+        /// <param name="eventNotification">The event notification to dispatch.</param>
+        protected void DispatchEventWithContext(V2.Core.EventNotification eventNotification)
+        {
+            if (eventNotification == null)
+            {
+                throw new ArgumentNullException(nameof(eventNotification));
+            }
+
+            // If client options somehow didn't get created, bail.
+            if (this.clientOptions == null)
+            {
+                throw new InvalidOperationException("Unable to create client with event context: client options not available.");
+            }
+
+            // Create a new client with the event's context
+            var eventClientOptions = this.clientOptions.Clone();
+            eventClientOptions.StripeContext = eventNotification.Context;
+            var eventClient = new StripeClient(eventClientOptions);
+
+            this.DispatchEvent(eventNotification, eventClient);
+        }
+
+        /// <summary>
+        /// Centralizes the logic for adding event handlers.
+        /// </summary>
+        private void AddEventHandler<T>(ref EventHandler<T> handler, EventHandler<T> value, string eventType)
+        where T : EventArgs
+        {
+            if (this.HasHandledEvent)
+            {
+                throw new InvalidOperationException("Cannot register new event handlers after Handle has been called. This is indicative of a bug.");
+            }
+
+            if (this.handledEventTypes.Add(eventType))
+            {
+                handler = value;
+            }
+            else
+            {
+                throw new InvalidOperationException($"A handler for event type '{eventType}' is already registered. Only one handler per event type is allowed.");
+            }
+        }
+
+        /// <summary>
+        /// Centralizes the logic for removing event handlers.
+        /// </summary>
+        private void RemoveEventHandler()
+        {
+            throw new InvalidOperationException("Removing handlers is not supported.");
+        }
+
+        private void DispatchEvent(V2.Core.EventNotification eventNotification, StripeClient client)
+        {
+            if (eventNotification == null)
+            {
+                throw new ArgumentNullException(nameof(eventNotification));
+            }
+
+            if (this.handledEventTypes.Contains(eventNotification.Type))
+            {
+                // Known event type; dispatch to the appropriate handler
+                if (false)
+                {
+                    // so all of our generated handlers can be `else if`s
+                }
+
+                // event-handler-dispatch: The beginning of the section generated from our OpenAPI spec
+                else if (eventNotification is Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification)
+                {
+                    this.v1BillingMeterErrorReportTriggered.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification>((Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V1BillingMeterNoMeterFoundEventNotification)
+                {
+                    this.v1BillingMeterNoMeterFound.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterNoMeterFoundEventNotification>((Stripe.Events.V1BillingMeterNoMeterFoundEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CommerceProductCatalogImportsFailedEventNotification)
+                {
+                    this.v2CommerceProductCatalogImportsFailed.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsFailedEventNotification>((Stripe.Events.V2CommerceProductCatalogImportsFailedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CommerceProductCatalogImportsProcessingEventNotification)
+                {
+                    this.v2CommerceProductCatalogImportsProcessing.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsProcessingEventNotification>((Stripe.Events.V2CommerceProductCatalogImportsProcessingEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CommerceProductCatalogImportsSucceededEventNotification)
+                {
+                    this.v2CommerceProductCatalogImportsSucceeded.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededEventNotification>((Stripe.Events.V2CommerceProductCatalogImportsSucceededEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification)
+                {
+                    this.v2CommerceProductCatalogImportsSucceededWithErrors.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification>((Stripe.Events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountClosedEventNotification)
+                {
+                    this.v2CoreAccountClosed.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountClosedEventNotification>((Stripe.Events.V2CoreAccountClosedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountCreatedEventNotification)
+                {
+                    this.v2CoreAccountCreated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountCreatedEventNotification>((Stripe.Events.V2CoreAccountCreatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountUpdatedEventNotification)
+                {
+                    this.v2CoreAccountUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountUpdatedEventNotification>((Stripe.Events.V2CoreAccountUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationCustomerUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationMerchantUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingConfigurationRecipientUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingDefaultsUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingDefaultsUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingDefaultsUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingDefaultsUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingFutureRequirementsUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingIdentityUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingIdentityUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingIdentityUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingIdentityUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountIncludingRequirementsUpdatedEventNotification)
+                {
+                    this.v2CoreAccountIncludingRequirementsUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountIncludingRequirementsUpdatedEventNotification>((Stripe.Events.V2CoreAccountIncludingRequirementsUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountLinkReturnedEventNotification)
+                {
+                    this.v2CoreAccountLinkReturned.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountLinkReturnedEventNotification>((Stripe.Events.V2CoreAccountLinkReturnedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountPersonCreatedEventNotification)
+                {
+                    this.v2CoreAccountPersonCreated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonCreatedEventNotification>((Stripe.Events.V2CoreAccountPersonCreatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountPersonDeletedEventNotification)
+                {
+                    this.v2CoreAccountPersonDeleted.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonDeletedEventNotification>((Stripe.Events.V2CoreAccountPersonDeletedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreAccountPersonUpdatedEventNotification)
+                {
+                    this.v2CoreAccountPersonUpdated.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreAccountPersonUpdatedEventNotification>((Stripe.Events.V2CoreAccountPersonUpdatedEventNotification)eventNotification, client));
+                }
+                else if (eventNotification is Stripe.Events.V2CoreEventDestinationPingEventNotification)
+                {
+                    this.v2CoreEventDestinationPing.Invoke(this, new StripeEventNotificationEventArgs<Stripe.Events.V2CoreEventDestinationPingEventNotification>((Stripe.Events.V2CoreEventDestinationPingEventNotification)eventNotification, client));
+                }
+
+                // event-handler-dispatch: The end of the section generated from our OpenAPI spec
+                else
+                {
+                    throw new Exception("unexpected state, please file a bug");
+                }
+            }
+            else
+            {
+                // Unknown event type; invoke the unhandled event handler
+                this.FallbackCallback.Invoke(
+                    this,
+                    new StripeUnhandledEventNotificationEventArgs(eventNotification, client, new UnhandledNotificationDetails(!(eventNotification is UnknownEventNotification))));
+            }
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerWithoutVerification.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerWithoutVerification.cs
@@ -1,0 +1,45 @@
+namespace Stripe
+{
+    using System;
+
+    /// <summary>
+    /// A variant of StripeEventNotificationHandler that parses events without
+    /// verifying webhook signatures. Intended for pre-authenticated channels
+    /// like AWS EventBridge or Azure Event Grid.
+    ///
+    /// Because this is a sibling of <see cref="StripeEventNotificationHandler"/> rather than a
+    /// subclass, it does not expose that class's two-argument Handle at all — passing a signature
+    /// header here is a compile error rather than a runtime one.
+    ///
+    /// Do not instantiate directly. Use
+    /// <see cref="StripeEventNotificationHandler.WithoutVerification"/> or
+    /// <see cref="StripeClient.NotificationHandlerWithoutVerification"/> instead.
+    /// </summary>
+    public class StripeEventNotificationHandlerWithoutVerification : StripeEventNotificationHandlerBase
+    {
+        internal StripeEventNotificationHandlerWithoutVerification(StripeClient client, Action<object, StripeUnhandledEventNotificationEventArgs> fallbackCallback)
+            : base(client, fallbackCallback)
+        {
+        }
+
+        /// <summary>
+        /// Handles an incoming webhook by parsing the payload without signature verification
+        /// and dispatching to the registered handler.
+        /// </summary>
+        /// <param name="json">The JSON payload from the webhook request body.</param>
+        public void Handle(string json)
+        {
+            if (json == null)
+            {
+                throw new ArgumentNullException(nameof(json));
+            }
+
+            // set after argument validation, so a bad call doesn't lock out registration
+            this.HasHandledEvent = true;
+
+            var eventNotification = this.client.ParseEventNotificationWithoutVerification(json);
+
+            this.DispatchEventWithContext(eventNotification);
+        }
+    }
+}

--- a/src/Stripe.net/Infrastructure/StripeUnhandledEventNotificationEventArgs.cs
+++ b/src/Stripe.net/Infrastructure/StripeUnhandledEventNotificationEventArgs.cs
@@ -1,0 +1,39 @@
+namespace Stripe
+{
+    using System;
+
+    /// <summary>
+    /// EventArgs for Stripe webhook event notifications.
+    /// Contains the strongly-typed EventNotification and the StripeClient instance.
+    /// </summary>
+    public class StripeUnhandledEventNotificationEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripeUnhandledEventNotificationEventArgs"/> class.
+        /// </summary>
+        /// <param name="eventNotification">The event notification instance.</param>
+        /// <param name="client">The StripeClient instance.</param>
+        /// <param name="details">Details about the unhandled notification.</param>
+        public StripeUnhandledEventNotificationEventArgs(V2.Core.EventNotification eventNotification, StripeClient client, UnhandledNotificationDetails details)
+        {
+            this.EventNotification = eventNotification ?? throw new ArgumentNullException(nameof(eventNotification));
+            this.Client = client ?? throw new ArgumentNullException(nameof(client));
+            this.Details = details ?? throw new ArgumentNullException(nameof(details));
+        }
+
+        /// <summary>
+        /// Gets the event notification instance.
+        /// </summary>
+        public V2.Core.EventNotification EventNotification { get; }
+
+        /// <summary>
+        /// Gets the StripeClient instance that can be used to make API requests.
+        /// </summary>
+        public StripeClient Client { get; }
+
+        /// <summary>
+        /// Gets details about the unhandled notification.
+        /// </summary>
+        public UnhandledNotificationDetails Details { get; }
+    }
+}

--- a/src/Stripe.net/Infrastructure/UnhandledNotificationDetails.cs
+++ b/src/Stripe.net/Infrastructure/UnhandledNotificationDetails.cs
@@ -1,0 +1,22 @@
+namespace Stripe
+{
+    /// <summary>
+    /// EventArgs for Stripe webhook event notifications.
+    /// Contains the strongly-typed EventNotification and the StripeClient instance.
+    /// </summary>
+    public class UnhandledNotificationDetails
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnhandledNotificationDetails"/> class.
+        /// </summary>
+        public UnhandledNotificationDetails(bool isKnownEventType)
+        {
+            this.IsKnownEventType = isKnownEventType;
+        }
+
+        /// <summary>
+        /// Gets the StripeClient instance that can be used to make API requests.
+        /// </summary>
+        public bool IsKnownEventType { get; }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
@@ -1,0 +1,755 @@
+namespace StripeTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Stripe;
+    using Stripe.Events;
+    using Xunit;
+
+    public class StripeEventNotificationHandlerTest : BaseStripeTest
+    {
+        private const string WebhookSecret = "whsec_test_secret";
+        private StripeClient stripeClient;
+
+        public StripeEventNotificationHandlerTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.stripeClient = this.StripeClient as StripeClient;
+        }
+
+        private string V1BillingMeterPayload => @"{
+            ""id"": ""evt_123"",
+            ""object"": ""v2.core.event"",
+            ""type"": ""v1.billing.meter.error_report_triggered"",
+            ""livemode"": false,
+            ""created"": ""2022-02-15T00:27:45.330Z"",
+            ""context"": ""event_context_456"",
+            ""related_object"": {
+                ""id"": ""mtr_123"",
+                ""type"": ""billing.meter"",
+                ""url"": ""/v1/billing/meters/mtr_123""
+            }
+        }";
+
+        private string V1BillingMeterNoMeterFoundPayload => @"{
+            ""id"": ""evt_789"",
+            ""object"": ""v2.core.event"",
+            ""type"": ""v1.billing.meter.no_meter_found"",
+            ""livemode"": false,
+            ""created"": ""2022-02-15T00:27:45.330Z"",
+            ""context"": null
+        }";
+
+        private string UnknownEventPayload => @"{
+            ""id"": ""evt_unknown"",
+            ""object"": ""v2.core.event"",
+            ""type"": ""llama.created"",
+            ""livemode"": false,
+            ""created"": ""2022-02-15T00:27:45.330Z"",
+            ""context"": ""event_context_unknown"",
+            ""related_object"": {
+                ""id"": ""llama_123"",
+                ""type"": ""llama"",
+                ""url"": ""/v1/llamas/llama_123""
+            }
+        }";
+
+        [Fact]
+        public void RoutesEventToRegisteredHandler()
+        {
+            var handlerCalled = false;
+            StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> receivedArgs = null;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+                receivedArgs = e;
+            }
+
+            var unhandledCalled = false;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.True(handlerCalled);
+            Assert.NotNull(receivedArgs);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(receivedArgs.EventNotification);
+            Assert.Equal("evt_123", receivedArgs.EventNotification.Id);
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void RoutesDifferentEventsToCorrectHandlers()
+        {
+            var billingHandlerCalled = false;
+            StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> billingArgs = null;
+
+            void BillingHandler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                billingHandlerCalled = true;
+                billingArgs = e;
+            }
+
+            var noMeterHandlerCalled = false;
+            StripeEventNotificationEventArgs<V1BillingMeterNoMeterFoundEventNotification> noMeterArgs = null;
+
+            void NoMeterHandler(object sender, StripeEventNotificationEventArgs<V1BillingMeterNoMeterFoundEventNotification> e)
+            {
+                noMeterHandlerCalled = true;
+                noMeterArgs = e;
+            }
+
+            var unhandledCalled = false;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += BillingHandler;
+            handler.V1BillingMeterNoMeterFound += NoMeterHandler;
+
+            var sigHeader1 = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader1);
+
+            var sigHeader2 = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterNoMeterFoundPayload);
+            handler.Handle(this.V1BillingMeterNoMeterFoundPayload, sigHeader2);
+
+            Assert.True(billingHandlerCalled);
+            Assert.NotNull(billingArgs);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(billingArgs.EventNotification);
+            Assert.Equal("evt_123", billingArgs.EventNotification.Id);
+
+            Assert.True(noMeterHandlerCalled);
+            Assert.NotNull(noMeterArgs);
+            Assert.IsType<V1BillingMeterNoMeterFoundEventNotification>(noMeterArgs.EventNotification);
+            Assert.Equal("evt_789", noMeterArgs.EventNotification.Id);
+
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void HandlerReceivesCorrectRuntimeType()
+        {
+            V1BillingMeterErrorReportTriggeredEventNotification receivedEvent = null;
+            StripeClient receivedClient = null;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                receivedEvent = e.EventNotification;
+                receivedClient = e.Client;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.NotNull(receivedEvent);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(receivedEvent);
+            Assert.Equal("v1.billing.meter.error_report_triggered", receivedEvent.Type);
+            Assert.Equal("evt_123", receivedEvent.Id);
+            Assert.Equal("mtr_123", receivedEvent.RelatedObject.Id);
+            Assert.NotNull(receivedClient);
+            Assert.IsType<StripeClient>(receivedClient);
+        }
+
+        [Fact]
+        public void CannotRegisterDuplicateHandler()
+        {
+            void Handler1(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            void Handler2(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler1;
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.V1BillingMeterErrorReportTriggered += Handler2;
+            });
+
+            Assert.Contains("already registered", exception.Message);
+        }
+
+        [Fact]
+        public void CannotRegisterHandlerAfterHandling()
+        {
+            void Handler1(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            void Handler2(object sender, StripeEventNotificationEventArgs<V1BillingMeterNoMeterFoundEventNotification> e)
+            {
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler1;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            // registration is expected to happen once at startup; doing it later is a bug
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.V1BillingMeterNoMeterFound += Handler2;
+            });
+
+            Assert.Contains("after Handle has been called", exception.Message);
+        }
+
+        [Fact]
+        public void CannotRemoveHandler()
+        {
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.V1BillingMeterErrorReportTriggered -= Handler;
+            });
+
+            Assert.Contains("not supported", exception.Message);
+        }
+
+        [Fact]
+        public void ValidatesWebhookSignature()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            var exception = Assert.Throws<StripeException>(() =>
+            {
+                handler.Handle(this.V1BillingMeterPayload, "invalid_signature");
+            });
+
+            Assert.Contains("header format is unexpected", exception.Message);
+        }
+
+        [Fact]
+        public void HandledEventTypesReturnsEmpty()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            var types = handler.HandledEventTypes();
+
+            Assert.Empty(types);
+        }
+
+        [Fact]
+        public void HandledEventTypesReturnsSingle()
+        {
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var types = handler.HandledEventTypes();
+
+            Assert.Single(types);
+            Assert.Equal("v1.billing.meter.error_report_triggered", types[0]);
+        }
+
+        [Fact]
+        public void HandledEventTypesReturnsMultipleAlphabetized()
+        {
+            void Handler(object sender, EventArgs e)
+            {
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            // Register in non-alphabetical order
+            handler.V2CoreAccountUpdated += Handler;
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+            handler.V2CoreAccountCreated += Handler;
+
+            var types = handler.HandledEventTypes();
+
+            Assert.Equal(3, types.Count);
+            Assert.Equal("v1.billing.meter.error_report_triggered", types[0]);
+            Assert.Equal("v2.core.account.created", types[1]);
+            Assert.Equal("v2.core.account.updated", types[2]);
+        }
+
+        [Fact]
+        public void UnknownEventRoutesToUnhandledHandler()
+        {
+            var unhandledCalled = false;
+            Stripe.V2.Core.EventNotification receivedNotification = null;
+            StripeClient receivedClient = null;
+            UnhandledNotificationDetails receivedDetails = null;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+                receivedNotification = e.EventNotification;
+                receivedClient = e.Client;
+                receivedDetails = e.Details;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.UnknownEventPayload);
+            handler.Handle(this.UnknownEventPayload, sigHeader);
+
+            Assert.True(unhandledCalled);
+            Assert.NotNull(receivedNotification);
+            Assert.IsType<UnknownEventNotification>(receivedNotification);
+            Assert.Equal("llama.created", receivedNotification.Type);
+            Assert.NotNull(receivedClient);
+            Assert.IsType<StripeClient>(receivedClient);
+            Assert.NotNull(receivedDetails);
+            Assert.False(receivedDetails.IsKnownEventType);
+        }
+
+        [Fact]
+        public void KnownUnregisteredEventRoutesToUnhandledHandler()
+        {
+            var unhandledCalled = false;
+            Stripe.V2.Core.EventNotification receivedNotification = null;
+            StripeClient receivedClient = null;
+            UnhandledNotificationDetails receivedDetails = null;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+                receivedNotification = e.EventNotification;
+                receivedClient = e.Client;
+                receivedDetails = e.Details;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+
+            // Don't register a handler for this event type
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.True(unhandledCalled);
+            Assert.NotNull(receivedNotification);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(receivedNotification);
+            Assert.Equal("v1.billing.meter.error_report_triggered", receivedNotification.Type);
+            Assert.NotNull(receivedClient);
+            Assert.IsType<StripeClient>(receivedClient);
+            Assert.NotNull(receivedDetails);
+            Assert.True(receivedDetails.IsKnownEventType);
+        }
+
+        [Fact]
+        public void RegisteredEventDoesNotCallUnhandledHandler()
+        {
+            var handlerCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            var unhandledCalled = false;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.True(handlerCalled);
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void HandlerUsesEventStripeContext()
+        {
+            StripeContext receivedContext = null;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                var requestor = e.Client.Requestor as LiveApiRequestor;
+                receivedContext = requestor?.CurrentStripeContext;
+            }
+
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "original_context_123",
+            };
+            var client = new StripeClient(clientOptions);
+            var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
+
+            // Verify original context is set
+            var requestor = client.Requestor as LiveApiRequestor;
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            // Handler should have received the event's context
+            Assert.NotNull(receivedContext);
+            Assert.Equal("event_context_456", receivedContext.ToString());
+
+            // Original context should be restored after handling
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+        }
+
+        [Fact]
+        public void HandlerExceptionRestoresOriginalContext()
+        {
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                var requestor = e.Client.Requestor as LiveApiRequestor;
+                Assert.Equal("event_context_456", requestor?.CurrentStripeContext?.ToString());
+                throw new InvalidOperationException("Handler error!");
+            }
+
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "original_context_123",
+            };
+            var client = new StripeClient(clientOptions);
+            var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
+
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var requestor = client.Requestor as LiveApiRequestor;
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(this.V1BillingMeterPayload, sigHeader);
+            });
+
+            // Original context should be restored even after exception
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+        }
+
+        [Fact]
+        public void HandlerWithNullEventContextUsesNull()
+        {
+            StripeContext receivedContext = StripeContext.Parse("should_be_replaced");
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V2CoreAccountCreatedEventNotification> e)
+            {
+                var requestor = e.Client.Requestor as LiveApiRequestor;
+                receivedContext = requestor?.CurrentStripeContext;
+            }
+
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "original_context_123",
+            };
+            var client = new StripeClient(clientOptions);
+            var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
+
+            handler.V2CoreAccountCreated += Handler;
+
+            var payload = @"{
+                ""id"": ""evt_account_created"",
+                ""object"": ""v2.core.event"",
+                ""type"": ""v2.core.account.created"",
+                ""livemode"": false,
+                ""created"": ""2022-02-15T00:27:45.330Z"",
+                ""context"": null
+            }";
+
+            var requestor = client.Requestor as LiveApiRequestor;
+            Assert.IsType<StripeContext>(requestor?.CurrentStripeContext);
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(payload);
+            handler.Handle(payload, sigHeader);
+
+            // Handler should have received null context
+            Assert.Null(receivedContext);
+
+            // Original context should be restored
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+        }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single type
+    public class StripeEventNotificationHandlerWithoutVerificationTest : BaseStripeTest
+    {
+        private StripeClient stripeClient;
+
+        public StripeEventNotificationHandlerWithoutVerificationTest(MockHttpClientFixture mockHttpClientFixture)
+            : base(mockHttpClientFixture)
+        {
+            this.stripeClient = this.StripeClient as StripeClient;
+        }
+
+        private string V1BillingMeterPayload => @"{
+            ""id"": ""evt_123"",
+            ""object"": ""v2.core.event"",
+            ""type"": ""v1.billing.meter.error_report_triggered"",
+            ""livemode"": false,
+            ""created"": ""2022-02-15T00:27:45.330Z"",
+            ""context"": ""event_context_456"",
+            ""related_object"": {
+                ""id"": ""mtr_123"",
+                ""type"": ""billing.meter"",
+                ""url"": ""/v1/billing/meters/mtr_123""
+            }
+        }";
+
+        private string UnknownEventPayload => @"{
+            ""id"": ""evt_unknown"",
+            ""object"": ""v2.core.event"",
+            ""type"": ""llama.created"",
+            ""livemode"": false,
+            ""created"": ""2022-02-15T00:27:45.330Z"",
+            ""context"": ""event_context_unknown"",
+            ""related_object"": {
+                ""id"": ""llama_123"",
+                ""type"": ""llama"",
+                ""url"": ""/v1/llamas/llama_123""
+            }
+        }";
+
+        [Fact]
+        public void RoutesEventToRegisteredHandler()
+        {
+            var handlerCalled = false;
+            StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> receivedArgs = null;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+                receivedArgs = e;
+            }
+
+            var unhandledCalled = false;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            handler.Handle(this.V1BillingMeterPayload);
+
+            Assert.True(handlerCalled);
+            Assert.NotNull(receivedArgs);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(receivedArgs.EventNotification);
+            Assert.Equal("evt_123", receivedArgs.EventNotification.Id);
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void HandleTakesOnlyBody()
+        {
+            // Handle(json) takes a single parameter — no signature header required.
+            var handlerCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            // No sig header — this must not throw.
+            handler.Handle(this.V1BillingMeterPayload);
+
+            Assert.True(handlerCalled);
+        }
+
+        [Fact]
+        public void KnownUnregisteredEventRoutesToFallbackWithIsKnownTrue()
+        {
+            var unhandledCalled = false;
+            Stripe.V2.Core.EventNotification receivedNotification = null;
+            StripeClient receivedClient = null;
+            UnhandledNotificationDetails receivedDetails = null;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+                receivedNotification = e.EventNotification;
+                receivedClient = e.Client;
+                receivedDetails = e.Details;
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
+
+            // Don't register a handler for this event type
+            handler.Handle(this.V1BillingMeterPayload);
+
+            Assert.True(unhandledCalled);
+            Assert.NotNull(receivedNotification);
+            Assert.IsType<V1BillingMeterErrorReportTriggeredEventNotification>(receivedNotification);
+            Assert.Equal("v1.billing.meter.error_report_triggered", receivedNotification.Type);
+            Assert.NotNull(receivedClient);
+            Assert.IsType<StripeClient>(receivedClient);
+            Assert.NotNull(receivedDetails);
+            Assert.True(receivedDetails.IsKnownEventType);
+        }
+
+        [Fact]
+        public void UnknownEventRoutesToFallbackWithIsKnownFalse()
+        {
+            var unhandledCalled = false;
+            Stripe.V2.Core.EventNotification receivedNotification = null;
+            StripeClient receivedClient = null;
+            UnhandledNotificationDetails receivedDetails = null;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+                receivedNotification = e.EventNotification;
+                receivedClient = e.Client;
+                receivedDetails = e.Details;
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
+
+            handler.Handle(this.UnknownEventPayload);
+
+            Assert.True(unhandledCalled);
+            Assert.NotNull(receivedNotification);
+            Assert.IsType<UnknownEventNotification>(receivedNotification);
+            Assert.Equal("llama.created", receivedNotification.Type);
+            Assert.NotNull(receivedClient);
+            Assert.IsType<StripeClient>(receivedClient);
+            Assert.NotNull(receivedDetails);
+            Assert.False(receivedDetails.IsKnownEventType);
+        }
+
+        [Fact]
+        public void HandlerUsesEventStripeContext()
+        {
+            StripeContext receivedContext = null;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                var requestor = e.Client.Requestor as LiveApiRequestor;
+                receivedContext = requestor?.CurrentStripeContext;
+            }
+
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "original_context_123",
+            };
+            var client = new StripeClient(clientOptions);
+            var handler = StripeEventNotificationHandler.WithoutVerification(client, (s, e) => { });
+
+            // Verify original context is set
+            var requestor = client.Requestor as LiveApiRequestor;
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            handler.Handle(this.V1BillingMeterPayload);
+
+            // Handler should have received the event's context
+            Assert.NotNull(receivedContext);
+            Assert.Equal("event_context_456", receivedContext.ToString());
+
+            // Original context should be restored after handling
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+        }
+
+        [Fact]
+        public void CannotRegisterHandlerAfterHandling()
+        {
+            void Handler1(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+            }
+
+            void Handler2(object sender, StripeEventNotificationEventArgs<V1BillingMeterNoMeterFoundEventNotification> e)
+            {
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler1;
+
+            handler.Handle(this.V1BillingMeterPayload);
+
+            // the guard lives on the shared base, so it applies to this sibling too
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.V1BillingMeterNoMeterFound += Handler2;
+            });
+
+            Assert.Contains("after Handle has been called", exception.Message);
+        }
+
+        [Fact]
+        public void DoesNotExposeVerifyingHandle()
+        {
+            // The two handlers are siblings, so the signature-verifying Handle(json, sigHeader)
+            // isn't inherited here at all -- passing a signature header is a compile error rather
+            // than a runtime one. Assert on the declared methods so a refactor can't quietly
+            // reintroduce it.
+            var handleMethods = typeof(StripeEventNotificationHandlerWithoutVerification)
+                .GetMethods()
+                .Where(m => m.Name == "Handle")
+                .ToList();
+
+            Assert.Single(handleMethods);
+            Assert.Single(handleMethods[0].GetParameters());
+        }
+
+        [Fact]
+        public void CannotBeDerivedOutsideThisAssembly()
+        {
+            // The shared base has to be public (CS0060), so its constructor is internal instead.
+            var ctors = typeof(StripeEventNotificationHandlerBase)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.Empty(ctors);
+        }
+
+        [Fact]
+        public void StaticFactoryReturnsCorrectType()
+        {
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, (s, e) => { });
+
+            Assert.IsType<StripeEventNotificationHandlerWithoutVerification>(handler);
+        }
+
+        [Fact]
+        public void ClientFactoryMethodReturnsCorrectType()
+        {
+            var handler = this.stripeClient.NotificationHandlerWithoutVerification((s, e) => { });
+
+            Assert.IsType<StripeEventNotificationHandlerWithoutVerification>(handler);
+        }
+    }
+#pragma warning restore SA1402 // File may only contain a single type
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The event notification handler code has been in the `beta` and `private-preview` branches since last year, but it's time to take it to GA!

This PR is entirely pre-approved code from previous PRs. It takes the static files from codegen, plus all the manual changes I made directly in `beta` to get everything working. It's stacked on top of the non-verified work from this week, too. Once this lands, the managed handler code should be in sync across all channels.

Notably, the static files that we used to share functionality are no longer sourced from codegen. Instead, they're now true manual files in `master` whose changes will flow into preview branches like normal.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `EventNotificationHandler` class & supporting infrastructure (ability to copy a `StripeClient`, etc)
- add `stripeClient` methods for creating a handler bound to that client
- add example
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://stripe.dev/blog/event-notification-handlers-thin-events
- [internal doc](https://docs.google.com/document/d/1hRpQLMLGfOHhZwXrYt5tvsKT-oIya11M4atunvTOih0/edit?tab=t.w21fiib3jsl3#heading=h.p5iqpr8dzdsz)
- Initial PR: https://github.com/stripe/stripe-dotnet/pull/3250
- Update PR (adds non-verified handlers): https://github.com/stripe/sdk-codegen/pull/3028

## Changelog

- We've been putting a lot of time into rethinking the event handling experience in the SDKs. This new class is the culmination [of that effort](https://stripe.dev/blog/event-notification-handlers-thin-events).
- They're designed for a tight coupling with both `StripeClient` and the fully-typed nature of [thin events](https://docs.stripe.com/event-destinations#thin-events). This delivers painless event destination upgrades, in-editor checks for common mistakes, and better code modularity.
- Now that we've released [thin event notifications for v1 objects](https://docs.stripe.com/changelog#2026-08-26.dahlia), these new handlers are our recommended path for all integrations using thin event notifications.
- See more detailed docs here: https://docs.stripe.com/webhooks/event-notification-handlers
