### PR TITLE
Add new wholesome deleted exemption

### DIFF
--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -27,8 +27,12 @@ namespace StripeTests.Wholesome
             List<string> results = new List<string>();
             List<string> skipTheseClasses = new List<string>
             {
-                // For some reason, Secret.Deleted is not nullable
+                // Some classes have non-generated, non-nullable `Deleted` fields
+                // The beginning of the section generated from our OpenAPI spec
                 "Stripe.Apps.Secret",
+                "Stripe.CustomerTaxExemption",
+
+                // The end of the section generated from our OpenAPI spec
             };
 
             // Get all StripeEntity subclasses
@@ -64,7 +68,7 @@ namespace StripeTests.Wholesome
 
                     if (!hasNullValueHandling)
                     {
-                        results.Add($"{entityClass.Name}.{property.Name}");
+                        results.Add($"{entityClass.FullName}.{property.Name}");
                     }
                 }
             }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We have a wholesome test to assert that all properties named `Deleted` are a nullable bool. But that means if any language adds a manual property named `Deleted` that's not a nullable bool, tests start failing.

Rather than keep adding classes manually, I'm adding a new generated range. this also includes a new class that's been failing our builds.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add new generated range
- add new excepted `Deleted` property
- switch from `Name` to `FullName` in error message so it accurately shows what to add to fix issues

### See Also
<!-- Include any links or additional information that help explain this change. -->
