### PR TITLE
Merge to private-preview

### DIFF
--- a/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
+++ b/src/StripeTests/Wholesome/DontSerializeNullDeletedAttrs.cs
@@ -27,8 +27,12 @@ namespace StripeTests.Wholesome
             List<string> results = new List<string>();
             List<string> skipTheseClasses = new List<string>
             {
-                // For some reason, Secret.Deleted is not nullable
+                // Some classes have non-generated, non-nullable `Deleted` fields
+                // The beginning of the section generated from our OpenAPI spec
                 "Stripe.Apps.Secret",
+                "Stripe.CustomerTaxExemption",
+
+                // The end of the section generated from our OpenAPI spec
             };
 
             // Get all StripeEntity subclasses
@@ -64,7 +68,7 @@ namespace StripeTests.Wholesome
 
                     if (!hasNullValueHandling)
                     {
-                        results.Add($"{entityClass.Name}.{property.Name}");
+                        results.Add($"{entityClass.FullName}.{property.Name}");
                     }
                 }
             }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with null argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
