### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -139,6 +139,41 @@ namespace Stripe
                 this.Uri.ToString());
         }
 
+        /// <summary>
+        /// Asserts that a request path is origin-relative: that it begins with a single
+        /// <c>"/"</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The absolute URL is built by concatenating a base URL onto this path, and no base URL
+        /// ends in a slash. A path like <c>"@evil.example/v1/x"</c> or
+        /// <c>".evil.example/v1/x"</c> would therefore land inside the authority component and
+        /// send the request -- <c>Authorization</c> header included -- to a host of the path's
+        /// choosing. Some request paths originate in remote data (a webhook body's
+        /// <c>related_object.url</c>, a response's <c>next_page_url</c>), so the path cannot be
+        /// assumed to be well-formed.
+        /// </para>
+        /// <para>
+        /// A single leading slash is sufficient: it terminates the authority component, after
+        /// which nothing in the path can extend it.
+        /// </para>
+        /// <para>
+        /// Stripe only ever issues plain paths, so anything else is tampering and is rejected
+        /// rather than sanitized.
+        /// </para>
+        /// </remarks>
+        /// <param name="path">The relative request path.</param>
+        internal static void ValidatePath(string path)
+        {
+            if (path == null || !path.StartsWith('/')
+                || path.StartsWith("//"))
+            {
+                throw new ArgumentException(
+                    $"Request path must begin with a single \"/\", got: {path}",
+                    nameof(path));
+            }
+        }
+
         internal static Uri BuildUri(
             string baseUrl,
             HttpMethod method,
@@ -146,6 +181,8 @@ namespace Stripe
             BaseOptions options,
             ApiMode apiMode)
         {
+            ValidatePath(path);
+
             var b = new StringBuilder();
 
             b.Append(baseUrl);

--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -165,8 +165,7 @@ namespace Stripe
         /// <param name="path">The relative request path.</param>
         internal static void ValidatePath(string path)
         {
-            if (path == null || !path.StartsWith('/')
-                || path.StartsWith("//"))
+            if (path == null || !path.StartsWith("/") || path.StartsWith("//"))
             {
                 throw new ArgumentException(
                     $"Request path must begin with a single \"/\", got: {path}",

--- a/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
+++ b/src/Stripe.net/Infrastructure/Public/StripeRequest.cs
@@ -147,19 +147,13 @@ namespace Stripe
         /// <para>
         /// The absolute URL is built by concatenating a base URL onto this path, and no base URL
         /// ends in a slash. A path like <c>"@evil.example/v1/x"</c> or
-        /// <c>".evil.example/v1/x"</c> would therefore land inside the authority component and
-        /// send the request -- <c>Authorization</c> header included -- to a host of the path's
-        /// choosing. Some request paths originate in remote data (a webhook body's
-        /// <c>related_object.url</c>, a response's <c>next_page_url</c>), so the path cannot be
-        /// assumed to be well-formed.
+        /// <c>".evil.example/v1/x"</c> would modify the resulting host and direct the request
+        /// (including the API key) to a non-Stripe host.
         /// </para>
         /// <para>
-        /// A single leading slash is sufficient: it terminates the authority component, after
-        /// which nothing in the path can extend it.
-        /// </para>
-        /// <para>
-        /// Stripe only ever issues plain paths, so anything else is tampering and is rejected
-        /// rather than sanitized.
+        /// Because some relative urls arrive from potentially untrusted sources (like webhook
+        /// bodies), we have to be a little defensive. So, we require that a path starts with a
+        /// leading slash.
         /// </para>
         /// </remarks>
         /// <param name="path">The relative request path.</param>

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -1,5 +1,6 @@
 namespace StripeTests
 {
+    using System;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Stripe;
@@ -303,6 +304,65 @@ namespace StripeTests
                 new StripeRequest(client, HttpMethod.Get, "/get", null, requestOptions));
 
             Assert.Contains("No API key provided.", exception.Message);
+        }
+
+        // The absolute URL is built by concatenating a base URL onto a relative path, and no base
+        // URL ends in a slash. A path that does not begin with a single "/" can therefore land
+        // inside the URL's authority component and redirect the request -- Authorization header
+        // included -- to a host of the path's choosing. This matters because some request paths
+        // originate in remote data: a webhook body's related_object.url, a response's
+        // next_page_url.
+        [Theory]
+        [InlineData("/v1/customers/cus_123")]
+        [InlineData("/v1/customers")]
+        [InlineData("/v2/core/accounts?page=page_123&limit=2")]
+
+        // '@' is legal inside a path or query string -- it only opens an authority when it
+        // precedes the first '/'.
+        [InlineData("/v1/customers?email=user%40example.com")]
+        [InlineData("/v1/invoices/in_123@456")]
+
+        // A backslash does not open an authority: the '/' already closed it.
+        [InlineData("/v1/\\evil.example")]
+        public void AssertOriginRelativePath_AcceptsOriginRelativePaths(string path)
+        {
+            StripeRequest.ValidatePath(path);
+        }
+
+        [Theory]
+
+        // Each of these moves the request's authority off api.stripe.com.
+        [InlineData("@evil.example/v1/leak")]
+        [InlineData(":pw@evil.example/v1/leak")]
+        [InlineData(":80@evil.example/v1/leak")]
+
+        // Extends the host into an attacker-owned subdomain
+        // (api.stripe.com.evil.example), which has a valid certificate.
+        [InlineData(".evil.example/v1/leak")]
+        [InlineData("-evil.example/v1/leak")]
+        [InlineData("https://evil.example/v1/leak")]
+        [InlineData("//evil.example/v1/leak")]
+        [InlineData("")]
+        [InlineData("v1/customers")]
+        [InlineData(null)]
+        public void AssertOriginRelativePath_RejectsHostilePaths(string path)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                StripeRequest.ValidatePath(path));
+        }
+
+        [Fact]
+        public void Ctor_RejectsHostilePath()
+        {
+            var exception = Assert.Throws<ArgumentException>(() =>
+                new StripeRequest(
+                    this.stripeClient,
+                    HttpMethod.Get,
+                    "@evil.example/v1/leak",
+                    null,
+                    new RequestOptions()));
+
+            Assert.Contains("must begin with a single", exception.Message);
         }
     }
 }

--- a/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
+++ b/src/StripeTests/Infrastructure/Public/StripeRequestTest.cs
@@ -306,12 +306,6 @@ namespace StripeTests
             Assert.Contains("No API key provided.", exception.Message);
         }
 
-        // The absolute URL is built by concatenating a base URL onto a relative path, and no base
-        // URL ends in a slash. A path that does not begin with a single "/" can therefore land
-        // inside the URL's authority component and redirect the request -- Authorization header
-        // included -- to a host of the path's choosing. This matters because some request paths
-        // originate in remote data: a webhook body's related_object.url, a response's
-        // next_page_url.
         [Theory]
         [InlineData("/v1/customers/cus_123")]
         [InlineData("/v1/customers")]


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
