### PR TITLE
Add `.preHandle` method to `EventNotificationHandler`

### DIFF
--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -17,8 +17,7 @@ namespace Examples.V2
     ///     - write a fallback callback to handle unrecognized event notifications
     ///     - create a StripeClient called client
     ///     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
-    ///     - register a PreHandle hook that deduplicates events we've already processed, so retried
-    ///       deliveries don't trigger the callback (or the fallback) a second time
+    ///     - register a PreHandle hook that deduplicates events by id before any callback runs
     ///     - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
     ///     - use handler.handle() to process the received notification webhook body.
     /// </summary>
@@ -34,8 +33,9 @@ namespace Examples.V2
         // this handler skips verification. Callbacks are registered separately from the one above.
         private readonly StripeEventNotificationHandlerWithoutVerification unverifiedHandler;
 
-        // Tracks event IDs we've already processed, so retried deliveries are skipped instead of
-        // re-triggering a callback. A real implementation would back this with persistent storage.
+        // Webhooks can be delivered more than once, so we track ids we've already
+        // processed. In production, back this with something durable and shared
+        // across processes (e.g. Redis or a database table) instead of an in-memory HashSet.
         private readonly HashSet<string> processedEventIds = new HashSet<string>();
 
         public EventNotificationHandlerEndpoint()
@@ -49,11 +49,15 @@ namespace Examples.V2
             handler.PreHandle(SkipAlreadyProcessedEvents);
             unverifiedHandler.PreHandle(SkipAlreadyProcessedEvents);
 
-            // register handlers
+            // can be anywhere in your codebase
             handler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
             unverifiedHandler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
         }
 
+        /// <summary>
+        /// Runs before any registered callback. Returning <c>false</c> here skips handling
+        /// entirely for this delivery, which is useful for deduplicating webhooks.
+        /// </summary>
         private bool SkipAlreadyProcessedEvents(Stripe.V2.Core.EventNotification eventNotification, StripeClient scopedClient)
         {
             // HashSet<T>.Add returns false if the item was already present, so this both records

--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -17,7 +17,7 @@ namespace Examples.V2
     ///     - write a fallback callback to handle unrecognized event notifications
     ///     - create a StripeClient called client
     ///     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
-    ///     - set a PreHandle hook that deduplicates events by id before any callback runs
+    ///     - register a PreHandle callback that deduplicates events by id before any callback runs
     ///     - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
     ///     - use handler.handle() to process the received notification webhook body.
     /// </summary>
@@ -45,9 +45,9 @@ namespace Examples.V2
             unverifiedHandler = client.NotificationHandlerWithoutVerification(FallbackCallback);
 
             // PreHandle runs after Handle parses the payload but before any callback fires.
-            // Returning false skips both the registered handler and the fallback for this event.
-            handler.PreHandle = SkipAlreadyProcessedEvents;
-            unverifiedHandler.PreHandle = SkipAlreadyProcessedEvents;
+            // Cancelling skips both the registered handler and the fallback for this event.
+            handler.PreHandle += SkipAlreadyProcessedEvents;
+            unverifiedHandler.PreHandle += SkipAlreadyProcessedEvents;
 
             // can be anywhere in your codebase
             handler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
@@ -55,14 +55,14 @@ namespace Examples.V2
         }
 
         /// <summary>
-        /// Runs before any registered callback. Returning <c>false</c> here skips handling
+        /// Runs before any registered callback. Setting <c>e.Cancel</c> here skips handling
         /// entirely for this delivery, which is useful for deduplicating webhooks.
         /// </summary>
-        private bool SkipAlreadyProcessedEvents(Stripe.V2.Core.EventNotification eventNotification, StripeClient scopedClient)
+        private void SkipAlreadyProcessedEvents(object sender, Stripe.StripePreHandleEventNotificationEventArgs e)
         {
             // HashSet<T>.Add returns false if the item was already present, so this both records
             // the event and tells us whether we've seen it before in a single call.
-            return processedEventIds.Add(eventNotification.Id);
+            e.Cancel = !processedEventIds.Add(e.EventNotification.Id);
         }
 
         private void HandleBillingMeterErrorReportTriggeredEventNotification(object sender, Stripe.StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification> e)

--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -3,6 +3,7 @@ namespace Examples.V2
 #pragma warning disable SA1101 // Prefix local calls with this
 
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,8 @@ namespace Examples.V2
     ///     - write a fallback callback to handle unrecognized event notifications
     ///     - create a StripeClient called client
     ///     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+    ///     - register a PreHandle hook that deduplicates events we've already processed, so retried
+    ///       deliveries don't trigger the callback (or the fallback) a second time
     ///     - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
     ///     - use handler.handle() to process the received notification webhook body.
     /// </summary>
@@ -31,15 +34,31 @@ namespace Examples.V2
         // this handler skips verification. Callbacks are registered separately from the one above.
         private readonly StripeEventNotificationHandlerWithoutVerification unverifiedHandler;
 
+        // Tracks event IDs we've already processed, so retried deliveries are skipped instead of
+        // re-triggering a callback. A real implementation would back this with persistent storage.
+        private readonly HashSet<string> processedEventIds = new HashSet<string>();
+
         public EventNotificationHandlerEndpoint()
         {
             client = new StripeClient(Environment.GetEnvironmentVariable("STRIPE_API_KEY"));
             handler = client.NotificationHandler(Environment.GetEnvironmentVariable("WEBHOOK_SECRET") ?? string.Empty, FallbackCallback);
             unverifiedHandler = client.NotificationHandlerWithoutVerification(FallbackCallback);
 
+            // PreHandle runs after Handle parses the payload but before any callback fires.
+            // Returning false skips both the registered handler and the fallback for this event.
+            handler.PreHandle(SkipAlreadyProcessedEvents);
+            unverifiedHandler.PreHandle(SkipAlreadyProcessedEvents);
+
             // register handlers
             handler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
             unverifiedHandler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;
+        }
+
+        private bool SkipAlreadyProcessedEvents(Stripe.V2.Core.EventNotification eventNotification, StripeClient scopedClient)
+        {
+            // HashSet<T>.Add returns false if the item was already present, so this both records
+            // the event and tells us whether we've seen it before in a single call.
+            return processedEventIds.Add(eventNotification.Id);
         }
 
         private void HandleBillingMeterErrorReportTriggeredEventNotification(object sender, Stripe.StripeEventNotificationEventArgs<Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification> e)

--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -17,7 +17,7 @@ namespace Examples.V2
     ///     - write a fallback callback to handle unrecognized event notifications
     ///     - create a StripeClient called client
     ///     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
-    ///     - register a PreHandle hook that deduplicates events by id before any callback runs
+    ///     - set a PreHandle hook that deduplicates events by id before any callback runs
     ///     - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
     ///     - use handler.handle() to process the received notification webhook body.
     /// </summary>
@@ -46,8 +46,8 @@ namespace Examples.V2
 
             // PreHandle runs after Handle parses the payload but before any callback fires.
             // Returning false skips both the registered handler and the fallback for this event.
-            handler.PreHandle(SkipAlreadyProcessedEvents);
-            unverifiedHandler.PreHandle(SkipAlreadyProcessedEvents);
+            handler.PreHandle = SkipAlreadyProcessedEvents;
+            unverifiedHandler.PreHandle = SkipAlreadyProcessedEvents;
 
             // can be anywhere in your codebase
             handler.V1BillingMeterErrorReportTriggered += HandleBillingMeterErrorReportTriggeredEventNotification;

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -286,7 +286,7 @@ namespace Stripe
 
             if (this.preHandleCallback != null)
             {
-                throw new InvalidOperationException("A PreHandle hook is already registered. Only one PreHandle hook is allowed.");
+                throw new InvalidOperationException("A PreHandle callback is already registered");
             }
 
             this.preHandleCallback = hook;
@@ -304,7 +304,7 @@ namespace Stripe
         {
             if (this.HasHandledEvent)
             {
-                throw new InvalidOperationException("Cannot register new event handlers after Handle has been called. This is indicative of a bug.");
+                throw new InvalidOperationException("Cannot register new callbacks after an event has been handled. This is indicative of a bug.");
             }
         }
 
@@ -335,10 +335,20 @@ namespace Stripe
 
         /// <summary>
         /// Centralizes the logic for adding event handlers.
+        ///
+        /// Rejects a null callback rather than storing it. C# permits <c>SomeEvent += null</c>,
+        /// which would otherwise record the event type as handled while leaving the backing
+        /// delegate null — dispatch would then take the registered branch (bypassing the
+        /// fallback) and throw a NullReferenceException far from the offending registration.
         /// </summary>
         private void AddEventHandler<T>(ref EventHandler<T> handler, EventHandler<T> value, string eventType)
         where T : EventArgs
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             this.AssertCanRegister();
 
             if (this.handledEventTypes.Add(eventType))
@@ -347,7 +357,7 @@ namespace Stripe
             }
             else
             {
-                throw new InvalidOperationException($"A handler for event type '{eventType}' is already registered. Only one handler per event type is allowed.");
+                throw new InvalidOperationException($"Callback for event type '{eventType}' is already registered");
             }
         }
 
@@ -356,7 +366,7 @@ namespace Stripe
         /// </summary>
         private void RemoveEventHandler()
         {
-            throw new InvalidOperationException("Removing handlers is not supported.");
+            throw new InvalidOperationException("Removing callbacks is not supported.");
         }
 
         private void DispatchEvent(V2.Core.EventNotification eventNotification, StripeClient client)
@@ -480,7 +490,7 @@ namespace Stripe
                 // event-handler-dispatch: The end of the section generated from our OpenAPI spec
                 else
                 {
-                    throw new Exception("unexpected state, please file a bug");
+                    throw new Exception("Unexpected state, please file a bug.");
                 }
             }
             else

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -243,6 +243,47 @@ namespace Stripe
         // public-event-handlers: The end of the section generated from our OpenAPI spec
 
         /// <summary>
+        /// Gets or sets a function that runs before any event-specific callbacks. A useful
+        /// place for event-agnostic logic, such as logging or checking for
+        /// <see href="https://docs.stripe.com/webhooks#handle-duplicate-events">duplicate event deliveries</see>.
+        ///
+        /// The function receives the parsed event notification and the context-scoped client.
+        /// Returning <c>true</c> causes handling to continue as normal; returning <c>false</c>
+        /// returns from <c>Handle</c> immediately, so neither the registered callback nor the
+        /// fallback callback are called.
+        /// </summary>
+        /// <value>The function to run before any event-specific callbacks, if any.</value>
+        /// <exception cref="ArgumentNullException">Thrown if set to null.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if set after <c>Handle</c> has already been called, or if a function is
+        /// already set.
+        /// </exception>
+        public Func<V2.Core.EventNotification, StripeClient, bool> PreHandle
+        {
+            get
+            {
+                return this.preHandleCallback;
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                this.AssertHasntHandled();
+
+                if (this.preHandleCallback != null)
+                {
+                    throw new InvalidOperationException("A PreHandle callback is already registered");
+                }
+
+                this.preHandleCallback = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this handler has already handled an event.
         /// Registering a callback afterwards is refused, since callbacks are expected to be
         /// registered once at startup; doing so later indicates a bug.
@@ -264,41 +305,6 @@ namespace Stripe
         }
 
         /// <summary>
-        /// Registers a function that will be run before any event-specific callbacks. A useful
-        /// place to store event-agnostic logic, such as logging or checking for
-        /// <see href="https://docs.stripe.com/webhooks#handle-duplicate-events">duplicate event deliveries</see>.
-        ///
-        /// Returning <c>true</c> causes handling to continue as normal; returning <c>false</c>
-        /// returns from <c>Handle</c> immediately, so neither the registered callback nor the
-        /// fallback callback are called.
-        /// </summary>
-        /// <param name="hook">
-        /// A function that receives the parsed event notification and the context-scoped
-        /// client, and returns whether handling should continue.
-        /// </param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hook"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if called after <c>Handle</c> has already been called, or if a hook is
-        /// already registered.
-        /// </exception>
-        public void PreHandle(Func<V2.Core.EventNotification, StripeClient, bool> hook)
-        {
-            if (hook == null)
-            {
-                throw new ArgumentNullException(nameof(hook));
-            }
-
-            this.AssertCanRegister();
-
-            if (this.preHandleCallback != null)
-            {
-                throw new InvalidOperationException("A PreHandle callback is already registered");
-            }
-
-            this.preHandleCallback = hook;
-        }
-
-        /// <summary>
         /// Throws if callbacks can no longer be registered. Callbacks are expected to be
         /// registered once at startup, so registering anything after handling has begun
         /// indicates a bug.
@@ -306,7 +312,7 @@ namespace Stripe
         /// <exception cref="InvalidOperationException">
         /// Thrown if <c>Handle</c> has already been called.
         /// </exception>
-        private void AssertCanRegister()
+        private void AssertHasntHandled()
         {
             if (this.HasHandledEvent)
             {
@@ -355,7 +361,7 @@ namespace Stripe
                 throw new ArgumentNullException(nameof(value));
             }
 
-            this.AssertCanRegister();
+            this.AssertHasntHandled();
 
             if (this.handledEventTypes.Add(eventType))
             {

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -53,7 +53,7 @@ namespace Stripe
         private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreEventDestinationPingEventNotification>> v2CoreEventDestinationPing;
 
         // private-event-handlers: The end of the section generated from our OpenAPI spec
-        private Func<V2.Core.EventNotification, StripeClient, bool> preHandleCallback;
+        private EventHandler<StripePreHandleEventNotificationEventArgs> preHandleCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StripeEventNotificationHandlerBase"/> class.
@@ -243,29 +243,17 @@ namespace Stripe
         // public-event-handlers: The end of the section generated from our OpenAPI spec
 
         /// <summary>
-        /// Gets or sets a function that runs before any event-specific callbacks. A useful
-        /// place for event-agnostic logic, such as logging or checking for
+        /// A callback that runs before any event-specific callbacks. A useful place for
+        /// event-agnostic logic, such as logging or checking for
         /// <see href="https://docs.stripe.com/webhooks#handle-duplicate-events">duplicate event deliveries</see>.
         ///
-        /// The function receives the parsed event notification and the context-scoped client.
-        /// Returning <c>true</c> causes handling to continue as normal; returning <c>false</c>
-        /// returns from <c>Handle</c> immediately, so neither the registered callback nor the
-        /// fallback callback are called.
+        /// The callback receives the parsed event notification and the context-scoped client.
+        /// Setting <see cref="StripePreHandleEventNotificationEventArgs.Cancel"/> to <c>true</c>
+        /// returns from <c>Handle</c> once the preHandle callback finishes, so further callbacks are called.
         /// </summary>
-        /// <value>The function to run before any event-specific callbacks, if any.</value>
-        /// <exception cref="ArgumentNullException">Thrown if set to null.</exception>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if set after <c>Handle</c> has already been called, or if a function is
-        /// already set.
-        /// </exception>
-        public Func<V2.Core.EventNotification, StripeClient, bool> PreHandle
+        public event EventHandler<StripePreHandleEventNotificationEventArgs> PreHandle
         {
-            get
-            {
-                return this.preHandleCallback;
-            }
-
-            set
+            add
             {
                 if (value == null)
                 {
@@ -280,6 +268,11 @@ namespace Stripe
                 }
 
                 this.preHandleCallback = value;
+            }
+
+            remove
+            {
+                this.RemoveEventHandler();
             }
         }
 
@@ -388,9 +381,15 @@ namespace Stripe
                 throw new ArgumentNullException(nameof(eventNotification));
             }
 
-            if (this.preHandleCallback != null && !this.preHandleCallback(eventNotification, client))
+            if (this.preHandleCallback != null)
             {
-                return;
+                var preHandleArgs = new StripePreHandleEventNotificationEventArgs(eventNotification, client);
+                this.preHandleCallback.Invoke(this, preHandleArgs);
+
+                if (preHandleArgs.Cancel)
+                {
+                    return;
+                }
             }
 
             if (this.handledEventTypes.Contains(eventNotification.Type))

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -264,7 +264,13 @@ namespace Stripe
         }
 
         /// <summary>
-        /// Registers a hook that runs after <c>Handle</c> parses the payload but before any callback fires. Returning <c>false</c> stops handling: no callback runs at all.
+        /// Registers a function that will be run before any event-specific callbacks. A useful
+        /// place to store event-agnostic logic, such as logging or checking for
+        /// <see href="https://docs.stripe.com/webhooks#handle-duplicate-events">duplicate event deliveries</see>.
+        ///
+        /// Returning <c>true</c> causes handling to continue as normal; returning <c>false</c>
+        /// returns from <c>Handle</c> immediately, so neither the registered callback nor the
+        /// fallback callback are called.
         /// </summary>
         /// <param name="hook">
         /// A function that receives the parsed event notification and the context-scoped

--- a/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeEventNotificationHandlerBase.cs
@@ -53,6 +53,7 @@ namespace Stripe
         private EventHandler<StripeEventNotificationEventArgs<Stripe.Events.V2CoreEventDestinationPingEventNotification>> v2CoreEventDestinationPing;
 
         // private-event-handlers: The end of the section generated from our OpenAPI spec
+        private Func<V2.Core.EventNotification, StripeClient, bool> preHandleCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StripeEventNotificationHandlerBase"/> class.
@@ -263,6 +264,51 @@ namespace Stripe
         }
 
         /// <summary>
+        /// Registers a hook that runs after <c>Handle</c> parses the payload but before any callback fires. Returning <c>false</c> stops handling: no callback runs at all.
+        /// </summary>
+        /// <param name="hook">
+        /// A function that receives the parsed event notification and the context-scoped
+        /// client, and returns whether handling should continue.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="hook"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if called after <c>Handle</c> has already been called, or if a hook is
+        /// already registered.
+        /// </exception>
+        public void PreHandle(Func<V2.Core.EventNotification, StripeClient, bool> hook)
+        {
+            if (hook == null)
+            {
+                throw new ArgumentNullException(nameof(hook));
+            }
+
+            this.AssertCanRegister();
+
+            if (this.preHandleCallback != null)
+            {
+                throw new InvalidOperationException("A PreHandle hook is already registered. Only one PreHandle hook is allowed.");
+            }
+
+            this.preHandleCallback = hook;
+        }
+
+        /// <summary>
+        /// Throws if callbacks can no longer be registered. Callbacks are expected to be
+        /// registered once at startup, so registering anything after handling has begun
+        /// indicates a bug.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if <c>Handle</c> has already been called.
+        /// </exception>
+        private void AssertCanRegister()
+        {
+            if (this.HasHandledEvent)
+            {
+                throw new InvalidOperationException("Cannot register new event handlers after Handle has been called. This is indicative of a bug.");
+            }
+        }
+
+        /// <summary>
         /// Dispatches the event with the event's StripeContext by creating a new client instance.
         /// </summary>
         /// <param name="eventNotification">The event notification to dispatch.</param>
@@ -293,10 +339,7 @@ namespace Stripe
         private void AddEventHandler<T>(ref EventHandler<T> handler, EventHandler<T> value, string eventType)
         where T : EventArgs
         {
-            if (this.HasHandledEvent)
-            {
-                throw new InvalidOperationException("Cannot register new event handlers after Handle has been called. This is indicative of a bug.");
-            }
+            this.AssertCanRegister();
 
             if (this.handledEventTypes.Add(eventType))
             {
@@ -321,6 +364,11 @@ namespace Stripe
             if (eventNotification == null)
             {
                 throw new ArgumentNullException(nameof(eventNotification));
+            }
+
+            if (this.preHandleCallback != null && !this.preHandleCallback(eventNotification, client))
+            {
+                return;
             }
 
             if (this.handledEventTypes.Contains(eventNotification.Type))

--- a/src/Stripe.net/Infrastructure/Public/StripePreHandleEventNotificationEventArgs.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripePreHandleEventNotificationEventArgs.cs
@@ -1,0 +1,28 @@
+namespace Stripe
+{
+    /// <summary>
+    /// EventArgs for the PreHandle callback, which runs before any event-specific callback.
+    /// Carries the parsed event notification, the context-scoped StripeClient, and a
+    /// <see cref="Cancel"/> flag that stops handling for this delivery.
+    /// </summary>
+    public class StripePreHandleEventNotificationEventArgs : StripeEventNotificationEventArgs<V2.Core.EventNotification>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StripePreHandleEventNotificationEventArgs"/> class.
+        /// </summary>
+        /// <param name="eventNotification">The event notification instance.</param>
+        /// <param name="client">The StripeClient instance.</param>
+        public StripePreHandleEventNotificationEventArgs(V2.Core.EventNotification eventNotification, StripeClient client)
+            : base(eventNotification, client)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to stop handling this event notification.
+        /// Setting it to <c>true</c> returns from <c>Handle</c> as soon as the PreHandle
+        /// callback finishes, so neither the registered callback nor the fallback callback are
+        /// called. Defaults to <c>false</c>, which lets handling continue as normal.
+        /// </summary>
+        public bool Cancel { get; set; }
+    }
+}

--- a/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
@@ -508,7 +508,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void PreHandleReturningTrueRunsBeforeRegisteredHandler()
+        public void PreHandleRunsBeforeRegisteredHandler()
         {
             var callOrder = new List<string>();
 
@@ -519,10 +519,9 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle = (notification, client) =>
+            handler.PreHandle += (sender, e) =>
             {
                 callOrder.Add("preHandle");
-                return true;
             };
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
@@ -532,7 +531,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void PreHandleReturningFalsePreventsRegisteredHandler()
+        public void PreHandleCancelPreventsRegisteredHandler()
         {
             var handlerCalled = false;
 
@@ -543,7 +542,7 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle = (notification, client) => false;
+            handler.PreHandle += (sender, e) => e.Cancel = true;
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
             handler.Handle(this.V1BillingMeterPayload, sigHeader);
@@ -552,7 +551,7 @@ namespace StripeTests
         }
 
         [Fact]
-        public void PreHandleReturningFalsePreventsFallbackForUnknownEvent()
+        public void PreHandleCancelPreventsFallbackForUnknownEvent()
         {
             var unhandledCalled = false;
 
@@ -562,7 +561,7 @@ namespace StripeTests
             }
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
-            handler.PreHandle = (notification, client) => false;
+            handler.PreHandle += (sender, e) => e.Cancel = true;
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.UnknownEventPayload);
             handler.Handle(this.UnknownEventPayload, sigHeader);
@@ -571,9 +570,10 @@ namespace StripeTests
         }
 
         [Fact]
-        public void PreHandleReceivesContextScopedClientAndDoesNotMutateHandlerClient()
+        public void PreHandleReceivesNotificationAndContextScopedClientAndDoesNotMutateHandlerClient()
         {
             StripeContext receivedContext = null;
+            Stripe.V2.Core.EventNotification receivedNotification = null;
 
             var clientOptions = new StripeClientOptions
             {
@@ -583,11 +583,11 @@ namespace StripeTests
             var client = new StripeClient(clientOptions);
             var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += (sender, e) => { };
-            handler.PreHandle = (notification, preHandleClient) =>
+            handler.PreHandle += (sender, e) =>
             {
-                var requestor = preHandleClient.Requestor as LiveApiRequestor;
-                receivedContext = requestor?.CurrentStripeContext;
-                return true;
+                receivedNotification = e.EventNotification;
+                var preHandleRequestor = e.Client.Requestor as LiveApiRequestor;
+                receivedContext = preHandleRequestor?.CurrentStripeContext;
             };
 
             var requestor = client.Requestor as LiveApiRequestor;
@@ -596,7 +596,9 @@ namespace StripeTests
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
             handler.Handle(this.V1BillingMeterPayload, sigHeader);
 
-            // PreHandle should have received the event's context-scoped client
+            // PreHandle should have received the parsed notification and the event's
+            // context-scoped client
+            Assert.Equal("v1.billing.meter.error_report_triggered", receivedNotification?.Type);
             Assert.NotNull(receivedContext);
             Assert.Equal("event_context_456", receivedContext.ToString());
 
@@ -622,7 +624,7 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle = (notification, client) => throw new InvalidOperationException("PreHandle blew up!");
+            handler.PreHandle += (sender, e) => throw new InvalidOperationException("PreHandle blew up!");
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
 
@@ -642,7 +644,7 @@ namespace StripeTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.PreHandle = null;
+                handler.PreHandle += null;
             });
         }
 
@@ -656,37 +658,42 @@ namespace StripeTests
 
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.PreHandle = (notification, client) => true;
+                handler.PreHandle += (sender, e) => { };
             });
 
             Assert.Contains("after an event has been handled", exception.Message);
         }
 
         [Fact]
-        public void PreHandleSetTwiceThrowsInvalidOperationException()
+        public void PreHandleRegisteredTwiceThrowsInvalidOperationException()
         {
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
-            handler.PreHandle = (notification, client) => true;
+            handler.PreHandle += (sender, e) => { };
 
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.PreHandle = (notification, client) => true;
+                handler.PreHandle += (sender, e) => { };
             });
 
             Assert.Contains("already registered", exception.Message);
         }
 
         [Fact]
-        public void PreHandleGetterReturnsTheSetHook()
+        public void CannotRemovePreHandle()
         {
+            void PreHandler(object sender, StripePreHandleEventNotificationEventArgs e)
+            {
+            }
+
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.PreHandle += PreHandler;
 
-            Assert.Null(handler.PreHandle);
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.PreHandle -= PreHandler;
+            });
 
-            Func<Stripe.V2.Core.EventNotification, StripeClient, bool> hook = (notification, client) => true;
-            handler.PreHandle = hook;
-
-            Assert.Same(hook, handler.PreHandle);
+            Assert.Contains("not supported", exception.Message);
         }
 
         [Fact]
@@ -964,7 +971,7 @@ namespace StripeTests
 
             var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle = (notification, client) => false;
+            handler.PreHandle += (sender, e) => e.Cancel = true;
 
             handler.Handle(this.V1BillingMeterPayload);
 

--- a/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
@@ -454,6 +454,194 @@ namespace StripeTests
         }
 
         [Fact]
+        public void NoPreHandleHookRegisteredHandlerStillRuns()
+        {
+            var handlerCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.True(handlerCalled);
+        }
+
+        [Fact]
+        public void PreHandleReturningTrueRunsBeforeRegisteredHandler()
+        {
+            var callOrder = new List<string>();
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                callOrder.Add("handler");
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+            handler.PreHandle((notification, client) =>
+            {
+                callOrder.Add("preHandle");
+                return true;
+            });
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.Equal(new List<string> { "preHandle", "handler" }, callOrder);
+        }
+
+        [Fact]
+        public void PreHandleReturningFalsePreventsRegisteredHandler()
+        {
+            var handlerCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+            handler.PreHandle((notification, client) => false);
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            Assert.False(handlerCalled);
+        }
+
+        [Fact]
+        public void PreHandleReturningFalsePreventsFallbackForUnknownEvent()
+        {
+            var unhandledCalled = false;
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+            handler.PreHandle((notification, client) => false);
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.UnknownEventPayload);
+            handler.Handle(this.UnknownEventPayload, sigHeader);
+
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void PreHandleReceivesContextScopedClientAndDoesNotMutateHandlerClient()
+        {
+            StripeContext receivedContext = null;
+
+            var clientOptions = new StripeClientOptions
+            {
+                ApiKey = "sk_test_123",
+                StripeContext = "original_context_123",
+            };
+            var client = new StripeClient(clientOptions);
+            var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
+            handler.V1BillingMeterErrorReportTriggered += (sender, e) => { };
+            handler.PreHandle((notification, preHandleClient) =>
+            {
+                var requestor = preHandleClient.Requestor as LiveApiRequestor;
+                receivedContext = requestor?.CurrentStripeContext;
+                return true;
+            });
+
+            var requestor = client.Requestor as LiveApiRequestor;
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            // PreHandle should have received the event's context-scoped client
+            Assert.NotNull(receivedContext);
+            Assert.Equal("event_context_456", receivedContext.ToString());
+
+            // The handler's own client is unmutated
+            Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
+        }
+
+        [Fact]
+        public void PreHandleThrowingPropagatesAndPreventsCallbacks()
+        {
+            var handlerCalled = false;
+            var unhandledCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+            handler.PreHandle((notification, client) => throw new InvalidOperationException("PreHandle blew up!"));
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(this.V1BillingMeterPayload, sigHeader);
+            });
+
+            Assert.False(handlerCalled);
+            Assert.False(unhandledCalled);
+        }
+
+        [Fact]
+        public void PreHandleNullThrowsArgumentNullException()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.PreHandle(null);
+            });
+        }
+
+        [Fact]
+        public void PreHandleAfterHandlingThrowsInvalidOperationException()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
+            handler.Handle(this.V1BillingMeterPayload, sigHeader);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.PreHandle((notification, client) => true);
+            });
+
+            Assert.Contains("after Handle has been called", exception.Message);
+        }
+
+        [Fact]
+        public void PreHandleRegisteredTwiceThrowsInvalidOperationException()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+            handler.PreHandle((notification, client) => true);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.PreHandle((notification, client) => true);
+            });
+
+            Assert.Contains("already registered", exception.Message);
+        }
+
+        [Fact]
         public void HandlerWithNullEventContextUsesNull()
         {
             StripeContext receivedContext = StripeContext.Parse("should_be_replaced");
@@ -707,6 +895,33 @@ namespace StripeTests
             });
 
             Assert.Contains("after Handle has been called", exception.Message);
+        }
+
+        [Fact]
+        public void PreHandleGatesRegisteredHandlerAndFallback()
+        {
+            // the PreHandle hook lives on the shared base, so it applies to this sibling too
+            var handlerCalled = false;
+            var unhandledCalled = false;
+
+            void Handler(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
+            {
+                handlerCalled = true;
+            }
+
+            void UnhandledHandler(object sender, StripeUnhandledEventNotificationEventArgs e)
+            {
+                unhandledCalled = true;
+            }
+
+            var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
+            handler.V1BillingMeterErrorReportTriggered += Handler;
+            handler.PreHandle((notification, client) => false);
+
+            handler.Handle(this.V1BillingMeterPayload);
+
+            Assert.False(handlerCalled);
+            Assert.False(unhandledCalled);
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
@@ -189,6 +189,41 @@ namespace StripeTests
         }
 
         [Fact]
+        public void CannotRegisterNullHandler()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.V1BillingMeterErrorReportTriggered += null;
+            });
+
+            // the event type must not have been recorded as handled, otherwise dispatch would
+            // take the registered branch and invoke a null delegate instead of the fallback
+            Assert.Empty(handler.HandledEventTypes());
+        }
+
+        [Fact]
+        public void RegisteringNullHandlerLeavesFallbackIntact()
+        {
+            var fallbackCalls = new List<string>();
+            var handler = new StripeEventNotificationHandler(
+                this.stripeClient,
+                WebhookSecret,
+                (s, e) => fallbackCalls.Add(e.EventNotification.Type));
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.V1BillingMeterErrorReportTriggered += null;
+            });
+
+            handler.Handle(this.V1BillingMeterPayload, StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload));
+
+            Assert.Single(fallbackCalls);
+            Assert.Equal("v1.billing.meter.error_report_triggered", fallbackCalls[0]);
+        }
+
+        [Fact]
         public void CannotRegisterHandlerAfterHandling()
         {
             void Handler1(object sender, StripeEventNotificationEventArgs<V1BillingMeterErrorReportTriggeredEventNotification> e)
@@ -211,7 +246,7 @@ namespace StripeTests
                 handler.V1BillingMeterNoMeterFound += Handler2;
             });
 
-            Assert.Contains("after Handle has been called", exception.Message);
+            Assert.Contains("after an event has been handled", exception.Message);
         }
 
         [Fact]
@@ -624,7 +659,7 @@ namespace StripeTests
                 handler.PreHandle((notification, client) => true);
             });
 
-            Assert.Contains("after Handle has been called", exception.Message);
+            Assert.Contains("after an event has been handled", exception.Message);
         }
 
         [Fact]
@@ -894,7 +929,7 @@ namespace StripeTests
                 handler.V1BillingMeterNoMeterFound += Handler2;
             });
 
-            Assert.Contains("after Handle has been called", exception.Message);
+            Assert.Contains("after an event has been handled", exception.Message);
         }
 
         [Fact]

--- a/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeEventNotificationHandlerTest.cs
@@ -519,11 +519,11 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle((notification, client) =>
+            handler.PreHandle = (notification, client) =>
             {
                 callOrder.Add("preHandle");
                 return true;
-            });
+            };
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
             handler.Handle(this.V1BillingMeterPayload, sigHeader);
@@ -543,7 +543,7 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle((notification, client) => false);
+            handler.PreHandle = (notification, client) => false;
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
             handler.Handle(this.V1BillingMeterPayload, sigHeader);
@@ -562,7 +562,7 @@ namespace StripeTests
             }
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
-            handler.PreHandle((notification, client) => false);
+            handler.PreHandle = (notification, client) => false;
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.UnknownEventPayload);
             handler.Handle(this.UnknownEventPayload, sigHeader);
@@ -583,12 +583,12 @@ namespace StripeTests
             var client = new StripeClient(clientOptions);
             var handler = new StripeEventNotificationHandler(client, WebhookSecret, (s, e) => { });
             handler.V1BillingMeterErrorReportTriggered += (sender, e) => { };
-            handler.PreHandle((notification, preHandleClient) =>
+            handler.PreHandle = (notification, preHandleClient) =>
             {
                 var requestor = preHandleClient.Requestor as LiveApiRequestor;
                 receivedContext = requestor?.CurrentStripeContext;
                 return true;
-            });
+            };
 
             var requestor = client.Requestor as LiveApiRequestor;
             Assert.Equal("original_context_123", requestor?.CurrentStripeContext?.ToString());
@@ -622,7 +622,7 @@ namespace StripeTests
 
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, UnhandledHandler);
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle((notification, client) => throw new InvalidOperationException("PreHandle blew up!"));
+            handler.PreHandle = (notification, client) => throw new InvalidOperationException("PreHandle blew up!");
 
             var sigHeader = StripeTests.V2.EventTest.GenerateSigHeader(this.V1BillingMeterPayload);
 
@@ -642,7 +642,7 @@ namespace StripeTests
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.PreHandle(null);
+                handler.PreHandle = null;
             });
         }
 
@@ -656,24 +656,37 @@ namespace StripeTests
 
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.PreHandle((notification, client) => true);
+                handler.PreHandle = (notification, client) => true;
             });
 
             Assert.Contains("after an event has been handled", exception.Message);
         }
 
         [Fact]
-        public void PreHandleRegisteredTwiceThrowsInvalidOperationException()
+        public void PreHandleSetTwiceThrowsInvalidOperationException()
         {
             var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
-            handler.PreHandle((notification, client) => true);
+            handler.PreHandle = (notification, client) => true;
 
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                handler.PreHandle((notification, client) => true);
+                handler.PreHandle = (notification, client) => true;
             });
 
             Assert.Contains("already registered", exception.Message);
+        }
+
+        [Fact]
+        public void PreHandleGetterReturnsTheSetHook()
+        {
+            var handler = new StripeEventNotificationHandler(this.stripeClient, WebhookSecret, (s, e) => { });
+
+            Assert.Null(handler.PreHandle);
+
+            Func<Stripe.V2.Core.EventNotification, StripeClient, bool> hook = (notification, client) => true;
+            handler.PreHandle = hook;
+
+            Assert.Same(hook, handler.PreHandle);
         }
 
         [Fact]
@@ -951,7 +964,7 @@ namespace StripeTests
 
             var handler = StripeEventNotificationHandler.WithoutVerification(this.stripeClient, UnhandledHandler);
             handler.V1BillingMeterErrorReportTriggered += Handler;
-            handler.PreHandle((notification, client) => false);
+            handler.PreHandle = (notification, client) => false;
 
             handler.Handle(this.V1BillingMeterPayload);
 


### PR DESCRIPTION
### Why?

In final testing, users have expressed interest in being able to centrally run code before any other handler executes. It can be used for centralized logging, event deduplication, and more. I don't want to go full middleware, but this felt like a reasonable way to dip our toe into the waters.

Because users are responsible for [deduplicating events](https://docs.stripe.com/webhooks#handle-duplicate-events), this pre-handle hook (if present) should return a `bool`, signifying whether handling should continue.

If the function sets `.Cancel = false` (or is missing entirely), the handler proceeds like normal (running at-most-one other callback). If it sets `.Cancel = true`, no further callback is run and the original `.handle()` call finishes cleanly.

### What?

- add the `.pre_handle` method
- & associated tests
- update some error messages with correct verbs & consistency
- refactored some internal error handling
- updated example
- dotnet: reject nil handler case and and test

### See Also

- http://go/j/DEVSDK-3249
