### PR TITLE
Support `EventNotification`s with singleton related objects

### DIFF
--- a/src/Stripe.net/Entities/V2/Core/EventNotification.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotification.cs
@@ -117,7 +117,25 @@ namespace Stripe.V2.Core
             return this.FetchRelatedObjectAsync<T>(relatedObject).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        protected virtual async Task<T> FetchRelatedObjectAsync<T>(EventNotificationRelatedObject relatedObject, CancellationToken cancellationToken = default)
+        protected virtual Task<T> FetchRelatedObjectAsync<T>(EventNotificationRelatedObject relatedObject, CancellationToken cancellationToken = default)
+        where T : IStripeEntity
+        {
+            return this.FetchRelatedObjectAsync<T>(relatedObject.Url, cancellationToken);
+        }
+
+        protected virtual T FetchRelatedObject<T>(EventNotificationRelatedSingletonObject relatedObject)
+        where T : IStripeEntity
+        {
+            return this.FetchRelatedObjectAsync<T>(relatedObject).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        protected virtual Task<T> FetchRelatedObjectAsync<T>(EventNotificationRelatedSingletonObject relatedObject, CancellationToken cancellationToken = default)
+        where T : IStripeEntity
+        {
+            return this.FetchRelatedObjectAsync<T>(relatedObject.Url, cancellationToken);
+        }
+
+        private async Task<T> FetchRelatedObjectAsync<T>(string url, CancellationToken cancellationToken)
         where T : IStripeEntity
         {
             if (this.Client == null)
@@ -127,7 +145,7 @@ namespace Stripe.V2.Core
 
             var res = await this.Client.RawRequestAsync(
                 HttpMethod.Get,
-                relatedObject.Url,
+                url,
                 requestOptions: new RawRequestOptions
                 {
                     Usage = new List<string> { "fetch_related_object" },

--- a/src/Stripe.net/Entities/V2/Core/EventNotificationRelatedSingletonObject.cs
+++ b/src/Stripe.net/Entities/V2/Core/EventNotificationRelatedSingletonObject.cs
@@ -1,0 +1,23 @@
+#nullable disable
+
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+    using STJS = System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Reference to a singleton API resource, which lacks an id.
+    /// </summary>
+    public class EventNotificationRelatedSingletonObject
+    {
+        [JsonProperty("type")]
+        [STJS.JsonPropertyName("type")]
+        [STJS.JsonInclude]
+        public string Type { get; internal set; }
+
+        [JsonProperty("url")]
+        [STJS.JsonPropertyName("url")]
+        [STJS.JsonInclude]
+        public string Url { get; internal set; }
+    }
+}

--- a/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/Event.partial.cs
@@ -30,13 +30,7 @@ namespace Stripe.V2.Core
         protected virtual T FetchRelatedObject<T>(EventRelatedObject relatedObject)
             where T : IStripeEntity
         {
-            Task<T> objectTask = this.FetchRelatedObjectAsync<T>(relatedObject);
-            if (objectTask == null)
-            {
-                return default(T);
-            }
-
-            return objectTask.ConfigureAwait(false).GetAwaiter().GetResult();
+            return this.FetchRelatedObject<T>(relatedObject?.Url);
         }
 
         /// <summary>
@@ -46,12 +40,45 @@ namespace Stripe.V2.Core
         protected virtual Task<T> FetchRelatedObjectAsync<T>(EventRelatedObject relatedObject, CancellationToken cancellationToken = default)
             where T : IStripeEntity
         {
-            if (relatedObject == null)
+            return this.FetchRelatedObjectAsync<T>(relatedObject?.Url, cancellationToken);
+        }
+
+        /// <summary>
+        /// Makes an API request to fetch the object associated with this event.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to fetch.</typeparam>
+        protected virtual T FetchRelatedObject<T>(EventRelatedSingletonObject relatedObject)
+            where T : IStripeEntity
+        {
+            return this.FetchRelatedObject<T>(relatedObject?.Url);
+        }
+
+        /// <summary>
+        /// Makes an API request to fetch the object associated with this event.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to fetch.</typeparam>
+        protected virtual Task<T> FetchRelatedObjectAsync<T>(EventRelatedSingletonObject relatedObject, CancellationToken cancellationToken = default)
+            where T : IStripeEntity
+        {
+            return this.FetchRelatedObjectAsync<T>(relatedObject?.Url, cancellationToken);
+        }
+
+        private T FetchRelatedObject<T>(string url)
+            where T : IStripeEntity
+        {
+            Task<T> objectTask = this.FetchRelatedObjectAsync<T>(url, default);
+            if (objectTask == null)
             {
-                return null;
+                return default(T);
             }
 
-            if (relatedObject.Url == null)
+            return objectTask.ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        private Task<T> FetchRelatedObjectAsync<T>(string url, CancellationToken cancellationToken)
+            where T : IStripeEntity
+        {
+            if (url == null)
             {
                 return null;
             }
@@ -68,7 +95,7 @@ namespace Stripe.V2.Core
             return this.Requestor.RequestAsync<T>(
                     BaseAddress.Api,
                     HttpMethod.Get,
-                    relatedObject.Url,
+                    url,
                     null,
                     opts,
                     cancellationToken: cancellationToken);

--- a/src/Stripe.net/Entities/V2/Core/Events/EventRelatedSingletonObject.cs
+++ b/src/Stripe.net/Entities/V2/Core/Events/EventRelatedSingletonObject.cs
@@ -1,0 +1,25 @@
+namespace Stripe.V2.Core
+{
+    using Newtonsoft.Json;
+    using STJS = System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Reference to a singleton API resource, which lacks an id.
+    /// </summary>
+    public class EventRelatedSingletonObject : StripeEntity<EventRelatedSingletonObject>
+    {
+        /// <summary>
+        /// Type of the object relevant to the event.
+        /// </summary>
+        [JsonProperty("type")]
+        [STJS.JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// URL to retrieve the resource.
+        /// </summary>
+        [JsonProperty("url")]
+        [STJS.JsonPropertyName("url")]
+        public string Url { get; set; }
+    }
+}

--- a/src/StripeTests/Events/V2/EventTest.cs
+++ b/src/StripeTests/Events/V2/EventTest.cs
@@ -15,6 +15,7 @@ namespace StripeTests.V2
     using Stripe.Infrastructure;
     using Stripe.V2;
     using Xunit;
+    using STJ = System.Text.Json;
 
     public class EventTest : BaseStripeTest
     {
@@ -128,6 +129,18 @@ namespace StripeTests.V2
                 }
               }";
 
+        private static string singletonRelatedObjectPayload =
+            @"{
+                ""type"": ""billing.meter"",
+                ""url"": ""/v1/billing/meters/me_123""
+              }";
+
+        private static string meterPayload =
+            @"{
+                ""id"": ""meter_123"",
+                ""object"": ""billing.meter""
+              }";
+
         private StripeClient stripeClient;
 
         public EventTest(MockHttpClientFixture mockHttpClientFixture)
@@ -209,6 +222,23 @@ namespace StripeTests.V2
         {
             Assert.IsType<T>(o);
             return (T)o;
+        }
+
+        /// <summary>
+        /// Sets up the mock http client to answer any request with the given payload.
+        /// </summary>
+        /// <param name="payload">The json payload to respond with.</param>
+        private void MockResponse(string payload)
+        {
+            this.MockHttpClientFixture.MockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    Content = new StringContent(payload),
+                });
         }
 
         [Fact]
@@ -479,6 +509,97 @@ namespace StripeTests.V2
             var v2EventService = new Stripe.V2.Core.EventService(this.stripeClient);
             var v2Event = await v2EventService.GetAsync("evt_234");
             Assert.Equal(this.stripeClient.Requestor, v2Event.Requestor);
+        }
+
+        [Fact]
+        public void ParseEventRelatedSingletonObject()
+        {
+            var nsjRelatedObject = JsonUtils.DeserializeObject<Stripe.V2.Core.EventRelatedSingletonObject>(
+                singletonRelatedObjectPayload);
+            Assert.Equal("billing.meter", nsjRelatedObject.Type);
+            Assert.Equal("/v1/billing/meters/me_123", nsjRelatedObject.Url);
+
+            var stjRelatedObject = STJ.JsonSerializer.Deserialize<Stripe.V2.Core.EventRelatedSingletonObject>(
+                singletonRelatedObjectPayload, StripeConfiguration.SerializerOptions);
+            Assert.Equal("billing.meter", stjRelatedObject.Type);
+            Assert.Equal("/v1/billing/meters/me_123", stjRelatedObject.Url);
+
+            // Singleton related objects have no id at all, so they don't implement IHasId.
+            Assert.Null(typeof(Stripe.V2.Core.EventRelatedSingletonObject).GetProperty("Id"));
+            Assert.DoesNotContain(
+                typeof(IHasId),
+                typeof(Stripe.V2.Core.EventRelatedSingletonObject).GetInterfaces());
+        }
+
+        [Fact]
+        public void ParseEventNotificationRelatedSingletonObject()
+        {
+            var nsjRelatedObject = JsonUtils.DeserializeObject<Stripe.V2.Core.EventNotificationRelatedSingletonObject>(
+                singletonRelatedObjectPayload);
+            Assert.Equal("billing.meter", nsjRelatedObject.Type);
+            Assert.Equal("/v1/billing/meters/me_123", nsjRelatedObject.Url);
+
+            var stjRelatedObject = STJ.JsonSerializer.Deserialize<Stripe.V2.Core.EventNotificationRelatedSingletonObject>(
+                singletonRelatedObjectPayload, StripeConfiguration.SerializerOptions);
+            Assert.Equal("billing.meter", stjRelatedObject.Type);
+            Assert.Equal("/v1/billing/meters/me_123", stjRelatedObject.Url);
+
+            Assert.Null(typeof(Stripe.V2.Core.EventNotificationRelatedSingletonObject).GetProperty("Id"));
+        }
+
+        [Fact]
+        public async Task FetchRelatedSingletonObjectFromNotif()
+        {
+            this.MockResponse(meterPayload);
+            var eventNotif = new SingletonEventNotification(this.stripeClient);
+
+            var relatedObject = await eventNotif.DoFetchRelatedObjectAsync(
+                new Stripe.V2.Core.EventNotificationRelatedSingletonObject
+                {
+                    Type = "billing.meter",
+                    Url = "/v1/billing/meters/me_123",
+                });
+            Assert.Equal("meter_123", relatedObject.Id);
+            Assert.Equal("billing.meter", relatedObject.Object);
+        }
+
+        /// <summary>
+        /// No singleton event is generated yet, so this stands in for one to exercise the
+        /// EventRelatedSingletonObject fetch helpers.
+        /// </summary>
+        private class SingletonEvent : Stripe.V2.Core.Event
+        {
+            public Meter DoFetchRelatedObject(Stripe.V2.Core.EventRelatedSingletonObject relatedObject)
+            {
+                return this.FetchRelatedObject<Meter>(relatedObject);
+            }
+
+            public Task<Meter> DoFetchRelatedObjectAsync(Stripe.V2.Core.EventRelatedSingletonObject relatedObject)
+            {
+                return this.FetchRelatedObjectAsync<Meter>(relatedObject);
+            }
+        }
+
+        /// <summary>
+        /// No singleton event is generated yet, so this stands in for one to exercise the
+        /// EventNotificationRelatedSingletonObject fetch helpers.
+        /// </summary>
+        private class SingletonEventNotification : Stripe.V2.Core.EventNotification
+        {
+            public SingletonEventNotification(StripeClient client)
+            {
+                this.Client = client;
+            }
+
+            public Meter DoFetchRelatedObject(Stripe.V2.Core.EventNotificationRelatedSingletonObject relatedObject)
+            {
+                return this.FetchRelatedObject<Meter>(relatedObject);
+            }
+
+            public Task<Meter> DoFetchRelatedObjectAsync(Stripe.V2.Core.EventNotificationRelatedSingletonObject relatedObject)
+            {
+                return this.FetchRelatedObjectAsync<Meter>(relatedObject);
+            }
         }
     }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a few event notification types whose related object is a singleton. As a result, its `id` field will always be `null`. Rather than mark the root `RelatedObject` class as having a nullable string for its id (causing every user to have to do null checks even when we _know_ it'll be there), we're adding a second class and generating accordingly. There'll never be any ambiguity as ot whether a id field will be present in the response.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `RelatedSingletonObject` class, which is a copy of `RelatedObject`, but without an `id`. I didn't do inheritance (when relevant) because it's such a tiny, colocated class. If the repetition bothers us, we can reassess.
- add related methods, as needed
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2825](https://go/j/RUN_DEVSDK-2825)
