### PR TITLE
Validate that webhook secrets are non-empty

### DIFF
--- a/src/Examples/V2/EventNotificationHandlerEndpoint.cs
+++ b/src/Examples/V2/EventNotificationHandlerEndpoint.cs
@@ -41,7 +41,9 @@ namespace Examples.V2
         public EventNotificationHandlerEndpoint()
         {
             client = new StripeClient(Environment.GetEnvironmentVariable("STRIPE_API_KEY"));
-            handler = client.NotificationHandler(Environment.GetEnvironmentVariable("WEBHOOK_SECRET") ?? string.Empty, FallbackCallback);
+            var webhookSecret = Environment.GetEnvironmentVariable("WEBHOOK_SECRET")
+                ?? throw new InvalidOperationException("WEBHOOK_SECRET environment variable is not set.");
+            handler = client.NotificationHandler(webhookSecret, FallbackCallback);
             unverifiedHandler = client.NotificationHandlerWithoutVerification(FallbackCallback);
 
             // PreHandle runs after Handle parses the payload but before any callback fires.

--- a/src/Examples/V2/EventNotificationWebhookHandler.cs
+++ b/src/Examples/V2/EventNotificationWebhookHandler.cs
@@ -31,7 +31,8 @@ namespace Examples.V2
             var apiKey = Environment.GetEnvironmentVariable("STRIPE_API_KEY");
             client = new StripeClient(apiKey);
 
-            webhookSecret = Environment.GetEnvironmentVariable("WEBHOOK_SECRET") ?? string.Empty;
+            webhookSecret = Environment.GetEnvironmentVariable("WEBHOOK_SECRET")
+                ?? throw new InvalidOperationException("WEBHOOK_SECRET environment variable is not set.");
         }
 
         [HttpPost]

--- a/src/Stripe.net/Services/Events/EventUtility.cs
+++ b/src/Stripe.net/Services/Events/EventUtility.cs
@@ -184,6 +184,13 @@ namespace Stripe
         public static void ValidateSignature(string json, string stripeSignatureHeader, string secret, long tolerance, long utcNow)
         {
             var signatureItems = ParseStripeSignature(stripeSignatureHeader);
+
+            if (string.IsNullOrEmpty(secret))
+            {
+                throw new StripeException(
+                    "No webhook secret value was provided. It should start with `whsec_`");
+            }
+
             var signature = string.Empty;
 
             try

--- a/src/StripeTests/Services/Events/EventUtilityTest.cs
+++ b/src/StripeTests/Services/Events/EventUtilityTest.cs
@@ -154,7 +154,23 @@ namespace StripeTests
         public void ValidateSignatureHandlesIncorrectHeaderValues(string headerValue)
         {
             Assert.Throws<StripeException>(() =>
-                EventUtility.ValidateSignature("{}", headerValue, string.Empty));
+                EventUtility.ValidateSignature("{}", headerValue, this.secret));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ValidateSignature_EmptyOrNullSecretThrows(string emptySecret)
+        {
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var header = EventUtility.GenerateSignatureHeader("{}", this.secret, timestamp);
+
+            var exception = Assert.Throws<StripeException>(() =>
+                EventUtility.ValidateSignature("{}", header, emptySecret, EventUtility.DefaultTimeTolerance, timestamp));
+
+            Assert.Equal(
+                "No webhook secret value was provided. It should start with `whsec_`",
+                exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a potential security issue where, if the user passes an empty string into the event validation functions, the SDK would still generate a signature. If an attacker knew that a victim was inadvertently using an empty webhook secret, the attacker could send signed webhooks (using the empty secret) that a victim's integration would treat as valid.

The solution is to throw an error if the webhook secret is empty. This ensures all payloads are validated against an actual secret.

We also updated our examples to have better defaults, helping users to avoid this issue.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- verify that a webhook secret is non-empty & non-null when verifying a webhook
- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
